### PR TITLE
Xcode source editor extension

### DIFF
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -2,7 +2,7 @@
 //  main.swift
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design
@@ -33,7 +33,7 @@
 
 import Foundation
 
-let version = "0.11.4"
+let version = "0.12"
 
 func showHelp() {
     print("swiftformat, version \(version)")

--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -2,7 +2,7 @@
 //  main.swift
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design
@@ -33,7 +33,7 @@
 
 import Foundation
 
-let version = "0.12"
+let version = "0.12.1"
 
 func showHelp() {
     print("swiftformat, version \(version)")

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,6 +1,6 @@
 SwiftFormat
 
-Version 0.12, October 8th, 2016
+Version 0.12.1, October 14th, 2016
 
 Copyright (c) 2016 Nick Lockwood
 

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,6 +1,6 @@
 SwiftFormat
 
-Version 0.11.4, October 5th, 2016
+Version 0.12, October 8th, 2016
 
 Copyright (c) 2016 Nick Lockwood
 

--- a/README.md
+++ b/README.md
@@ -403,11 +403,13 @@ What's next?
 Release notes
 ----------------
 
-Version ?
+Version 0.12
 
 - Linewrapped `case` elements are now vertically aligned
 - The `else` keyword in a `guard` statement is no longer indented
 - The `elseOnSameLine` rule is no longer applied if previous `} is not on its own line
+- Fixed handling of `case` after comma in an `if` statement
+- Added support for formatting partial file fragments
 - Reduced compilation time by ~500ms
 
 Version 0.11.4

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Release notes
 
 Version ?
 
+- Linewrapped `case` elements are now vertically aligned
 - The `else` keyword in a `guard` statement is no longer indented
 - The `elseOnSameLine` rule is no longer applied if previous `} is not on its own line
 - Reduced compilation time by ~500ms

--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ What's next?
 Release notes
 ----------------
 
+Version ?
+
+- The `else` keyword in a `guard` statement is no longer indented
+- The `elseOnSameLine` rule is no longer applied if previous `} is not on its own line
+- Reduced compilation time by ~500ms
+
 Version 0.11.4
 
 - Fixed critical bug where optionals with a default value were not handled correctly

--- a/README.md
+++ b/README.md
@@ -403,6 +403,11 @@ What's next?
 Release notes
 ----------------
 
+Version 0.12.1
+
+- Fixed stripping of space after `@escaping`, `@autoclosure` and `inout`
+- Fixed stripping of trailing linebreaks when using --fragment option
+
 Version 0.12
 
 - Linewrapped `case` elements are now vertically aligned

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -32,8 +32,10 @@
 		90C4B6D41DA4B04A009EB000 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 90C4B6D21DA4B04A009EB000 /* Main.storyboard */; };
 		90C4B6E01DA4B059009EB000 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90C4B6DF1DA4B059009EB000 /* Cocoa.framework */; };
 		90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */; };
-		90C4B6E71DA4B059009EB000 /* SourceEditorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */; };
+		90C4B6E71DA4B059009EB000 /* FormatSelectedSourceCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E61DA4B059009EB000 /* FormatSelectedSourceCommand.swift */; };
 		90C4B6EB1DA4B059009EB000 /* Swift Formatter.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		90F16AF81DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AF71DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift */; };
+		90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,9 +95,11 @@
 		90C4B6DF1DA4B059009EB000 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		90C4B6E31DA4B059009EB000 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
 		90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorExtension.swift; sourceTree = "<group>"; };
-		90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorCommand.swift; sourceTree = "<group>"; };
+		90C4B6E61DA4B059009EB000 /* FormatSelectedSourceCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatSelectedSourceCommand.swift; sourceTree = "<group>"; };
 		90C4B6E81DA4B059009EB000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		90CB44D81DA4B56500F86C22 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
+		90F16AF71DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatEntireFileCommand.swift; sourceTree = "<group>"; };
+		90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,7 +239,8 @@
 		90C4B6E11DA4B059009EB000 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
-				90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */,
+				90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */,
+				90F16AF91DA5ECBA00EB4EA1 /* Commands */,
 				90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */,
 				90C4B6E21DA4B059009EB000 /* Supporting Files */,
 			);
@@ -267,6 +272,15 @@
 				90CB44D81DA4B56500F86C22 /* SwiftFormatter.entitlements */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		90F16AF91DA5ECBA00EB4EA1 /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				90F16AF71DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift */,
+				90C4B6E61DA4B059009EB000 /* FormatSelectedSourceCommand.swift */,
+			);
+			name = Commands;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -541,9 +555,11 @@
 			files = (
 				90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */,
 				9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */,
+				90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */,
 				9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */,
 				9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */,
-				90C4B6E71DA4B059009EB000 /* SourceEditorCommand.swift in Sources */,
+				90C4B6E71DA4B059009EB000 /* FormatSelectedSourceCommand.swift in Sources */,
+				90F16AF81DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift in Sources */,
 				9028F7861DA4B435009FE5B4 /* Rules.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		90C4B6E01DA4B059009EB000 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90C4B6DF1DA4B059009EB000 /* Cocoa.framework */; };
 		90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */; };
 		90C4B6E71DA4B059009EB000 /* FormatSelectedSourceCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E61DA4B059009EB000 /* FormatSelectedSourceCommand.swift */; };
-		90C4B6EB1DA4B059009EB000 /* Swift Formatter.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		90C4B6EB1DA4B059009EB000 /* SwiftFormat.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 90C4B6DD1DA4B059009EB000 /* SwiftFormat.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		90F16AF81DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AF71DA5EB4600EB4EA1 /* FormatEntireFileCommand.swift */; };
 		90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */; };
 /* End PBXBuildFile section */
@@ -62,7 +62,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				90C4B6EB1DA4B059009EB000 /* Swift Formatter.appex in Embed App Extensions */,
+				90C4B6EB1DA4B059009EB000 /* SwiftFormat.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -91,7 +91,7 @@
 		90C4B6D01DA4B04A009EB000 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		90C4B6D31DA4B04A009EB000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		90C4B6D51DA4B04A009EB000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Swift Formatter.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		90C4B6DD1DA4B059009EB000 /* SwiftFormat.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SwiftFormat.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C4B6DF1DA4B059009EB000 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		90C4B6E31DA4B059009EB000 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
 		90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorExtension.swift; sourceTree = "<group>"; };
@@ -162,7 +162,7 @@
 				01A0EAAE1D5DB4D000A0A8E3 /* SwiftFormatTests.xctest */,
 				01A0EACA1D5DB5F500A0A8E3 /* swiftformat */,
 				90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */,
-				90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */,
+				90C4B6DD1DA4B059009EB000 /* SwiftFormat.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -370,9 +370,9 @@
 			productReference = 90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */;
 			productType = "com.apple.product-type.application";
 		};
-		90C4B6DC1DA4B059009EB000 /* Swift Formatter */ = {
+		90C4B6DC1DA4B059009EB000 /* Xcode Source Editor Extension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Swift Formatter" */;
+			buildConfigurationList = 90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Xcode Source Editor Extension" */;
 			buildPhases = (
 				90C4B6D91DA4B059009EB000 /* Sources */,
 				90C4B6DA1DA4B059009EB000 /* Frameworks */,
@@ -382,9 +382,9 @@
 			);
 			dependencies = (
 			);
-			name = "Swift Formatter";
+			name = "Xcode Source Editor Extension";
 			productName = "Swift Formatter";
-			productReference = 90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */;
+			productReference = 90C4B6DD1DA4B059009EB000 /* SwiftFormat.appex */;
 			productType = "com.apple.product-type.xcode-extension";
 		};
 /* End PBXNativeTarget section */
@@ -412,10 +412,12 @@
 					};
 					90C4B6C91DA4B04A009EB000 = {
 						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = HJKFVK94J4;
 						ProvisioningStyle = Automatic;
 					};
 					90C4B6DC1DA4B059009EB000 = {
 						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = HJKFVK94J4;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -437,7 +439,7 @@
 				01A0EAAD1D5DB4D000A0A8E3 /* SwiftFormatTests */,
 				01A0EAC91D5DB5F500A0A8E3 /* CommandLineTool */,
 				90C4B6C91DA4B04A009EB000 /* SwiftFormat for Xcode */,
-				90C4B6DC1DA4B059009EB000 /* Swift Formatter */,
+				90C4B6DC1DA4B059009EB000 /* Xcode Source Editor Extension */,
 			);
 		};
 /* End PBXProject section */
@@ -574,7 +576,7 @@
 		};
 		90C4B6EA1DA4B059009EB000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 90C4B6DC1DA4B059009EB000 /* Swift Formatter */;
+			target = 90C4B6DC1DA4B059009EB000 /* Xcode Source Editor Extension */;
 			targetProxy = 90C4B6E91DA4B059009EB000 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -786,11 +788,11 @@
 				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Application/SwiftFormatter.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HJKFVK94J4;
 				INFOPLIST_FILE = "Xcode Source Editor Extension/Application/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "SwiftFormat for Xcode";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 3.0.1;
 			};
@@ -806,11 +808,11 @@
 				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Application/SwiftFormatter.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HJKFVK94J4;
 				INFOPLIST_FILE = "Xcode Source Editor Extension/Application/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "SwiftFormat for Xcode";
 				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
@@ -824,11 +826,11 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HJKFVK94J4;
 				INFOPLIST_FILE = "Xcode Source Editor Extension/Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.Swift-Formatter";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.SourceEditorExtension";
+				PRODUCT_NAME = SwiftFormat;
 				STRIP_STYLE = all;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 3.0.1;
@@ -844,11 +846,11 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HJKFVK94J4;
 				INFOPLIST_FILE = "Xcode Source Editor Extension/Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.Swift-Formatter";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.SourceEditorExtension";
+				PRODUCT_NAME = SwiftFormat;
 				STRIP_STYLE = all;
 				SWIFT_VERSION = 3.0.1;
 			};
@@ -902,7 +904,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Swift Formatter" */ = {
+		90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Xcode Source Editor Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				90C4B6ED1DA4B059009EB000 /* Debug */,

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -637,7 +637,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -680,7 +679,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -22,6 +22,18 @@
 		01B3987B1D763424009ADE61 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987A1D763424009ADE61 /* FormatterTests.swift */; };
 		01B3987D1D763493009ADE61 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
 		01B3987F1D7634A0009ADE61 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
+		9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EAC41D5DB54A00A0A8E3 /* SwiftFormat.swift */; };
+		9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EABF1D5DB4F700A0A8E3 /* Tokenizer.swift */; };
+		9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
+		9028F7861DA4B435009FE5B4 /* Rules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EABE1D5DB4F700A0A8E3 /* Rules.swift */; };
+		90C4B6CD1DA4B04A009EB000 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */; };
+		90C4B6CF1DA4B04A009EB000 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6CE1DA4B04A009EB000 /* ViewController.swift */; };
+		90C4B6D11DA4B04A009EB000 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 90C4B6D01DA4B04A009EB000 /* Assets.xcassets */; };
+		90C4B6D41DA4B04A009EB000 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 90C4B6D21DA4B04A009EB000 /* Main.storyboard */; };
+		90C4B6E01DA4B059009EB000 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90C4B6DF1DA4B059009EB000 /* Cocoa.framework */; };
+		90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */; };
+		90C4B6E71DA4B059009EB000 /* SourceEditorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */; };
+		90C4B6EB1DA4B059009EB000 /* Swift Formatter.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,7 +44,28 @@
 			remoteGlobalIDString = 01A0EAA31D5DB4CF00A0A8E3;
 			remoteInfo = SwiftFormat;
 		};
+		90C4B6E91DA4B059009EB000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 01A0EA9B1D5DB4CF00A0A8E3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 90C4B6DC1DA4B059009EB000;
+			remoteInfo = "Swift Formatter";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		90C4B6EF1DA4B059009EB000 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				90C4B6EB1DA4B059009EB000 /* Swift Formatter.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0142F06E1D72FE10007D66CC /* SwiftFormatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftFormatTests.swift; sourceTree = "<group>"; };
@@ -50,6 +83,19 @@
 		01A0EACC1D5DB5F500A0A8E3 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		01B3987A1D763424009ADE61 /* FormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatterTests.swift; sourceTree = "<group>"; };
 		01B3987C1D763493009ADE61 /* Formatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
+		90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftFormat for Xcode.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		90C4B6CE1DA4B04A009EB000 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		90C4B6D01DA4B04A009EB000 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		90C4B6D31DA4B04A009EB000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		90C4B6D51DA4B04A009EB000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Swift Formatter.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		90C4B6DF1DA4B059009EB000 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		90C4B6E31DA4B059009EB000 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
+		90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorExtension.swift; sourceTree = "<group>"; };
+		90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorCommand.swift; sourceTree = "<group>"; };
+		90C4B6E81DA4B059009EB000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90CB44D81DA4B56500F86C22 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +121,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		90C4B6C71DA4B04A009EB000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90C4B6DA1DA4B059009EB000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90C4B6E01DA4B059009EB000 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -84,6 +145,8 @@
 				01A0EACB1D5DB5F500A0A8E3 /* CommandLineTool */,
 				01A0EAA61D5DB4CF00A0A8E3 /* SwiftFormat */,
 				01A0EAB21D5DB4D000A0A8E3 /* SwiftFormatTests */,
+				90C4B6F01DA4B0BF009EB000 /* Xcode Source Editor Extension */,
+				90C4B6DE1DA4B059009EB000 /* Frameworks */,
 				01A0EAA51D5DB4CF00A0A8E3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -94,6 +157,8 @@
 				01A0EAA41D5DB4CF00A0A8E3 /* SwiftFormat.framework */,
 				01A0EAAE1D5DB4D000A0A8E3 /* SwiftFormatTests.xctest */,
 				01A0EACA1D5DB5F500A0A8E3 /* swiftformat */,
+				90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */,
+				90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -129,6 +194,79 @@
 				01A0EACC1D5DB5F500A0A8E3 /* main.swift */,
 			);
 			path = CommandLineTool;
+			sourceTree = "<group>";
+		};
+		9016DEFD1DA5042E008A4E36 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6D01DA4B04A009EB000 /* Assets.xcassets */,
+				90C4B6D21DA4B04A009EB000 /* Main.storyboard */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		9016DEFE1DA50433008A4E36 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */,
+				90C4B6CE1DA4B04A009EB000 /* ViewController.swift */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		90C4B6CB1DA4B04A009EB000 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				9016DEFE1DA50433008A4E36 /* Source */,
+				9016DEFD1DA5042E008A4E36 /* Resources */,
+				90CB44D91DA4B56800F86C22 /* Supporting Files */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		90C4B6DE1DA4B059009EB000 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6DF1DA4B059009EB000 /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		90C4B6E11DA4B059009EB000 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6E61DA4B059009EB000 /* SourceEditorCommand.swift */,
+				90C4B6E41DA4B059009EB000 /* SourceEditorExtension.swift */,
+				90C4B6E21DA4B059009EB000 /* Supporting Files */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		90C4B6E21DA4B059009EB000 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6E81DA4B059009EB000 /* Info.plist */,
+				90C4B6E31DA4B059009EB000 /* SwiftFormatter.entitlements */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		90C4B6F01DA4B0BF009EB000 /* Xcode Source Editor Extension */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6CB1DA4B04A009EB000 /* Application */,
+				90C4B6E11DA4B059009EB000 /* Extension */,
+			);
+			path = "Xcode Source Editor Extension";
+			sourceTree = "<group>";
+		};
+		90CB44D91DA4B56800F86C22 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				90C4B6D51DA4B04A009EB000 /* Info.plist */,
+				90CB44D81DA4B56500F86C22 /* SwiftFormatter.entitlements */,
+			);
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -199,13 +337,49 @@
 			productReference = 01A0EACA1D5DB5F500A0A8E3 /* swiftformat */;
 			productType = "com.apple.product-type.tool";
 		};
+		90C4B6C91DA4B04A009EB000 /* SwiftFormat for Xcode */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 90C4B6D81DA4B04A009EB000 /* Build configuration list for PBXNativeTarget "SwiftFormat for Xcode" */;
+			buildPhases = (
+				90C4B6C61DA4B04A009EB000 /* Sources */,
+				90C4B6C71DA4B04A009EB000 /* Frameworks */,
+				90C4B6C81DA4B04A009EB000 /* Resources */,
+				90C4B6EF1DA4B059009EB000 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				90C4B6EA1DA4B059009EB000 /* PBXTargetDependency */,
+			);
+			name = "SwiftFormat for Xcode";
+			productName = "SwiftFormat for Xcode";
+			productReference = 90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */;
+			productType = "com.apple.product-type.application";
+		};
+		90C4B6DC1DA4B059009EB000 /* Swift Formatter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Swift Formatter" */;
+			buildPhases = (
+				90C4B6D91DA4B059009EB000 /* Sources */,
+				90C4B6DA1DA4B059009EB000 /* Frameworks */,
+				90C4B6DB1DA4B059009EB000 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Swift Formatter";
+			productName = "Swift Formatter";
+			productReference = 90C4B6DD1DA4B059009EB000 /* Swift Formatter.appex */;
+			productType = "com.apple.product-type.xcode-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		01A0EA9B1D5DB4CF00A0A8E3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 0810;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Nick Lockwood";
 				TargetAttributes = {
@@ -222,6 +396,14 @@
 						DevelopmentTeam = 8VQKF583ED;
 						LastSwiftMigration = 0800;
 					};
+					90C4B6C91DA4B04A009EB000 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
+					90C4B6DC1DA4B059009EB000 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 01A0EA9E1D5DB4CF00A0A8E3 /* Build configuration list for PBXProject "SwiftFormat" */;
@@ -230,6 +412,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 01A0EA9A1D5DB4CF00A0A8E3;
 			productRefGroup = 01A0EAA51D5DB4CF00A0A8E3 /* Products */;
@@ -239,6 +422,8 @@
 				01A0EAA31D5DB4CF00A0A8E3 /* SwiftFormat */,
 				01A0EAAD1D5DB4D000A0A8E3 /* SwiftFormatTests */,
 				01A0EAC91D5DB5F500A0A8E3 /* CommandLineTool */,
+				90C4B6C91DA4B04A009EB000 /* SwiftFormat for Xcode */,
+				90C4B6DC1DA4B059009EB000 /* Swift Formatter */,
 			);
 		};
 /* End PBXProject section */
@@ -252,6 +437,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		01A0EAAC1D5DB4D000A0A8E3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90C4B6C81DA4B04A009EB000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90C4B6D11DA4B04A009EB000 /* Assets.xcassets in Resources */,
+				90C4B6D41DA4B04A009EB000 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90C4B6DB1DA4B059009EB000 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,6 +526,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		90C4B6C61DA4B04A009EB000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90C4B6CF1DA4B04A009EB000 /* ViewController.swift in Sources */,
+				90C4B6CD1DA4B04A009EB000 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90C4B6D91DA4B059009EB000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */,
+				9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */,
+				9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */,
+				9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */,
+				90C4B6E71DA4B059009EB000 /* SourceEditorCommand.swift in Sources */,
+				9028F7861DA4B435009FE5B4 /* Rules.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -333,7 +556,23 @@
 			target = 01A0EAA31D5DB4CF00A0A8E3 /* SwiftFormat */;
 			targetProxy = 01A0EAB01D5DB4D000A0A8E3 /* PBXContainerItemProxy */;
 		};
+		90C4B6EA1DA4B059009EB000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 90C4B6DC1DA4B059009EB000 /* Swift Formatter */;
+			targetProxy = 90C4B6E91DA4B059009EB000 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		90C4B6D21DA4B04A009EB000 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				90C4B6D31DA4B04A009EB000 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		01A0EAB61D5DB4D000A0A8E3 /* Debug */ = {
@@ -523,6 +762,84 @@
 			};
 			name = Release;
 		};
+		90C4B6D61DA4B04A009EB000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Application/SwiftFormatter.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Xcode Source Editor Extension/Application/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Debug;
+		};
+		90C4B6D71DA4B04A009EB000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Application/SwiftFormatter.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Xcode Source Editor Extension/Application/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Release;
+		};
+		90C4B6ED1DA4B059009EB000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Extension/SwiftFormatter.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Xcode Source Editor Extension/Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.Swift-Formatter";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Debug;
+		};
+		90C4B6EE1DA4B059009EB000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Xcode Source Editor Extension/Extension/SwiftFormatter.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Xcode Source Editor Extension/Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.SwiftFormat-for-Xcode.Swift-Formatter";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = all;
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -558,6 +875,24 @@
 			buildConfigurations = (
 				01A0EACF1D5DB5F500A0A8E3 /* Debug */,
 				01A0EAD01D5DB5F500A0A8E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		90C4B6D81DA4B04A009EB000 /* Build configuration list for PBXNativeTarget "SwiftFormat for Xcode" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90C4B6D61DA4B04A009EB000 /* Debug */,
+				90C4B6D71DA4B04A009EB000 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		90C4B6EC1DA4B059009EB000 /* Build configuration list for PBXNativeTarget "Swift Formatter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90C4B6ED1DA4B059009EB000 /* Debug */,
+				90C4B6EE1DA4B059009EB000 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Xcode Source Editor Extension).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Xcode Source Editor Extension).xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "90C4B6DC1DA4B059009EB000"
+               BuildableName = "SwiftFormat.appex"
+               BlueprintName = "Xcode Source Editor Extension"
+               ReferencedContainer = "container:SwiftFormat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+               BuildableName = "SwiftFormat for Xcode.app"
+               BlueprintName = "SwiftFormat for Xcode"
+               ReferencedContainer = "container:SwiftFormat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6DC1DA4B059009EB000"
+            BuildableName = "SwiftFormat.appex"
+            BlueprintName = "Xcode Source Editor Extension"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+            BuildableName = "SwiftFormat for Xcode.app"
+            BlueprintName = "SwiftFormat for Xcode"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+            BuildableName = "SwiftFormat for Xcode.app"
+            BlueprintName = "SwiftFormat for Xcode"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+               BuildableName = "SwiftFormat for Xcode.app"
+               BlueprintName = "SwiftFormat for Xcode"
+               ReferencedContainer = "container:SwiftFormat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+            BuildableName = "SwiftFormat for Xcode.app"
+            BlueprintName = "SwiftFormat for Xcode"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+            BuildableName = "SwiftFormat for Xcode.app"
+            BlueprintName = "SwiftFormat for Xcode"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "90C4B6C91DA4B04A009EB000"
+            BuildableName = "SwiftFormat for Xcode.app"
+            BlueprintName = "SwiftFormat for Xcode"
+            ReferencedContainer = "container:SwiftFormat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftFormat/Formatter.swift
+++ b/SwiftFormat/Formatter.swift
@@ -2,7 +2,7 @@
 //  Formatter.swift
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/Formatter.swift
+++ b/SwiftFormat/Formatter.swift
@@ -2,7 +2,7 @@
 //  Formatter.swift
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/Info.plist
+++ b/SwiftFormat/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -2,7 +2,7 @@
 //  Rules.swift
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -585,7 +585,7 @@ public func consecutiveBlankLines(_ formatter: Formatter) {
         }
         lastTokenType = token.type
     }
-    if linebreakCount > 1 {
+    if linebreakCount > 1 && !formatter.options.fragment {
         if lastTokenType == .whitespace {
             formatter.removeLastToken()
         }

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -2,7 +2,7 @@
 //  Rules.swift
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design
@@ -46,23 +46,23 @@ public func spaceAroundParens(_ formatter: Formatter) {
     func spaceAfter(_ identifier: String, index: Int) -> Bool {
         switch identifier {
         case "internal",
-            "case",
-            "for",
-            "guard",
-            "if",
-            "in",
-            "return",
-            "switch",
-            "where",
-            "while",
-            "as",
-            "catch",
-            "is",
-            "let",
-            "rethrows",
-            "throw",
-            "throws",
-            "try":
+             "case",
+             "for",
+             "guard",
+             "if",
+             "in",
+             "return",
+             "switch",
+             "where",
+             "while",
+             "as",
+             "catch",
+             "is",
+             "let",
+             "rethrows",
+             "throw",
+             "throws",
+             "try":
             return formatter.previousNonWhitespaceToken(fromIndex: index)?.string != "."
         default:
             return false
@@ -152,15 +152,15 @@ public func spaceAroundBrackets(_ formatter: Formatter) {
     func spaceAfter(_ identifier: String, index: Int) -> Bool {
         switch identifier {
         case "case",
-            "guard",
-            "if",
-            "in",
-            "return",
-            "switch",
-            "where",
-            "while",
-            "as",
-            "is":
+             "guard",
+             "if",
+             "in",
+             "return",
+             "switch",
+             "where",
+             "while",
+             "as",
+             "is":
             return formatter.previousNonWhitespaceToken(fromIndex: index)?.string != "."
         default:
             return false
@@ -319,16 +319,16 @@ public func spaceAroundOperators(_ formatter: Formatter) {
     func spaceAfter(_ identifier: String, index: Int) -> Bool {
         switch identifier {
         case "case",
-            "guard",
-            "if",
-            "in",
-            "let",
-            "return",
-            "switch",
-            "where",
-            "while",
-            "as",
-            "is":
+             "guard",
+             "if",
+             "in",
+             "let",
+             "return",
+             "switch",
+             "where",
+             "while",
+             "as",
+             "is":
             return formatter.previousNonWhitespaceToken(fromIndex: index)?.string != "."
         default:
             return false
@@ -641,10 +641,10 @@ public func blankLinesBetweenScopes(_ formatter: Formatter) {
                 nextToken.type == .identifier {
                 switch nextToken.string {
                 case "var", "let", "func",
-                    "private", "fileprivate", "public", "internal", "open",
-                    "final", "required", "override", "convenience",
-                    "lazy", "dynamic", "static",
-                    "prefix", "postfix":
+                     "private", "fileprivate", "public", "internal", "open",
+                     "final", "required", "override", "convenience",
+                     "lazy", "dynamic", "static",
+                     "prefix", "postfix":
                     return
                 default:
                     break
@@ -716,8 +716,8 @@ public func blankLinesBetweenScopes(_ formatter: Formatter) {
                 case .identifier:
                     switch token.string {
                     case "private", "fileprivate", "internal", "public", "open",
-                        "final", "required", "override", "convenience",
-                        "prefix", "postfix":
+                         "final", "required", "override", "convenience",
+                         "prefix", "postfix":
                         break
                     default:
                         if !token.string.hasPrefix("@") {
@@ -829,26 +829,26 @@ public func indent(_ formatter: Formatter) {
                 // prefix, Protocol, required, right, set, Type, unowned, weak, willSet
                 switch token.string {
                 case "associatedtype",
-                    "import",
-                    "init",
-                    "inout",
-                    "let",
-                    "subscript",
-                    "var",
-                    "case",
-                    "default",
-                    "for",
-                    "guard",
-                    "if",
-                    "switch",
-                    "where",
-                    "while",
-                    "as",
-                    "catch",
-                    "is",
-                    "super",
-                    "throw",
-                    "try":
+                     "import",
+                     "init",
+                     "inout",
+                     "let",
+                     "subscript",
+                     "var",
+                     "case",
+                     "default",
+                     "for",
+                     "guard",
+                     "if",
+                     "switch",
+                     "where",
+                     "while",
+                     "as",
+                     "catch",
+                     "is",
+                     "super",
+                     "throw",
+                     "try":
                     return formatter.previousNonWhitespaceToken(fromIndex: i)?.string == "."
                 default:
                     return true
@@ -888,14 +888,14 @@ public func indent(_ formatter: Formatter) {
                 // TODO: handle "in"
                 switch token.string {
                 case "as",
-                    "dynamicType",
-                    "false",
-                    "is",
-                    "nil",
-                    "rethrows",
-                    "throws",
-                    "true",
-                    "where":
+                     "dynamicType",
+                     "false",
+                     "is",
+                     "nil",
+                     "rethrows",
+                     "throws",
+                     "true",
+                     "where":
                     return false
                 default:
                     return true
@@ -1255,9 +1255,9 @@ public func specifiers(_ formatter: Formatter) {
         }
         switch token.string {
         case "let", "var",
-            "typealias", "associatedtype",
-            "class", "struct", "enum", "protocol", "extension",
-            "func", "init", "subscript":
+             "typealias", "associatedtype",
+             "class", "struct", "enum", "protocol", "extension",
+             "func", "init", "subscript":
             break
         default:
             return

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -45,12 +45,15 @@ public func spaceAroundParens(_ formatter: Formatter) {
 
     func spaceAfter(_ identifier: String, index: Int) -> Bool {
         switch identifier {
-        case "internal",
+        case "@escaping",
+             "@autoclosure",
+             "internal",
              "case",
              "for",
              "guard",
              "if",
              "in",
+             "inout",
              "return",
              "switch",
              "where",
@@ -62,8 +65,6 @@ public func spaceAroundParens(_ formatter: Formatter) {
              "rethrows",
              "throw",
              "throws",
-             "@escaping",
-             "@autoclosure",
              "try":
             return formatter.previousNonWhitespaceToken(fromIndex: index)?.string != "."
         default:

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -897,11 +897,6 @@ public func indent(_ formatter: Formatter) {
                     "true",
                     "where":
                     return false
-                case "else":
-                    if let token = formatter.tokenAtIndex(lastNonWhitespaceOrLinebreakIndex) {
-                        return token.string == "}"
-                    }
-                    return false
                 default:
                     return true
                 }
@@ -1121,7 +1116,8 @@ public func elseOnSameLine(_ formatter: Formatter) {
             case .whitespace:
                 break
             case .endOfScope:
-                if token.string == "}" && containsLinebreak {
+                if token.string == "}" && containsLinebreak &&
+                    formatter.previousNonWhitespaceToken(fromIndex: index)?.type == .linebreak {
                     formatter.replaceTokensInRange(index + 1 ..< i, with: [Token(.whitespace, " ")])
                 }
                 return

--- a/SwiftFormat/Rules.swift
+++ b/SwiftFormat/Rules.swift
@@ -62,6 +62,8 @@ public func spaceAroundParens(_ formatter: Formatter) {
              "rethrows",
              "throw",
              "throws",
+             "@escaping",
+             "@autoclosure",
              "try":
             return formatter.previousNonWhitespaceToken(fromIndex: index)?.string != "."
         default:

--- a/SwiftFormat/SwiftFormat.h
+++ b/SwiftFormat/SwiftFormat.h
@@ -2,7 +2,7 @@
 //  SwiftFormat.h
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/SwiftFormat.h
+++ b/SwiftFormat/SwiftFormat.h
@@ -2,7 +2,7 @@
 //  SwiftFormat.h
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/SwiftFormat.swift
+++ b/SwiftFormat/SwiftFormat.swift
@@ -2,7 +2,7 @@
 //  SwiftFormat.swift
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/SwiftFormat.swift
+++ b/SwiftFormat/SwiftFormat.swift
@@ -2,7 +2,7 @@
 //  SwiftFormat.swift
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 12/08/2016.
 //  Copyright 2016 Charcoal Design

--- a/SwiftFormat/Tokenizer.swift
+++ b/SwiftFormat/Tokenizer.swift
@@ -2,7 +2,7 @@
 //  Tokenizer.swift
 //  SwiftFormat
 //
-//  Version 0.11.4
+//  Version 0.12
 //
 //  Created by Nick Lockwood on 11/08/2016.
 //  Copyright 2016 Charcoal Design
@@ -201,20 +201,20 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x00A1 ... 0x00A7,
-                0x00A9, 0x00AB, 0x00AC, 0x00AE,
-                0x00B0 ... 0x00B1,
-                0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
-                0x2016 ... 0x2017,
-                0x2020 ... 0x2027,
-                0x2030 ... 0x203E,
-                0x2041 ... 0x2053,
-                0x2055 ... 0x205E,
-                0x2190 ... 0x23FF,
-                0x2500 ... 0x2775,
-                0x2794 ... 0x2BFF,
-                0x2E00 ... 0x2E7F,
-                0x3001 ... 0x3003,
-                0x3008 ... 0x3030:
+                 0x00A9, 0x00AB, 0x00AC, 0x00AE,
+                 0x00B0 ... 0x00B1,
+                 0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
+                 0x2016 ... 0x2017,
+                 0x2020 ... 0x2027,
+                 0x2030 ... 0x203E,
+                 0x2041 ... 0x2053,
+                 0x2055 ... 0x205E,
+                 0x2190 ... 0x23FF,
+                 0x2500 ... 0x2775,
+                 0x2794 ... 0x2BFF,
+                 0x2E00 ... 0x2E7F,
+                 0x3001 ... 0x3003,
+                 0x3008 ... 0x3030:
                 return true
             default:
                 return false
@@ -227,11 +227,11 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x0300 ... 0x036F,
-                0x1DC0 ... 0x1DFF,
-                0x20D0 ... 0x20FF,
-                0xFE00 ... 0xFE0F,
-                0xFE20 ... 0xFE2F,
-                0xE0100 ... 0xE01EF:
+                 0x1DC0 ... 0x1DFF,
+                 0x20D0 ... 0x20FF,
+                 0xFE00 ... 0xFE0F,
+                 0xFE20 ... 0xFE2F,
+                 0xE0100 ... 0xE01EF:
                 return true
             default:
                 return false
@@ -274,54 +274,54 @@ private extension String.CharacterView {
         func isHead(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x41 ... 0x5A, // A-Z
-                0x61 ... 0x7A, // a-z
-                0x5F, 0x24, // _ and $
-                0x00A8, 0x00AA, 0x00AD, 0x00AF,
-                0x00B2 ... 0x00B5,
-                0x00B7 ... 0x00BA,
-                0x00BC ... 0x00BE,
-                0x00C0 ... 0x00D6,
-                0x00D8 ... 0x00F6,
-                0x00F8 ... 0x00FF,
-                0x0100 ... 0x02FF,
-                0x0370 ... 0x167F,
-                0x1681 ... 0x180D,
-                0x180F ... 0x1DBF,
-                0x1E00 ... 0x1FFF,
-                0x200B ... 0x200D,
-                0x202A ... 0x202E,
-                0x203F ... 0x2040,
-                0x2054,
-                0x2060 ... 0x206F,
-                0x2070 ... 0x20CF,
-                0x2100 ... 0x218F,
-                0x2460 ... 0x24FF,
-                0x2776 ... 0x2793,
-                0x2C00 ... 0x2DFF,
-                0x2E80 ... 0x2FFF,
-                0x3004 ... 0x3007,
-                0x3021 ... 0x302F,
-                0x3031 ... 0x303F,
-                0x3040 ... 0xD7FF,
-                0xF900 ... 0xFD3D,
-                0xFD40 ... 0xFDCF,
-                0xFDF0 ... 0xFE1F,
-                0xFE30 ... 0xFE44,
-                0xFE47 ... 0xFFFD,
-                0x10000 ... 0x1FFFD,
-                0x20000 ... 0x2FFFD,
-                0x30000 ... 0x3FFFD,
-                0x40000 ... 0x4FFFD,
-                0x50000 ... 0x5FFFD,
-                0x60000 ... 0x6FFFD,
-                0x70000 ... 0x7FFFD,
-                0x80000 ... 0x8FFFD,
-                0x90000 ... 0x9FFFD,
-                0xA0000 ... 0xAFFFD,
-                0xB0000 ... 0xBFFFD,
-                0xC0000 ... 0xCFFFD,
-                0xD0000 ... 0xDFFFD,
-                0xE0000 ... 0xEFFFD:
+                 0x61 ... 0x7A, // a-z
+                 0x5F, 0x24, // _ and $
+                 0x00A8, 0x00AA, 0x00AD, 0x00AF,
+                 0x00B2 ... 0x00B5,
+                 0x00B7 ... 0x00BA,
+                 0x00BC ... 0x00BE,
+                 0x00C0 ... 0x00D6,
+                 0x00D8 ... 0x00F6,
+                 0x00F8 ... 0x00FF,
+                 0x0100 ... 0x02FF,
+                 0x0370 ... 0x167F,
+                 0x1681 ... 0x180D,
+                 0x180F ... 0x1DBF,
+                 0x1E00 ... 0x1FFF,
+                 0x200B ... 0x200D,
+                 0x202A ... 0x202E,
+                 0x203F ... 0x2040,
+                 0x2054,
+                 0x2060 ... 0x206F,
+                 0x2070 ... 0x20CF,
+                 0x2100 ... 0x218F,
+                 0x2460 ... 0x24FF,
+                 0x2776 ... 0x2793,
+                 0x2C00 ... 0x2DFF,
+                 0x2E80 ... 0x2FFF,
+                 0x3004 ... 0x3007,
+                 0x3021 ... 0x302F,
+                 0x3031 ... 0x303F,
+                 0x3040 ... 0xD7FF,
+                 0xF900 ... 0xFD3D,
+                 0xFD40 ... 0xFDCF,
+                 0xFDF0 ... 0xFE1F,
+                 0xFE30 ... 0xFE44,
+                 0xFE47 ... 0xFFFD,
+                 0x10000 ... 0x1FFFD,
+                 0x20000 ... 0x2FFFD,
+                 0x30000 ... 0x3FFFD,
+                 0x40000 ... 0x4FFFD,
+                 0x50000 ... 0x5FFFD,
+                 0x60000 ... 0x6FFFD,
+                 0x70000 ... 0x7FFFD,
+                 0x80000 ... 0x8FFFD,
+                 0x90000 ... 0x9FFFD,
+                 0xA0000 ... 0xAFFFD,
+                 0xB0000 ... 0xBFFFD,
+                 0xC0000 ... 0xCFFFD,
+                 0xD0000 ... 0xDFFFD,
+                 0xE0000 ... 0xEFFFD:
                 return true
             default:
                 return false
@@ -331,10 +331,10 @@ private extension String.CharacterView {
         func isTail(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x30 ... 0x39, // 0-9
-                0x0300 ... 0x036F,
-                0x1DC0 ... 0x1DFF,
-                0x20D0 ... 0x20FF,
-                0xFE20 ... 0xFE2F:
+                 0x0300 ... 0x036F,
+                 0x1DC0 ... 0x1DFF,
+                 0x20D0 ... 0x20FF,
+                 0xFE20 ... 0xFE2F:
                 return true
             default:
                 return isHead(c)

--- a/SwiftFormat/Tokenizer.swift
+++ b/SwiftFormat/Tokenizer.swift
@@ -201,20 +201,20 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x00A1 ... 0x00A7,
-                0x00A9, 0x00AB, 0x00AC, 0x00AE,
-                0x00B0 ... 0x00B1,
-                0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
-                0x2016 ... 0x2017,
-                0x2020 ... 0x2027,
-                0x2030 ... 0x203E,
-                0x2041 ... 0x2053,
-                0x2055 ... 0x205E,
-                0x2190 ... 0x23FF,
-                0x2500 ... 0x2775,
-                0x2794 ... 0x2BFF,
-                0x2E00 ... 0x2E7F,
-                0x3001 ... 0x3003,
-                0x3008 ... 0x3030:
+                 0x00A9, 0x00AB, 0x00AC, 0x00AE,
+                 0x00B0 ... 0x00B1,
+                 0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
+                 0x2016 ... 0x2017,
+                 0x2020 ... 0x2027,
+                 0x2030 ... 0x203E,
+                 0x2041 ... 0x2053,
+                 0x2055 ... 0x205E,
+                 0x2190 ... 0x23FF,
+                 0x2500 ... 0x2775,
+                 0x2794 ... 0x2BFF,
+                 0x2E00 ... 0x2E7F,
+                 0x3001 ... 0x3003,
+                 0x3008 ... 0x3030:
                 return true
             default:
                 return false
@@ -227,11 +227,11 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x0300 ... 0x036F,
-                0x1DC0 ... 0x1DFF,
-                0x20D0 ... 0x20FF,
-                0xFE00 ... 0xFE0F,
-                0xFE20 ... 0xFE2F,
-                0xE0100 ... 0xE01EF:
+                 0x1DC0 ... 0x1DFF,
+                 0x20D0 ... 0x20FF,
+                 0xFE00 ... 0xFE0F,
+                 0xFE20 ... 0xFE2F,
+                 0xE0100 ... 0xE01EF:
                 return true
             default:
                 return false
@@ -274,54 +274,54 @@ private extension String.CharacterView {
         func isHead(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x41 ... 0x5A, // A-Z
-                0x61 ... 0x7A, // a-z
-                0x5F, 0x24, // _ and $
-                0x00A8, 0x00AA, 0x00AD, 0x00AF,
-                0x00B2 ... 0x00B5,
-                0x00B7 ... 0x00BA,
-                0x00BC ... 0x00BE,
-                0x00C0 ... 0x00D6,
-                0x00D8 ... 0x00F6,
-                0x00F8 ... 0x00FF,
-                0x0100 ... 0x02FF,
-                0x0370 ... 0x167F,
-                0x1681 ... 0x180D,
-                0x180F ... 0x1DBF,
-                0x1E00 ... 0x1FFF,
-                0x200B ... 0x200D,
-                0x202A ... 0x202E,
-                0x203F ... 0x2040,
-                0x2054,
-                0x2060 ... 0x206F,
-                0x2070 ... 0x20CF,
-                0x2100 ... 0x218F,
-                0x2460 ... 0x24FF,
-                0x2776 ... 0x2793,
-                0x2C00 ... 0x2DFF,
-                0x2E80 ... 0x2FFF,
-                0x3004 ... 0x3007,
-                0x3021 ... 0x302F,
-                0x3031 ... 0x303F,
-                0x3040 ... 0xD7FF,
-                0xF900 ... 0xFD3D,
-                0xFD40 ... 0xFDCF,
-                0xFDF0 ... 0xFE1F,
-                0xFE30 ... 0xFE44,
-                0xFE47 ... 0xFFFD,
-                0x10000 ... 0x1FFFD,
-                0x20000 ... 0x2FFFD,
-                0x30000 ... 0x3FFFD,
-                0x40000 ... 0x4FFFD,
-                0x50000 ... 0x5FFFD,
-                0x60000 ... 0x6FFFD,
-                0x70000 ... 0x7FFFD,
-                0x80000 ... 0x8FFFD,
-                0x90000 ... 0x9FFFD,
-                0xA0000 ... 0xAFFFD,
-                0xB0000 ... 0xBFFFD,
-                0xC0000 ... 0xCFFFD,
-                0xD0000 ... 0xDFFFD,
-                0xE0000 ... 0xEFFFD:
+                 0x61 ... 0x7A, // a-z
+                 0x5F, 0x24, // _ and $
+                 0x00A8, 0x00AA, 0x00AD, 0x00AF,
+                 0x00B2 ... 0x00B5,
+                 0x00B7 ... 0x00BA,
+                 0x00BC ... 0x00BE,
+                 0x00C0 ... 0x00D6,
+                 0x00D8 ... 0x00F6,
+                 0x00F8 ... 0x00FF,
+                 0x0100 ... 0x02FF,
+                 0x0370 ... 0x167F,
+                 0x1681 ... 0x180D,
+                 0x180F ... 0x1DBF,
+                 0x1E00 ... 0x1FFF,
+                 0x200B ... 0x200D,
+                 0x202A ... 0x202E,
+                 0x203F ... 0x2040,
+                 0x2054,
+                 0x2060 ... 0x206F,
+                 0x2070 ... 0x20CF,
+                 0x2100 ... 0x218F,
+                 0x2460 ... 0x24FF,
+                 0x2776 ... 0x2793,
+                 0x2C00 ... 0x2DFF,
+                 0x2E80 ... 0x2FFF,
+                 0x3004 ... 0x3007,
+                 0x3021 ... 0x302F,
+                 0x3031 ... 0x303F,
+                 0x3040 ... 0xD7FF,
+                 0xF900 ... 0xFD3D,
+                 0xFD40 ... 0xFDCF,
+                 0xFDF0 ... 0xFE1F,
+                 0xFE30 ... 0xFE44,
+                 0xFE47 ... 0xFFFD,
+                 0x10000 ... 0x1FFFD,
+                 0x20000 ... 0x2FFFD,
+                 0x30000 ... 0x3FFFD,
+                 0x40000 ... 0x4FFFD,
+                 0x50000 ... 0x5FFFD,
+                 0x60000 ... 0x6FFFD,
+                 0x70000 ... 0x7FFFD,
+                 0x80000 ... 0x8FFFD,
+                 0x90000 ... 0x9FFFD,
+                 0xA0000 ... 0xAFFFD,
+                 0xB0000 ... 0xBFFFD,
+                 0xC0000 ... 0xCFFFD,
+                 0xD0000 ... 0xDFFFD,
+                 0xE0000 ... 0xEFFFD:
                 return true
             default:
                 return false
@@ -331,10 +331,10 @@ private extension String.CharacterView {
         func isTail(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x30 ... 0x39, // 0-9
-                0x0300 ... 0x036F,
-                0x1DC0 ... 0x1DFF,
-                0x20D0 ... 0x20FF,
-                0xFE20 ... 0xFE2F:
+                 0x0300 ... 0x036F,
+                 0x1DC0 ... 0x1DFF,
+                 0x20D0 ... 0x20FF,
+                 0xFE20 ... 0xFE2F:
                 return true
             default:
                 return isHead(c)
@@ -576,29 +576,26 @@ func tokenize(_ source: String) -> [Token] {
     func processToken() {
         let token = tokens.last!
         if token.type != .whitespace {
-            let possibleKeyword: Bool = {
-                guard token.type == .identifier else { return false }
-                guard let nw = lastNonWhitespaceIndex else { return true }
-                switch tokens[nw].string {
-                case "if", "guard", "while", "for", ".":
-                    return false
-                default:
-                    return true
-                }
-            }()
             // Track switch/case statements
-            if possibleKeyword {
-                switch token.string {
-                case "switch":
-                    nestedSwitches += 1
-                case "default", "case":
-                    if nestedSwitches > 0 {
-                        tokens[tokens.count - 1] = Token(.endOfScope, token.string)
-                        processToken()
-                        return
-                    }
-                default:
+            if token.type == .identifier {
+                let previousToken: Token? =
+                    (lastNonWhitespaceIndex != nil) ? tokens[lastNonWhitespaceIndex!] : nil
+                switch previousToken?.string ?? "" {
+                case "if", "guard", "while", "for", ".", ",":
                     break
+                default:
+                    switch token.string {
+                    case "switch":
+                        nestedSwitches += 1
+                    case "default", "case":
+                        if nestedSwitches > 0 {
+                            tokens[tokens.count - 1] = Token(.endOfScope, token.string)
+                            processToken()
+                            return
+                        }
+                    default:
+                        break
+                    }
                 }
             }
             // Fix up optional indicator misidentified as operator

--- a/SwiftFormat/Tokenizer.swift
+++ b/SwiftFormat/Tokenizer.swift
@@ -2,7 +2,7 @@
 //  Tokenizer.swift
 //  SwiftFormat
 //
-//  Version 0.12
+//  Version 0.12.1
 //
 //  Created by Nick Lockwood on 11/08/2016.
 //  Copyright 2016 Charcoal Design
@@ -367,7 +367,7 @@ private extension String.CharacterView {
 
     mutating func parseNumber() -> Token? {
 
-        func scanNumber(_ head: @escaping(Character) -> Bool) -> String? {
+        func scanNumber(_ head: @escaping (Character) -> Bool) -> String? {
             return scanCharacters(head: head, tail: { head($0) || $0 == "_" })
         }
 

--- a/SwiftFormat/Tokenizer.swift
+++ b/SwiftFormat/Tokenizer.swift
@@ -80,7 +80,7 @@ public struct Token: Equatable {
 
     public func closesScopeForToken(_ token: Token) -> Bool {
         guard token.type == .startOfScope else {
-            return token.type == .endOfScope && string == ":" &&
+            return string == ":" && token.type == .endOfScope &&
                 (token.string == "case" || token.string == "default")
         }
         if type == .endOfScope {

--- a/SwiftFormat/Tokenizer.swift
+++ b/SwiftFormat/Tokenizer.swift
@@ -201,20 +201,20 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x00A1 ... 0x00A7,
-                 0x00A9, 0x00AB, 0x00AC, 0x00AE,
-                 0x00B0 ... 0x00B1,
-                 0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
-                 0x2016 ... 0x2017,
-                 0x2020 ... 0x2027,
-                 0x2030 ... 0x203E,
-                 0x2041 ... 0x2053,
-                 0x2055 ... 0x205E,
-                 0x2190 ... 0x23FF,
-                 0x2500 ... 0x2775,
-                 0x2794 ... 0x2BFF,
-                 0x2E00 ... 0x2E7F,
-                 0x3001 ... 0x3003,
-                 0x3008 ... 0x3030:
+                0x00A9, 0x00AB, 0x00AC, 0x00AE,
+                0x00B0 ... 0x00B1,
+                0x00B6, 0x00BB, 0x00BF, 0x00D7, 0x00F7,
+                0x2016 ... 0x2017,
+                0x2020 ... 0x2027,
+                0x2030 ... 0x203E,
+                0x2041 ... 0x2053,
+                0x2055 ... 0x205E,
+                0x2190 ... 0x23FF,
+                0x2500 ... 0x2775,
+                0x2794 ... 0x2BFF,
+                0x2E00 ... 0x2E7F,
+                0x3001 ... 0x3003,
+                0x3008 ... 0x3030:
                 return true
             default:
                 return false
@@ -227,11 +227,11 @@ private extension String.CharacterView {
             }
             switch c.unicodeValue {
             case 0x0300 ... 0x036F,
-                 0x1DC0 ... 0x1DFF,
-                 0x20D0 ... 0x20FF,
-                 0xFE00 ... 0xFE0F,
-                 0xFE20 ... 0xFE2F,
-                 0xE0100 ... 0xE01EF:
+                0x1DC0 ... 0x1DFF,
+                0x20D0 ... 0x20FF,
+                0xFE00 ... 0xFE0F,
+                0xFE20 ... 0xFE2F,
+                0xE0100 ... 0xE01EF:
                 return true
             default:
                 return false
@@ -274,54 +274,54 @@ private extension String.CharacterView {
         func isHead(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x41 ... 0x5A, // A-Z
-                 0x61 ... 0x7A, // a-z
-                 0x5F, 0x24, // _ and $
-                 0x00A8, 0x00AA, 0x00AD, 0x00AF,
-                 0x00B2 ... 0x00B5,
-                 0x00B7 ... 0x00BA,
-                 0x00BC ... 0x00BE,
-                 0x00C0 ... 0x00D6,
-                 0x00D8 ... 0x00F6,
-                 0x00F8 ... 0x00FF,
-                 0x0100 ... 0x02FF,
-                 0x0370 ... 0x167F,
-                 0x1681 ... 0x180D,
-                 0x180F ... 0x1DBF,
-                 0x1E00 ... 0x1FFF,
-                 0x200B ... 0x200D,
-                 0x202A ... 0x202E,
-                 0x203F ... 0x2040,
-                 0x2054,
-                 0x2060 ... 0x206F,
-                 0x2070 ... 0x20CF,
-                 0x2100 ... 0x218F,
-                 0x2460 ... 0x24FF,
-                 0x2776 ... 0x2793,
-                 0x2C00 ... 0x2DFF,
-                 0x2E80 ... 0x2FFF,
-                 0x3004 ... 0x3007,
-                 0x3021 ... 0x302F,
-                 0x3031 ... 0x303F,
-                 0x3040 ... 0xD7FF,
-                 0xF900 ... 0xFD3D,
-                 0xFD40 ... 0xFDCF,
-                 0xFDF0 ... 0xFE1F,
-                 0xFE30 ... 0xFE44,
-                 0xFE47 ... 0xFFFD,
-                 0x10000 ... 0x1FFFD,
-                 0x20000 ... 0x2FFFD,
-                 0x30000 ... 0x3FFFD,
-                 0x40000 ... 0x4FFFD,
-                 0x50000 ... 0x5FFFD,
-                 0x60000 ... 0x6FFFD,
-                 0x70000 ... 0x7FFFD,
-                 0x80000 ... 0x8FFFD,
-                 0x90000 ... 0x9FFFD,
-                 0xA0000 ... 0xAFFFD,
-                 0xB0000 ... 0xBFFFD,
-                 0xC0000 ... 0xCFFFD,
-                 0xD0000 ... 0xDFFFD,
-                 0xE0000 ... 0xEFFFD:
+                0x61 ... 0x7A, // a-z
+                0x5F, 0x24, // _ and $
+                0x00A8, 0x00AA, 0x00AD, 0x00AF,
+                0x00B2 ... 0x00B5,
+                0x00B7 ... 0x00BA,
+                0x00BC ... 0x00BE,
+                0x00C0 ... 0x00D6,
+                0x00D8 ... 0x00F6,
+                0x00F8 ... 0x00FF,
+                0x0100 ... 0x02FF,
+                0x0370 ... 0x167F,
+                0x1681 ... 0x180D,
+                0x180F ... 0x1DBF,
+                0x1E00 ... 0x1FFF,
+                0x200B ... 0x200D,
+                0x202A ... 0x202E,
+                0x203F ... 0x2040,
+                0x2054,
+                0x2060 ... 0x206F,
+                0x2070 ... 0x20CF,
+                0x2100 ... 0x218F,
+                0x2460 ... 0x24FF,
+                0x2776 ... 0x2793,
+                0x2C00 ... 0x2DFF,
+                0x2E80 ... 0x2FFF,
+                0x3004 ... 0x3007,
+                0x3021 ... 0x302F,
+                0x3031 ... 0x303F,
+                0x3040 ... 0xD7FF,
+                0xF900 ... 0xFD3D,
+                0xFD40 ... 0xFDCF,
+                0xFDF0 ... 0xFE1F,
+                0xFE30 ... 0xFE44,
+                0xFE47 ... 0xFFFD,
+                0x10000 ... 0x1FFFD,
+                0x20000 ... 0x2FFFD,
+                0x30000 ... 0x3FFFD,
+                0x40000 ... 0x4FFFD,
+                0x50000 ... 0x5FFFD,
+                0x60000 ... 0x6FFFD,
+                0x70000 ... 0x7FFFD,
+                0x80000 ... 0x8FFFD,
+                0x90000 ... 0x9FFFD,
+                0xA0000 ... 0xAFFFD,
+                0xB0000 ... 0xBFFFD,
+                0xC0000 ... 0xCFFFD,
+                0xD0000 ... 0xDFFFD,
+                0xE0000 ... 0xEFFFD:
                 return true
             default:
                 return false
@@ -331,10 +331,10 @@ private extension String.CharacterView {
         func isTail(_ c: Character) -> Bool {
             switch c.unicodeValue {
             case 0x30 ... 0x39, // 0-9
-                 0x0300 ... 0x036F,
-                 0x1DC0 ... 0x1DFF,
-                 0x20D0 ... 0x20FF,
-                 0xFE20 ... 0xFE2F:
+                0x0300 ... 0x036F,
+                0x1DC0 ... 0x1DFF,
+                0x20D0 ... 0x20FF,
+                0xFE20 ... 0xFE2F:
                 return true
             default:
                 return isHead(c)

--- a/SwiftFormatTests/Info.plist
+++ b/SwiftFormatTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>
 </plist>

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -879,6 +879,14 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
+    func testFragmentWithTrailingLinebreaks() {
+        let input = "func foo() {\n}\n\n\n"
+        let output = "func foo() {\n}\n\n"
+        let options = FormatOptions(fragment: true)
+        XCTAssertEqual(try! format(input, rules: [consecutiveBlankLines], options: options), output)
+        XCTAssertEqual(try! format(input, rules: defaultRules, options: options), output)
+    }
+
     // MARK: blankLinesAtEndOfScope
 
     func testBlankLinesRemovedAtEndOfFunction() {

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -1468,14 +1468,14 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
-    
+
     func testIndentEnumDictionaryKeysAndValues() {
         let input = "[\n.foo:\n.bar,\n.baz:\n.quux,]"
         let output = "[\n    .foo:\n    .bar,\n    .baz:\n    .quux,]"
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
-    
+
     // MARK: indent comments
 
     func testCommentIndenting() {

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -1344,8 +1344,15 @@ class RulesTests: XCTestCase {
     }
 
     func testIndentIfCase() {
-        let input = "{\nif case .Foo = error {}\n}"
-        let output = "{\n    if case .Foo = error {}\n}"
+        let input = "{\nif case .Foo(let msg) = error {}\n}"
+        let output = "{\n    if case .Foo(let msg) = error {}\n}"
+        XCTAssertEqual(try! format(input, rules: [indent]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+    
+    func testIndentIfCaseCommaCase() {
+        let input = "{\nif case .Foo(let msg) = a,\ncase .Bar(let msg) = b {}\n}"
+        let output = "{\n    if case .Foo(let msg) = a,\n        case .Bar(let msg) = b {}\n}"
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -155,6 +155,27 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
+    func testSpaceAfterInoutParam() {
+        let input = "func foo(bar: inout(Int, String)) {}"
+        let output = "func foo(bar: inout (Int, String)) {}"
+        XCTAssertEqual(try! format(input, rules: [spaceAroundParens]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
+    func testSpaceAfterEscapingAttribute() {
+        let input = "func foo(bar: @escaping() -> Void)"
+        let output = "func foo(bar: @escaping () -> Void)"
+        XCTAssertEqual(try! format(input, rules: [spaceAroundParens]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
+    func testSpaceAfterAutoclosureAttribute() {
+        let input = "func foo(bar: @autoclosure () -> Void)"
+        let output = "func foo(bar: @autoclosure () -> Void)"
+        XCTAssertEqual(try! format(input, rules: [spaceAroundParens]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
     // MARK: spaceInsideParens
 
     func testSpaceInsideParens() {

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -1301,14 +1301,14 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
-    func testWrappedLineBeforeElse() {
+    func testWrappedLineBeforeGuardElse() {
         let input = "guard let foo = bar\nelse { return }"
-        let output = "guard let foo = bar\n    else { return }"
+        let output = "guard let foo = bar\nelse { return }"
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
-    func testWrappedLineAfterElse() {
+    func testWrappedLineAfterGuardElse() {
         // Don't indent because this case is handled by braces rule
         let input = "guard let foo = bar else\n{ return }"
         let output = "guard let foo = bar else\n{ return }"
@@ -1561,15 +1561,22 @@ class RulesTests: XCTestCase {
     // MARK: elseOnSameLine
 
     func testElseOnSameLine() {
+        let input = "if true {\n    1\n}\nelse { 2 }"
+        let output = "if true {\n    1\n} else { 2 }"
+        XCTAssertEqual(try! format(input, rules: [elseOnSameLine]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
+    func testElseOnSameLineOnlyAppliedToDanglingBrace() {
         let input = "if true { 1 }\nelse { 2 }"
-        let output = "if true { 1 } else { 2 }"
+        let output = "if true { 1 }\nelse { 2 }"
         XCTAssertEqual(try! format(input, rules: [elseOnSameLine]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
     func testGuardNotAffectedByElseOnSameLine() {
-        let input = "guard true\n    else { return }"
-        let output = "guard true\n    else { return }"
+        let input = "guard true\nelse { return }"
+        let output = "guard true\nelse { return }"
         XCTAssertEqual(try! format(input, rules: [elseOnSameLine]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -1152,6 +1152,20 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
 
+    func testSwitchWrappedEnumCaseIndenting() {
+        let input = "switch x {\ncase .foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
+        let output = "switch x {\ncase .foo,\n     .bar,\n     .baz:\n    break\ndefault:\n    break\n}"
+        XCTAssertEqual(try! format(input, rules: [indent]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
+    func testSwitchWrappedEnumCaseIndentingVariant2() {
+        let input = "switch x {\ncase\n.foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
+        let output = "switch x {\ncase\n    .foo,\n    .bar,\n    .baz:\n    break\ndefault:\n    break\n}"
+        XCTAssertEqual(try! format(input, rules: [indent]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+
     func testSwitchCaseIsDictionaryIndenting() {
         let input = "switch x {\ncase foo is [Key: Value]:\nfallthrough\ndefault:\nbreak\n}"
         let output = "switch x {\ncase foo is [Key: Value]:\n    fallthrough\ndefault:\n    break\n}"
@@ -1349,7 +1363,7 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
-    
+
     func testIndentIfCaseCommaCase() {
         let input = "{\nif case .Foo(let msg) = a,\ncase .Bar(let msg) = b {}\n}"
         let output = "{\n    if case .Foo(let msg) = a,\n        case .Bar(let msg) = b {}\n}"
@@ -1454,7 +1468,14 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }
-
+    
+    func testIndentEnumDictionaryKeysAndValues() {
+        let input = "[\n.foo:\n.bar,\n.baz:\n.quux,]"
+        let output = "[\n    .foo:\n    .bar,\n    .baz:\n    .quux,]"
+        XCTAssertEqual(try! format(input, rules: [indent]), output)
+        XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
+    }
+    
     // MARK: indent comments
 
     func testCommentIndenting() {

--- a/SwiftFormatTests/RulesTests.swift
+++ b/SwiftFormatTests/RulesTests.swift
@@ -1147,7 +1147,7 @@ class RulesTests: XCTestCase {
 
     func testSwitchWrappedCaseIndenting() {
         let input = "switch x {\ncase foo,\nbar,\n    baz:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase foo,\n    bar,\n    baz:\n    break\ndefault:\n    break\n}"
+        let output = "switch x {\ncase foo,\n     bar,\n     baz:\n    break\ndefault:\n    break\n}"
         XCTAssertEqual(try! format(input, rules: [indent]), output)
         XCTAssertEqual(try! format(input + "\n", rules: defaultRules), output + "\n")
     }

--- a/SwiftFormatTests/SwiftFormatTests.swift
+++ b/SwiftFormatTests/SwiftFormatTests.swift
@@ -61,60 +61,6 @@ class SwiftFormatTests: XCTestCase {
         ])!, output)
     }
 
-    func testPathWithSpaces() {
-        let input = ["", "foo\\", "bar\\", "baz"]
-        let output = ["0": "", "1": "foo bar baz"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testPathInQuotes() {
-        let input = ["", "\"foo", "bar", "baz\""]
-        let output = ["0": "", "1": "foo bar baz"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testEscapedQuotesInPath() {
-        let input = ["", "\"\\\"foo", "bar", "baz\\\"\""]
-        let output = ["0": "", "1": "\"foo bar baz\""]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testEscapedBackslashInPath() {
-        let input = ["", "\"\\\\foo", "bar", "baz\\\\\""]
-        let output = ["0": "", "1": "\\foo bar baz\\"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testSinglePartInQuotes() {
-        let input = ["", "\"foobar\""]
-        let output = ["0": "", "1": "foobar"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testEscapedQuotesInSinglePartPath() {
-        let input = ["", "\"\\\"foobar\\\"\""]
-        let output = ["0": "", "1": "\"foobar\""]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testEscapedQuoteInTwoPartPath() {
-        let input = ["", "\"foo\\\"", "bar\""]
-        let output = ["0": "", "1": "foo\" bar"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testEscapedSlashInTwoPartPath() {
-        let input = ["", "\"foo\\\\", "bar\""]
-        let output = ["0": "", "1": "foo\\ bar"]
-        XCTAssertEqual(preprocessArguments(input, [])!, output)
-    }
-
-    func testDashInQuotedPath() {
-        let input = ["", "\"foo", "-bar", "baz\""]
-        let output = ["0": "", "1": "foo -bar baz"]
-        XCTAssertEqual(preprocessArguments(input, ["bar"])!, output)
-    }
-
     // MARK: performance
 
     //    func testPerformance() {

--- a/SwiftFormatTests/TokenizerTests.swift
+++ b/SwiftFormatTests/TokenizerTests.swift
@@ -1243,6 +1243,37 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
+    func testSwitchStatementWithEnumCases() {
+        let input = "switch x {\ncase .foo,\n.bar:\nbreak\ndefault:\nbreak\n}"
+        let output = [
+            Token(.identifier, "switch"),
+            Token(.whitespace, " "),
+            Token(.identifier, "x"),
+            Token(.whitespace, " "),
+            Token(.startOfScope, "{"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "case"),
+            Token(.whitespace, " "),
+            Token(.symbol, "."),
+            Token(.identifier, "foo"),
+            Token(.symbol, ","),
+            Token(.linebreak, "\n"),
+            Token(.symbol, "."),
+            Token(.identifier, "bar"),
+            Token(.startOfScope, ":"),
+            Token(.linebreak, "\n"),
+            Token(.identifier, "break"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "default"),
+            Token(.startOfScope, ":"),
+            Token(.linebreak, "\n"),
+            Token(.identifier, "break"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "}"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
     func testSwitchCaseIsDictionaryStatement() {
         let input = "switch x {\ncase foo is [Key: Value]:\nbreak\ndefault:\nbreak\n}"
         let output = [

--- a/SwiftFormatTests/TokenizerTests.swift
+++ b/SwiftFormatTests/TokenizerTests.swift
@@ -1371,6 +1371,52 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
+    func testSwitchCaseContainingIfCaseCommaCase() {
+        let input = "switch x {\ncase 1:\nif case w = x, case y = z {}\ndefault:\nbreak\n}"
+        let output = [
+            Token(.identifier, "switch"),
+            Token(.whitespace, " "),
+            Token(.identifier, "x"),
+            Token(.whitespace, " "),
+            Token(.startOfScope, "{"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "case"),
+            Token(.whitespace, " "),
+            Token(.number, "1"),
+            Token(.startOfScope, ":"),
+            Token(.linebreak, "\n"),
+            Token(.identifier, "if"),
+            Token(.whitespace, " "),
+            Token(.identifier, "case"),
+            Token(.whitespace, " "),
+            Token(.identifier, "w"),
+            Token(.whitespace, " "),
+            Token(.symbol, "="),
+            Token(.whitespace, " "),
+            Token(.identifier, "x"),
+            Token(.symbol, ","),
+            Token(.whitespace, " "),
+            Token(.identifier, "case"),
+            Token(.whitespace, " "),
+            Token(.identifier, "y"),
+            Token(.whitespace, " "),
+            Token(.symbol, "="),
+            Token(.whitespace, " "),
+            Token(.identifier, "z"),
+            Token(.whitespace, " "),
+            Token(.startOfScope, "{"),
+            Token(.endOfScope, "}"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "default"),
+            Token(.startOfScope, ":"),
+            Token(.linebreak, "\n"),
+            Token(.identifier, "break"),
+            Token(.linebreak, "\n"),
+            Token(.endOfScope, "}"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
     func testSwitchCaseContainingGuardCase() {
         let input = "switch x {\ncase 1:\nguard case x = y else {}\ndefault:\nbreak\n}"
         let output = [

--- a/Xcode Source Editor Extension/Application/AppDelegate.swift
+++ b/Xcode Source Editor Extension/Application/AppDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  AppDelegate.swift
+//  SwiftFormat for Xcode
+//
+//  Created by Tony Arnold on 5/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {}

--- a/Xcode Source Editor Extension/Application/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Xcode Source Editor Extension/Application/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
+++ b/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11535.1" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11535.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -653,7 +656,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="SwiftFormat_for_Xcode" customModuleProvider="target"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="75" y="0.0"/>
@@ -662,9 +665,8 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
-                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
-                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                    <window key="window" title="SwiftFormat" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" miniaturizable="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                     </window>
@@ -676,18 +678,153 @@
             </objects>
             <point key="canvasLocation" x="75" y="250"/>
         </scene>
-        <!--View Controller-->
+        <!--SwiftFormat-->
         <scene sceneID="hIz-AP-VOD">
             <objects>
-                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="SwiftFormat" storyboardIdentifier="ViewController" showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="ViewController" customModule="SwiftFormat_for_Xcode" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="494"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aNJ-6N-CED">
+                                <rect key="frame" x="18" y="457" width="349" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="What is SwiftFormat for Xcode?" id="DWG-95-tUK">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Zkf-d0-hNG">
+                                <rect key="frame" x="18" y="381" width="349" height="68"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="xVj-5Y-11n">
+                                    <font key="font" metaFont="system"/>
+                                    <string key="title">SwiftFormat for Xcode is an extension for Apple's IDE, Xcode that reformats swift code. It applies a set of rules to the whitespace around the code, leaving the meaning intact.</string>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qnt-Gk-VpH">
+                                <rect key="frame" x="18" y="348" width="349" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="How do I install it?" id="NmP-Dn-biY">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VVr-7o-9zD">
+                                <rect key="frame" x="18" y="255" width="349" height="85"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="9no-dM-Qlu">
+                                    <font key="font" metaFont="system"/>
+                                    <string key="title">1. Open System Preferences
+2. Click on "Extensions"
+3. Select "Xcode Source Editor"
+4. Ensure the checkbox next to "SwiftFormat" is checked
+5. Relaunch Xcode</string>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BT8-iH-xPF">
+                                <rect key="frame" x="18" y="222" width="349" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Using SwiftFormat in Xcode" id="oXO-Zs-OzH">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8zw-Wj-eDm">
+                                <rect key="frame" x="18" y="163" width="349" height="51"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Open any Swift source code in Xcode — under the &quot;Editor&quot; menu, you will find &quot;SwiftFormat&quot; which has two options:" allowsEditingTextAttributes="YES" id="hXB-Qi-ovD">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GQk-6A-jIk">
+                                <rect key="frame" x="246" y="13" width="125" height="32"/>
+                                <buttonCell key="cell" type="push" title="Got it, thanks!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Fk9-TQ-XqU">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                    <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="terminate:" target="rPt-NT-nkU" id="F5D-ZO-Sjd"/>
+                                </connections>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OUH-Zg-5E6">
+                                <rect key="frame" x="18" y="138" width="113" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Entire File" id="Hrg-QH-mw6">
+                                    <font key="font" metaFont="systemMedium" size="13"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0fv-q4-LYw">
+                                <rect key="frame" x="18" y="88" width="154" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Selected Source" id="TzM-um-Cxx">
+                                    <font key="font" metaFont="systemMedium" size="13"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="f7w-oN-I0u">
+                                <rect key="frame" x="18" y="63" width="349" height="17"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats just the swift code you have selected" id="TvB-5m-5S4">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3tw-Xe-luV">
+                                <rect key="frame" x="18" y="113" width="349" height="17"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats the swift file you’re currently editing" id="kCm-Pj-5CN">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="GQk-6A-jIk" firstAttribute="top" secondItem="f7w-oN-I0u" secondAttribute="bottom" constant="22" id="20q-VB-ONO"/>
+                            <constraint firstItem="3tw-Xe-luV" firstAttribute="top" secondItem="OUH-Zg-5E6" secondAttribute="bottom" constant="8" symbolic="YES" id="4q1-8r-z4I"/>
+                            <constraint firstItem="qnt-Gk-VpH" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="8zH-8M-B3o"/>
+                            <constraint firstItem="0fv-q4-LYw" firstAttribute="leading" secondItem="OUH-Zg-5E6" secondAttribute="leading" id="95j-tH-qIF"/>
+                            <constraint firstItem="BT8-iH-xPF" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="9Zc-9a-gjc"/>
+                            <constraint firstItem="Zkf-d0-hNG" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="DFs-BK-idd"/>
+                            <constraint firstAttribute="trailing" secondItem="Zkf-d0-hNG" secondAttribute="trailing" constant="20" symbolic="YES" id="OVl-wP-9Cu"/>
+                            <constraint firstItem="Zkf-d0-hNG" firstAttribute="top" secondItem="aNJ-6N-CED" secondAttribute="bottom" constant="8" symbolic="YES" id="Ovr-gf-o9G"/>
+                            <constraint firstItem="f7w-oN-I0u" firstAttribute="top" secondItem="0fv-q4-LYw" secondAttribute="bottom" constant="8" symbolic="YES" id="QHZ-cv-wXr"/>
+                            <constraint firstAttribute="trailing" secondItem="f7w-oN-I0u" secondAttribute="trailing" constant="20" symbolic="YES" id="SIM-AT-wfl"/>
+                            <constraint firstItem="8zw-Wj-eDm" firstAttribute="top" secondItem="BT8-iH-xPF" secondAttribute="bottom" constant="8" symbolic="YES" id="USZ-YJ-6yu"/>
+                            <constraint firstAttribute="trailing" secondItem="GQk-6A-jIk" secondAttribute="trailing" constant="20" symbolic="YES" id="UV3-rs-moX"/>
+                            <constraint firstItem="aNJ-6N-CED" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="Ugf-5c-ZCV"/>
+                            <constraint firstItem="VVr-7o-9zD" firstAttribute="top" secondItem="qnt-Gk-VpH" secondAttribute="bottom" constant="8" symbolic="YES" id="Vri-n8-tf7"/>
+                            <constraint firstItem="f7w-oN-I0u" firstAttribute="leading" secondItem="0fv-q4-LYw" secondAttribute="leading" id="XO9-q5-xqw"/>
+                            <constraint firstAttribute="trailing" secondItem="VVr-7o-9zD" secondAttribute="trailing" constant="20" symbolic="YES" id="Zm1-cZ-3is"/>
+                            <constraint firstItem="VVr-7o-9zD" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="a73-Fq-yGR"/>
+                            <constraint firstItem="BT8-iH-xPF" firstAttribute="top" secondItem="VVr-7o-9zD" secondAttribute="bottom" constant="16" id="aRt-mU-3zD"/>
+                            <constraint firstItem="OUH-Zg-5E6" firstAttribute="leading" secondItem="8zw-Wj-eDm" secondAttribute="leading" id="bFY-ee-qCG"/>
+                            <constraint firstAttribute="trailing" secondItem="qnt-Gk-VpH" secondAttribute="trailing" constant="20" symbolic="YES" id="bxl-PW-1W3"/>
+                            <constraint firstAttribute="trailing" secondItem="3tw-Xe-luV" secondAttribute="trailing" constant="20" symbolic="YES" id="cpR-hc-fUU"/>
+                            <constraint firstAttribute="trailing" secondItem="BT8-iH-xPF" secondAttribute="trailing" constant="20" symbolic="YES" id="eTa-a5-FhC"/>
+                            <constraint firstAttribute="trailing" secondItem="8zw-Wj-eDm" secondAttribute="trailing" constant="20" symbolic="YES" id="fZ3-5j-r2r"/>
+                            <constraint firstAttribute="trailing" secondItem="aNJ-6N-CED" secondAttribute="trailing" constant="20" symbolic="YES" id="hI6-IH-RFc"/>
+                            <constraint firstItem="3tw-Xe-luV" firstAttribute="top" secondItem="OUH-Zg-5E6" secondAttribute="bottom" constant="8" symbolic="YES" id="kH7-9c-TpL"/>
+                            <constraint firstItem="8zw-Wj-eDm" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="l3G-Oo-SwJ"/>
+                            <constraint firstAttribute="bottom" secondItem="GQk-6A-jIk" secondAttribute="bottom" constant="20" symbolic="YES" id="nxu-8v-azg"/>
+                            <constraint firstItem="3tw-Xe-luV" firstAttribute="leading" secondItem="OUH-Zg-5E6" secondAttribute="leading" id="s0U-Ud-Izp"/>
+                            <constraint firstItem="qnt-Gk-VpH" firstAttribute="top" secondItem="Zkf-d0-hNG" secondAttribute="bottom" constant="16" id="tiH-6g-ALA"/>
+                            <constraint firstItem="OUH-Zg-5E6" firstAttribute="top" secondItem="8zw-Wj-eDm" secondAttribute="bottom" constant="8" symbolic="YES" id="uWd-JY-Hhx"/>
+                            <constraint firstItem="0fv-q4-LYw" firstAttribute="top" secondItem="3tw-Xe-luV" secondAttribute="bottom" constant="8" symbolic="YES" id="wBk-Ab-bdR"/>
+                            <constraint firstItem="aNJ-6N-CED" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" symbolic="YES" id="xiA-eD-jTg"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="655"/>
+            <point key="canvasLocation" x="75.5" y="878"/>
         </scene>
     </scenes>
 </document>

--- a/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
+++ b/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
@@ -754,16 +754,16 @@ DQ
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OUH-Zg-5E6">
-                                <rect key="frame" x="18" y="138" width="113" height="17"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Entire File" id="Hrg-QH-mw6">
+                                <rect key="frame" x="18" y="134" width="154" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Selected Source" id="Hrg-QH-mw6">
                                     <font key="font" metaFont="systemMedium" size="13"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0fv-q4-LYw">
-                                <rect key="frame" x="18" y="88" width="154" height="17"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Selected Source" id="TzM-um-Cxx">
+                                <rect key="frame" x="18" y="84" width="113" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Entire File" id="TzM-um-Cxx">
                                     <font key="font" metaFont="systemMedium" size="13"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -771,7 +771,7 @@ DQ
                             </textField>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="f7w-oN-I0u">
                                 <rect key="frame" x="18" y="63" width="349" height="17"/>
-                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats just the swift code you have selected" id="TvB-5m-5S4">
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats the entire swift file you’re currently editing." id="TvB-5m-5S4">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -779,7 +779,7 @@ DQ
                             </textField>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3tw-Xe-luV">
                                 <rect key="frame" x="18" y="113" width="349" height="17"/>
-                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats the swift file you’re currently editing" id="kCm-Pj-5CN">
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Re-formats just the swift code you have selected." id="kCm-Pj-5CN">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -788,14 +788,13 @@ DQ
                         </subviews>
                         <constraints>
                             <constraint firstItem="GQk-6A-jIk" firstAttribute="top" secondItem="f7w-oN-I0u" secondAttribute="bottom" constant="22" id="20q-VB-ONO"/>
-                            <constraint firstItem="3tw-Xe-luV" firstAttribute="top" secondItem="OUH-Zg-5E6" secondAttribute="bottom" constant="8" symbolic="YES" id="4q1-8r-z4I"/>
                             <constraint firstItem="qnt-Gk-VpH" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="8zH-8M-B3o"/>
                             <constraint firstItem="0fv-q4-LYw" firstAttribute="leading" secondItem="OUH-Zg-5E6" secondAttribute="leading" id="95j-tH-qIF"/>
                             <constraint firstItem="BT8-iH-xPF" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="9Zc-9a-gjc"/>
                             <constraint firstItem="Zkf-d0-hNG" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="DFs-BK-idd"/>
                             <constraint firstAttribute="trailing" secondItem="Zkf-d0-hNG" secondAttribute="trailing" constant="20" symbolic="YES" id="OVl-wP-9Cu"/>
                             <constraint firstItem="Zkf-d0-hNG" firstAttribute="top" secondItem="aNJ-6N-CED" secondAttribute="bottom" constant="8" symbolic="YES" id="Ovr-gf-o9G"/>
-                            <constraint firstItem="f7w-oN-I0u" firstAttribute="top" secondItem="0fv-q4-LYw" secondAttribute="bottom" constant="8" symbolic="YES" id="QHZ-cv-wXr"/>
+                            <constraint firstItem="f7w-oN-I0u" firstAttribute="top" secondItem="0fv-q4-LYw" secondAttribute="bottom" constant="4" id="QHZ-cv-wXr"/>
                             <constraint firstAttribute="trailing" secondItem="f7w-oN-I0u" secondAttribute="trailing" constant="20" symbolic="YES" id="SIM-AT-wfl"/>
                             <constraint firstItem="8zw-Wj-eDm" firstAttribute="top" secondItem="BT8-iH-xPF" secondAttribute="bottom" constant="8" symbolic="YES" id="USZ-YJ-6yu"/>
                             <constraint firstAttribute="trailing" secondItem="GQk-6A-jIk" secondAttribute="trailing" constant="20" symbolic="YES" id="UV3-rs-moX"/>
@@ -811,13 +810,13 @@ DQ
                             <constraint firstAttribute="trailing" secondItem="BT8-iH-xPF" secondAttribute="trailing" constant="20" symbolic="YES" id="eTa-a5-FhC"/>
                             <constraint firstAttribute="trailing" secondItem="8zw-Wj-eDm" secondAttribute="trailing" constant="20" symbolic="YES" id="fZ3-5j-r2r"/>
                             <constraint firstAttribute="trailing" secondItem="aNJ-6N-CED" secondAttribute="trailing" constant="20" symbolic="YES" id="hI6-IH-RFc"/>
-                            <constraint firstItem="3tw-Xe-luV" firstAttribute="top" secondItem="OUH-Zg-5E6" secondAttribute="bottom" constant="8" symbolic="YES" id="kH7-9c-TpL"/>
+                            <constraint firstItem="3tw-Xe-luV" firstAttribute="top" secondItem="OUH-Zg-5E6" secondAttribute="bottom" constant="4" id="kH7-9c-TpL"/>
                             <constraint firstItem="8zw-Wj-eDm" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="l3G-Oo-SwJ"/>
                             <constraint firstAttribute="bottom" secondItem="GQk-6A-jIk" secondAttribute="bottom" constant="20" symbolic="YES" id="nxu-8v-azg"/>
                             <constraint firstItem="3tw-Xe-luV" firstAttribute="leading" secondItem="OUH-Zg-5E6" secondAttribute="leading" id="s0U-Ud-Izp"/>
                             <constraint firstItem="qnt-Gk-VpH" firstAttribute="top" secondItem="Zkf-d0-hNG" secondAttribute="bottom" constant="16" id="tiH-6g-ALA"/>
-                            <constraint firstItem="OUH-Zg-5E6" firstAttribute="top" secondItem="8zw-Wj-eDm" secondAttribute="bottom" constant="8" symbolic="YES" id="uWd-JY-Hhx"/>
-                            <constraint firstItem="0fv-q4-LYw" firstAttribute="top" secondItem="3tw-Xe-luV" secondAttribute="bottom" constant="8" symbolic="YES" id="wBk-Ab-bdR"/>
+                            <constraint firstItem="OUH-Zg-5E6" firstAttribute="top" secondItem="8zw-Wj-eDm" secondAttribute="bottom" constant="12" id="uWd-JY-Hhx"/>
+                            <constraint firstItem="0fv-q4-LYw" firstAttribute="top" secondItem="3tw-Xe-luV" secondAttribute="bottom" constant="12" id="wBk-Ab-bdR"/>
                             <constraint firstItem="aNJ-6N-CED" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" symbolic="YES" id="xiA-eD-jTg"/>
                         </constraints>
                     </view>

--- a/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
+++ b/Xcode Source Editor Extension/Application/Base.lproj/Main.storyboard
@@ -1,0 +1,693 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="SwiftFormat for Xcode" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="SwiftFormat for Xcode" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About SwiftFormat for Xcode" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide SwiftFormat for Xcode" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit SwiftFormat for Xcode" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="SwiftFormat for Xcode Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+    </scenes>
+</document>

--- a/Xcode Source Editor Extension/Application/Info.plist
+++ b/Xcode Source Editor Extension/Application/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.3</string>
+	<string>0.11.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Xcode Source Editor Extension/Application/Info.plist
+++ b/Xcode Source Editor Extension/Application/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.4</string>
+	<string>0.12</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Xcode Source Editor Extension/Application/Info.plist
+++ b/Xcode Source Editor Extension/Application/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.11.3</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Nick Lockwood. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Xcode Source Editor Extension/Application/SwiftFormatter.entitlements
+++ b/Xcode Source Editor Extension/Application/SwiftFormatter.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>XcodeSwiftFormatter</string>
+	</array>
+</dict>
+</plist>

--- a/Xcode Source Editor Extension/Application/ViewController.swift
+++ b/Xcode Source Editor Extension/Application/ViewController.swift
@@ -1,0 +1,34 @@
+//
+//  ViewController.swift
+//  SwiftFormat for Xcode
+//
+//  Created by Tony Arnold on 5/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import Cocoa
+
+class ViewController: NSViewController {}

--- a/Xcode Source Editor Extension/Extension/CommandErrors.swift
+++ b/Xcode Source Editor Extension/Extension/CommandErrors.swift
@@ -1,0 +1,35 @@
+//
+//  CommandErrors.swift
+//  Swift Formatter
+//
+//  Created by Tony Arnold on 6/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+enum FormatCommandError: Error {
+    case notSwiftLanguage
+    case invalidSelection
+}

--- a/Xcode Source Editor Extension/Extension/CommandErrors.swift
+++ b/Xcode Source Editor Extension/Extension/CommandErrors.swift
@@ -31,5 +31,6 @@
 
 enum FormatCommandError: Error {
     case notSwiftLanguage
+    case noSelection
     case invalidSelection
 }

--- a/Xcode Source Editor Extension/Extension/CommandErrors.swift
+++ b/Xcode Source Editor Extension/Extension/CommandErrors.swift
@@ -33,4 +33,6 @@ enum FormatCommandError: Error {
     case notSwiftLanguage
     case noSelection
     case invalidSelection
+    case invalidLineContent
+    case cannotRestoreSelection
 }

--- a/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
+++ b/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
@@ -55,7 +55,7 @@ class FormatSelectedSourceCommand: NSObject, XCSourceEditorCommand {
 
         do {
             let indent = String(repeating: " ", count: invocation.buffer.indentationWidth)
-            let options = FormatOptions(indent: indent)
+            let options = FormatOptions(indent: indent, fragment: true)
             let output = try format(sourceToFormat, rules: defaultRules, options: options)
 
             for line in selectionRange.reversed() {

--- a/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
+++ b/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
@@ -40,7 +40,7 @@ class FormatSelectedSourceCommand: NSObject, XCSourceEditorCommand {
         }
 
         guard let selection = invocation.buffer.selections.firstObject as? XCSourceTextRange else {
-            return completionHandler(FormatCommandError.invalidSelection)
+            return completionHandler(FormatCommandError.noSelection)
         }
 
         // Ensure that we're not greedy about end selections — this can cause empty lines to be removed

--- a/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
+++ b/Xcode Source Editor Extension/Extension/FormatSelectedSourceCommand.swift
@@ -1,0 +1,83 @@
+//
+//  FormatSelectedSourceCommand.swift
+//  Swift Formatter
+//
+//  Created by Tony Arnold on 5/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import Foundation
+import XcodeKit
+
+class FormatSelectedSourceCommand: NSObject, XCSourceEditorCommand {
+
+    func perform(with invocation: XCSourceEditorCommandInvocation, completionHandler: @escaping(Error?) -> Void) -> Void {
+        guard invocation.buffer.contentUTI == "public.swift-source" else {
+            return completionHandler(FormatCommandError.notSwiftLanguage)
+        }
+
+        guard let selection = invocation.buffer.selections.firstObject as? XCSourceTextRange else {
+            return completionHandler(FormatCommandError.invalidSelection)
+        }
+
+        // Ensure that we're not greedy about end selections — this can cause empty lines to be removed
+        let selectionEndLine = (selection.end.column > 0) ? selection.end.line : selection.end.line - 1
+
+        // Grab the selected source to format
+        let selectionRange = selection.start.line ... selectionEndLine
+        let sourceToFormat = selectionRange.flatMap { invocation.buffer.lines[$0] as? String }.joined()
+
+        // Remove all selections to avoid a crash when changing the contents of the buffer.
+        invocation.buffer.selections.removeAllObjects()
+
+        do {
+            let indent = String(repeating: " ", count: invocation.buffer.indentationWidth)
+            let options = FormatOptions(indent: indent)
+            let output = try format(sourceToFormat, rules: defaultRules, options: options)
+
+            for line in selectionRange.reversed() {
+                invocation.buffer.lines.removeObject(at: line)
+            }
+
+            invocation.buffer.lines.insert(output, at: selection.start.line)
+        } catch let error {
+            return completionHandler(error)
+        }
+
+        if (invocation.buffer.selections.count == 0) {
+            // For the time being, set the selection back to the first character of the selected range
+            let position = XCSourceTextPosition(line: selection.start.line, column: 0)
+            let updatedSelectionRange = XCSourceTextRange(
+                start: position,
+                end: position
+            )
+
+            invocation.buffer.selections.add(updatedSelectionRange)
+        }
+
+        return completionHandler(nil)
+    }
+}

--- a/Xcode Source Editor Extension/Extension/Info.plist
+++ b/Xcode Source Editor Extension/Extension/Info.plist
@@ -30,11 +30,19 @@
 			<array>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<string>$(PRODUCT_MODULE_NAME).FormatSelectedSourceCommand</string>
 					<key>XCSourceEditorCommandIdentifier</key>
-					<string>$(PRODUCT_BUNDLE_IDENTIFIER).SourceEditorCommand</string>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).FormatSelectedSourceCommand</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Format Selected Code</string>
+					<string>Format Selected Source</string>
+				</dict>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).FormatEntireFileCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).FormatEntireFileCommand</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Format Entire File</string>
 				</dict>
 			</array>
 			<key>XCSourceEditorExtensionPrincipalClass</key>

--- a/Xcode Source Editor Extension/Extension/Info.plist
+++ b/Xcode Source Editor Extension/Extension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.3</string>
+	<string>0.11.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Xcode Source Editor Extension/Extension/Info.plist
+++ b/Xcode Source Editor Extension/Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.4</string>
+	<string>0.12</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSExtension</key>

--- a/Xcode Source Editor Extension/Extension/Info.plist
+++ b/Xcode Source Editor Extension/Extension/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Swift Formatter</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.11.3</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>XCSourceEditorCommandDefinitions</key>
+			<array>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Format Selected Code</string>
+				</dict>
+			</array>
+			<key>XCSourceEditorExtensionPrincipalClass</key>
+			<string>$(PRODUCT_MODULE_NAME).SourceEditorExtension</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.dt.Xcode.extension.source-editor</string>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Nick Lockwood. All rights reserved.</string>
+</dict>
+</plist>

--- a/Xcode Source Editor Extension/Extension/Info.plist
+++ b/Xcode Source Editor Extension/Extension/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleDisplayName</key>
-	<string>Swift Formatter</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Xcode Source Editor Extension/Extension/SourceEditorCommand.swift
+++ b/Xcode Source Editor Extension/Extension/SourceEditorCommand.swift
@@ -1,0 +1,73 @@
+//
+//  SourceEditorCommand.swift
+//  Swift Formatter
+//
+//  Created by Tony Arnold on 5/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import Foundation
+import XcodeKit
+
+class SourceEditorCommand: NSObject, XCSourceEditorCommand {
+
+    func perform(with invocation: XCSourceEditorCommandInvocation, completionHandler: @escaping(Error?) -> Void) -> Void {
+        guard invocation.buffer.contentUTI == "public.swift-source" else {
+            // Ignore non-Swift source code
+            completionHandler(nil)
+            return
+        }
+
+        var options = FormatOptions()
+        options.indent = String(repeating: " ", count: invocation.buffer.indentationWidth)
+
+        // Remove all selections, to avoid a crash. This is not ideal.
+        invocation.buffer.selections.removeAllObjects()
+
+        let buffer = invocation.buffer.completeBuffer
+
+        do {
+            let output = try format(buffer, rules: defaultRules, options: options)
+
+            // Update the entire buffer with the formatted result
+            invocation.buffer.completeBuffer = output
+        } catch let error {
+            completionHandler(error)
+            return
+        }
+
+        // For the time being, set the selection back to the first character of the buffer
+        if (invocation.buffer.selections.count == 0) {
+            let defaultSelection = XCSourceTextRange(
+                start: XCSourceTextPosition(line: 0, column: 0),
+                end: XCSourceTextPosition(line: 0, column: 0)
+            )
+            invocation.buffer.selections.add(defaultSelection)
+        }
+
+        completionHandler(nil)
+    }
+}

--- a/Xcode Source Editor Extension/Extension/SourceEditorExtension.swift
+++ b/Xcode Source Editor Extension/Extension/SourceEditorExtension.swift
@@ -1,0 +1,35 @@
+//
+//  SourceEditorExtension.swift
+//  Swift Formatter
+//
+//  Created by Tony Arnold on 5/10/16.
+//  Copyright 2016 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+import Foundation
+import XcodeKit
+
+class SourceEditorExtension: NSObject, XCSourceEditorExtension {}

--- a/Xcode Source Editor Extension/Extension/SwiftFormatter.entitlements
+++ b/Xcode Source Editor Extension/Extension/SwiftFormatter.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>XcodeSwiftFormatter</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR introduces an Xcode Source Editor Extension for SwiftFormat.

It works, but there are a few things still left to sort out, namely:

#### Xcode Source Editor Extension
- [x] Handle formatting just the user's selection (I might need to expand the selection to include the entire lines of selections so that there's enough context for the formatter)
- [x] Restore the user's previous selection
- [x] Handling tabs for indentation (currently it respects the user's indentation settings, so long as they use spaces)
- [x] Version information is manually set - I think it's wise to keep the version of the framework, app and app extension the same, so this should be set somewhere central to reduce maintenance

#### Hosting Application
- [x] Provide a simple explanatory UI outlining how to enable and use the extension, as well as set a keyboard shortcut

To use this PR, you will need to archive and export the application target using a proper certificate. Unsigned or improperly signed application/application extensions are not loaded by Xcode 8.x.

#### 🚧 Download 🚧 

Here's a preview release: [SwiftFormat for Xcode 0.12.zip](https://github.com/nicklockwood/SwiftFormat/files/521015/SwiftFormat.for.Xcode.0.12.zip)

You'll need to enable the extension in System Preferences → Extensions:

<img width="780" alt="screen shot 2016-10-05 at 21 01 46" src="https://cloud.githubusercontent.com/assets/4802/19108986/f7cfa41e-8b3e-11e6-9420-493ee88ba6ca.png">

After relaunching Xcode, you should be able to set a keyboard shortcut for this as follows:

<img width="862" alt="screen shot 2016-10-06 at 13 32 51" src="https://cloud.githubusercontent.com/assets/4802/19138604/6f0b70d2-8bc9-11e6-9e35-1894e44e408d.png">

No promises, ensure you're not working with uncommitted code, etc, etc.