### PR TITLE
This resolves parentheses removal issue in case`for condition where method() {}`

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1438,6 +1438,7 @@ extension FormatRules {
                             .keyword("case"),
                             .keyword("switch"),
                             .keyword("import"),
+                            .keyword("where"),
                         ]
                         if disallowed.contains(prevKeyword) {
                             break

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -2886,6 +2886,13 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
+    func testParensForLoopWhereClauseMethodNotRemoved() {
+        let input = "for foo in foos where foo.method() { print(foo) }"
+        let output = "for foo in foos where foo.method() { print(foo) }"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantParens]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
     // around closure arguments
 
     func testSingleClosureArgumentUnwrapped() {


### PR DESCRIPTION
As reported in issue #136, current redundantParens rule also remove the parens from method in for loop, where condition. This PR try to resolve the same via added `where` token check. 