### PR TITLE
Add check for Pointer Function call "&" for spaceAroundOperator.

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -378,7 +378,7 @@ extension FormatRules {
                 if (formatter.token(at: i - 1).map { !$0.isSpaceOrLinebreak }) ?? false {
                     formatter.insertToken(.space(" "), at: i)
                 }
-            case .operator(_, .prefix):
+            case .operator(_, .prefix) where !token.isAmpersandOperator:
                 if (formatter.token(at: i - 1).map { !$0.isSpaceOrLinebreak }) ?? false {
                     formatter.insertToken(.space(" "), at: i)
                 }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -306,6 +306,7 @@ public enum Token: Equatable {
 
     public var isOperator: Bool { return hasType(of: .operator("", .none)) }
     public var isUnwrapOperator: Bool { return isOperator("?") || isOperator("!") }
+    public var isAmpersandOperator: Bool { return isOperator("&") }
     public var isRangeOperator: Bool { return isOperator("...") || isOperator("..<") }
     public var isNumber: Bool { return hasType(of: .number("", .integer)) }
     public var isError: Bool { return hasType(of: .error("")) }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -778,6 +778,27 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
+    func testAmpersandArgumentFunctionExpression() {
+        let input = "foo(&r, green: &g, blue: &b, alpha: &a)"
+        let output = "foo(&r, green: &g, blue: &b, alpha: &a)"
+        XCTAssertEqual(try format(input, rules: [FormatRules.spaceAroundOperators]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testBitwiseAndExpression() {
+        let input = "c =a&b"
+        let output = "c = a & b"
+        XCTAssertEqual(try format(input, rules: [FormatRules.spaceAroundOperators]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testMultiplyIgnoreOverflowExpression() {
+        let input = "c = a&*b"
+        let output = "c = a &* b"
+        XCTAssertEqual(try format(input, rules: [FormatRules.spaceAroundOperators]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
     // MARK: spaceAroundComments
 
     func testSpaceAroundCommentInParens() {


### PR DESCRIPTION
As mentioned in issue #138, currently `spaceAroundOperator` Rule adds a space in pointerFunction calls. This PR adds check for `&` Operator in prefix case, not to add additional space.

- spaceAroundOperator Rule(`hexColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)`) --> (`hexColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)`)

- Previously it was resulting in this  (`hexColor.getRed( &red, green: &green, blue: &blue, alpha: &alpha)`)
