### PR TITLE
Remove explicit .init

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,14 @@ Here are all the rules that SwiftFormat currently applies, and the effect that t
 +   // returns nothing
 + }
 ```
+
+***redundantInit*** - removes unnecessary `init` when instantiating Types:
+
+```diff
+- String.init("text")
+
++ String("text")
+```
     
 ***semicolons*** - removes semicolons at the end of lines and optionally (depending on the `--semicolons` option) replaces inline semicolons with a linebreak:
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2785,4 +2785,42 @@ extension FormatRules {
         let headerTokens = tokenize(header)
         formatter.insertTokens(headerTokens, at: 0)
     }
+
+    public class func redundantInit(_ formatter: Formatter) {
+        // Assumes identifier is a type if starting with capital
+        func isType(_ token: Token) -> Bool {
+            let str = token.string
+            
+            guard !str.isEmpty else {
+                return false
+            }
+            
+            let firstChar = str.substring(to: str.index(after: str.startIndex))
+            
+            guard firstChar != "$" else {
+                return false
+            }
+            
+            return firstChar.uppercased() == firstChar
+        }
+        
+        formatter.forEach(.identifier) { i, token in
+            guard isType(token) else {
+                return
+            }
+            
+            guard let dot = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i),
+                dot == .operator(".", .infix),
+                let dotIndex = formatter.index(of: dot, after: i),
+                let initToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                let initIndex = formatter.index(of: initToken, after: dotIndex),
+                let openScope = formatter.next(.nonSpaceOrCommentOrLinebreak, after: initIndex),
+                openScope == .startOfScope("(")
+            else {
+                return
+            }
+            
+            formatter.removeTokens(inRange: dotIndex...initIndex)
+        }
+    }
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2790,25 +2790,25 @@ extension FormatRules {
         // Assumes identifier is a type if starting with capital
         func isType(_ token: Token) -> Bool {
             let str = token.string
-            
+
             guard !str.isEmpty else {
                 return false
             }
-            
+
             let firstChar = str.substring(to: str.index(after: str.startIndex))
-            
+
             guard firstChar != "$" else {
                 return false
             }
-            
+
             return firstChar.uppercased() == firstChar
         }
-        
+
         formatter.forEach(.identifier) { i, token in
             guard isType(token) else {
                 return
             }
-            
+
             guard let dot = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i),
                 dot == .operator(".", .infix),
                 let dotIndex = formatter.index(of: dot, after: i),
@@ -2819,8 +2819,8 @@ extension FormatRules {
             else {
                 return
             }
-            
-            formatter.removeTokens(inRange: dotIndex...initIndex)
+
+            formatter.removeTokens(inRange: dotIndex ... initIndex)
         }
     }
 }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -5012,4 +5012,48 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input, rules: [FormatRules.fileHeader], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
+
+    // MARK: redundantInit
+    
+    func testRemoveRedundantInit() {
+        let input = "[1].flatMap{String.init($0)}"
+        let output = "[1].flatMap{String($0)}"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testRemoveRedundantInit2() {
+        let input = "[String.self].map { Type in Type.init(1) }"
+        let output = "[String.self].map { Type in Type(1) }"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testDontRemoveInitInSuperCall() {
+        let input = "import Foundation; class C: NSObject { override init() { super.init() }}"
+        let output = "import Foundation; class C: NSObject { override init() { super.init() }}"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testDontRemoveInitInSelfCall() {
+        let input = "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }"
+        let output = "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testDontRemoveInitWhenPassedAsFunction() {
+        let input = "[1].flatMap(String.init)"
+        let output = "[1].flatMap(String.init)"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testDontRemoveInitWhenUsedOnMetatype() {
+        let input = "[String.self].map { type in type.init(1) }"
+        let output = "[String.self].map { type in type.init(1) }"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
+    
+    func testDontRemoveInitWhenUsedOnImplicitClosureMetatype() {
+        let input = "[String.self].map { $0.init(1) }"
+        let output = "[String.self].map { $0.init(1) }"
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+    }
 }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -5014,7 +5014,7 @@ class RulesTests: XCTestCase {
     }
 
     // MARK: redundantInit
-    
+
     func testRemoveRedundantInit() {
         do {
             let input = "[1].flatMap{String.init($0)}"
@@ -5032,31 +5032,31 @@ class RulesTests: XCTestCase {
             XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
         }
     }
-        
+
     func testDontRemoveInitInSuperCall() {
         let input = "import Foundation; class C: NSObject { override init() { super.init() }}"
         let output = "import Foundation; class C: NSObject { override init() { super.init() }}"
         XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
     }
-    
+
     func testDontRemoveInitInSelfCall() {
         let input = "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }"
         let output = "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }"
         XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
     }
-    
+
     func testDontRemoveInitWhenPassedAsFunction() {
         let input = "[1].flatMap(String.init)"
         let output = "[1].flatMap(String.init)"
         XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
     }
-    
+
     func testDontRemoveInitWhenUsedOnMetatype() {
         let input = "[String.self].map { type in type.init(1) }"
         let output = "[String.self].map { type in type.init(1) }"
         XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
     }
-    
+
     func testDontRemoveInitWhenUsedOnImplicitClosureMetatype() {
         let input = "[String.self].map { $0.init(1) }"
         let output = "[String.self].map { $0.init(1) }"

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -5016,17 +5016,23 @@ class RulesTests: XCTestCase {
     // MARK: redundantInit
     
     func testRemoveRedundantInit() {
-        let input = "[1].flatMap{String.init($0)}"
-        let output = "[1].flatMap{String($0)}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+        do {
+            let input = "[1].flatMap{String.init($0)}"
+            let output = "[1].flatMap{String($0)}"
+            XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+        }
+        do {
+            let input = "[String.self].map { Type in Type.init(1) }"
+            let output = "[String.self].map { Type in Type(1) }"
+            XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+        }
+        do {
+            let input = "String.init(\"text\")"
+            let output = "String(\"text\")"
+            XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+        }
     }
-    
-    func testRemoveRedundantInit2() {
-        let input = "[String.self].map { Type in Type.init(1) }"
-        let output = "[String.self].map { Type in Type(1) }"
-        XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
-    }
-    
+        
     func testDontRemoveInitInSuperCall() {
         let input = "import Foundation; class C: NSObject { override init() { super.init() }}"
         let output = "import Foundation; class C: NSObject { override init() { super.init() }}"


### PR DESCRIPTION
Hi there!
I've tried to implement the removal of redundant .init calls when creating instances because is something that I keep seeing in PRs.
Feel free to provide any feedback to improve the implementation, specially around knowing if an identifier is a type. 
I wrote as much tests as I could come up with, also taken from SwiftLint https://github.com/realm/SwiftLint/blob/master/Source/SwiftLintFramework/Rules/ExplicitInitRule.swift#L18 as mentioned in #130. Not sure if there is something that already does that in the codebase. 