### PR TITLE
Fixing build issue in Xcode 9 beta 5

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2720,7 +2720,7 @@ extension FormatRules {
             }
             let characters: String.UnicodeScalarView
             if case .ignore = grouping {
-                characters = string.unicodeScalars.suffix(from: prefix.unicodeScalars.endIndex)
+                characters = String.UnicodeScalarView(string.unicodeScalars.suffix(from: prefix.unicodeScalars.endIndex))
             } else {
                 characters = token.unescaped().unicodeScalars
             }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -449,7 +449,7 @@ private extension String.UnicodeScalarView {
         }
         if index > startIndex {
             let string = String(prefix(upTo: index))
-            self = suffix(from: index)
+            self = String.UnicodeScalarView(suffix(from: index))
             return string
         }
         return nil
@@ -465,7 +465,7 @@ private extension String.UnicodeScalarView {
                 index = self.index(after: index)
             }
             let string = String(prefix(upTo: index))
-            self = suffix(from: index)
+            self = String.UnicodeScalarView(suffix(from: index))
             return string
         }
         return nil
@@ -473,7 +473,7 @@ private extension String.UnicodeScalarView {
 
     mutating func readCharacter(where matching: (UnicodeScalar) -> Bool = { _ in true }) -> UnicodeScalar? {
         if let c = first, matching(c) {
-            self = dropFirst()
+            self = String.UnicodeScalarView(dropFirst())
             return c
         }
         return nil
@@ -481,7 +481,7 @@ private extension String.UnicodeScalarView {
 
     mutating func read(_ character: UnicodeScalar) -> Bool {
         if first == character {
-            self = dropFirst()
+            self = String.UnicodeScalarView(dropFirst())
             return true
         }
         return false


### PR DESCRIPTION
- When attempting to build the project with Xcode 9 beta 5 the following build error occurs:

`Cannot assign value of type 'String.UnicodeScalarView.SubSequence' (aka 'Substring.UnicodeScalarView') to type 'String.UnicodeScalarView'`

- As of Xcode 9, `suffix` and `dropFirst` methods on `String` types return `SubString` ([see documentation updates](https://developer.apple.com/documentation/swift/string.unicodescalarview/1688582-suffix?changes=latest_minor))
- This change simply converts the substring types to their equivalent base types to ensure compatibility with existing code

Test Plan:

- Make sure the project compiles on both Xcode 8.3.3 and Xcode 9 beta 5
- Make sure all the unit tests pass as before