### PR TITLE
Update README.md - Fix git pre-commit hook whitespace issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Git pre-commit hook
 3. Add the following line in the pre-commit file (unlike the Xcode build phase approach, this uses your locally installed version of SwiftFormat, not a separate copy in your project repository)
 
         #!/bin/bash
-        git status --porcelain | grep -e '^ [AM] \(.*\).swift$' | cut -c 3- | while read line; do
+        git diff --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
           swiftformat ${line};
           git add $line;
         done


### PR DESCRIPTION
Today I had some issues with whitespaces using ``git status --porcelain``. 

Before adding a file, the result from above was like
``
[:space:]M[:space:]path/to/file.swift
``
and after adding it was like
``
M[:space:]path/to/file.swift
``

Therefore I changed the line, detecting the changes to the following:
``
git diff --staged --name-only | grep -e '\(.*\).swift$'
``