### PR TITLE
Build with Swift PM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 *.hmap
 *.ipa
 *.dot
+.build

--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -30,7 +30,9 @@
 //
 
 import Foundation
+#if SWIFT_PACKAGE
 import SwiftFormat
+#endif
 
 extension String {
     var inDefault: String { return "\u{001B}[39m\(self)" }

--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -30,6 +30,7 @@
 //
 
 import Foundation
+import SwiftFormat
 
 extension String {
     var inDefault: String { return "\u{001B}[39m\(self)" }

--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,13 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftFormat"
+    name: "SwiftFormat",
+    products: [
+        .executable(name: "swiftFormat", targets: ["CommandLineTool"]),
+    ],
+    targets: [
+        .target(name: "CommandLineTool", dependencies: ["SwiftFormat"], path: "CommandLineTool"),
+        .target(name: "SwiftFormat", path: "Sources"),
+        .testTarget(name: "Tests", dependencies: ["SwiftFormat"], path: "Tests"),
+    ]
 )

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -139,8 +139,7 @@ func printHelp() {
 
 func expandPath(_ path: String, in directory: String) -> URL {
     let path = NSString(string: path).expandingTildeInPath
-    let directoryURL = URL(fileURLWithPath: directory)
-    return URL(fileURLWithPath: path, relativeTo: directoryURL)
+    return URL(fileURLWithPath: directory + "/" + path)
 }
 
 func timeEvent(block: () throws -> Void) rethrows -> String {


### PR DESCRIPTION
Resolves #178 

To get Swiftformat working with Swift PM a couple of things had to be done:
- define products and targets
- make Swiftformat a dependency of CommandLineTool
- make certain things public in SwiftFormat for CommandLineTool
- change a OSX 10.11+ api call (SPM defaults to OSX 10.10)
- update the Swiftformat.xcodeproj to remove the Swiftformat sources from CommandLineTool and make SwiftFormat a dependency of CommandLintTool

This leave the current directory structure and target names intact.