### PR TITLE
Add sortedImports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,30 @@ return;
 goto(fail)
 ```
 
+***sortedImports*** - rearranges import statements so that they are sorted:
+
+```diff
+- import Foo
+- import Bar
++ import Bar
++ import Foo
+```
+
+```diff
+- import B
+- import A
+- #if os(iOS)
+-   import Foo-iOS
+-   import Bar-iOS
+- #endif
++ import A
++ import B
++ #if os(iOS)
++   import Bar-iOS
++   import Foo-iOS
++ #endif
+```
+
 ***spaceAroundBraces*** - contextually adds or removes space around { }. For example:
 
 ```diff

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -29,8 +29,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-import XCTest
 @testable import SwiftFormat
+import XCTest
 
 private var readme: String = {
     let directoryURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -29,8 +29,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class FormatterTests: XCTestCase {
 

--- a/Tests/OptionsTests.swift
+++ b/Tests/OptionsTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2016 Nick Lockwood. All rights reserved.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class OptionsTests: XCTestCase {
 

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2016 Nick Lockwood. All rights reserved.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class PerformanceTests: XCTestCase {
 

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -29,8 +29,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class RulesTests: XCTestCase {
 
@@ -5435,6 +5435,43 @@ class RulesTests: XCTestCase {
         let input = "[String.self].map(Foo.init(bar:))"
         let output = "[String.self].map(Foo.init(bar:))"
         XCTAssertEqual(try format(input, rules: [FormatRules.redundantInit]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    // MARK: sortedImports
+
+    func testSortedImportsSimpleCase() {
+        let input = "import Foo\nimport Bar"
+        let output = "import Bar\nimport Foo"
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testAlreadySortedImportsDoesNothing() {
+        let input = "import Bar\nimport Foo"
+        let output = input
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testPreprocessorSortedImports() {
+        let input = "#if os(iOS)\n    import Foo2\n    import Bar2\n#else\n    import Foo1\n    import Bar1\n#endif\nimport Foo3\nimport Bar3"
+        let output = "#if os(iOS)\n    import Bar2\n    import Foo2\n#else\n    import Bar1\n    import Foo1\n#endif\nimport Bar3\nimport Foo3"
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testTestableSortedImports() {
+        let input = "@testable import Foo3\nimport Bar3"
+        let output = "import Bar3\n@testable import Foo3"
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testCaseInsensitiveSortedImports() {
+        let input = "import Zlib\nimport lib"
+        let output = "import lib\nimport Zlib"
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 }

--- a/Tests/SwiftFormatTests.swift
+++ b/Tests/SwiftFormatTests.swift
@@ -29,8 +29,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class SwiftFormatTests: XCTestCase {
 

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -29,8 +29,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-import XCTest
 import SwiftFormat
+import XCTest
 
 class TokenizerTests: XCTestCase {
 


### PR DESCRIPTION
This adds a rule to sort imports alphabetically for consistency.
I didn't disable it by default, but if you think it should be I can do that.