### PR TITLE
Added preserving wrap mode

### DIFF
--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -40,6 +40,7 @@ public enum IndentMode: String {
 
 /// Wrap mode for arguments
 public enum WrapMode: String {
+    case preserving
     case beforeFirst = "beforefirst"
     case afterFirst = "afterfirst"
     case disabled

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2654,6 +2654,116 @@ extension FormatRules {
         }
     }
 
+    private class func wrapArgumentsBeforeFirst(formatter: Formatter,
+                                                startOfScope i: Int,
+                                                closingBraceIndex: Int,
+                                                allowGrouping: Bool) {
+        // Get indent
+        let start = formatter.startOfLine(at: i)
+        let indent: String
+        if let indentToken = formatter.token(at: start), case let .space(string) = indentToken {
+            indent = string
+        } else {
+            indent = ""
+        }
+        // Insert linebreak before closing paren
+        if let lastIndex = formatter.index(of: .nonSpace, before: closingBraceIndex, if: {
+            !$0.isLinebreak
+        }) {
+            formatter.insertSpace(indent, at: lastIndex + 1)
+            formatter.insertToken(.linebreak(formatter.options.linebreak), at: lastIndex + 1)
+        }
+        // Insert linebreak after each comma
+        var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex)!
+        if formatter.tokens[index] != .delimiter(",") {
+            index += 1
+        }
+        while index > i {
+            guard let commaIndex = formatter.index(of: .delimiter(","), before: index) else {
+                break
+            }
+            let linebreakIndex = formatter.index(of: .nonSpaceOrComment, after: commaIndex)!
+            if formatter.tokens[linebreakIndex].isLinebreak, !formatter.options.truncateBlankLines ||
+                formatter.next(.nonSpace, after: linebreakIndex).map({ !$0.isLinebreak }) ?? false {
+                formatter.insertSpace(indent + formatter.options.indent, at: linebreakIndex + 1)
+            } else if !allowGrouping {
+                formatter.insertToken(.linebreak(formatter.options.linebreak), at: linebreakIndex)
+                formatter.insertSpace(indent + formatter.options.indent, at: linebreakIndex + 1)
+            }
+            index = commaIndex
+        }
+        // Insert linebreak after opening paren
+        if formatter.next(.nonSpaceOrComment, after: i)?.isLinebreak == false {
+            formatter.insertSpace(indent + formatter.options.indent, at: i + 1)
+            formatter.insertToken(.linebreak(formatter.options.linebreak), at: i + 1)
+        }
+    }
+
+    private class func wrapArgumentsAfterFirst(formatter: Formatter,
+                                               startOfScope i: Int,
+                                               closingBraceIndex: Int,
+                                               allowGrouping: Bool) {
+        guard var firstArgumentIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i) else {
+            return
+        }
+        // Remove linebreak after opening paren
+        formatter.removeTokens(inRange: i + 1 ..< firstArgumentIndex)
+        var closingBraceIndex = closingBraceIndex - (firstArgumentIndex - (i + 1))
+        firstArgumentIndex = i + 1
+        // Get indent
+        let start = formatter.startOfLine(at: i)
+        var indent = ""
+        for token in formatter.tokens[start ..< firstArgumentIndex] {
+            if case let .space(string) = token {
+                indent += string
+            } else {
+                indent += String(repeating: " ", count: token.string.count)
+            }
+        }
+        // Remove linebreak before closing paren
+        if var lastIndex = formatter.index(of: .nonSpace, before: closingBraceIndex, if: {
+            $0.isLinebreak
+        }) {
+            if let prevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: closingBraceIndex),
+                case .commentBody = formatter.tokens[prevIndex],
+                let startIndex = formatter.index(of: .startOfScope("//"), before: prevIndex) {
+                lastIndex = formatter.index(of: .space, before: startIndex) ?? startIndex
+                formatter.insertToken(formatter.tokens[closingBraceIndex], at: lastIndex)
+                formatter.removeToken(at: closingBraceIndex + 1)
+                closingBraceIndex = lastIndex
+            } else {
+                formatter.removeTokens(inRange: lastIndex ..< closingBraceIndex)
+                closingBraceIndex = lastIndex
+            }
+            // Remove trailing comma
+            if let prevCommaIndex = formatter.index(
+                of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex, if: {
+                    $0 == .delimiter(",")
+            }) {
+                formatter.removeToken(at: prevCommaIndex)
+                closingBraceIndex -= 1
+            }
+        }
+        // Insert linebreak after each comma
+        var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex)!
+        if formatter.tokens[index] != .delimiter(",") {
+            index += 1
+        }
+        while index > i {
+            guard let commaIndex = formatter.index(of: .delimiter(","), before: index) else {
+                break
+            }
+            let linebreakIndex = formatter.index(of: .nonSpaceOrComment, after: commaIndex)!
+            if formatter.tokens[linebreakIndex].isLinebreak {
+                formatter.insertSpace(indent, at: linebreakIndex + 1)
+            } else if !allowGrouping {
+                formatter.insertToken(.linebreak(formatter.options.linebreak), at: linebreakIndex)
+                formatter.insertSpace(indent, at: linebreakIndex + 1)
+            }
+            index = commaIndex
+        }
+    }
+
     /// Normalize argument wrapping style
     @objc public class func wrapArguments(_ formatter: Formatter) {
         func wrapArguments(for scopes: String..., mode: WrapMode, allowGrouping: Bool) {
@@ -2661,111 +2771,34 @@ extension FormatRules {
             formatter.forEach(.startOfScope) { i, token in
                 guard scopes.contains(token.string),
                     let firstLinebreakIndex = formatter.index(of: .linebreak, after: i),
-                    var closingBraceIndex = formatter.endOfScope(at: i),
+                    let closingBraceIndex = formatter.endOfScope(at: i),
                     firstLinebreakIndex < closingBraceIndex else {
                     return
                 }
                 switch mode {
-                case .beforeFirst:
-                    // Get indent
-                    let start = formatter.startOfLine(at: i)
-                    let indent: String
-                    if let indentToken = formatter.token(at: start), case let .space(string) = indentToken {
-                        indent = string
+                case .preserving:
+                    if let firstIdentifierIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i),
+                        firstIdentifierIndex > firstLinebreakIndex {
+                        wrapArgumentsBeforeFirst(formatter: formatter,
+                                                 startOfScope: i,
+                                                 closingBraceIndex: closingBraceIndex,
+                                                 allowGrouping: allowGrouping)
                     } else {
-                        indent = ""
+                        wrapArgumentsAfterFirst(formatter: formatter,
+                                                startOfScope: i,
+                                                closingBraceIndex: closingBraceIndex,
+                                                allowGrouping: allowGrouping)
                     }
-                    // Insert linebreak before closing paren
-                    if let lastIndex = formatter.index(of: .nonSpace, before: closingBraceIndex, if: {
-                        !$0.isLinebreak
-                    }) {
-                        formatter.insertSpace(indent, at: lastIndex + 1)
-                        formatter.insertToken(.linebreak(formatter.options.linebreak), at: lastIndex + 1)
-                    }
-                    // Insert linebreak after each comma
-                    var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex)!
-                    if formatter.tokens[index] != .delimiter(",") {
-                        index += 1
-                    }
-                    while index > i {
-                        guard let commaIndex = formatter.index(of: .delimiter(","), before: index) else {
-                            break
-                        }
-                        let linebreakIndex = formatter.index(of: .nonSpaceOrComment, after: commaIndex)!
-                        if formatter.tokens[linebreakIndex].isLinebreak, !formatter.options.truncateBlankLines ||
-                            formatter.next(.nonSpace, after: linebreakIndex).map({ !$0.isLinebreak }) ?? false {
-                            formatter.insertSpace(indent + formatter.options.indent, at: linebreakIndex + 1)
-                        } else if !allowGrouping {
-                            formatter.insertToken(.linebreak(formatter.options.linebreak), at: linebreakIndex)
-                            formatter.insertSpace(indent + formatter.options.indent, at: linebreakIndex + 1)
-                        }
-                        index = commaIndex
-                    }
-                    // Insert linebreak after opening paren
-                    if formatter.next(.nonSpaceOrComment, after: i)?.isLinebreak == false {
-                        formatter.insertSpace(indent + formatter.options.indent, at: i + 1)
-                        formatter.insertToken(.linebreak(formatter.options.linebreak), at: i + 1)
-                    }
+                case .beforeFirst:
+                    wrapArgumentsBeforeFirst(formatter: formatter,
+                                             startOfScope: i,
+                                             closingBraceIndex: closingBraceIndex,
+                                             allowGrouping: allowGrouping)
                 case .afterFirst:
-                    guard var firstArgumentIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i) else {
-                        return
-                    }
-                    // Remove linebreak after opening paren
-                    formatter.removeTokens(inRange: i + 1 ..< firstArgumentIndex)
-                    closingBraceIndex -= (firstArgumentIndex - (i + 1))
-                    firstArgumentIndex = i + 1
-                    // Get indent
-                    let start = formatter.startOfLine(at: i)
-                    var indent = ""
-                    for token in formatter.tokens[start ..< firstArgumentIndex] {
-                        if case let .space(string) = token {
-                            indent += string
-                        } else {
-                            indent += String(repeating: " ", count: token.string.count)
-                        }
-                    }
-                    // Remove linebreak before closing paren
-                    if var lastIndex = formatter.index(of: .nonSpace, before: closingBraceIndex, if: {
-                        $0.isLinebreak
-                    }) {
-                        if let prevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: closingBraceIndex),
-                            case .commentBody = formatter.tokens[prevIndex],
-                            let startIndex = formatter.index(of: .startOfScope("//"), before: prevIndex) {
-                            lastIndex = formatter.index(of: .space, before: startIndex) ?? startIndex
-                            formatter.insertToken(formatter.tokens[closingBraceIndex], at: lastIndex)
-                            formatter.removeToken(at: closingBraceIndex + 1)
-                            closingBraceIndex = lastIndex
-                        } else {
-                            formatter.removeTokens(inRange: lastIndex ..< closingBraceIndex)
-                            closingBraceIndex = lastIndex
-                        }
-                        // Remove trailing comma
-                        if let prevCommaIndex = formatter.index(
-                            of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex, if: {
-                                $0 == .delimiter(",")
-                        }) {
-                            formatter.removeToken(at: prevCommaIndex)
-                            closingBraceIndex -= 1
-                        }
-                    }
-                    // Insert linebreak after each comma
-                    var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: closingBraceIndex)!
-                    if formatter.tokens[index] != .delimiter(",") {
-                        index += 1
-                    }
-                    while index > i {
-                        guard let commaIndex = formatter.index(of: .delimiter(","), before: index) else {
-                            break
-                        }
-                        let linebreakIndex = formatter.index(of: .nonSpaceOrComment, after: commaIndex)!
-                        if formatter.tokens[linebreakIndex].isLinebreak {
-                            formatter.insertSpace(indent, at: linebreakIndex + 1)
-                        } else if !allowGrouping {
-                            formatter.insertToken(.linebreak(formatter.options.linebreak), at: linebreakIndex)
-                            formatter.insertSpace(indent, at: linebreakIndex + 1)
-                        }
-                        index = commaIndex
-                    }
+                    wrapArgumentsAfterFirst(formatter: formatter,
+                                            startOfScope: i,
+                                            closingBraceIndex: closingBraceIndex,
+                                            allowGrouping: allowGrouping)
                 case .disabled:
                     assertionFailure() // Shouldn't happen
                 }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -5223,10 +5223,58 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
+    func testAfterFirstPreserved() {
+        let input = "func foo(bar _: Int,\n         baz _: String) {\n}"
+        let output = input
+        let options = FormatOptions(wrapArguments: .preserving)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testAfterFirstPreservedIndentFixed() {
+        let input = "func foo(bar _: Int,\n baz _: String) {\n}"
+        let output = "func foo(bar _: Int,\n         baz _: String) {\n}"
+        let options = FormatOptions(wrapArguments: .preserving)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testAfterFirstPreservedNewlineRemoved() {
+        let input = "func foo(bar _: Int,\n         baz _: String\n) {\n}"
+        let output = "func foo(bar _: Int,\n         baz _: String) {\n}"
+        let options = FormatOptions(wrapArguments: .preserving)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
     func testBeforeFirstConvertedToAfterFirst() {
         let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {\n}"
         let output = "func foo(bar _: Int,\n         baz _: String) {\n}"
         let options = FormatOptions(wrapArguments: .afterFirst)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testBeforeFirstPreserved() {
+        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {\n}"
+        let output = input
+        let options = FormatOptions(wrapArguments: .preserving)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testBeforeFirstPreservedIndentFixed() {
+        let input = "func foo(\n    bar _: Int,\n baz _: String\n) {\n}"
+        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {\n}"
+        let options = FormatOptions(wrapArguments: .preserving)
+        XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testBeforeFirstPreservedNewlineAdded() {
+        let input = "func foo(\n    bar _: Int,\n    baz _: String) {\n}"
+        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {\n}"
+        let options = FormatOptions(wrapArguments: .preserving)
         XCTAssertEqual(try format(input, rules: [FormatRules.wrapArguments], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }


### PR DESCRIPTION
Added `preserving` arguments wrap rule: if it finds that there's a newline before the first argument, it uses `beforeFirst` rule, and `afterFirst` otherwise.