### PR TITLE
Fix "exclusive accesses" violations

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -558,7 +558,7 @@ func format(_ source: String,
             tokens = updatedTokens
         }
     } : nil
-    try applyRules(rules, to: &tokens, with: options, callback: callback)
+    tokens = try applyRules(rules, to: tokens, with: options, callback: callback)
 
     // Display info
     if verbose {

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -226,9 +226,11 @@ public func sourceCode(for tokens: [Token]) -> String {
 /// Apply specified rules to a token array with optional callback
 /// Useful for perfoming additional logic after each rule is applied
 public func applyRules(_ rules: [FormatRule],
-                       to tokens: inout [Token],
+                       to originalTokens: [Token],
                        with options: FormatOptions,
-                       callback: ((Int, [Token]) -> Void)? = nil) throws {
+                       callback: ((Int, [Token]) -> Void)? = nil) throws -> [Token] {
+    var tokens = originalTokens
+
     // Parse
     if let error = parsingError(for: tokens, options: options) {
         throw error
@@ -243,7 +245,7 @@ public func applyRules(_ rules: [FormatRule],
             callback?(i, formatter.tokens)
         }
         if tokens == formatter.tokens {
-            return
+            return tokens
         }
         tokens = formatter.tokens
         options.fileHeader = nil // Prevents infinite recursion
@@ -256,10 +258,7 @@ public func applyRules(_ rules: [FormatRule],
 public func format(_ tokens: [Token],
                    rules: [FormatRule] = FormatRules.default,
                    options: FormatOptions = FormatOptions()) throws -> [Token] {
-
-    var tokens = tokens
-    try applyRules(rules, to: &tokens, with: options)
-    return tokens
+    return try applyRules(rules, to: tokens, with: options)
 }
 
 /// Format code with specified rules and options


### PR DESCRIPTION
A single variable was being captured by a block and modified while also being passed by inout reference

See: https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md