### PR TITLE
Add --no-ansi option

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -98,6 +98,7 @@ func printHelp() {
     print("--cache            path to cache file, or \"clear\" or \"ignore\" the default cache")
     print("--verbose          display detailed formatting output and warnings/errors")
     print("--dryrun           run in \"dry\" mode (without actually changing any files)")
+    print("--no-ansi          show output without ANSI codes")
     print("")
     print("swiftformat has a number of rules that can be enabled or disabled. by default")
     print("most rules are enabled. use --rules to display all enabled/disabled rules:")
@@ -282,6 +283,26 @@ func processArguments(_ args: [String], in directory: String) {
             dryrun = true
             if !arg.isEmpty {
                 // dryrun doesn't take an argument, so treat argument as another input path
+                inputURLs.append(expandPath(arg, in: directory))
+            }
+        }
+
+        // No ANSI
+        if let arg = args["no-ansi"] {
+            // Override the CLI output handler to remove the color escape codes
+            var stderr = FileHandle.standardError
+            var stdout = FileHandle.standardOutput
+            CLI.print = { message, type in
+                switch type {
+                case .error, .warning:
+                    print(message, to: &stderr)
+                default:
+                    print(message, to: &stdout)
+                }
+            }
+
+            if !arg.isEmpty {
+                // no-ansi doesn't take an argument, so treat argument as another input path
                 inputURLs.append(expandPath(arg, in: directory))
             }
         }
@@ -1247,6 +1268,7 @@ let commandLineArguments = [
     "cache",
     "verbose",
     "dryrun",
+    "no-ansi",
     // Rules
     "disable",
     "enable",


### PR DESCRIPTION
With this option on, the CLI output handler is overridden to remove the color escape codes. This is useful when parsing the command output.

I'm not super happy with the solution in this PR because since the default handler is defined in `main.swift`, it's not a given that all `print` calls will use the overridden output handler. The solution isn't robust to refactorings.

An alternative could be the following changes to `main.swift`:

```diff
diff --git a/CommandLineTool/main.swift b/CommandLineTool/main.swift
index f4111a0..27edaa0 100644
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -46,21 +46,36 @@ extension FileHandle: TextOutputStream {
     }
 }

+private var arguments = CommandLine.arguments
+
 private var stderr = FileHandle.standardError
+private var stdout = FileHandle.standardOutput

-CLI.print = { message, type in
-    switch type {
-    case .info:
-        print(message.inDefault)
-    case .success:
-        print(message.inGreen)
-    case .error:
-        print(message.inRed, to: &stderr)
-    case .warning:
-        print(message.inYellow, to: &stderr)
-    case .content:
-        print(message)
+if let noAnsiIndex = arguments.index(of: "--no-ansi") {
+    arguments.remove(at: noAnsiIndex)
+    CLI.print = { message, type in
+        switch type {
+        case .error, .warning:
+            print(message, to: &stderr)
+        default:
+            print(message, to: &stdout)
+        }
+    }
+} else {
+    CLI.print = { message, type in
+        switch type {
+        case .info:
+            print(message.inDefault)
+        case .success:
+            print(message.inGreen)
+        case .error:
+            print(message.inRed, to: &stderr)
+        case .warning:
+            print(message.inYellow, to: &stderr)
+        case .content:
+            print(message)
+        }
     }
 }

-CLI.run(in: FileManager.default.currentDirectoryPath)
+CLI.run(in: FileManager.default.currentDirectoryPath, with: arguments)
```

What do you think?