### PR TITLE
Allow Communication between the Xcode Extension and Companion App

### DIFF
--- a/EditorExtension/Application/SwiftFormatter.entitlements
+++ b/EditorExtension/Application/SwiftFormatter.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>com.charcoaldesign.xcode-swift-formatter</string>
+		<string>com.charcoaldesign.SwiftFormat</string>
 	</array>
 </dict>
 </plist>

--- a/EditorExtension/Extension/SwiftFormatter.entitlements
+++ b/EditorExtension/Extension/SwiftFormatter.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>com.charcoaldesign.xcode-swift-formatter</string>
+		<string>com.charcoaldesign.SwiftFormat</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This is a follow up on #212 refactoring. 

The key for UserDefaults group domain was change to "com.charcoaldesign.SwiftFormat" to be the same as the bundle ID of the Framework target. But it was not change in the capabilities tab of the App and the Extension. 
Consequence: the app and the Xcode extension currently don't share their rules settings, meaning that the extension will always use the default rules and never the user defined one.