### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OS X
 .DS_Store
 
+# Swift Package Manager
+.build/
+
 # Xcode
 build/
 *.pbxuser

--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -30,6 +30,7 @@
 //
 
 import Foundation
+import SwiftFormat
 
 extension String {
     var inDefault: String { return "\u{001B}[39m\(self)" }

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,16 @@
 // swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
 let package = Package(
-    name: "SwiftFormat"
+    name: "SwiftFormat",
+    products: [
+        .executable(name: "swiftformat", targets: ["CLI"]),
+        .library(name: "SwiftFormat", targets: ["SwiftFormat"]),
+    ],
+    targets: [
+        .target(name: "CLI", dependencies: ["SwiftFormat"], path: "CommandLineTool"),
+        .target(name: "SwiftFormat", path: "Sources"),
+        .testTarget(name: "Tests", dependencies: ["SwiftFormat"], path: "Tests"),
+    ]
 )


### PR DESCRIPTION
Benefits:

- Easy to build, run and run tests 🐎 
- Usage with [Mint](https://github.com/yonaskolb/Mint) (after yonaskolb/Mint#61)
  - `mint run nicklockwood/SwiftFormat`

Left to do:

- [ ] Figure out why there wasn't an `import SwiftFormat` in `CommandLineTool/main.swift` before 🤔 will adding it break anything?
- [ ] Maybe update the readme with build and Mint instructions?

What works:

- [x] Building: `swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11`
- [x] Running tests: `swift test -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11`

Notes:

- `-Xswiftc -target -Xswiftc x86_64-apple-macosx10.11` is added since SwiftPM targets macOS 10.10 by default, and there is currently no way to set it, see:
  - Carthage/Carthage#2381
  - yonaskolb/Mint#58
  - [Swift Package Manager macOS deployment target override](https://oleb.net/blog/2017/04/swift-3-1-package-manager-deployment-target/)

All tests passed locally:

```text
Test Suite 'CommandLineTests' passed at 2018-03-28 15:07:51.344.
	 Executed 21 tests, with 0 failures (0 unexpected) in 0.270 (0.271) seconds
Test Suite 'FormatterTests' passed at 2018-03-28 15:07:51.367.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.023 (0.023) seconds
Test Suite 'OptionsTests' passed at 2018-03-28 15:07:51.422.
	 Executed 52 tests, with 0 failures (0 unexpected) in 0.052 (0.055) seconds
Test Suite 'PerformanceTests' passed at 2018-03-28 15:23:35.086.
	 Executed 10 tests, with 0 failures (0 unexpected) in 943.663 (943.663) seconds
Test Suite 'RulesTests' passed at 2018-03-28 15:23:38.563.
	 Executed 778 tests, with 0 failures (0 unexpected) in 3.381 (3.477) seconds
Test Suite 'SwiftFormatTests' passed at 2018-03-28 15:23:38.592.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.027 (0.028) seconds
Test Suite 'TokenizerTests' passed at 2018-03-28 15:23:38.683.
	 Executed 200 tests, with 0 failures (0 unexpected) in 0.079 (0.091) seconds
Test Suite 'SwiftFormatPackageTests.xctest' passed at 2018-03-28 15:23:38.683.
	 Executed 1079 tests, with 0 failures (0 unexpected) in 947.494 (947.611) seconds
Test Suite 'All tests' passed at 2018-03-28 15:23:38.684.
	 Executed 1079 tests, with 0 failures (0 unexpected) in 947.494 (947.612) seconds
```