### PR TITLE
Add integration with pre-commit tool

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: swiftformat
+    name: SwiftFormat
+    description: "Check swift files for formating issues with SwiftFormat"
+    entry: swiftformat
+    language: swift
+    types: [swift]


### PR DESCRIPTION
#183 makes possible to use [pre-commit](https://github.com/pre-commit/pre-commit) tool to manage and sync git hooks. I add required for that .pre-commit-hook.yaml file. 
Unfortunately, that tool can't update files and can only use for the check but I think it can be useful for some dev workflows.