### PR TITLE
Export SwiftFormat for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     products: [
         .executable(name: "swiftFormat", targets: ["CommandLineTool"]),
         .library(
-            name: "SwiftFormatCore",
+            name: "SwiftFormat",
             targets: ["SwiftFormat"]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ let package = Package(
     name: "SwiftFormat",
     products: [
         .executable(name: "swiftFormat", targets: ["CommandLineTool"]),
+        .library(
+            name: "SwiftFormatCore",
+            targets: ["SwiftFormat"]
+        ),
     ],
     targets: [
         .target(name: "CommandLineTool", dependencies: ["SwiftFormat"], path: "CommandLineTool"),


### PR DESCRIPTION
I tried to use SwiftFormat as dependency within my Swift Package Manager project.
Although the core library has not been exported. This PR does add the export. 

I called the library `SwiftFormatCore` to match the subspec's name within `SwiftFormat.podspec.json`.