### PR TITLE
Excluding deleted swift files from pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Git pre-commit hook
         #!/bin/bash
         git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
           swiftformat "${line}";
-          git add $line;
+          git add "$line";
         done
 
 4. enable the hook by typing `chmod +x .git/hooks/pre-commit` in the terminal

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Git pre-commit hook
 
         #!/bin/bash
         git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
-          swiftformat ${line};
+          swiftformat "${line}";
           git add $line;
         done
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Git pre-commit hook
 3. Add the following line in the pre-commit file (unlike the Xcode build phase approach, this uses your locally installed version of SwiftFormat, not a separate copy in your project repository)
 
         #!/bin/bash
-        git diff --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
+        git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
           swiftformat ${line};
           git add $line;
         done


### PR DESCRIPTION
- Update the git pre-commit hook instruction to exclude all the deleted files from going through SwiftFormat.