### PR TITLE
Handle absolute paths

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -138,8 +138,13 @@ func printHelp() {
 }
 
 func expandPath(_ path: String, in directory: String) -> URL {
-    let path = NSString(string: path).expandingTildeInPath
-    return URL(fileURLWithPath: directory + "/" + path)
+    if path.starts(with: "/") {
+        return URL(fileURLWithPath: path)
+    }
+    if path.starts(with: "~") {
+        return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+    }
+    return URL(fileURLWithPath: directory).appendingPathComponent(path)
 }
 
 func timeEvent(block: () throws -> Void) rethrows -> String {

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -176,6 +176,29 @@ class CommandLineTests: XCTestCase {
         processArguments([""], in: "")
     }
 
+    // MARK: input paths
+
+    func testExpandPathWithRelativePath() {
+        XCTAssertEqual(
+            expandPath("relpath/to/file.swift", in: "/dir").path,
+            "/dir/relpath/to/file.swift"
+        )
+    }
+
+    func testExpandPathWithFullPath() {
+        XCTAssertEqual(
+            expandPath("/full/path/to/file.swift", in: "/dir").path,
+            "/full/path/to/file.swift"
+        )
+    }
+
+    func testExpandPathWithUserPath() {
+        XCTAssertEqual(
+            expandPath("~/file.swift", in: "/dir").path,
+            NSString(string: "~/file.swift").expandingTildeInPath
+        )
+    }
+
     // MARK: help
 
     func testHelpLineLength() {


### PR DESCRIPTION
Fixes the case when passing absolute paths as inputs would raise an error.
Example:
```lang=sh
$ swiftformat /Users/thelvis4/test.swift
running swiftformat...
error: file not found at /Users/thelvis4//Users/thelvis4/test.swift
```