### PR TITLE
Rename `insertBlankLines` and `removeBlankLines`  rules for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,108 +244,6 @@ To enable the rule(s) again, use:
 **Note:** The `swiftformat:enable` directive only serves to counter a previous `swiftformat:disable` directive in the same file. It is not possible to use `swiftformat:enable` to enable a rule that was not already enabled when formatting started.
 
 Here are all the rules that SwiftFormat currently applies, and the effects that they have:
-
-***blankLinesAtEndOfScope*** - removes trailing blank lines from inside braces, brackets, parens or chevrons. This rule can be configured using the `--removelines` option:
-
-```diff
-  func foo() {
-    // foo
-- 
-  }
-
-  func foo() {
-    // foo
-  }
-```
-
-```diff
-  array = [
-    foo,
-    bar,
-    baz,
-- 
-  ]
-
-  array = [
-    foo,
-    bar,
-    baz,
-  ]
-```
-
-***blankLinesAtStartOfScope*** - removes leading blank lines from inside braces, brackets, parens or chevrons. This rule can be configured using the `--removelines` option:
-
-```diff
-  func foo() {
--
-    // foo 
-  }
-
-  func foo() {
-    // foo
-  }
-```
-
-```diff
-  array = [
--
-    foo,
-    bar,
-    baz, 
-  ]
-
-  array = [
-    foo,
-    bar,
-    baz,
-  ]
-```
-
-***blankLinesBetweenScopes*** - adds a blank line before each class, struct, enum, extension, protocol or function. This rule can be configured using the `--insertlines` option:
-
-```diff
-  func foo() {
-    // foo
-  }
-  func bar() {
-    // bar
-  }
-  var baz: Bool
-  var quux: Int
-
-  func foo() {
-    // foo
-  }
-+ 
-  func bar() {
-    // bar
-  }
-+ 
-  var baz: Bool
-  var quux: Int
-```
-
-***blankLinesAroundMark*** - adds a blank line before and after each `MARK:` comment. This rule can be configured using the `--insertlines` option:
-
-```diff
-  func foo() {
-    // foo
-  }
-  // MARK: bar
-  func bar() {
-    // bar
-  }
-  
-  func foo() {
-    // foo
-  }
-+
-  // MARK: bar
-+
-  func bar() {
-    // bar
-  }
-```
                          
 ***braces*** - implements K&R (default) or Allman-style indentation, depending on the `--allman` option:
 
@@ -520,6 +418,52 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
+***insertBlankLinesAroundMark*** - adds a blank line before and after each `MARK:` comment:
+
+```diff
+  func foo() {
+    // foo
+  }
+  // MARK: bar
+  func bar() {
+    // bar
+  }
+  
+  func foo() {
+    // foo
+  }
++
+  // MARK: bar
++
+  func bar() {
+    // bar
+  }
+```
+
+***insertBlankLinesBetweenScopes*** - adds a blank line before each class, struct, enum, extension, protocol or function:
+
+```diff
+  func foo() {
+    // foo
+  }
+  func bar() {
+    // bar
+  }
+  var baz: Bool
+  var quux: Int
+
+  func foo() {
+    // foo
+  }
++ 
+  func bar() {
+    // bar
+  }
++ 
+  var baz: Bool
+  var quux: Int
+```
+
 ***linebreakAtEndOfFile*** - ensures that the last line of the file is empty.
        
 ***linebreaks*** - normalizes all linebreaks to use the same character, as specified in options (either CR, LF or CRLF, depending on the `--linebreaks` option).
@@ -688,6 +632,62 @@ var foo: Int? = 0
 + String("text")
 ```
     
+***removeBlankLinesAtEndOfScope*** - removes trailing blank lines from inside braces, brackets, parens or chevrons:
+
+```diff
+  func foo() {
+    // foo
+- 
+  }
+
+  func foo() {
+    // foo
+  }
+```
+
+```diff
+  array = [
+    foo,
+    bar,
+    baz,
+- 
+  ]
+
+  array = [
+    foo,
+    bar,
+    baz,
+  ]
+```
+
+***removeBlankLinesAtStartOfScope*** - removes leading blank lines from inside braces, brackets, parens or chevrons:
+
+```diff
+  func foo() {
+-
+    // foo 
+  }
+
+  func foo() {
+    // foo
+  }
+```
+
+```diff
+  array = [
+-
+    foo,
+    bar,
+    baz, 
+  ]
+
+  array = [
+    foo,
+    bar,
+    baz,
+  ]
+```
+ 
 ***semicolons*** - removes semicolons at the end of lines and optionally (depending on the `--semicolons` option) replaces inline semicolons with a linebreak:
 
 ```diff

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -1176,10 +1176,10 @@ func formatOptionsFor(_ args: [String: String]) throws -> FormatOptions {
     try processOption("insertlines", in: args, from: &arguments) {
         switch $0.lowercased() {
         case "enabled", "true":
-            print("`--insertlines` option is deprecated. Use `--enable blankLinesBetweenScopes` or `--enable blankLinesAroundMark` instead", as: .warning)
+            print("`--insertlines` option is deprecated. Use `--enable insertBlankLinesBetweenScopes` or `--enable insertBlankLinesAroundMark` instead", as: .warning)
             options.insertBlankLines = true
         case "disabled", "false":
-            print("`--insertlines` option is deprecated. Use `--disable blankLinesBetweenScopes` or `--disable blankLinesAroundMark` instead", as: .warning)
+            print("`--insertlines` option is deprecated. Use `--disable insertBlankLinesBetweenScopes` or `--disable insertBlankLinesAroundMark` instead", as: .warning)
             options.insertBlankLines = false
         default:
             throw FormatError.options("")
@@ -1188,10 +1188,10 @@ func formatOptionsFor(_ args: [String: String]) throws -> FormatOptions {
     try processOption("removelines", in: args, from: &arguments) {
         switch $0.lowercased() {
         case "enabled", "true":
-            print("`--removelines` option is deprecated. Use `--enable blankLinesAtStartOfScope` or `--enable blankLinesAtEndOfScope` instead", as: .warning)
+            print("`--removelines` option is deprecated. Use `--enable removeBlankLinesAtStartOfScope` or `--enable removeBlankLinesAtEndOfScope` instead", as: .warning)
             options.removeBlankLines = true
         case "disabled", "false":
-            print("`--removelines` option is deprecated. Use `--disable blankLinesAtStartOfScope` or `--disable blankLinesAtEndOfScope` instead", as: .warning)
+            print("`--removelines` option is deprecated. Use `--disable removeBlankLinesAtStartOfScope` or `--disable removeBlankLinesAtEndOfScope` instead", as: .warning)
             options.removeBlankLines = false
         default:
             throw FormatError.options("")

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -581,7 +581,7 @@ extension FormatRules {
     }
 
     /// Remove blank lines immediately after an opening brace, bracket, paren or chevron
-    @objc public class func blankLinesAtStartOfScope(_ formatter: Formatter) {
+    @objc public class func removeBlankLinesAtStartOfScope(_ formatter: Formatter) {
         guard formatter.options.removeBlankLines else { return }
         formatter.forEach(.startOfScope) { i, token in
             guard ["{", "(", "[", "<"].contains(token.string),
@@ -612,7 +612,7 @@ extension FormatRules {
 
     /// Remove blank lines immediately before a closing brace, bracket, paren or chevron
     /// unless it's followed by more code on the same line (e.g. } else { )
-    @objc public class func blankLinesAtEndOfScope(_ formatter: Formatter) {
+    @objc public class func removeBlankLinesAtEndOfScope(_ formatter: Formatter) {
         guard formatter.options.removeBlankLines else { return }
         formatter.forEach(.endOfScope) { i, token in
             guard ["}", ")", "]", ">"].contains(token.string),
@@ -646,7 +646,7 @@ extension FormatRules {
     }
 
     /// Adds a blank line immediately after a closing brace, unless followed by another closing brace
-    @objc public class func blankLinesBetweenScopes(_ formatter: Formatter) {
+    @objc public class func insertBlankLinesBetweenScopes(_ formatter: Formatter) {
         guard formatter.options.insertBlankLines else { return }
         var spaceableScopeStack = [true]
         var isSpaceableScopeType = false
@@ -711,7 +711,7 @@ extension FormatRules {
     }
 
     /// Adds a blank line around MARK: comments
-    @objc public class func blankLinesAroundMark(_ formatter: Formatter) {
+    @objc public class func insertBlankLinesAroundMark(_ formatter: Formatter) {
         guard formatter.options.insertBlankLines else { return }
         formatter.forEachToken { i, token in
             guard case let .commentBody(comment) = token, comment.hasPrefix("MARK:"),

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -114,7 +114,7 @@ class FormatterTests: XCTestCase {
 
     func testFormatterDirectives() {
         let input = """
-        // swiftformat:disable indent blankLinesBetweenScopes redundantSelf
+        // swiftformat:disable indent insertBlankLinesBetweenScopes redundantSelf
         class Foo {
         let _foo = "foo"
         func foo() {
@@ -130,7 +130,7 @@ class FormatterTests: XCTestCase {
         }
         """
         let output = """
-        // swiftformat:disable indent blankLinesBetweenScopes redundantSelf
+        // swiftformat:disable indent insertBlankLinesBetweenScopes redundantSelf
         class Foo {
         let _foo = "foo"
         func foo() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -1216,163 +1216,163 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input, rules: FormatRules.default, options: options), output)
     }
 
-    // MARK: blankLinesAtStartOfScope
+    // MARK: removeBlankLinesAtStartOfScope
 
     func testBlankLinesRemovedAtStartOfFunction() {
         let input = "func foo() {\n\n    // code\n}"
         let output = "func foo() {\n    // code\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtStartOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtStartOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLinesRemovedAtStartOfParens() {
         let input = "(\n\n    foo: Int\n)"
         let output = "(\n    foo: Int\n)"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtStartOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtStartOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLinesRemovedAtStartOfBrackets() {
         let input = "[\n\n    foo,\n    bar,\n]"
         let output = "[\n    foo,\n    bar,\n]"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtStartOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtStartOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLinesNotRemovedBetweenElementsInsideBrackets() {
         let input = "[foo,\n\n bar]"
         let output = "[foo,\n\n bar]"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtStartOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtStartOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.all(except: ["wrapArguments"])), output + "\n")
     }
 
-    // MARK: blankLinesAtEndOfScope
+    // MARK: removeBlankLinesAtEndOfScope
 
     func testBlankLinesRemovedAtEndOfFunction() {
         let input = "func foo() {\n    // code\n\n}"
         let output = "func foo() {\n    // code\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtEndOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtEndOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLinesRemovedAtEndOfParens() {
         let input = "(\n    foo: Int\n\n)"
         let output = "(\n    foo: Int\n)"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtEndOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtEndOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLinesRemovedAtEndOfBrackets() {
         let input = "[\n    foo,\n    bar,\n\n]"
         let output = "[\n    foo,\n    bar,\n]"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtEndOfScope]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtEndOfScope]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLineNotRemovedBeforeElse() {
         let input = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n\n}"
         let output = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAtEndOfScope]), output)
-        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all(except: ["blankLinesAtStartOfScope"])), output + "\n")
+        XCTAssertEqual(try format(input, rules: [FormatRules.removeBlankLinesAtEndOfScope]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all(except: ["removeBlankLinesAtStartOfScope"])), output + "\n")
     }
 
-    // MARK: blankLinesBetweenScopes
+    // MARK: insertBlankLinesBetweenScopes
 
     func testBlankLineBetweenFunctions() {
         let input = "func foo() {\n}\nfunc bar() {\n}"
         let output = "func foo() {\n}\n\nfunc bar() {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineBetweenPropertyAndFunction() {
         let input = "var foo: Int\nfunc bar() {\n}"
         let output = "var foo: Int\nfunc bar() {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLineBetweenFunctionsIsBeforeComment() {
         let input = "func foo() {\n}\n// headerdoc\nfunc bar() {\n}"
         let output = "func foo() {\n}\n\n// headerdoc\nfunc bar() {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLineBeforeAtObjcOnLineBeforeProtocol() {
         let input = "@objc\nprotocol Foo {\n}\n@objc\nprotocol Bar {\n}"
         let output = "@objc\nprotocol Foo {\n}\n\n@objc\nprotocol Bar {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLineBeforeAtAvailabilityOnLineBeforeClass() {
         let input = "protocol Foo {\n}\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
         let output = "protocol Foo {\n}\n\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoExtraBlankLineBetweenFunctions() {
         let input = "func foo() {\n}\n\nfunc bar() {\n}"
         let output = "func foo() {\n}\n\nfunc bar() {\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineBetweenFunctionsInProtocol() {
         let input = "protocol Foo {\n    func bar() -> Void\n    func baz() -> Int\n}"
         let output = "protocol Foo {\n    func bar() -> Void\n    func baz() -> Int\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineInsideInitFunction() {
         let input = "init() {\n    super.init()\n}"
         let output = "init() {\n    super.init()\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testBlankLineAfterProtocolBeforeProperty() {
         let input = "protocol Foo {\n}\nvar bar: String"
         let output = "protocol Foo {\n}\n\nvar bar: String"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoExtraBlankLineAfterSingleLineComment() {
         let input = "var foo: Bar? // comment\n\nfunc bar() {}"
         let output = "var foo: Bar? // comment\n\nfunc bar() {}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoExtraBlankLineAfterMultilineComment() {
         let input = "var foo: Bar? /* comment */\n\nfunc bar() {}"
         let output = "var foo: Bar? /* comment */\n\nfunc bar() {}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineBeforeFuncAsIdentifier() {
         let input = "var foo: Bar?\nfoo.func(x) {}"
         let output = "var foo: Bar?\nfoo.func(x) {}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineBetweenFunctionsWithInlineBody() {
         let input = "class Foo {\n    func foo() { print(\"foo\") }\n    func bar() { print(\"bar\") }\n}"
         let output = "class Foo {\n    func foo() { print(\"foo\") }\n    func bar() { print(\"bar\") }\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineBetweenIfStatements() {
         let input = "func foo() {\n    if x {\n    }\n    if y {\n    }\n}"
         let output = "func foo() {\n    if x {\n    }\n    if y {\n    }\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
@@ -1380,7 +1380,7 @@ class RulesTests: XCTestCase {
         let input = "class func foo {\n    if x {\n    }\n    if y {\n    }\n}"
         let output = "class func foo {\n    if x {\n    }\n    if y {\n    }\n}"
         let options = FormatOptions(fragment: true)
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes], options: options), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
@@ -1388,21 +1388,21 @@ class RulesTests: XCTestCase {
         let input = "class var foo: Int {\n    if x {\n    }\n    if y {\n    }\n}"
         let output = "class var foo: Int {\n    if x {\n    }\n    if y {\n    }\n}"
         let options = FormatOptions(fragment: true)
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes], options: options), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
     func testBlankLineBetweenCalledClosures() {
         let input = "class Foo {\n    var foo = {\n    }()\n    func bar {\n    }\n}"
         let output = "class Foo {\n    var foo = {\n    }()\n\n    func bar {\n    }\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
     func testNoBlankLineAfterCalledClosureAtEndOfScope() {
         let input = "class Foo {\n    var foo = {\n    }()\n}"
         let output = "class Foo {\n    var foo = {\n    }()\n}"
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
@@ -1410,7 +1410,7 @@ class RulesTests: XCTestCase {
         let input = "repeat\n{\n}\nwhile true\n{\n}()"
         let output = "repeat\n{\n}\nwhile true\n{\n}()"
         let options = FormatOptions(allmanBraces: true)
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes], options: options), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
@@ -1418,13 +1418,13 @@ class RulesTests: XCTestCase {
         let input = "func foo(x)\n{\n}\nwhile true\n{\n}"
         let output = "func foo(x)\n{\n}\n\nwhile true\n{\n}"
         let options = FormatOptions(allmanBraces: true)
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesBetweenScopes], options: options), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesBetweenScopes], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
-    // MARK: blankLinesAroundMark
+    // MARK: insertBlankLinesAroundMark
 
-    func testInsertBlankLinesAroundMark() {
+    func testInsertinsertBlankLinesAroundMark() {
         let input = """
         let foo = "foo"
         // MARK: bar
@@ -1437,11 +1437,11 @@ class RulesTests: XCTestCase {
 
         let bar = "bar"
         """
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAroundMark]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesAroundMark]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
-    func testNoInsertExtraBlankLinesAroundMark() {
+    func testNoInsertExtrainsertBlankLinesAroundMark() {
         let input = """
         let foo = "foo"
 
@@ -1449,7 +1449,7 @@ class RulesTests: XCTestCase {
 
         let bar = "bar"
         """
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAroundMark]), input)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesAroundMark]), input)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), input + "\n")
     }
 
@@ -1463,7 +1463,7 @@ class RulesTests: XCTestCase {
 
         let bar = "bar"
         """
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAroundMark]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesAroundMark]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
@@ -1477,7 +1477,7 @@ class RulesTests: XCTestCase {
 
         // MARK: bar
         """
-        XCTAssertEqual(try format(input, rules: [FormatRules.blankLinesAroundMark]), output)
+        XCTAssertEqual(try format(input, rules: [FormatRules.insertBlankLinesAroundMark]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
@@ -1587,7 +1587,7 @@ class RulesTests: XCTestCase {
         let input = "{\n\n// foo\n}"
         let output = "{\n\n    // foo\n}"
         XCTAssertEqual(try format(input, rules: [FormatRules.indent]), output)
-        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all(except: ["blankLinesAtStartOfScope"])), output + "\n")
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all(except: ["removeBlankLinesAtStartOfScope"])), output + "\n")
     }
 
     func testNestedBraces() {


### PR DESCRIPTION
- `blankLinesBetweenScopes` => `insertBlankLinesBetweenScopes`

- `blankLinesAroundMark` => `insertBlankLinesAroundMark`

- `blankLinesAtStartOfScope` => `removeBlankLinesAtStartOfScope`

- `blankLinesAtEndOfScope` => `removeBlankLinesAtEndOfScope`