### PR TITLE
Add support for swiftformat:enable:all and swiftformat:disable:all

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -53,9 +53,8 @@ public class Formatter: NSObject {
 
     // Process a comment token (which may contain directives)
     func processCommentBody(_ comment: String) {
-        guard let rule = currentRule, comment.hasPrefix("swiftformat:"),
-            let directive = ["disable", "enable"].first(where: { comment.hasPrefix("swiftformat:\($0)") }),
-            comment.range(of: "\\b\(rule)\\b", options: .regularExpression) != nil else {
+        guard let directive = self.directive(inComment: comment),
+            hasCurrentRule(inComment: comment) || hasAllRule(inComment: comment) else {
             return
         }
         switch directive {
@@ -66,6 +65,19 @@ public class Formatter: NSObject {
         default:
             preconditionFailure()
         }
+    }
+
+    private func directive(inComment comment: String) -> String? {
+        return ["disable", "enable"].first(where: { comment.hasPrefix("swiftformat:\($0)") })
+    }
+
+    private func hasCurrentRule(inComment comment: String) -> Bool {
+        guard let rule = currentRule else { return false }
+        return comment.range(of: "\\b\(rule)\\b", options: .regularExpression) != nil
+    }
+
+    private func hasAllRule(inComment comment: String) -> Bool {
+        return comment.range(of: "\\ball\\b", options: .regularExpression) != nil
     }
 
     /// The options that the formatter was initialized with

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -147,4 +147,40 @@ class FormatterTests: XCTestCase {
         """
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
+
+    func testFormatterAllDirective() {
+        let input = """
+        // swiftformat:disable all
+        class Foo {
+        let _foo = "foo"
+        func foo() {
+        print(self._foo)
+        }
+        }
+        // swiftformat:enable all
+        class Bar {
+        let _bar = "bar"
+        func bar() {
+        print(_bar)
+        }
+        }
+        """
+        let output = """
+        // swiftformat:disable all
+        class Foo {
+        let _foo = "foo"
+        func foo() {
+        print(self._foo)
+        }
+        }
+        // swiftformat:enable all
+        class Bar {
+            let _bar = "bar"
+            func bar() {
+                print(_bar)
+            }
+        }
+        """
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
 }


### PR DESCRIPTION
We use SwiftFormat in our project together with Sourcery as a build step, and we face an issue where Sourcery and SwiftFormatter are overriding each other in some cases. I know, there is a possibility to use `--exclude` but this requires to pass paths, and we use our Sourcery templates in many projects in one big workspace, so it is not exactly easy to get all paths. It would be easier for us to specify one line in our templates.

SwiftLint offers this option, so it is not entirely out of mind.

Even if you don't like my implementation that is rather basic and expands the current simple implementation please still consider adding this.

Thank you.