### PR TITLE
Rf develop newline at swiftformat eof

### DIFF
--- a/EditorExtension/Application/Source/AppDelegate.swift
+++ b/EditorExtension/Application/Source/AppDelegate.swift
@@ -112,7 +112,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let optionsStore = OptionsStore()
             let formatOptions = optionsStore.inferOptions ? nil : optionsStore.formatOptions
             let rules = RulesStore().rules.compactMap { $0.isEnabled ? $0.name : nil }
-            let config = serialize(options: Options(formatOptions: formatOptions, rules: Set(rules)))
+            var config = serialize(options: Options(formatOptions: formatOptions, rules: Set(rules)))
+            if !config.isEmpty {
+                config += "\n"
+            }
             do {
                 try config.write(to: url, atomically: true, encoding: .utf8)
             } catch let error {

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -233,7 +233,7 @@ func serialize(options: Options,
     return optionSets.map {
         let arguments = argumentsFor($0, excludingDefaults: excludingDefaults)
         return serialize(arguments: arguments, separator: separator)
-    }.joined(separator: separator)
+    }.filter { !$0.isEmpty }.joined(separator: separator)
 }
 
 // Serialize arguments

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -303,7 +303,7 @@ class ArgumentsTests: XCTestCase {
     func testSerializeOptionsEnabledAllRulesEnabled() throws {
         let (formatOptions, rules) = optionsAndRulesForTest(allOptionsEnabled: true, allRulesEnabled: true)
         let config: String = serialize(options: Options(formatOptions: formatOptions, rules: rules))
-        XCTAssertEqual("\n", config.last)
+        XCTAssertNotEqual("\n", config.last)
     }
 
     func testSerializeOptionsEnabledSomeRulesDisabled() throws {


### PR DESCRIPTION
This PR is a follow-up to the issue ***.swiftformat file should end with a linefeed in all configurations #293***.

After a further study of the SwiftFormat code and the use of `func serialize(options:excludingDefaults:separator:) -> String`, I deviated from my first patch.

This PR 

- modifies `func serialize` to make sure that it returns a string without a trailing separator
- adds 4 tests to verify above behavior, for principal use cases 
- modifies `func saveConfiguration` to add a newline to a nonempty config string

The modified code passes manual tests with saving the settings of `SwiftFormat for Xcode` to a `.swiftformat` file:
- `Reset to Defaults` + `Save`: `.swiftformat` is empty (0 length)
- `Reset to Defaults` + uncheck `Infer Automatically from Source Files`,
- `Reset to Defaults` + disable some Rules,
- `Reset to Defaults` + uncheck `Infer Automatically from Source Files` + disable some Rules:
in the 3 cases `.swiftformat` is non-empty and ends with a newline.
