### PR TITLE
Omit unrequired parameter for Mint install

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can install the `swiftformat` command-line tool using [Homebrew](http://brew
 Alternatively, you can install the tool using [Mint](https://github.com/yonaskolb/Mint) as follows:
 
 ```bash
-> mint install nicklockwood/SwiftFormat swiftformat
+> mint install nicklockwood/SwiftFormat
 ```
     
 And then run it using:


### PR DESCRIPTION
This PR forwards changes from vknabel/vscode-swiftformat#1

> **Remove unrequired mint param**
> This is no longer needed in Mint, as it reads the executable name from the package 😀
> It wasn’t required for macOS anyway as it used to take the repo name by default
> *by [@yonaskolb](https://github.com/yonaskolb)* 