### PR TITLE
Adding config options to rule descriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ There is no need to manually re-enable a rule after using the `next` directive.
 
 Here are all the rules that SwiftFormat currently applies, and the effects that they have:
 
-***blankLinesAtEndOfScope*** - removes trailing blank lines from inside braces, brackets, parens or chevrons. This rule can be configured using the `--removelines` option:
+***blankLinesAtEndOfScope*** - removes trailing blank lines from inside braces, brackets, parens or chevrons. `--enable blankLinesAtEndOfScope`.
 
 ```diff
   func foo() {
@@ -333,7 +333,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   ]
 ```
 
-***blankLinesAtStartOfScope*** - removes leading blank lines from inside braces, brackets, parens or chevrons. This rule can be configured using the `--removelines` option:
+***blankLinesAtStartOfScope*** - removes leading blank lines from inside braces, brackets, parens or chevrons. `--enable blankLinesAtStartOfScope`.
 
 ```diff
   func foo() {
@@ -361,7 +361,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   ]
 ```
 
-***blankLinesBetweenScopes*** - adds a blank line before each class, struct, enum, extension, protocol or function. This rule can be configured using the `--insertlines` option:
+***blankLinesBetweenScopes*** - adds a blank line before each class, struct, enum, extension, protocol or function. `--enable blankLinesBetweenScopes`.
 
 ```diff
   func foo() {
@@ -385,7 +385,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   var quux: Int
 ```
 
-***blankLinesAroundMark*** - adds a blank line before and after each `MARK:` comment. This rule can be configured using the `--insertlines` option:
+***blankLinesAroundMark*** - adds a blank line before and after each `MARK:` comment. `--enable blankLinesAroundMark`.
 
 ```diff
   func foo() {
@@ -407,7 +407,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
                          
-***braces*** - implements K&R (default) or Allman-style indentation, depending on the `--allman` option:
+***braces*** - implements K&R (default, `--allman false`) or Allman-style indentation (`--allman true`):
 
 ```diff
 - if x
@@ -427,7 +427,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
                          
-***consecutiveBlankLines*** - reduces multiple sequential blank lines to a single blank line
+***consecutiveBlankLines*** - reduces multiple sequential blank lines to a single blank line. `--enable consecutiveBlankLines`.
 
 ```diff
   func foo() {
@@ -444,14 +444,14 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
-***consecutiveSpaces*** - reduces a sequence of spaces to a single space:
+***consecutiveSpaces*** - reduces a sequence of spaces to a single space. `--enable consecutiveSpaces`.
 
 ```diff
 - let     foo = 5
 + let foo = 5
 ```
 
-***duplicateImports*** - removes duplicate import statements:
+***duplicateImports*** - removes duplicate import statements.  `--enable duplicateImports`.
 
 ```diff
   import Foo
@@ -467,7 +467,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   #endif
 ```
 
-***elseOnSameLine*** - controls whether an `else`, `catch` or `while` keyword after a `}` appears on the same line, depending on the `--elseposition` option:
+***elseOnSameLine*** - controls whether an `else`, `catch` or `while` keyword after a `}` appears on the same line, depending on the `--elseposition` option (`same-line` (default) or `next-line`):
 
 ```diff
   if x {
@@ -514,7 +514,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
-***emptyBraces*** - removes all white space between otherwise empty braces:
+***emptyBraces*** - removes all white space between otherwise empty braces. `--enable emptyBraces`.
 
 ```diff
 - func foo() {
@@ -532,7 +532,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
 
     See the File Headers section below for more information.
 
-***hoistPatternLet*** - moves `let` or `var` bindings inside patterns to the start of the expression, or vice-versa. Use the `--patternlet` command-line option to toggle between hoisted and inline style.
+***hoistPatternLet*** - moves `let` or `var` bindings inside patterns to the start of the expression, or vice-versa, depending on the `--patternlet` option (`hoist` or `inline`).
 
 ```diff
 - (let foo, let bar) = baz()
@@ -549,7 +549,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
-***indent*** - adjusts leading whitespace based on scope and line wrapping. Uses either tabs or spaces, depending on the `--indent` option. By default, `case` statements will be indented level with their containing `switch`, but this can be controlled with the `--indentcase` options. Also affects comments and `#if ...` statements, depending on the configuration of the `--comments` and `--ifdef` options:
+***indent*** - adjusts leading whitespace based on scope and line wrapping. Uses either tabs (`--indent tab`) or spaces (`--indent 4`). By default, `case` statements will be indented level with their containing `switch`, but this can be controlled with the `--indentcase` options. Also affects comments and `#if ...` statements, depending on the configuration of the `--comments` option (`indent` or `ignore`) and the `--ifdef` option (`indent` (default), `noindent` or `ignore`):
 
 ```diff
   if x {
@@ -591,11 +591,15 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
-***linebreakAtEndOfFile*** - ensures that the last line of the file is empty.
+***linebreakAtEndOfFile*** - ensures that the last line of the file is empty. `--enable linebreakAtEndOfFile`.
        
-***linebreaks*** - normalizes all linebreaks to use the same character, as specified in options (either CR, LF or CRLF, depending on the `--linebreaks` option).
+***linebreaks*** - normalizes all linebreaks to use the same character, depending on the `--linebreaks` option (`cr`, `crlf` or `lf`).
 
-***numberFormatting*** - handles case and grouping of number literals, depending on the `--hexliteralcase`, `--exponentcase`, `--hexgrouping`, `--binarygrouping`, `--decimalgrouping`, `--octalgrouping`, `--fractiongrouping` and `--exponentgrouping` options:
+***numberFormatting*** - handles case and grouping of number literals, depending on the following options:
+- `--hexliteralcase` and `--exponentcase` (`uppercase` (default) or `lowercase`)
+- `--hexgrouping`, `--binarygrouping`, `--octalgrouping` (`4,8` (default grouping,threshold), `none` or `ignore`) 
+- `--decimalgrouping` (`3,6` (default grouping,threshold), `none` or `ignore`)
+- `--fractiongrouping` and `--exponentgrouping` (`disabled` (default) or `enabled`)
 
 ```diff
 - let color = 0xFF77A5
@@ -607,9 +611,9 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
 + let big = 123_456.123
 ```
 
-***ranges*** - controls the spacing around range operators. By default, a space is added, but this can be configured using the `--ranges` option.
+***ranges*** - controls the spacing around range operators. By default, a space is added, but this can be configured using the `--ranges` option (`spaced` (default) or `nospace`).
 
-***redundantBackticks*** - removes unnecessary escaping of identifiers using backticks, e.g. in cases where the escaped word is not a keyword, or is not ambiguous in that context:
+***redundantBackticks*** - removes unnecessary escaping of identifiers using backticks, e.g. in cases where the escaped word is not a keyword, or is not ambiguous in that context. `--enable redundantBackticks`.
 
 ```diff
 - let `infix` = bar
@@ -621,7 +625,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
 + func foo(with default: Int) {}
 ```
 
-***redundantGet*** - removes unnecessary `get { }` clauses from inside read-only computed properties:
+***redundantGet*** - removes unnecessary `get { }` clauses from inside read-only computed properties. `--enable redundantGet`.
 
 ```diff
   var foo: Int {
@@ -635,7 +639,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
   }
 ```
 
-***redundantLet*** - removes redundant `let` or `var` from ignored variables in bindings (which is a warning in Xcode):
+***redundantLet*** - removes redundant `let` or `var` from ignored variables in bindings (which is a warning in Xcode). `--enable redundantLet`.
 
 ```diff
 - let _ = resultIgnorableFunction()
@@ -652,7 +656,7 @@ Here are all the rules that SwiftFormat currently applies, and the effects that 
 + if case .foo( /* unused */ _) = bar {}
 ```
 
-***redundantNilInit*** - removes unnecessary nil initialization of Optional vars (which are nil by default anyway):
+***redundantNilInit*** - removes unnecessary nil initialization of Optional vars (which are nil by default anyway). `--enable redundantNilInit`.
 
 ```diff
 - var foo: Int? = nil
@@ -669,7 +673,7 @@ let foo: Int? = nil
 var foo: Int? = 0
 ```
 
-***redundantParens*** - removes unnecessary parens from expressions and branch conditions:
+***redundantParens*** - removes unnecessary parens from expressions and branch conditions. `--enable redundantParens`.
 
 ```diff
 - if (foo == true) {} 
@@ -691,7 +695,7 @@ var foo: Int? = 0
 + let foo: Int = { ... }()
 ```
     
-***redundantPattern*** - removes redundant pattern matching arguments for ignored variables:
+***redundantPattern*** - removes redundant pattern matching arguments for ignored variables. `--enable redundantPattern`.
 
 ```diff
 - if case .foo(_, _) = bar {}
@@ -703,7 +707,7 @@ var foo: Int? = 0
 + let _ = bar
 ```
     
-***redundantRawValues*** - removes raw string values from enum cases when they match the case name:
+***redundantRawValues*** - removes raw string values from enum cases when they match the case name. `--enable redundantRawValues`.
 
 ```diff
   enum Foo: String {
@@ -717,14 +721,14 @@ var foo: Int? = 0
   }
 ```
 
-***redundantReturn*** - removes unnecessary `return` keyword from single-line closures:
+***redundantReturn*** - removes unnecessary `return` keyword from single-line closures. `--enable redundantReturn`.
 
 ```diff
 - array.filter { return $0.foo == bar }
 + array.filter { $0.foo == bar }
 ```
     
-***redundantSelf*** - removes or inserts `self` prefix from class and instance member references, depending on the `--self` option:
+***redundantSelf*** - removes or inserts `self` prefix from class and instance member references, depending on the `--self` option. `--enable redundantSelf`.
 
 ```diff
   init(foo: Int, bar: Int) {
@@ -740,7 +744,7 @@ var foo: Int? = 0
   }  
 ```
     
-***redundantVoidReturnType*** - removes unnecessary `Void` return type from function declarations:
+***redundantVoidReturnType*** - removes unnecessary `Void` return type from function declarations. `--enable redundantVoidReturnType`.
 
 ```diff
 - func foo() -> Void {
@@ -752,14 +756,14 @@ var foo: Int? = 0
   }
 ```
 
-***redundantInit*** - removes unnecessary `init` when instantiating Types:
+***redundantInit*** - removes unnecessary `init` when instantiating Types. `--enable redundantInit`.
 
 ```diff
 - String.init("text")
 + String("text")
 ```
     
-***semicolons*** - removes semicolons at the end of lines and optionally (depending on the `--semicolons` option) replaces inline semicolons with a linebreak:
+***semicolons*** - removes semicolons at the end of lines.  Also replaces inline semicolons with a linebreak, depending on the `--semicolons` option (`inline` (default) or `never`).
 
 ```diff
 - let foo = 5;
@@ -778,7 +782,7 @@ return;
 goto(fail)
 ```
 
-***sortedImports*** - rearranges import statements so that they are sorted:
+***sortedImports*** - rearranges import statements so that they are sorted. `--enable sortedImports`.
 
 ```diff
 - import Foo
@@ -802,7 +806,7 @@ goto(fail)
 + #endif
 ```
 
-***spaceAroundBraces*** - contextually adds or removes space around { }. For example:
+***spaceAroundBraces*** - contextually adds or removes space around { }. `--enable spaceAroundBraces`.
 
 ```diff
 - foo.filter{ return true }.map{ $0 }
@@ -814,7 +818,7 @@ goto(fail)
 + foo({})
 ```
 
-***spaceAroundBrackets*** - contextually adjusts the space around [ ]. For example:
+***spaceAroundBrackets*** - contextually adjusts the space around [ ]. `--enable spaceAroundBrackets`.
 
 ```diff
 - foo as[String]
@@ -826,7 +830,7 @@ goto(fail)
 + foo = bar[5]
 ```
 
-***spaceAroundComments*** - adds space around /* ... */ comments and before // comments. Configure using `--comments` option:
+***spaceAroundComments*** - adds space around /* ... */ comments and before // comments, depending on the `--comments` option (`indent` (default) or `ignore`).
 
 ```diff
 - let a = 5// assignment
@@ -838,14 +842,14 @@ goto(fail)
 + func foo() { /* no-op */ }
 ```
 
-***spaceAroundGenerics*** - removes the space around < >. For example:
+***spaceAroundGenerics*** - removes the space around < >. `--enable spaceAroundGenerics`.
 
 ```diff
 - Foo <Bar> ()
 + Foo<Bar>()
 ```
 
-***spaceAroundOperators*** - contextually adjusts the space around infix operators. Also adds or removes the space between an operator function declaration and its arguments, depending on value of the `--operatorfunc` option.
+***spaceAroundOperators*** - contextually adjusts the space around infix operators. Also adds or removes the space between an operator function declaration and its arguments, depending on the `--operatorfunc` option (`spaced` (default) or `nospace`).
 
 ```diff
 - foo . bar()
@@ -862,7 +866,7 @@ goto(fail)
 + func == (lhs: Int, rhs: Int) -> Bool
 ```
 
-***spaceAroundParens*** - contextually adjusts the space around ( ). For example:
+***spaceAroundParens*** - contextually adjusts the space around ( ). `--enable spaceAroundParens`.
 
 ```diff
 - init (foo)
@@ -874,21 +878,21 @@ goto(fail)
 + switch (x) {
 ```
 
-***spaceInsideBraces*** - adds space inside `{ ... }`. For example:
+***spaceInsideBraces*** - adds space inside `{ ... }`. `--enable spaceInsideBraces`.
 
 ```diff
 - foo.filter {return true}
 + foo.filter { return true }
 ```
 
-***spaceInsideBrackets*** - removes the space inside `[ ... ]`. For example:
+***spaceInsideBrackets*** - removes the space inside `[ ... ]`. `--enable spaceInsideBrackets`.
 
 ```diff
 - [ 1, 2, 3 ]
 + [1, 2, 3]
 ```
 
-***spaceInsideComments*** - adds space inside `/* ... */` comments and at the start of `//` comments. Configure using `--comments` option:
+***spaceInsideComments*** - adds a space inside `/* ... */` comments and at the start of `//` comments, depending on the `--comments` option (`indent` (default) or `ignore`).
 
 ```diff
 - let a = 5 //assignment
@@ -900,21 +904,21 @@ goto(fail)
 + func foo() { /* no-op */ }
 ```
 
-***spaceInsideGenerics*** - removes the space inside `< ... >`. For example:
+***spaceInsideGenerics*** - removes the space inside `< ... >`. `--enable spaceInsideGenerics`.
 
 ```diff
 - Foo< Bar, Baz >
 + Foo<Bar, Baz>
 ```
 
-***spaceInsideParens*** - removes the space inside `( ... )`. For example:
+***spaceInsideParens*** - removes the space inside `( ... )`. `--enable spaceInsideParens`.
 
 ```diff
 - ( a, b )
 + (a, b)
 ```
 
-***specifiers*** - normalizes the order for access specifiers, and other property/function/class/etc. specifiers:
+***specifiers*** - normalizes the order for access specifiers, and other property/function/class/etc. specifiers. `--enable specifiers`.
 
 ```diff
 - lazy public weak private(set) var foo: UIView?
@@ -931,14 +935,14 @@ goto(fail)
 + private convenience init()
 ```
 
-***strongOutlets*** - removes the `weak` specifier from `@IBOutlet` properties, as per [Apple's recommendation](https://developer.apple.com/videos/play/wwdc2015/407/):
+***strongOutlets*** - removes the `weak` specifier from `@IBOutlet` properties, as per [Apple's recommendation](https://developer.apple.com/videos/play/wwdc2015/407/). `--enable strongOutlets`.
 
 ```diff
 - @IBOutlet weak var label: UILabel!
 + @IBOutlet var label: UILabel!
 ```
 
-***trailingClosures*** - converts the last closure argument in a function call to trailing closure syntax where possible.
+***trailingClosures*** - converts the last closure argument in a function call to trailing closure syntax where possible. `--enable trailingClosures`.
 
 ```diff
 - DispatchQueue.main.async(execute: {
@@ -950,9 +954,9 @@ goto(fail)
 + }
 ```
 
-**NOTE:** Occasionally, using trailing closure syntax makes a function call ambiguous, and the compiler can't understand it. Since SwiftFormat isn't able to detect this in all cases, the `trailingClosures` rule is disabled by default, and must be manually enabled by adding `--enable trailingClosures` to the command-line.
+**NOTE:** Occasionally, using trailing closure syntax makes a function call ambiguous, and the compiler can't understand it. Since SwiftFormat isn't able to detect this in all cases, the `trailingClosures` rule is disabled by default, and must be manually enabled via the `--enable trailingClosures` option.
 
-***trailingCommas*** - adds or removes trailing commas from the last item in an array or dictionary literal, depending on the `--commas` option:
+***trailingCommas*** - adds or removes trailing commas from the last item in an array or dictionary literal, depending on the `--commas` option (`always` (default) or `inline`).
 
 ```diff
   let array = [
@@ -968,9 +972,9 @@ goto(fail)
   ]
 ```
 
-***trailingSpace*** - removes the whitespace at the end of a line. This rule can be configured using the `--trimwhitespace` option.
+***trailingSpace*** - removes the whitespace at the end of a line, depending on the `--trimwhitespace` option (`always` (default) or `nonblank-lines`).
  
-***todos*** - ensures that `TODO:`, `MARK:` and `FIXME:` comments include the trailing colon (else they're ignored by Xcode)
+***todos*** - ensures that `TODO:`, `MARK:` and `FIXME:` comments include the trailing colon (else they're ignored by Xcode). `--enable todos`.
 
 ```diff
 - /* TODO fix this properly */
@@ -982,7 +986,7 @@ goto(fail)
 + // MARK: - UIScrollViewDelegate
 ```
 
-***unusedArguments*** - marks unused arguments in functions and closures with `_` to make it clear they aren't used. Use the `--stripunusedargs` option to configure which argument types are affected.
+***unusedArguments*** - marks unused arguments in functions and closures with `_` to make it clear they aren't used. Use the `--stripunusedargs` option to configure which argument types are affected (`always` (default), `closure-only` or `unnamed-only`).
 
 ```diff
 - func foo(bar: Int, baz: String) {
@@ -1014,7 +1018,7 @@ goto(fail)
   }
 ```
     
-***void*** - standardizes the use of `Void` vs an empty tuple `()` to represent empty argument lists and return values, depending on the `--empty` option:
+***void*** - standardizes the use of `Void` vs an empty tuple `()` to represent empty argument lists and return values, depending on the `--empty` option (`void` (default) or `tuple`).
 
 ```diff
 - let foo: () -> (
@@ -1036,7 +1040,7 @@ goto(fail)
 + func quux() -> Void
 ```
 
-***wrapArguments*** - wraps function arguments and collection literals depending on the `--wraparguments`, and `--wrapcollections` modes specified, and the `--closingparen` option. E.g. for `--wraparguments beforefirst` and `--closingparen balanced`:
+***wrapArguments*** - wraps function arguments and collection literals depending on the `--wraparguments` and `--wrapcollections` options (`beforefirst`, `afterfirst` or `preserve`) and the `--closingparen` option (`balanced` (default) or `same-line`). E.g. for `--wraparguments beforefirst` and `--closingparen balanced`:
 
 ```diff
 - func foo(bar: Int,


### PR DESCRIPTION
Thanks so much for creating SwiftFormat!

I found the onboarding process a bit confusing.  The README describes all of the rules, but then you have to run `swiftformat --help` to find the options for those rules.

This PR adds the config options to the rule descriptions in the README, so that new users don't have to piece together the documentation from several places while getting started.