### PR TITLE
Remove extra space in `--exclude` config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ The config file format is designed to be human editable. You may include blank l
 --indent tabs # tabs FTW!
 
 # file options
--- exclude Pods
+--exclude Pods
 
 # rules
 --disable elseOnSameLine,semicolons


### PR DESCRIPTION
Just noticed a minor typo when setting up my own config, thanks 😄 