### PR TITLE
Extend `--wrapCollections beforeFirst` to nested collections

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -381,4 +381,31 @@ public class Formatter: NSObject {
         }
         return 0 // Inserted 0 tokens
     }
+
+    /// Returns whether the scope or subscopes contain a token that matches
+    public func subScopeContains(after index: Int, where matches: (Token) -> Bool) -> Bool {
+        guard index < tokens.count else { return false }
+        var scopeStack: [Token] = []
+        for i in index + 1 ..< tokens.count {
+            let token = tokens[i]
+            if let scope = scopeStack.last, token.isEndOfScope(scope) {
+                scopeStack.removeLast()
+                if case .linebreak = token, scopeStack.count == 0, matches(token) {
+                    return true
+                }
+            } else if matches(token) {
+                return true
+            } else if token.isEndOfScope {
+                return false
+            } else if case .startOfScope = token {
+                scopeStack.append(token)
+            }
+        }
+        return false
+    }
+
+    /// Returns whether the scope or subscopes contain a token of the specified type
+    public func subScopeContains(_ type: TokenType, after index: Int) -> Bool {
+        return subScopeContains(after: index, where: { $0.is(type) })
+    }
 }

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -382,30 +382,14 @@ public class Formatter: NSObject {
         return 0 // Inserted 0 tokens
     }
 
-    /// Returns whether the scope or subscopes contain a token that matches
-    public func subScopeContains(after index: Int, where matches: (Token) -> Bool) -> Bool {
-        guard index < tokens.count else { return false }
-        var scopeStack: [Token] = []
-        for i in index + 1 ..< tokens.count {
-            let token = tokens[i]
-            if let scope = scopeStack.last, token.isEndOfScope(scope) {
-                scopeStack.removeLast()
-                if case .linebreak = token, scopeStack.count == 0, matches(token) {
-                    return true
-                }
-            } else if matches(token) {
+    /// Returns whether the range contains a linebreak
+    public func hasLinebreakBetween(start: Int, end: Int) -> Bool {
+        guard start < tokens.count && end < tokens.count else { return false }
+        for i in start + 1 ..< end {
+            if tokens[i].isLinebreak {
                 return true
-            } else if token.isEndOfScope {
-                return false
-            } else if case .startOfScope = token {
-                scopeStack.append(token)
             }
         }
         return false
-    }
-
-    /// Returns whether the scope or subscopes contain a token of the specified type
-    public func subScopeContains(_ type: TokenType, after index: Int) -> Bool {
-        return subScopeContains(after: index, where: { $0.is(type) })
     }
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2932,7 +2932,7 @@ extension FormatRules {
             }
 
             guard let firstLinebreakIndex = formatter.index(of: .linebreak, after: i), firstLinebreakIndex < closingBraceIndex else {
-                if mode == .beforeFirst && formatter.subScopeContains(.linebreak, after: i) {
+                if mode == .beforeFirst && formatter.hasLinebreakBetween(start: i, end: closingBraceIndex) {
                     wrapArgumentsBeforeFirst(startOfScope: i,
                                              closingBraceIndex: closingBraceIndex,
                                              allowGrouping: true,

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2925,12 +2925,22 @@ extension FormatRules {
             default:
                 return
             }
+
             guard mode != .disabled,
-                let firstLinebreakIndex = formatter.index(of: .linebreak, after: i),
-                let closingBraceIndex = formatter.endOfScope(at: i),
-                firstLinebreakIndex < closingBraceIndex else {
+                let closingBraceIndex = formatter.endOfScope(at: i) else {
                 return
             }
+
+            guard let firstLinebreakIndex = formatter.index(of: .linebreak, after: i), firstLinebreakIndex < closingBraceIndex else {
+                if mode == .beforeFirst && formatter.subScopeContains(.linebreak, after: i) {
+                    wrapArgumentsBeforeFirst(startOfScope: i,
+                                             closingBraceIndex: closingBraceIndex,
+                                             allowGrouping: true,
+                                             closingBraceOnSameLine: closingBraceOnSameLine)
+                }
+                return
+            }
+
             let firstIdentifierIndex = formatter.index(of:
                 .nonSpaceOrCommentOrLinebreak, after: i) ?? firstLinebreakIndex
             switch mode {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6231,6 +6231,24 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
+    func testTrailingCommasAddedToWrappedNestedDictionary() {
+        let input = "[foo: [bar: baz,\n    bar2: baz2]]"
+        let output = "[\n    foo: [\n        bar: baz,\n        bar2: baz2,\n    ],\n]"
+        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let rules = [FormatRules.wrapArguments, FormatRules.trailingCommas]
+        XCTAssertEqual(try format(input, rules: rules, options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testTrailingCommasAddedToWrappedNestedDictionaries() {
+        let input = "[foo: [bar: baz,\n    bar2: baz2],\n    foo2: [bar: baz,\n    bar2: baz2]]"
+        let output = "[\n    foo: [\n        bar: baz,\n        bar2: baz2,\n    ],\n    foo2: [\n        bar: baz,\n        bar2: baz2,\n    ],\n]"
+        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let rules = [FormatRules.wrapArguments, FormatRules.trailingCommas]
+        XCTAssertEqual(try format(input, rules: rules, options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
     func testSpaceAroundEnumValuesInArray() {
         let input = "[\n    .foo,\n    .bar, .baz,\n]"
         let output = "[\n    .foo,\n    .bar, .baz,\n]"

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6159,6 +6159,24 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
+    func testNoBeforeFirstPreservedAndTrailingCommaIgnoredInMultilineNestedDictionary() {
+        let input = "[foo: [bar: baz,\n    bar2: baz2]]"
+        let output = "[foo: [bar: baz,\n       bar2: baz2]]"
+        let options = FormatOptions(trailingCommas: true, wrapCollections: .preserve)
+        let rules = [FormatRules.wrapArguments, FormatRules.trailingCommas]
+        XCTAssertEqual(try format(input, rules: rules, options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testBeforeFirstPreservedAndTrailingCommaAddedInSingleLineNestedDictionary() {
+        let input = "[\n    foo: [bar: baz, bar2: baz2]]"
+        let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
+        let options = FormatOptions(trailingCommas: true, wrapCollections: .preserve)
+        let rules = [FormatRules.wrapArguments, FormatRules.trailingCommas]
+        XCTAssertEqual(try format(input, rules: rules, options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
     // beforeFirst
 
     func testWrapAfterFirstConvertedToWrapBefore() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6240,6 +6240,15 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }
 
+    func testTrailingCommasAddedToSingleLineNestedDictionary() {
+        let input = "[\n    foo: [bar: baz, bar2: baz2]]"
+        let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
+        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let rules = [FormatRules.wrapArguments, FormatRules.trailingCommas]
+        XCTAssertEqual(try format(input, rules: rules, options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
     func testTrailingCommasAddedToWrappedNestedDictionaries() {
         let input = "[foo: [bar: baz,\n    bar2: baz2],\n    foo2: [bar: baz,\n    bar2: baz2]]"
         let output = "[\n    foo: [\n        bar: baz,\n        bar2: baz2,\n    ],\n    foo2: [\n        bar: baz,\n        bar2: baz2,\n    ],\n]"


### PR DESCRIPTION
I've been integrating SwiftFormat into my existing codebase (which already uses SwiftLint) and I've found that the `--wrapcollections beforefirst` rule doesn't behave exactly how I'd expect it to. I've never written or worked on a parser but have tried to isolate my changes to this very specific case.

At a high level: SwiftFormat currently only considers whether the current scope contains new lines when applying any of the `wrapcollections` rules and ignores any new lines in nested scopes (by design). This proposal modifies the `beforeFirst` rule specifically so that it is applied to a collection if any of the sub-scopes contain new lines. The examples below outline the scope of what I intend my changes to achieve.

I'd appreciate any feedback on a) the basic premise of the proposal, b) the changes themselves and c) the format of this PR proposal.

----

Currently, applying SwiftFormat with the setting `--wrapcollections beforefirst` (with the default enforcement of trailing commas) on the following code:

a)
``` swift
let validReponse: [String: [String: Any]] = ["user": [
    "username": "test_username",
    "is_premium": true
]]
```

Will yield this:

b)
``` swift
let validReponse: [String: [String: Any]] = ["user": [
    "username": "test_username",
    "is_premium": true,
]]
```

Whilst applying it to the following code:

c)
``` swift
let validReponse: [String: [String: Any]] = [
    "user": [
    "username": "test_username",
    "is_premium": true
]]
```

Will yield this:

d)
``` swift
let validReponse: [String: [String: Any]] = [
    "user": [
        "username": "test_username",
        "is_premium": true,
    ],
]
```

I consider the latter to feel more consistent in both cases (I realise this is a value judgement), in that once any part of the collection declaration spans multiple lines then the rules should be applied consistently throughout the nested collections. That is to say, with either a) or c) as input, the output would be d).

Furthermore, this would align with the expectations of SwiftLint with the somewhat equivalent settings:

``` yaml
trailing_comma:
  mandatory_comma: true
```