### PR TITLE
Don't apply strongOutlets to delegates

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3225,9 +3225,17 @@ extension FormatRules {
         }
     }
 
-    /// Strip unnecessary `weak` from @IBOutlet properties
+    /// Strip unnecessary `weak` from @IBOutlet properties (except delegates)
     @objc public class func strongOutlets(_ formatter: Formatter) {
         formatter.forEach(.keyword("@IBOutlet")) { i, _ in
+            let delegateIdentifierIndex = formatter.index(after: i, where: { token in
+                if case let .identifier(val) = token {
+                    return val.lowercased().contains("delegate")
+                }
+                return false
+            })
+            guard delegateIdentifierIndex == nil else { return }
+
             guard let varIndex = formatter.index(of: .keyword("var"), after: i) else { return }
             for index in i ..< varIndex where formatter.tokens[index] == .identifier("weak") {
                 if formatter.tokens[index + 1].isSpace {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3225,12 +3225,13 @@ extension FormatRules {
         }
     }
 
-    /// Strip unnecessary `weak` from @IBOutlet properties (except delegates)
+    /// Strip unnecessary `weak` from @IBOutlet properties (except delegates and datasources)
     @objc public class func strongOutlets(_ formatter: Formatter) {
         formatter.forEach(.keyword("@IBOutlet")) { i, _ in
             let delegateIdentifierIndex = formatter.index(after: i, where: { token in
                 if case let .identifier(val) = token {
-                    return val.lowercased().contains("delegate")
+                    let lowercased = val.lowercased()
+                    return lowercased.hasSuffix("delegate") || lowercased.hasSuffix("datasource")
                 }
                 return false
             })

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6841,6 +6841,20 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
     }
 
+    func testNoRemoveWeakFromDelegateOutlet() {
+        let input = "@IBOutlet weak var delegate: UITableViewDelegate?"
+        let output = "@IBOutlet weak var delegate: UITableViewDelegate?"
+        XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testRemoveWeakFromOutletAfterDelegateOutlet() {
+        let input = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet weak var label1: UILabel!"
+        let output = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet var label1: UILabel!"
+        XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
     // MARK: emptyBraces
 
     func testLinebreaksRemovedInsideBraces() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6848,9 +6848,23 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
+    func testNoRemoveWeakFromDataSourceOutlet() {
+        let input = "@IBOutlet weak var dataSource: UITableViewDataSource?"
+        let output = "@IBOutlet weak var dataSource: UITableViewDataSource?"
+        XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
     func testRemoveWeakFromOutletAfterDelegateOutlet() {
         let input = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet weak var label1: UILabel!"
         let output = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet var label1: UILabel!"
+        XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
+
+    func testRemoveWeakFromOutletAfterDataSourceOutlet() {
+        let input = "@IBOutlet weak var dataSource: UITableViewDataSource?\n@IBOutlet weak var label1: UILabel!"
+        let output = "@IBOutlet weak var dataSource: UITableViewDataSource?\n@IBOutlet var label1: UILabel!"
         XCTAssertEqual(try format(input, rules: [FormatRules.strongOutlets]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }


### PR DESCRIPTION
Whilst Apple does recommend strong IBOutlets, this rule can't apply to delegates. This proposal disables the rules if any of the identifiers in the scope contain the string `delegate`.

I realise that this does rely on Cocoa conventions, that delegates as IBOutlets might be an uncommon pattern, and it can be worked around using `// swiftformat:disable:next strongOutlets`, but I think this change is still worthwhile to avoid potential unexpected retain cycles after applying SwiftFormat.

Looking forward to hearing your thoughts on this 😄 