### PR TITLE
Remove all in UserDefaults associated with the group on reset to default

### DIFF
--- a/EditorExtension/Application/Source/AppDelegate.swift
+++ b/EditorExtension/Application/Source/AppDelegate.swift
@@ -74,6 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc
     @IBAction func resetToDefault(_: NSMenuItem) {
+        UserDefaults(suiteName: UserDefaults.groupDomain)?.clearAll(in: UserDefaults.groupDomain)
         RulesStore().resetRulesToDefaults()
         OptionsStore().resetOptionsToDefaults()
         NotificationCenter.default.post(name: .applicationDidLoadNewConfiguration, object: nil)


### PR DESCRIPTION
Hi @nicklockwood ,

I've encounter a problem with saved options due to the fact that I've originally develop the format saved into UserDefault to use Options ID instead of argumentName as key.

Because of that my store was not clean and options were always change for the default and the keys were never properly updated.

It got me thinking that if a change of key would occur in the future there would be no way for the end user to reset his store to a clean state, as a way to restore proper behaviour.

I'm not sure this pull request represent the best way to deal with it.
I would appreciate your opinion on the subject.