### PR TITLE
Add option to group @testable imports at the top or bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ return;
 goto(fail)
 ```
 
-***sortedImports*** - rearranges import statements so that they are sorted:
+***sortedImports*** - rearranges import statements so that they are sorted. Use the `--importgrouping` option to configure how to group `@testable import`s (alphabetically (default), testable-top or testable-bottom).
 
 ```diff
 - import Foo

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -147,7 +147,7 @@ func printHelp(as type: CLI.OutputType) {
     --ranges           spacing for ranges. "spaced" (default) or "nospace"
     --semicolons       allow semicolons. "never" or "inline" (default)
     --self             use self for member variables. "remove" (default) or "insert"
-    --importgrouping   "testable-top", "testable-bottom" or "alphabetically" (default)
+    --importgrouping   "testable-top", "testable-bottom" or "alphabetized" (default)
     --stripunusedargs  "closure-only", "unnamed-only" or "always" (default)
     --trimwhitespace   trim trailing space. "always" (default) or "nonblank-lines"
     --wraparguments    wrap function args. "beforefirst", "afterfirst", "preserve"

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -147,6 +147,7 @@ func printHelp(as type: CLI.OutputType) {
     --ranges           spacing for ranges. "spaced" (default) or "nospace"
     --semicolons       allow semicolons. "never" or "inline" (default)
     --self             use self for member variables. "remove" (default) or "insert"
+    --importgrouping   "testable-top", "testable-bottom" or "alphabetically" (default)
     --stripunusedargs  "closure-only", "unnamed-only" or "always" (default)
     --trimwhitespace   trim trailing space. "always" (default) or "nonblank-lines"
     --wraparguments    wrap function args. "beforefirst", "afterfirst", "preserve"

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -165,7 +165,7 @@ public enum Grouping: Equatable, RawRepresentable, CustomStringConvertible {
 }
 
 /// Grouping for sorting imports
-public enum ImportGrouping: String, Equatable {
+public enum ImportGrouping: String {
     case alphabetically
     case testableTop
     case testableBottom

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -166,7 +166,7 @@ public enum Grouping: Equatable, RawRepresentable, CustomStringConvertible {
 
 /// Grouping for sorting imports
 public enum ImportGrouping: String {
-    case alphabetically
+    case alphabetized
     case testableTop
     case testableBottom
 }
@@ -246,7 +246,7 @@ public struct FormatOptions: CustomStringConvertible {
                 experimentalRules: Bool = false,
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
-                importGrouping: ImportGrouping = .alphabetically) {
+                importGrouping: ImportGrouping = .alphabetized) {
         self.indent = indent
         self.linebreak = linebreak
         self.allowInlineSemicolons = allowInlineSemicolons

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -164,6 +164,13 @@ public enum Grouping: Equatable, RawRepresentable, CustomStringConvertible {
     }
 }
 
+/// Grouping for sorting imports
+public enum ImportGrouping: String, Equatable {
+    case alphabetically
+    case testableTop
+    case testableBottom
+}
+
 /// Configuration options for formatting. These aren't actually used by the
 /// Formatter class itself, but it makes them available to the format rules.
 public struct FormatOptions: CustomStringConvertible {
@@ -199,7 +206,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var removeSelf: Bool
     public var experimentalRules: Bool
     public var fragment: Bool
-    public var groupTestableImport: Bool
+    public var importGrouping: ImportGrouping
 
     // Doesn't really belong here, but hard to put elsewhere
     public var ignoreConflictMarkers: Bool
@@ -239,7 +246,7 @@ public struct FormatOptions: CustomStringConvertible {
                 experimentalRules: Bool = false,
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
-                groupTestableImport: Bool = false) {
+                importGrouping: ImportGrouping = .alphabetically) {
         self.indent = indent
         self.linebreak = linebreak
         self.allowInlineSemicolons = allowInlineSemicolons
@@ -273,7 +280,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.experimentalRules = experimentalRules
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers
-        self.groupTestableImport = groupTestableImport
+        self.importGrouping = importGrouping
     }
 
     public var allOptions: [String: Any] {

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -199,6 +199,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var removeSelf: Bool
     public var experimentalRules: Bool
     public var fragment: Bool
+    public var groupTestableImport: Bool
 
     // Doesn't really belong here, but hard to put elsewhere
     public var ignoreConflictMarkers: Bool
@@ -237,7 +238,8 @@ public struct FormatOptions: CustomStringConvertible {
                 removeSelf: Bool = true,
                 experimentalRules: Bool = false,
                 fragment: Bool = false,
-                ignoreConflictMarkers: Bool = false) {
+                ignoreConflictMarkers: Bool = false,
+                groupTestableImport: Bool = false) {
         self.indent = indent
         self.linebreak = linebreak
         self.allowInlineSemicolons = allowInlineSemicolons
@@ -271,6 +273,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.experimentalRules = experimentalRules
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers
+        self.groupTestableImport = groupTestableImport
     }
 
     public var allOptions: [String: Any] {

--- a/Sources/OptionsDescriptor.swift
+++ b/Sources/OptionsDescriptor.swift
@@ -199,6 +199,7 @@ extension FormatOptions.Descriptor {
         stripUnusedArguments,
         elsePosition,
         removeSelf,
+        importGrouping,
 
         // Deprecated
         insertBlankLines,
@@ -449,6 +450,14 @@ extension FormatOptions.Descriptor {
         keyPath: \.removeSelf,
         trueValues: ["remove"],
         falseValues: ["insert"]
+    )
+
+    static let importGrouping = FormatOptions.Descriptor(
+        argumentName: "importgrouping",
+        propertyName: "importGrouping",
+        displayName: "Import Grouping",
+        keyPath: \FormatOptions.importGrouping,
+        options: ["alphabetically", "testable-top", "testable-bottom"]
     )
 
     // MARK: - Internal

--- a/Sources/OptionsDescriptor.swift
+++ b/Sources/OptionsDescriptor.swift
@@ -457,7 +457,7 @@ extension FormatOptions.Descriptor {
         propertyName: "importGrouping",
         displayName: "Import Grouping",
         keyPath: \FormatOptions.importGrouping,
-        options: ["alphabetically", "testable-top", "testable-bottom"]
+        options: ["alphabetized", "testable-top", "testable-bottom"]
     )
 
     // MARK: - Internal

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3285,9 +3285,10 @@ private extension FormatRules {
     }()
 
     // Shared import rules implementation
-    static func parseImports(_ formatter: Formatter) -> [[(String, Range<Int>)]] {
-        var importStack = [[(String, Range<Int>)]]()
-        var importRanges = [(String, Range<Int>)]()
+    typealias ImportRange = (String, Range<Int>)
+    static func parseImports(_ formatter: Formatter) -> [[ImportRange]] {
+        var importStack = [[ImportRange]]()
+        var importRanges = [ImportRange]()
         formatter.forEach(.keyword("import")) { i, _ in
 
             func pushStack() {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3211,7 +3211,7 @@ extension FormatRules {
     /// Sort import statements
     @objc public class func sortedImports(_ formatter: Formatter) {
         func sortRanges(_ ranges: [ImportRange]) -> [ImportRange] {
-            if case .alphabetically = formatter.options.importGrouping {
+            if case .alphabetized = formatter.options.importGrouping {
                 return ranges.sorted { $0.0 < $1.0 }
             }
 

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -150,7 +150,7 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testCommandLineArgumentsAreCorrect() {
-        let output = ["allman": "false", "wraparguments": "preserve", "stripunusedargs": "always", "self": "remove", "header": "ignore", "fractiongrouping": "disabled", "binarygrouping": "4,8", "octalgrouping": "4,8", "indentcase": "false", "trimwhitespace": "always", "decimalgrouping": "3,6", "exponentgrouping": "disabled", "patternlet": "hoist", "commas": "always", "wrapcollections": "preserve", "semicolons": "inline", "indent": "4", "exponentcase": "lowercase", "operatorfunc": "spaced", "symlinks": "ignore", "elseposition": "same-line", "empty": "void", "ranges": "spaced", "hexliteralcase": "uppercase", "linebreaks": "lf", "hexgrouping": "4,8", "comments": "indent", "ifdef": "indent", "closingparen": "balanced"]
+        let output = ["allman": "false", "wraparguments": "preserve", "stripunusedargs": "always", "self": "remove", "header": "ignore", "importgrouping": "alphabetically", "fractiongrouping": "disabled", "binarygrouping": "4,8", "octalgrouping": "4,8", "indentcase": "false", "trimwhitespace": "always", "decimalgrouping": "3,6", "exponentgrouping": "disabled", "patternlet": "hoist", "commas": "always", "wrapcollections": "preserve", "semicolons": "inline", "indent": "4", "exponentcase": "lowercase", "operatorfunc": "spaced", "symlinks": "ignore", "elseposition": "same-line", "empty": "void", "ranges": "spaced", "hexliteralcase": "uppercase", "linebreaks": "lf", "hexgrouping": "4,8", "comments": "indent", "ifdef": "indent", "closingparen": "balanced"]
         XCTAssertEqual(argumentsFor(.default), output)
     }
 

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -150,7 +150,7 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testCommandLineArgumentsAreCorrect() {
-        let output = ["allman": "false", "wraparguments": "preserve", "stripunusedargs": "always", "self": "remove", "header": "ignore", "importgrouping": "alphabetically", "fractiongrouping": "disabled", "binarygrouping": "4,8", "octalgrouping": "4,8", "indentcase": "false", "trimwhitespace": "always", "decimalgrouping": "3,6", "exponentgrouping": "disabled", "patternlet": "hoist", "commas": "always", "wrapcollections": "preserve", "semicolons": "inline", "indent": "4", "exponentcase": "lowercase", "operatorfunc": "spaced", "symlinks": "ignore", "elseposition": "same-line", "empty": "void", "ranges": "spaced", "hexliteralcase": "uppercase", "linebreaks": "lf", "hexgrouping": "4,8", "comments": "indent", "ifdef": "indent", "closingparen": "balanced"]
+        let output = ["allman": "false", "wraparguments": "preserve", "stripunusedargs": "always", "self": "remove", "header": "ignore", "importgrouping": "alphabetized", "fractiongrouping": "disabled", "binarygrouping": "4,8", "octalgrouping": "4,8", "indentcase": "false", "trimwhitespace": "always", "decimalgrouping": "3,6", "exponentgrouping": "disabled", "patternlet": "hoist", "commas": "always", "wrapcollections": "preserve", "semicolons": "inline", "indent": "4", "exponentcase": "lowercase", "operatorfunc": "spaced", "symlinks": "ignore", "elseposition": "same-line", "empty": "void", "ranges": "spaced", "hexliteralcase": "uppercase", "linebreaks": "lf", "hexgrouping": "4,8", "comments": "indent", "ifdef": "indent", "closingparen": "balanced"]
         XCTAssertEqual(argumentsFor(.default), output)
     }
 

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6859,6 +6859,14 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
+    func testTestableImportsWithGroup() {
+        let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
+        let output = "import Foo\n@testable import Foo\n@testable import UIKit"
+        let options = FormatOptions(groupTestableImport: true)
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
     func testCaseInsensitiveSortedImports() {
         let input = "import Zlib\nimport lib"
         let output = "import lib\nimport Zlib"

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6861,7 +6861,7 @@ class RulesTests: XCTestCase {
 
     func testTestableImportsWithGroup() {
         let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
-        let output = "import Foo\n@testable import Foo\n@testable import UIKit"
+        let output = "import Foo\n@testable import Bar\n@testable import UIKit"
         let options = FormatOptions(groupTestableImport: true)
         XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6859,10 +6859,18 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
     }
 
-    func testTestableImportsWithGroup() {
+    func testTestableImportsWithGroupingTestableBottom() {
         let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
         let output = "import Foo\n@testable import Bar\n@testable import UIKit"
-        let options = FormatOptions(groupTestableImport: true)
+        let options = FormatOptions(importGrouping: .testableBottom)
+        XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
+    }
+
+    func testTestableImportsWithGroupingTestableTop() {
+        let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
+        let output = "@testable import Bar\n@testable import UIKit\nimport Foo"
+        let options = FormatOptions(importGrouping: .testableTop)
         XCTAssertEqual(try format(input, rules: [FormatRules.sortedImports], options: options), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.default, options: options), output + "\n")
     }


### PR DESCRIPTION
This PR adds a config option to group `@testable import`s at the top or bottom when sorting them.

This way instead of:

```swift
import Bar
@testable import Foo
import UIKit
```

we could get:

```swift
import Bar
import UIKit
@testable import Foo
```

or:

```swift
@testable import Foo
import Bar
import UIKit
```

This is a style I've seen in some projects, putting the `@testable` at the bottom so it's easier to know what module is being tested.

_This is my first PR to `SwiftFormat` so I'm more than happy to revisit anything._