### PR TITLE
Renames the app to "swiftformat" when coming in via SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftFormat",
     products: [
-        .executable(name: "swiftFormat", targets: ["CommandLineTool"]),
+        .executable(name: "swiftformat", targets: ["CommandLineTool"]),
         .library(
             name: "SwiftFormat",
             targets: ["SwiftFormat"]


### PR DESCRIPTION
I have a PR adding support for SwiftFormat being installed locally to vscode ( https://github.com/vknabel/vscode-swiftformat/pull/2 ) and realized that this is the only instance when the capitalization is different and so I _assume_ that this is a bug?

This fixes the command to be consistent with all the rest of the docs 👍 