### PR TITLE
Rename the test target to not clash with other 'test' targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,6 @@ let package = Package(
     targets: [
         .target(name: "CommandLineTool", dependencies: ["SwiftFormat"], path: "CommandLineTool"),
         .target(name: "SwiftFormat", path: "Sources"),
-        .testTarget(name: "Tests", dependencies: ["SwiftFormat"], path: "Tests"),
+        .testTarget(name: "SwiftFormatTests", dependencies: ["SwiftFormat"], path: "Tests"),
     ]
 )

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -106,7 +106,6 @@ class PerformanceTests: XCTestCase {
             hexGrouping: .group(1, 1),
             hoistPatternLet: false,
             elseOnNextLine: true,
-            removeSelf: false,
             experimentalRules: true
         )
         measure {
@@ -152,7 +151,7 @@ class PerformanceTests: XCTestCase {
     func testWorstCaseRedundantSelf() {
         let files = PerformanceTests.files
         let tokens = files.map { tokenize($0) }
-        let options = FormatOptions(removeSelf: false)
+        let options = FormatOptions()
         measure {
             _ = tokens.map { try! format($0, rules: [FormatRules.redundantSelf], options: options) }
         }

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -106,6 +106,7 @@ class PerformanceTests: XCTestCase {
             hexGrouping: .group(1, 1),
             hoistPatternLet: false,
             elseOnNextLine: true,
+            explicitSelf: .insert,
             experimentalRules: true
         )
         measure {
@@ -151,7 +152,7 @@ class PerformanceTests: XCTestCase {
     func testWorstCaseRedundantSelf() {
         let files = PerformanceTests.files
         let tokens = files.map { tokenize($0) }
-        let options = FormatOptions()
+        let options = FormatOptions(explicitSelf: .insert)
         measure {
             _ = tokens.map { try! format($0, rules: [FormatRules.redundantSelf], options: options) }
         }


### PR DESCRIPTION
Danger Swift won't run tests on Linux because this lib and CryptoSwift both happen to use the word "Tests" for your tests, turns out that's in a global namespace in SwiftPM. Who knew? 

See: https://travis-ci.org/danger/swift/jobs/468922700#L524 ( from https://github.com/danger/swift/pull/145 )

So, this PR fixes that, and then also makes tests run via `swift test`, before:

<img width="1393" alt="screen shot 2018-12-17 at 9 45 51 am" src="https://user-images.githubusercontent.com/49038/50079582-e2737e80-01e1-11e9-8ff7-c699619c04a0.png">

After:

> Executed 1362 tests, with 1 failure (0 unexpected) in 460.674 (460.940) seconds

and if you're interested

> /Users/ortatherox/dev/projects/oss/swift/libs/SwiftFormat/Tests/SwiftFormatTests.swift:263: error: -[SwiftFormatTests.SwiftFormatTests testDoubleWildcardMatchesDirectorySlash] : XCTAssertEqual failed: ("2") is not equal to ("1") -

Looks unrelated to my change though, so I'm not gonna go after it. 