### PR TITLE
Fix `testDoubleWildcardMatchesDirectorySlash()`

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3561,7 +3561,7 @@ public struct _FormatRules {
     }
 
     public let typeMarks = FormatRule { formatter in
-        // TODO
+        // TODO:
         print(formatter)
     }
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3559,6 +3559,11 @@ public struct _FormatRules {
             formatter.replaceToken(at: i, with: .identifier("self"))
         }
     }
+
+    public let typeMarks = FormatRule { formatter in
+        // TODO
+        print(formatter)
+    }
 }
 
 // MARK: shared helper methods

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3559,11 +3559,6 @@ public struct _FormatRules {
             formatter.replaceToken(at: i, with: .identifier("self"))
         }
     }
-
-    public let typeMarks = FormatRule { formatter in
-        // TODO:
-        print(formatter)
-    }
 }
 
 // MARK: shared helper methods

--- a/Tests/GlobsTests.swift
+++ b/Tests/GlobsTests.swift
@@ -114,7 +114,7 @@ class GlobsTests: XCTestCase {
     func testDoubleWildcardMatchesDirectorySlash() {
         let path = "**/SwiftFormatTests.swift"
         let directory = URL(fileURLWithPath: #file)
-            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
         XCTAssertEqual(matchGlobs(expandGlobs(path, in: directory.path), in: directory.path).count, 1)
     }
 


### PR DESCRIPTION
Fixes https://github.com/nicklockwood/SwiftFormat/issues/350 using @nicklockwood 's suggestion.

![screen shot 2019-02-02 at 3 11 32 pm](https://user-images.githubusercontent.com/1791049/52170362-8a46fc00-26fd-11e9-9300-fdd5bf55a05b.png)
