### PR TITLE
Associate . swiftformat file format with the SwiftFormat for Xcode

### DIFF
--- a/EditorExtension/Application/Info.plist
+++ b/EditorExtension/Application/Info.plist
@@ -4,6 +4,21 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>swiftformat</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>swiftformat</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>

--- a/EditorExtension/Application/Source/AppDelegate.swift
+++ b/EditorExtension/Application/Source/AppDelegate.swift
@@ -69,7 +69,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_: NSApplication, openFile file: String) -> Bool {
-        return loadConfiguration(URL(fileURLWithPath: file))
+        let url = URL(fileURLWithPath: file)
+        if loadConfiguration(url) {
+            NSDocumentController.shared.noteNewRecentDocumentURL(url)
+            NotificationCenter.default.post(name: .applicationDidLoadNewConfiguration, object: nil)
+            return true
+        }
+        return false
     }
 
     @IBAction func resetToDefault(_: NSMenuItem) {

--- a/EditorExtension/Application/Source/OptionsViewController.swift
+++ b/EditorExtension/Application/Source/OptionsViewController.swift
@@ -33,7 +33,7 @@ import Cocoa
 
 extension FormatOptions.Descriptor {
     var toolTip: String {
-        return stripMarkdown(from: help) + "."
+        return stripMarkdown(help) + "."
     }
 }
 

--- a/EditorExtension/Application/Source/RulesViewController.swift
+++ b/EditorExtension/Application/Source/RulesViewController.swift
@@ -33,7 +33,7 @@ import Cocoa
 
 extension FormatRule {
     var toolTip: String {
-        return stripMarkdown(from: help) + "."
+        return stripMarkdown(help) + "."
     }
 }
 


### PR DESCRIPTION
Hi @nicklockwood ,

This pull request is to be able to:

1. Drag and drop a . swiftformat file on the app icon to have it load the configuration into the application
2. Double click on a . swiftformat file an have it open the application and load the configuration
3. Be able to use the "open" command in the terminal with a config file as parameter and have it being loaded in the application
4. Fix the Open Recent not updating the UI
5. Fix not compiling develop branch

We were mostly interested in point 3, because we are scripting our "new guy" computer setup and we wanted to be able to add Swift Format to the computer and have it load our default config file for the Xcode extension.