### PR TITLE
don't add self in front of parameter names

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2527,8 +2527,10 @@ public struct _FormatRules {
                             lastToken.isOperator(".") {
                             break
                         }
-                        formatter.insertTokens([.identifier("self"), .operator(".", .infix)], at: index)
-                        index += 2
+                        if formatter.nextToken(after: index) != .delimiter(":") {
+                            formatter.insertTokens([.identifier("self"), .operator(".", .infix)], at: index)
+                            index += 2
+                        }
                     }
                 case .endOfScope("case"), .endOfScope("default"):
                     return

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6552,6 +6552,32 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.all, options: options), output + "\n")
     }
 
+    func testSelfNotInsertedInParameterNames() {
+        let input = """
+        func foo(a: String) {}
+        class Bar {
+            let a: String
+                    
+            func hoge() {
+                foo(a:a)
+            }
+        }
+        """
+        let output = """
+        func foo(a: String) {}
+        class Bar {
+            let a: String
+                    
+            func hoge() {
+                foo(a:self.a)
+            }
+        }
+        """
+        let options = FormatOptions(explicitSelf: .insert)
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantSelf], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all, options: options), output + "\n")
+    }
+
     // explicitSelf = .initOnly
 
     func testPreserveSelfInsideClassInit() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6554,22 +6554,22 @@ class RulesTests: XCTestCase {
 
     func testSelfNotInsertedInParameterNames() {
         let input = """
-        func foo(a: String) {}
+        func foo(a _: String) {}
         class Bar {
             let a: String
-                    
+
             func hoge() {
-                foo(a:a)
+                foo(a: a)
             }
         }
         """
         let output = """
-        func foo(a: String) {}
+        func foo(a _: String) {}
         class Bar {
             let a: String
-                    
+
             func hoge() {
-                foo(a:self.a)
+                foo(a: self.a)
             }
         }
         """


### PR DESCRIPTION
This pull request adds a test for #417 

~I probably won't be able to fix this myself, but thought at least a test for reproducing it might be useful.~ I came up with a very simplistic fix. I don't claim to have a deep understanding of the codebase though so this might not be enough.