### PR TITLE
added test for self-insert in case let

### DIFF
--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6576,6 +6576,32 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.all, options: options), output + "\n")
     }
 
+    func testSelfNotInsertedInCaseLet() {
+        let input = """
+        class Foo {
+            let a: String?
+
+            func bar() {
+                if case let .some(a) = self.a {
+                }
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            let a: String?
+
+            func bar() {
+                if case let .some(a) = self.a {
+                }
+            }
+        }
+        """
+        let options = FormatOptions(explicitSelf: .insert)
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantSelf], options: options), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all, options: options), output + "\n")
+    }
+
     // explicitSelf = .initOnly
 
     func testPreserveSelfInsideClassInit() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -6580,20 +6580,20 @@ class RulesTests: XCTestCase {
         let input = """
         class Foo {
             let a: String?
+            let b: String
 
             func bar() {
-                if case let .some(a) = self.a {
-                }
+                if case let .some(a) = self.a, case var .some(b) = self.b {}
             }
         }
         """
         let output = """
         class Foo {
             let a: String?
+            let b: String
 
             func bar() {
-                if case let .some(a) = self.a {
-                }
+                if case let .some(a) = self.a, case var .some(b) = self.b {}
             }
         }
         """


### PR DESCRIPTION
Similar to #418, `if case let .some(propertyOfClass) = ...` inserts a `self.` in front of `propertyOfClass` if it is indeed a property of the class. I'll try to find a fix for this, but this looks harder than #418