### PR TITLE
Fix extra newline when printing content to stdout

### DIFF
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -69,7 +69,7 @@ CLI.print = { message, type in
     case .warning:
         print(stderrIsTTY ? message.inYellow : message, to: &stderr)
     case .content:
-        print(message)
+        print(message, terminator: "")
     }
 }
 


### PR DESCRIPTION
I didn't spot a good place for adding a test, since this is sort of the glue code for main.swift. If you point me to it I can add a test case, too.

Fixes nicklockwood/SwiftFormat#429