### PR TITLE
Fixes enhanced `fileHeader` rule

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -41,7 +41,11 @@ extension Options {
     mutating func addArguments(_ args: [String: String], in directory: String) throws {
         let oldArguments = argumentsFor(self)
         let newArguments = try mergeArguments(args, into: oldArguments)
-        self = try Options(newArguments, in: directory)
+        var newOptions = try Options(newArguments, in: directory)
+        if let fileInfo = self.formatOptions?.fileInfo {
+            newOptions.formatOptions?.fileInfo = fileInfo
+        }
+        self = newOptions
     }
 }
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -179,6 +179,11 @@ public struct FileInfo: Equatable {
         self.fileName = fileName
         self.creationDate = creationDate
     }
+
+    public static func == (lhs: FileInfo, rhs: FileInfo) -> Bool {
+        return lhs.fileName == rhs.fileName &&
+            lhs.creationDate == rhs.creationDate
+    }
 }
 
 /// Grouping for numeric literals

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -171,7 +171,7 @@ public enum HeaderStrippingMode: Equatable, RawRepresentable, ExpressibleByStrin
 }
 
 /// File info, used for constructing header comments
-public struct FileInfo {
+public struct FileInfo: Equatable {
     var fileName: String?
     var creationDate: Date?
 

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -515,6 +515,17 @@ class ArgumentsTests: XCTestCase {
         XCTAssertTrue(formatOptions.fragment)
     }
 
+    func testAddArgumentsDoesntBreakFileInfo() throws {
+        let fileInfo = FileInfo(fileName: "Foo.swift", creationDate: Date())
+        var options = Options(formatOptions: FormatOptions(fileInfo: fileInfo))
+        try options.addArguments(["indent": "2"], in: "")
+        guard let formatOptions = options.formatOptions else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(formatOptions.fileInfo, fileInfo)
+    }
+
     // MARK: Options parsing
 
     func testParseEmptyOptions() throws {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 extension ArgumentsTests {
     static let __allTests = [
+        ("testAddArgumentsDoesntBreakFileInfo", testAddArgumentsDoesntBreakFileInfo),
         ("testAddArgumentsDoesntBreakFragment", testAddArgumentsDoesntBreakFragment),
         ("testAddArgumentsDoesntBreakSwiftVersion", testAddArgumentsDoesntBreakSwiftVersion),
         ("testAddFormatArguments", testAddFormatArguments),


### PR DESCRIPTION
Currently the enhanced `fileHeader` rule (`{file}`, `{created}` and `{created.year}`) is broken. 
This is because the `FileInfo` was lost when mutating the `Options`.

This PR keeps the `FileInfo` when merging arguments and adds a test for it.