### PR TITLE
Fixed `redundantObjc` rule for fileprivate members

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3777,7 +3777,7 @@ public struct _FormatRules {
                      // Not actually allowed currently, but: future-proofing!
                      .keyword("protocol"), .keyword("struct"):
                     return
-                case .keyword("private"):
+                case .keyword("private"), .keyword("fileprivate"):
                     // Can't safely remove objc from private members
                     return
                 case let token where token.isAttribute:

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -9066,6 +9066,17 @@ class RulesTests: XCTestCase {
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.all), output + "\n")
     }
 
+    func testObjcNotRemovedOnFileprivateFunc() {
+        let input = """
+        @objcMembers class Foo: NSObject {
+            @objc fileprivate func bar() {}
+        }
+        """
+        let output = input
+        XCTAssertEqual(try format(input, rules: [FormatRules.redundantObjc]), output)
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.all), output + "\n")
+    }
+
     // MARK: typeSugar
 
     func testArrayTypeConvertedToSugar() {


### PR DESCRIPTION
First of all, thanks for making this nice tool! 

We ran it on our repo and found the build was broken, and thus sent a similar fix following 7eaf6859066d0b270723f5b8633e03f732e5b3cb.