### PR TITLE
bugfix - xcode indentation breaks `if case let` indentation

### DIFF
--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -1847,6 +1847,8 @@ class RulesTests: XCTestCase {
         let output = "{\n    if case let .foo(msg) = a,\n        case let .bar(msg) = b {}\n}"
         XCTAssertEqual(try format(input, rules: [FormatRules.indent]), output)
         XCTAssertEqual(try format(input + "\n", rules: FormatRules.all), output + "\n")
+        XCTAssertEqual(try format(input, rules: [FormatRules.indent]),
+                       try format(input, rules: [FormatRules.indent], options: FormatOptions(xcodeIndentation: true)))
     }
 
     func testIndentGuardCase() {


### PR DESCRIPTION
Better handling of wrapped enums to avoid changing indentation of multiline `if case let` and similar scenarios where `case` appears above the current linebreak.

Includes an assertion that would have failed prior to the code change.