### PR TITLE
Xcode output for  for --lint option

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -243,7 +243,7 @@ func processArguments(_ args: [String], in directory: String) -> ExitCode {
         let lint = (args["lint"] != nil)
 
         // Dry run
-        let dryrun = lint || (args["dryrun"] != nil)
+        let dryrun = lint || args["dryrun"] != nil
 
         // Input path(s)
         var inputURLs = [URL]()
@@ -598,7 +598,7 @@ func printResult(_ dryrun: Bool, _ lint: Bool, _ flags: OutputFlags) -> ExitCode
 }
 
 func inferOptions(from inputURLs: [URL], options: FileOptions) -> (Int, FormatOptions, [Error]) {
-    var tokens = [Token]()
+    var tokens = [TokenWL]()
     var errors = [Error]()
     var filesParsed = 0
     let baseOptions = Options(fileOptions: options)
@@ -637,7 +637,7 @@ func format(_ source: String, options: Options, verbose: Bool) throws -> String 
     let ruleNames = Array(options.rules ?? allRules.subtracting(FormatRules.disabledByDefault)).sorted()
     let rules = ruleNames.compactMap { rulesByName[$0] }
     var rulesApplied = Set<String>()
-    let callback: ((Int, [Token]) -> Void)? = verbose ? { i, updatedTokens in
+    let callback: ((Int, [TokenWL]) -> Void)? = verbose ? { i, updatedTokens in
         if updatedTokens != tokens {
             rulesApplied.insert(ruleNames[i])
             tokens = updatedTokens
@@ -659,7 +659,7 @@ func format(_ source: String, options: Options, verbose: Bool) throws -> String 
     }
 
     // Output
-    return sourceCode(for: tokens)
+    return sourceCode(for: tokens.map { $0.token })
 }
 
 func processInput(_ inputURLs: [URL],

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -44,6 +44,7 @@ public class Formatter: NSObject {
     private var disabledCount = 0
     private var disabledNext = 0
     private var wasNextDirective = false
+    public var help = ""
 
     // Current rule, used for handling comment directives
     var currentRule: String? {
@@ -96,10 +97,10 @@ public class Formatter: NSObject {
     public let options: FormatOptions
 
     /// The token array managed by the formatter (read-only)
-    public private(set) var tokens: [Token]
+    public private(set) var tokens: [TokenWL]
 
     /// Create a new formatter instance from a token array
-    public init(_ tokens: [Token], options: FormatOptions = FormatOptions()) {
+    public init(_ tokens: [TokenWL], options: FormatOptions = FormatOptions()) {
         self.tokens = tokens
         self.options = options
     }
@@ -109,7 +110,7 @@ public class Formatter: NSObject {
     /// Returns the token at the specified index, or nil if index is invalid
     public func token(at index: Int) -> Token? {
         guard index >= 0, index < tokens.count else { return nil }
-        return tokens[index]
+        return tokens[index].token
     }
 
     /// Replaces the token at the specified index with one or more new tokens
@@ -117,7 +118,7 @@ public class Formatter: NSObject {
         if tokens.isEmpty {
             removeToken(at: index)
         } else {
-            self.tokens[index] = tokens[0]
+            self.tokens[index].token = tokens[0]
             for (i, token) in tokens.dropFirst().enumerated() {
                 insertToken(token, at: index + i + 1)
             }
@@ -128,7 +129,7 @@ public class Formatter: NSObject {
     public func replaceTokens(inRange range: Range<Int>, with tokens: [Token]) {
         let max = min(range.count, tokens.count)
         for i in 0 ..< max {
-            self.tokens[range.lowerBound + i] = tokens[i]
+            self.tokens[range.lowerBound + i].token = tokens[i]
         }
         if range.count > max {
             for _ in max ..< range.count {
@@ -171,8 +172,9 @@ public class Formatter: NSObject {
 
     /// Inserts an array of tokens at the specified index
     public func insertTokens(_ tokens: [Token], at index: Int) {
+        let ln = self.tokens[index - 1].lineNum
         for token in tokens.reversed() {
-            self.tokens.insert(token, at: index)
+            self.tokens.insert((token, ln), at: index)
         }
         if enumerationIndex >= index {
             enumerationIndex += tokens.count
@@ -193,7 +195,7 @@ public class Formatter: NSObject {
         assert(enumerationIndex == -1, "forEachToken does not support re-entrancy")
         enumerationIndex = 0
         while enumerationIndex < tokens.count {
-            let token = tokens[enumerationIndex]
+            let token = tokens[enumerationIndex].token
             switch token {
             case let .commentBody(comment):
                 processCommentBody(comment)
@@ -236,7 +238,7 @@ public class Formatter: NSObject {
         let range = range.clamped(to: 0 ..< tokens.count)
         var scopeStack: [Token] = []
         for i in range {
-            let token = tokens[i]
+            let token = tokens[i].token
             // TODO: find a better way to deal with this special case
             if token == .endOfScope("#endif") {
                 while let scope = scopeStack.last, scope != .startOfScope("#if") {
@@ -280,27 +282,27 @@ public class Formatter: NSObject {
 
     /// Returns the index of the next token in the specified range of the specified type
     public func index(of type: TokenType, in range: CountableRange<Int>, if matches: (Token) -> Bool = { _ in true }) -> Int? {
-        return index(in: range, where: { $0.is(type) }).flatMap { matches(tokens[$0]) ? $0 : nil }
+        return index(in: range, where: { $0.is(type) }).flatMap { matches(tokens[$0].token) ? $0 : nil }
     }
 
     /// Returns the index of the next token at the current scope of the specified type
     public func index(of type: TokenType, after index: Int, if matches: (Token) -> Bool = { _ in true }) -> Int? {
-        return self.index(after: index, where: { $0.is(type) }).flatMap { matches(tokens[$0]) ? $0 : nil }
+        return self.index(after: index, where: { $0.is(type) }).flatMap { matches(tokens[$0].token) ? $0 : nil }
     }
 
     /// Returns the next token at the current scope that matches the block
     public func nextToken(after index: Int, where matches: (Token) -> Bool = { _ in true }) -> Token? {
-        return self.index(after: index, where: matches).map { tokens[$0] }
+        return self.index(after: index, where: matches).map { tokens[$0].token }
     }
 
     /// Returns the next token at the current scope of the specified type
     public func next(_ type: TokenType, after index: Int, if matches: (Token) -> Bool = { _ in true }) -> Token? {
-        return self.index(of: type, after: index, if: matches).map { tokens[$0] }
+        return self.index(of: type, after: index, if: matches).map { tokens[$0].token }
     }
 
     /// Returns the next token in the specified range of the specified type
     public func next(_ type: TokenType, in range: CountableRange<Int>, if matches: (Token) -> Bool = { _ in true }) -> Token? {
-        return index(of: type, in: range, if: matches).map { tokens[$0] }
+        return index(of: type, in: range, if: matches).map { tokens[$0].token }
     }
 
     /// Returns the index of the last token in the specified range that matches the block
@@ -309,7 +311,7 @@ public class Formatter: NSObject {
         var linebreakEncountered = false
         var scopeStack: [Token] = []
         for i in range.reversed() {
-            let token = tokens[i]
+            let token = tokens[i].token
             if case .startOfScope = token {
                 if let scope = scopeStack.last, scope.isEndOfScope(token) {
                     scopeStack.removeLast()
@@ -351,27 +353,27 @@ public class Formatter: NSObject {
 
     /// Returns the index of the last token in the specified range of the specified type
     public func lastIndex(of type: TokenType, in range: CountableRange<Int>, if matches: (Token) -> Bool = { _ in true }) -> Int? {
-        return lastIndex(in: range, where: { $0.is(type) }).flatMap { matches(tokens[$0]) ? $0 : nil }
+        return lastIndex(in: range, where: { $0.is(type) }).flatMap { matches(tokens[$0].token) ? $0 : nil }
     }
 
     /// Returns the index of the previous token at the current scope of the specified type
     public func index(of type: TokenType, before index: Int, if matches: (Token) -> Bool = { _ in true }) -> Int? {
-        return self.index(before: index, where: { $0.is(type) }).flatMap { matches(tokens[$0]) ? $0 : nil }
+        return self.index(before: index, where: { $0.is(type) }).flatMap { matches(tokens[$0].token) ? $0 : nil }
     }
 
     /// Returns the previous token at the current scope that matches the block
     public func lastToken(before index: Int, where matches: (Token) -> Bool) -> Token? {
-        return self.index(before: index, where: matches).map { tokens[$0] }
+        return self.index(before: index, where: matches).map { tokens[$0].token }
     }
 
     /// Returns the previous token at the current scope of the specified type
     public func last(_ type: TokenType, before index: Int, if matches: (Token) -> Bool = { _ in true }) -> Token? {
-        return self.index(of: type, before: index, if: matches).map { tokens[$0] }
+        return self.index(of: type, before: index, if: matches).map { tokens[$0].token }
     }
 
     /// Returns the previous token in the specified range of the specified type
     public func last(_ type: TokenType, in range: CountableRange<Int>, if matches: (Token) -> Bool = { _ in true }) -> Token? {
-        return lastIndex(of: type, in: range, if: matches).map { tokens[$0] }
+        return lastIndex(of: type, in: range, if: matches).map { tokens[$0].token }
     }
 
     /// Returns the starting token for the containing scope at the specified index
@@ -387,7 +389,7 @@ public class Formatter: NSObject {
         if case .startOfScope = startToken {
             startIndex = index
         } else if let index = self.index(of: .startOfScope, before: index) {
-            startToken = tokens[index]
+            startToken = tokens[index].token
             startIndex = index
         } else {
             return nil

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -186,7 +186,7 @@ public class Formatter: NSObject {
 
     /// Inserts an array of tokens at the specified index
     public func insertTokens(_ tokens: [Token], at index: Int) {
-        let ln = self.tokens[index - 1].lineNum
+        let ln = index > 0 ? self.tokens[index - 1].lineNum : 0
         for token in tokens.reversed() {
             _printWarning(ln)
             self.tokens.insert((token, ln), at: index)

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -204,7 +204,10 @@ public class Formatter: NSObject {
     // MARK: - Show warnings
 
     private func _printWarning(_ lineNumber: Int) {
-        defer { _prevLineNum = lineNumber; _prevRuleIndex = ruleIndex }
+        defer {
+            _prevLineNum = lineNumber
+            _prevRuleIndex = ruleIndex
+        }
         guard !isSilent, lineNumber != _prevLineNum || ruleIndex != _prevRuleIndex else { return }
         warnings.append("\(_fileName):\(lineNumber):1: warning: \(help)")
     }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -152,7 +152,7 @@ public struct _FormatRules {
             case "@autoclosure":
                 if let nextIndex = formatter.index(of: .nonSpaceOrLinebreak, after: index),
                     formatter.next(.nonSpaceOrCommentOrLinebreak, after: nextIndex) == .identifier("escaping") {
-                    assert(formatter.tokens[nextIndex] == .startOfScope("("))
+                    assert(formatter.tokens[nextIndex].token == .startOfScope("("))
                     return false
                 }
                 return true
@@ -167,7 +167,7 @@ public struct _FormatRules {
         }
 
         func isCaptureList(at i: Int) -> Bool {
-            assert(formatter.tokens[i] == .endOfScope("]"))
+            assert(formatter.tokens[i] == .endOfScope("].token"))
             guard formatter.lastToken(before: i + 1, where: {
                 !$0.isSpaceOrCommentOrLinebreak && $0 != .endOfScope("]")
             }) == .startOfScope("{"),
@@ -180,7 +180,7 @@ public struct _FormatRules {
         }
 
         func isAttribute(at i: Int) -> Bool {
-            assert(formatter.tokens[i] == .endOfScope(")"))
+            assert(formatter.tokens[i].token == .endOfScope(")"))
             guard let openParenIndex = formatter.index(of: .startOfScope("("), before: i),
                 let prevToken = formatter.last(.nonSpaceOrCommentOrLinebreak, before: openParenIndex),
                 prevToken.isAttribute else { return false }
@@ -431,8 +431,8 @@ public struct _FormatRules {
                 if type == .infix {
                     if formatter.token(at: i - 1)?.isSpace == true,
                         let lastTokenIndex = formatter.index(of: .nonSpace, before: i),
-                        formatter.tokens[lastTokenIndex].isLvalue {
-                        if ["!", "?"].contains(formatter.tokens[lastTokenIndex].string),
+                        formatter.tokens[lastTokenIndex].token.isLvalue {
+                        if ["!", "?"].contains(formatter.tokens[lastTokenIndex].token.string),
                             let prevToken = formatter.last(.nonSpace, before: lastTokenIndex),
                             [.keyword("try"), .keyword("as")].contains(prevToken) {} else {
                             formatter.removeToken(at: i - 1)
@@ -650,7 +650,7 @@ public struct _FormatRules {
             guard ["{", "(", "[", "<"].contains(token.string),
                 let indexOfFirstLineBreak = formatter.index(of: .nonSpaceOrComment, after: i),
                 // If there is extra code on the same line, ignore it
-                formatter.tokens[indexOfFirstLineBreak].isLinebreak
+                formatter.tokens[indexOfFirstLineBreak].token.isLinebreak
             else { return }
             // Find next non-space token
             var index = indexOfFirstLineBreak + 1
@@ -752,7 +752,7 @@ public struct _FormatRules {
                 guard let nextTokenIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i) else {
                     break
                 }
-                switch formatter.tokens[nextTokenIndex] {
+                switch formatter.tokens[nextTokenIndex].token {
                 case .error, .endOfScope,
                      .operator(".", _), .delimiter(","), .delimiter(":"),
                      .keyword("else"), .keyword("catch"):
@@ -785,7 +785,7 @@ public struct _FormatRules {
         formatter.forEachToken { i, token in
             guard case let .commentBody(comment) = token, comment.hasPrefix("MARK:"),
                 let startIndex = formatter.index(of: .nonSpace, before: i),
-                formatter.tokens[startIndex] == .startOfScope("//") else { return }
+                formatter.tokens[startIndex].token == .startOfScope("//") else { return }
             if let nextIndex = formatter.index(of: .linebreak, after: i),
                 let nextToken = formatter.next(.nonSpace, after: nextIndex),
                 !nextToken.isLinebreak, nextToken != .endOfScope("}") {
@@ -1088,7 +1088,7 @@ public struct _FormatRules {
                 var index = formatter.startOfLine(at: i)
                 if index == i || index == i - 1 {
                     let indent: String
-                    if case let .space(space) = formatter.tokens[index] {
+                    if case let .space(space) = formatter.tokens[index].token {
                         indent = space
                     } else {
                         indent = ""
@@ -1096,7 +1096,7 @@ public struct _FormatRules {
                     index -= 1
                     while let prevToken = formatter.token(at: index - 1), prevToken.isComment,
                         let startIndex = formatter.index(of: .nonSpaceOrComment, before: index),
-                        formatter.tokens[startIndex].isLinebreak {
+                        formatter.tokens[startIndex].token.isLinebreak {
                         // Set indent for comment immediately before this line to match this line
                         if !isCommentedCode(at: startIndex + 1) {
                             formatter.insertSpace(indent, at: startIndex + 1)
@@ -1163,7 +1163,7 @@ public struct _FormatRules {
                 }
                 // Apply indent
                 if let nextTokenIndex = formatter.index(of: .nonSpace, after: i) {
-                    switch formatter.tokens[nextTokenIndex] {
+                    switch formatter.tokens[nextTokenIndex].token {
                     case .linebreak where formatter.options.truncateBlankLines:
                         formatter.insertSpace("", at: i + 1)
                     case .error:
@@ -1244,7 +1244,7 @@ public struct _FormatRules {
                             formatter.removeTokens(inRange: breakIndex ..< nextIndex)
                         }
                         formatter.insertSpace(formatter.indentForLine(at: i), at: i + 1)
-                        if formatter.tokens[i - 1].isSpace {
+                        if formatter.tokens[i - 1].token.isSpace {
                             formatter.removeToken(at: i - 1)
                         }
                     default:
@@ -1254,7 +1254,7 @@ public struct _FormatRules {
             } else {
                 // Implement K&R-style braces, where opening brace appears on the same line
                 guard let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i),
-                    prevIndex < i - 2 || formatter.tokens[i - 1] != .space(" ") else {
+                    prevIndex < i - 2 || formatter.tokens[i - 1].token != .space(" ") else {
                     return
                 }
                 formatter.removeToken(at: i)
@@ -1286,7 +1286,7 @@ public struct _FormatRules {
             guard let startIndex = formatter.index(of: .startOfScope("{"), before: endIndex) else {
                 return false
             }
-            return (startIndex ..< endIndex).contains(where: { formatter.tokens[$0].isLinebreak })
+            return (startIndex ..< endIndex).contains(where: { formatter.tokens[$0].token.isLinebreak })
         }
         formatter.forEachToken { i, token in
             switch token {
@@ -1302,7 +1302,7 @@ public struct _FormatRules {
                     return
                 }
                 let shouldWrap = formatter.options.allmanBraces || formatter.options.elseOnNextLine
-                if !shouldWrap, formatter.tokens[prevIndex].isLinebreak {
+                if !shouldWrap, formatter.tokens[prevIndex].token.isLinebreak {
                     if let prevBraceIndex = formatter.index(of: .nonSpaceOrLinebreak, before: prevIndex, if: {
                         $0 == .endOfScope("}")
                     }), bracesContainLinebreak(prevBraceIndex) {
@@ -1342,7 +1342,7 @@ public struct _FormatRules {
                 // Check for type declaration
                 if prevToken == .delimiter(":") {
                     if let scopeStart = formatter.index(of: .startOfScope, before: startIndex),
-                        formatter.tokens[scopeStart] == .startOfScope("(") {
+                        formatter.tokens[scopeStart].token == .startOfScope("(") {
                         if formatter.last(.keyword, before: scopeStart) == .keyword("func") {
                             return
                         }
@@ -1352,11 +1352,11 @@ public struct _FormatRules {
                     }
                 }
             }
-            let prevToken = formatter.tokens[prevTokenIndex]
+            let prevToken = formatter.tokens[prevTokenIndex].token
             if prevToken.isLinebreak {
                 if let prevTokenIndex = formatter.index(of:
                     .nonSpaceOrCommentOrLinebreak, before: prevTokenIndex + 1) {
-                    switch formatter.tokens[prevTokenIndex] {
+                    switch formatter.tokens[prevTokenIndex].token {
                     case .startOfScope("["), .delimiter(":"):
                         break // do nothing
                     case .delimiter(","):
@@ -1489,7 +1489,7 @@ public struct _FormatRules {
             var lastIndex = i
             var previousIndex = lastIndex
             loop: while let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: lastIndex) {
-                switch formatter.tokens[index] {
+                switch formatter.tokens[index].token {
                 case .operator(_, .prefix), .operator(_, .infix), .keyword("case"):
                     // Last specifier was invalid
                     lastSpecifier = nil
@@ -1500,7 +1500,7 @@ public struct _FormatRules {
                         break loop
                     }
                     lastSpecifier.map { specifiers[$0.0] = $0.1 }
-                    lastSpecifier = (string, [Token](formatter.tokens[index ..< lastIndex]))
+                    lastSpecifier = (string, [Token](formatter.tokens[index ..< lastIndex].map { $0.token }))
                     previousIndex = lastIndex
                     lastIndex = index
                 case .endOfScope(")"):
@@ -1509,7 +1509,7 @@ public struct _FormatRules {
                         let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: openParenIndex),
                         case let .keyword(string)? = formatter.token(at: index), aclSpecifiers.contains(string) {
                         lastSpecifier.map { specifiers[$0.0] = $0.1 }
-                        lastSpecifier = (string + "(set)", [Token](formatter.tokens[index ..< lastIndex]))
+                        lastSpecifier = (string + "(set)", [Token](formatter.tokens[index ..< lastIndex].map { $0.token }))
                         previousIndex = lastIndex
                         lastIndex = index
                     } else {
@@ -1567,18 +1567,18 @@ public struct _FormatRules {
             guard var index = formatter.index(of: .keyword, before: index) else {
                 return false
             }
-            var keyword = formatter.tokens[index].string
+            var keyword = formatter.tokens[index].token.string
             while ["try", "as", "is", "in"].contains(keyword) ||
                 keyword.hasPrefix("#") || keyword.hasPrefix("@") {
                 guard let prevIndex = formatter.index(of: .keyword, before: index) else {
                     return false
                 }
                 index = prevIndex
-                keyword = formatter.tokens[index].string
+                keyword = formatter.tokens[index].token.string
             }
             if ["let", "var"].contains(keyword) {
                 index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: index) ?? index
-                switch formatter.tokens[index] {
+                switch formatter.tokens[index].token {
                 case .delimiter(","):
                     return true
                 case let .keyword(name):
@@ -1607,7 +1607,7 @@ public struct _FormatRules {
                 var startIndex = formatter.index(of: .nonSpaceOrLinebreak, before: openingBraceIndex) else {
                 return
             }
-            switch formatter.tokens[startIndex] {
+            switch formatter.tokens[startIndex].token {
             case .delimiter(","), .startOfScope("("):
                 break
             case .delimiter(":"):
@@ -1660,7 +1660,7 @@ public struct _FormatRules {
                 formatter.token(at: index + 1)?.isSpace == true {
                 // Need to remove one
                 formatter.removeToken(at: index + 1)
-            } else if case .startOfScope = formatter.tokens[index] {
+            } else if case .startOfScope = formatter.tokens[index].token {
                 if tokenOutsideParenRequiresSpacing(at: index - 1),
                     tokenInsideParenRequiresSpacing(at: index + 1) {
                     // Need to insert one
@@ -1742,12 +1742,12 @@ public struct _FormatRules {
                     return
                 }
                 if var prevIndex = formatter.index(of: .keyword, before: i) {
-                    var prevKeyword = formatter.tokens[prevIndex].string
+                    var prevKeyword = formatter.tokens[prevIndex].token.string
                     while prevKeyword.hasPrefix("#") || prevKeyword.hasPrefix("@") ||
                         ["try", "is", "as"].contains(prevKeyword),
                         let index = formatter.index(of: .keyword, before: prevIndex) {
                         prevIndex = index
-                        prevKeyword = formatter.tokens[index].string
+                        prevKeyword = formatter.tokens[index].token.string
                     }
                     if conditionals.contains(prevKeyword) {
                         return
@@ -1769,7 +1769,7 @@ public struct _FormatRules {
             case let .keyword(name) where !conditionals.contains(name) && !["let", "var"].contains(name):
                 return
             case .endOfScope("}"), .endOfScope(")"), .endOfScope("]"), .endOfScope(">"):
-                if formatter.tokens[previousIndex + 1 ..< i].contains(where: { $0.isLinebreak }) {
+                if formatter.tokens[previousIndex + 1 ..< i].contains(where: { $0.token.isLinebreak }) {
                     fallthrough
                 }
                 return // Probably a method invocation
@@ -1888,7 +1888,7 @@ public struct _FormatRules {
                 if formatter.index(of: .endOfStatement, in: index + 1 ..< optionalIndex) != nil {
                     return
                 }
-                if !formatter.tokens[optionalIndex - 1].isSpaceOrCommentOrLinebreak,
+                if !formatter.tokens[optionalIndex - 1].token.isSpaceOrCommentOrLinebreak,
                     let equalsIndex = formatter.index(of: .nonSpaceOrLinebreak, after: optionalIndex, if: {
                         $0 == .operator("=", .infix)
                     }), let nilIndex = formatter.index(of: .nonSpaceOrLinebreak, after: equalsIndex, if: {
@@ -1912,7 +1912,7 @@ public struct _FormatRules {
             if let scopeIndex = formatter.index(of: .startOfScope("{"), before: i) {
                 var prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: scopeIndex)
                 loop: while let index = prevIndex {
-                    switch formatter.tokens[index] {
+                    switch formatter.tokens[index].token {
                     case .identifier("Codable"), .identifier("Decodable"):
                         return // Can't safely remove the default value
                     case .delimiter(":"), .keyword:
@@ -1966,7 +1966,7 @@ public struct _FormatRules {
         func redundantBindings(inRange range: Range<Int>) -> Bool {
             var isEmpty = true
             for token in formatter.tokens[range.lowerBound ..< range.upperBound] {
-                switch token {
+                switch token.token {
                 case .identifier("_"):
                     isEmpty = false
                 case .space, .linebreak, .delimiter(","), .keyword("let"), .keyword("var"):
@@ -1992,7 +1992,7 @@ public struct _FormatRules {
                 return
             }
             formatter.removeTokens(inRange: i ... endIndex)
-            if let prevIndex = prevIndex, formatter.tokens[prevIndex].isIdentifier,
+            if let prevIndex = prevIndex, formatter.tokens[prevIndex].token.isIdentifier,
                 formatter.last(.nonSpaceOrComment, before: prevIndex)?.string == "." {
                 // Was an enum case
                 return
@@ -2028,7 +2028,7 @@ public struct _FormatRules {
                 }), let quoteIndex = formatter.index(of: .nonSpaceOrLinebreak, after: equalsIndex, if: {
                     $0 == .startOfScope("\"")
                 }), formatter.token(at: quoteIndex + 2) == .endOfScope("\"") {
-                    if formatter.tokens[nameIndex].string == formatter.token(at: quoteIndex + 1)?.string {
+                    if formatter.tokens[nameIndex].token.string == formatter.token(at: quoteIndex + 1)?.string {
                         formatter.removeTokens(inRange: nameIndex + 1 ... quoteIndex + 2)
                         index = nameIndex
                     } else {
@@ -2050,17 +2050,17 @@ public struct _FormatRules {
     ) { formatter in
         formatter.forEach(.operator("->", .infix)) { i, _ in
             guard var endIndex = formatter.index(of: .nonSpace, after: i) else { return }
-            switch formatter.tokens[endIndex] {
+            switch formatter.tokens[endIndex].token {
             case .identifier("Void"):
                 break
             case .startOfScope("("):
                 guard let nextIndex = formatter.index(of: .nonSpace, after: endIndex) else { return }
-                switch formatter.tokens[nextIndex] {
+                switch formatter.tokens[nextIndex].token {
                 case .endOfScope(")"):
                     endIndex = nextIndex
                 case .identifier("Void"):
                     guard let nextIndex = formatter.index(of: .nonSpace, after: nextIndex),
-                        case .endOfScope(")") = formatter.tokens[nextIndex] else { return }
+                        case .endOfScope(")") = formatter.tokens[nextIndex].token else { return }
                     endIndex = nextIndex
                 default:
                     return
@@ -2091,7 +2091,7 @@ public struct _FormatRules {
             guard let startIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i) else {
                 return
             }
-            switch formatter.tokens[startIndex] {
+            switch formatter.tokens[startIndex].token {
             case .keyword("in"):
                 break
             case .startOfScope("{"):
@@ -2101,29 +2101,29 @@ public struct _FormatRules {
                 guard var prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: startIndex) else {
                     break
                 }
-                if formatter.tokens[prevIndex] == .endOfScope(")"),
+                if formatter.tokens[prevIndex].token == .endOfScope(")"),
                     let j = formatter.index(of: .startOfScope("("), before: prevIndex) {
                     prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: j) ?? j
-                    if formatter.tokens[prevIndex] == .operator("?", .postfix) {
+                    if formatter.tokens[prevIndex].token == .operator("?", .postfix) {
                         prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex) ?? prevIndex
                     }
-                    let prevToken = formatter.tokens[prevIndex]
+                    let prevToken = formatter.tokens[prevIndex].token
                     guard prevToken.isIdentifier || prevToken == .keyword("init") else {
                         return
                     }
                 }
-                let prevToken = formatter.tokens[prevIndex]
+                let prevToken = formatter.tokens[prevIndex].token
                 guard ![.delimiter(":"), .startOfScope("(")].contains(prevToken),
                     var prevKeywordIndex = formatter.index(of: .keyword, before: startIndex) else {
                     break
                 }
-                var keyword = formatter.tokens[prevKeywordIndex].string
+                var keyword = formatter.tokens[prevKeywordIndex].token.string
                 while ["try", "as", "is"].contains(keyword) || keyword.hasPrefix("#") || keyword.hasPrefix("@") {
                     guard let prevIndex = formatter.index(of: .keyword, before: prevKeywordIndex) else {
                         return
                     }
                     prevKeywordIndex = prevIndex
-                    keyword = formatter.tokens[prevKeywordIndex].string
+                    keyword = formatter.tokens[prevKeywordIndex].token.string
                 }
                 if ["else", "if", "case", "where", "for", "in", "while", "repeat", "do", "catch"].contains(keyword) {
                     return
@@ -2197,7 +2197,7 @@ public struct _FormatRules {
                 }
             }
             if let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i),
-                formatter.tokens[prevIndex].isOperator(".") {
+                formatter.tokens[prevIndex].token.isOperator(".") {
                 if formatter.options.swiftVersion >= "5" || formatter.token(at: prevIndex - 1)?.isOperator("\\") != true {
                     formatter.replaceToken(at: i, with: .identifier(unescaped))
                 }
@@ -2207,7 +2207,7 @@ public struct _FormatRules {
                 let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i) else {
                 return
             }
-            let nextToken = formatter.tokens[nextIndex]
+            let nextToken = formatter.tokens[nextIndex].token
             if formatter.currentScope(at: i) == .startOfScope("("),
                 nextToken == .delimiter(":") || (nextToken.isIdentifier &&
                     formatter.next(.nonSpaceOrCommentOrLinebreak, after: nextIndex) == .delimiter(":")) {
@@ -2238,7 +2238,7 @@ public struct _FormatRules {
             ]
             let explicitSelf = formatter.options.explicitSelf
             let currentScope = formatter.currentScope(at: index)
-            let isWhereClause = index > 0 && formatter.tokens[index - 1] == .keyword("where")
+            let isWhereClause = index > 0 && formatter.tokens[index - 1].token == .keyword("where")
             assert(isWhereClause || currentScope.map { token -> Bool in
                 [.startOfScope("{"), .startOfScope(":"), .startOfScope("#if")].contains(token)
             } ?? true)
@@ -2246,7 +2246,7 @@ public struct _FormatRules {
                 // Check if scope actually includes self before we waste a bunch of time
                 var scopeCount = 0
                 loop: for i in index ..< formatter.tokens.count {
-                    switch formatter.tokens[i] {
+                    switch formatter.tokens[i].token {
                     case .identifier("self"):
                         break loop // Contains self
                     case .startOfScope("{"), .startOfScope(":"):
@@ -2295,7 +2295,7 @@ public struct _FormatRules {
                             var endIndex = formatter.index(of: .endOfScope, after: nextIndex) else {
                             return // error
                         }
-                        while formatter.tokens[endIndex] != .endOfScope("}") {
+                        while formatter.tokens[endIndex].token != .endOfScope("}") {
                             guard let nextIndex = formatter.index(of: .startOfScope(":"), after: endIndex),
                                 let _endIndex = formatter.index(of: .endOfScope, after: nextIndex) else {
                                 return // error
@@ -2401,7 +2401,7 @@ public struct _FormatRules {
                     case "lazy":
                         loop: while let nextIndex =
                             formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index) {
-                            switch formatter.tokens[nextIndex] {
+                            switch formatter.tokens[nextIndex].token {
                             case .keyword("as"), .keyword("is"), .keyword("try"):
                                 break
                             case .keyword, .startOfScope("{"):
@@ -2439,8 +2439,8 @@ public struct _FormatRules {
                         return
                     }
                     for token in formatter.tokens[prevKeywordIndex + 1 ..< keywordIndex] {
-                        if case let .identifier(name) = token, name != "_" {
-                            localNames.insert(token.unescaped())
+                        if case let .identifier(name) = token.token, name != "_" {
+                            localNames.insert(token.token.unescaped())
                         }
                     }
                     index += 1
@@ -2489,8 +2489,8 @@ public struct _FormatRules {
                         let prevKeywordToken = formatter.token(at: prevKeywordIndex),
                         case .keyword("for") = prevKeywordToken else { return }
                     for token in formatter.tokens[prevKeywordIndex + 1 ..< keywordIndex] {
-                        if case let .identifier(name) = token, name != "_" {
-                            localNames.insert(token.unescaped())
+                        if case let .identifier(name) = token.token, name != "_" {
+                            localNames.insert(token.token.unescaped())
                         }
                     }
                     index += 1
@@ -2589,7 +2589,7 @@ public struct _FormatRules {
                             break
                         }
                     }
-                    if case let .identifier(name) = formatter.tokens[nextIndex], name.isContextualKeyword {
+                    if case let .identifier(name) = formatter.tokens[nextIndex].token, name.isContextualKeyword {
                         // May be unnecessary, but will be reverted by `redundantBackticks` rule if so
                         formatter.replaceToken(at: nextIndex, with: .identifier("`\(name)`"))
                     }
@@ -2689,7 +2689,7 @@ public struct _FormatRules {
                 }), let varToken = formatter.next(.identifier, after: parenStart) {
                     localNames.insert(varToken.unescaped())
                 } else {
-                    switch formatter.tokens[nextIndex].string {
+                    switch formatter.tokens[nextIndex].token.string {
                     case "get":
                         localNames.insert(name)
                     case "set":
@@ -2722,7 +2722,7 @@ public struct _FormatRules {
                              typeStack: inout [String],
                              membersByType: inout [String: Set<String>],
                              classMembersByType: inout [String: Set<String>]) {
-            let startToken = formatter.tokens[index]
+            let startToken = formatter.tokens[index].token
             var localNames = localNames
             guard let startIndex = formatter.index(of: .startOfScope("("), after: index),
                 let endIndex = formatter.index(of: .endOfScope(")"), after: startIndex) else {
@@ -2735,12 +2735,12 @@ public struct _FormatRules {
                 guard let externalNameIndex = formatter.index(of: .identifier, after: index),
                     let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: externalNameIndex)
                 else { break }
-                let token = formatter.tokens[nextIndex]
+                let token = formatter.tokens[nextIndex].token
                 switch token {
                 case let .identifier(name) where name != "_":
                     localNames.insert(token.unescaped())
                 case .delimiter(":"):
-                    let externalNameToken = formatter.tokens[externalNameIndex]
+                    let externalNameToken = formatter.tokens[externalNameIndex].token
                     if case let .identifier(name) = externalNameToken, name != "_" {
                         localNames.insert(externalNameToken.unescaped())
                     }
@@ -2763,7 +2763,7 @@ public struct _FormatRules {
                 default:
                     return false // Keep looking
                 }
-            }), formatter.tokens[bodyStartIndex] == .startOfScope("{") else {
+            }), formatter.tokens[bodyStartIndex].token == .startOfScope("{") else {
                 return
             }
             if startToken == .keyword("subscript") {
@@ -2803,7 +2803,7 @@ public struct _FormatRules {
     ) { formatter in
         func removeUsed<T>(from argNames: inout [String], with associatedData: inout [T], in range: CountableRange<Int>) {
             for i in range {
-                let token = formatter.tokens[i]
+                let token = formatter.tokens[i].token
                 if case .identifier = token, let index = argNames.index(of: token.unescaped()),
                     formatter.last(.nonSpaceOrCommentOrLinebreak, before: i)?.isOperator(".") == false,
                     formatter.next(.nonSpaceOrCommentOrLinebreak, after: i) != .delimiter(":") ||
@@ -2824,7 +2824,7 @@ public struct _FormatRules {
                 var index = i - 1
                 var argCountStack = [0]
                 while index > start {
-                    let token = formatter.tokens[index]
+                    let token = formatter.tokens[index].token
                     switch token {
                     case let .keyword(name) where !token.isAttribute && !name.hasPrefix("#") && name != "inout":
                         return
@@ -2846,7 +2846,7 @@ public struct _FormatRules {
                             let prevToken = formatter.last(.nonSpaceOrCommentOrLinebreak, before: index), [
                                 .delimiter(","), .startOfScope("("), .startOfScope("{"), .endOfScope("]"),
                             ].contains(prevToken), let scopeStart = formatter.index(of: .startOfScope, before: index),
-                            ![.startOfScope("["), .startOfScope("<")].contains(formatter.tokens[scopeStart]) else {
+                            ![.startOfScope("["), .startOfScope("<")].contains(formatter.tokens[scopeStart].token) else {
                             break
                         }
                         let name = token.unescaped()
@@ -2872,9 +2872,9 @@ public struct _FormatRules {
             }
             removeUsed(from: &argNames, with: &nameIndexPairs, in: i + 1 ..< bodyEndIndex)
             for pair in nameIndexPairs {
-                if case .identifier("_") = formatter.tokens[pair.0], pair.0 != pair.1 {
+                if case .identifier("_") = formatter.tokens[pair.0].token, pair.0 != pair.1 {
                     formatter.removeToken(at: pair.1)
-                    if formatter.tokens[pair.1 - 1] == .space(" ") {
+                    if formatter.tokens[pair.1 - 1].token == .space(" ") {
                         formatter.removeToken(at: pair.1 - 1)
                     }
                 } else {
@@ -2905,13 +2905,13 @@ public struct _FormatRules {
                 }) else { return }
                 guard let nextIndex =
                     formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: externalNameIndex) else { return }
-                let nextToken = formatter.tokens[nextIndex]
+                let nextToken = formatter.tokens[nextIndex].token
                 switch nextToken {
                 case let .identifier(name) where name != "_":
                     argNames.append(nextToken.unescaped())
                     nameIndexPairs.append((externalNameIndex, nextIndex))
                 case .delimiter(":"):
-                    let externalNameToken = formatter.tokens[externalNameIndex]
+                    let externalNameToken = formatter.tokens[externalNameIndex].token
                     if case let .identifier(name) = externalNameToken, name != "_" {
                         argNames.append(externalNameToken.unescaped())
                         nameIndexPairs.append((externalNameIndex, externalNameIndex))
@@ -2935,7 +2935,7 @@ public struct _FormatRules {
                 default:
                     return false // Keep looking
                 }
-            }), formatter.tokens[bodyStartIndex] == .startOfScope("{"),
+            }), formatter.tokens[bodyStartIndex].token == .startOfScope("{"),
                 let bodyEndIndex = formatter.index(of: .endOfScope("}"), after: bodyStartIndex) else {
                 return
             }
@@ -2948,9 +2948,9 @@ public struct _FormatRules {
                         formatter.insertToken(.identifier("_"), at: pair.0 + 1)
                         formatter.insertToken(.space(" "), at: pair.0 + 1)
                     }
-                } else if case .identifier("_") = formatter.tokens[pair.0] {
+                } else if case .identifier("_") = formatter.tokens[pair.0].token {
                     formatter.removeToken(at: pair.1)
-                    if formatter.tokens[pair.1 - 1] == .space(" ") {
+                    if formatter.tokens[pair.1 - 1].token == .space(" ") {
                         formatter.removeToken(at: pair.1 - 1)
                     }
                 } else {
@@ -2973,7 +2973,7 @@ public struct _FormatRules {
             var keywordFound = false, identifierFound = false
             var count = 0
             for index in range {
-                switch formatter.tokens[index] {
+                switch formatter.tokens[index].token {
                 case .keyword(keyword):
                     indices.append(index)
                     keywordFound = true
@@ -3006,14 +3006,14 @@ public struct _FormatRules {
             var startIndex = i
             var keyword = "let"
             if var prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i) {
-                if case .identifier = formatter.tokens[prevIndex] {
+                if case .identifier = formatter.tokens[prevIndex].token {
                     prevIndex = formatter.index(before: prevIndex) {
                         $0.isSpaceOrCommentOrLinebreak || $0.isStartOfScope || $0 == .endOfScope("case")
                     } ?? -1
                     startIndex = prevIndex + 1
                     prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: startIndex) ?? 0
                 }
-                let prevToken = formatter.tokens[prevIndex]
+                let prevToken = formatter.tokens[prevIndex].token
                 if [.keyword("let"), .keyword("var")].contains(prevToken) {
                     if hoist {
                         // No changes needed
@@ -3021,7 +3021,7 @@ public struct _FormatRules {
                     }
                     var prevKeywordIndex = prevIndex
                     loop: while let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: prevKeywordIndex) {
-                        switch formatter.tokens[index] {
+                        switch formatter.tokens[index].token {
                         case .keyword("case"), .endOfScope("case"):
                             break loop
                         case .keyword("let"), .keyword("var"),
@@ -3065,7 +3065,7 @@ public struct _FormatRules {
                 }
                 // Remove keywords inside parens
                 for index in indices.reversed() {
-                    if formatter.tokens[index + 1].isSpace {
+                    if formatter.tokens[index + 1].token.isSpace {
                         formatter.removeToken(at: index + 1)
                     }
                     formatter.removeToken(at: index)
@@ -3083,7 +3083,7 @@ public struct _FormatRules {
                 var index = openParenIndex + 1
                 var wasParenOrComma = true
                 while index < endIndex {
-                    let token = formatter.tokens[index]
+                    let token = formatter.tokens[index].token
                     switch token {
                     case .delimiter(","), .startOfScope("("):
                         wasParenOrComma = true
@@ -3148,7 +3148,7 @@ public struct _FormatRules {
                 // Insert linebreak before closing paren
                 if let lastIndex = formatter.index(of: .nonSpace, before: endOfScope) {
                     endOfScope += formatter.insertSpace(indent, at: lastIndex + 1)
-                    if !formatter.tokens[lastIndex].isLinebreak {
+                    if !formatter.tokens[lastIndex].token.isLinebreak {
                         formatter.insertToken(.linebreak(formatter.options.linebreak), at: lastIndex + 1)
                         endOfScope += 1
                     }
@@ -3156,7 +3156,7 @@ public struct _FormatRules {
             }
             // Insert linebreak after each comma
             var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: endOfScope)!
-            if formatter.tokens[index] != .delimiter(",") {
+            if formatter.tokens[index].token != .delimiter(",") {
                 index += 1
             }
             while let commaIndex = formatter.lastIndex(of: .delimiter(","), in: i + 1 ..< index),
@@ -3164,7 +3164,7 @@ public struct _FormatRules {
                 if let index = formatter.index(of: .nonSpace, before: linebreakIndex) {
                     linebreakIndex = index + 1
                 }
-                if formatter.tokens[linebreakIndex].isLinebreak, !formatter.options.truncateBlankLines ||
+                if formatter.tokens[linebreakIndex].token.isLinebreak, !formatter.options.truncateBlankLines ||
                     formatter.next(.nonSpace, after: linebreakIndex).map({ !$0.isLinebreak }) ?? false {
                     formatter.insertSpace(indent + formatter.options.indent, at: linebreakIndex + 1)
                 } else if !allowGrouping || (maxWidth > 0 &&
@@ -3208,7 +3208,7 @@ public struct _FormatRules {
                     index = commaIndex
                     continue
                 }
-                if formatter.tokens[linebreakIndex].isLinebreak {
+                if formatter.tokens[linebreakIndex].token.isLinebreak {
                     if linebreakIndex + 1 != endOfScope {
                         endOfScope += formatter.insertSpace(indent, at: linebreakIndex + 1)
                     }
@@ -3254,7 +3254,7 @@ public struct _FormatRules {
             }
             let maxWidth = formatter.options.maxWidth
             if let firstLinebreakIndex = checkNestedScopes ?
-                (i ..< endOfScope).first(where: { formatter.tokens[$0].isLinebreak }) :
+                (i ..< endOfScope).first(where: { formatter.tokens[$0].token.isLinebreak }) :
                 formatter.index(of: .linebreak, in: i + 1 ..< endOfScope) {
                 switch mode {
                 case .beforeFirst:
@@ -3302,7 +3302,7 @@ public struct _FormatRules {
             case .operator("->", .infix), .keyword("throws"), .keyword("rethrows"):
                 return true
             case .startOfScope("{"):
-                if formatter.tokens[index] == .endOfScope(")"),
+                if formatter.tokens[index].token == .endOfScope(")"),
                     let index = formatter.index(of: .startOfScope("("), before: index),
                     let nameIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: index, if: {
                         $0.isIdentifier
@@ -3311,7 +3311,7 @@ public struct _FormatRules {
                 }
                 return false
             case .keyword("in"):
-                if formatter.tokens[index] == .endOfScope(")"),
+                if formatter.tokens[index].token == .endOfScope(")"),
                     let index = formatter.index(of: .startOfScope("("), before: index) {
                     return formatter.last(.nonSpaceOrCommentOrLinebreak, before: index) == .startOfScope("{")
                 }
@@ -3325,12 +3325,12 @@ public struct _FormatRules {
             if let nextIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i, if: {
                 $0 == .endOfScope(")")
             }), var prevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: i), {
-                let token = formatter.tokens[prevIndex]
+                let token = formatter.tokens[prevIndex].token
                 if token == .delimiter(":"),
                     let prevPrevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: prevIndex),
-                    formatter.tokens[prevPrevIndex] == .identifier("_"),
+                    formatter.tokens[prevPrevIndex].token == .identifier("_"),
                     let startIndex = formatter.index(of: .nonSpaceOrLinebreak, before: prevPrevIndex),
-                    formatter.tokens[startIndex] == .startOfScope("(") {
+                    formatter.tokens[startIndex].token == .startOfScope("(") {
                     prevIndex = startIndex
                     return true
                 }
@@ -3500,7 +3500,7 @@ public struct _FormatRules {
             header = string
         }
         if let startIndex = formatter.index(of: .nonSpaceOrLinebreak, after: -1) {
-            switch formatter.tokens[startIndex] {
+            switch formatter.tokens[startIndex].token {
             case .startOfScope("//"):
                 if case let .commentBody(body)? = formatter.next(.nonSpace, after: startIndex) {
                     formatter.processCommentBody(body)
@@ -3548,11 +3548,11 @@ public struct _FormatRules {
             }
         }
         guard !header.isEmpty else { return }
-        let headerTokens = tokenize(header)
-        if Array(formatter.tokens.prefix(headerTokens.count)) == headerTokens {
+        let headerTokens = tokenize(header).map { $0.token }
+        if formatter.tokens.prefix(headerTokens.count).map({ $0.token }) == headerTokens {
             formatter.removeTokens(inRange: 0 ..< headerTokens.count)
         }
-        if formatter.tokens.first?.isSpaceOrLinebreak == false {
+        if formatter.tokens.first?.token.isSpaceOrLinebreak == false {
             formatter.insertToken(.linebreak(formatter.options.linebreak), at: 0)
         }
         formatter.insertToken(.linebreak(formatter.options.linebreak), at: 0)
@@ -3599,8 +3599,8 @@ public struct _FormatRules {
             }
             // Group @testable imports at the top or bottom
             return ranges.sorted {
-                let isLhsTestable = formatter.tokens[$0.1].contains(.keyword("@testable"))
-                let isRhsTestable = formatter.tokens[$1.1].contains(.keyword("@testable"))
+                let isLhsTestable = formatter.tokens[$0.1].map { $0.token }.contains(.keyword("@testable"))
+                let isRhsTestable = formatter.tokens[$1.1].map { $0.token }.contains(.keyword("@testable"))
                 // If both have a @testable keyword, or neither has one, just sort alphabetically
                 guard isLhsTestable != isRhsTestable else {
                     return isCaseInsensitiveLessThan($0, $1)
@@ -3616,7 +3616,7 @@ public struct _FormatRules {
             let sortedRanges = sortRanges(importRanges)
             var insertedLinebreak = false
             var sortedTokens = sortedRanges.flatMap { inputRange -> [Token] in
-                var tokens = Array(formatter.tokens[inputRange.1])
+                var tokens = formatter.tokens[inputRange.1].map { $0.token }
                 if tokens.first?.isLinebreak == false {
                     insertedLinebreak = true
                     tokens.insert(Token.linebreak(formatter.options.linebreak), at: tokens.startIndex)
@@ -3650,7 +3650,7 @@ public struct _FormatRules {
     ) { formatter in
         formatter.forEach(.keyword("@IBOutlet")) { i, _ in
             guard let varIndex = formatter.index(of: .keyword("var"), after: i),
-                let weakIndex = (i ..< varIndex).first(where: { formatter.tokens[$0] == .identifier("weak") }),
+                let weakIndex = (i ..< varIndex).first(where: { formatter.tokens[$0].token == .identifier("weak") }),
                 case let .identifier(name)? = formatter.next(.identifier, after: varIndex) else {
                 return
             }
@@ -3658,9 +3658,9 @@ public struct _FormatRules {
             if lowercased.hasSuffix("delegate") || lowercased.hasSuffix("datasource") {
                 return
             }
-            if formatter.tokens[weakIndex + 1].isSpace {
+            if formatter.tokens[weakIndex + 1].token.isSpace {
                 formatter.removeToken(at: weakIndex + 1)
-            } else if formatter.tokens[weakIndex - 1].isSpace {
+            } else if formatter.tokens[weakIndex - 1].token.isSpace {
                 formatter.removeToken(at: weakIndex - 1)
             }
             formatter.removeToken(at: weakIndex)
@@ -3711,28 +3711,28 @@ public struct _FormatRules {
             }
             var index = i + 1
             outer: while index < endIndex {
-                switch formatter.tokens[index] {
+                switch formatter.tokens[index].token {
                 case .operator("&&", .infix):
                     let endOfGroup = formatter.index(of: .delimiter(","), after: index) ?? endIndex
                     var nextOpIndex = index
                     while let next = formatter.index(of: .operator, after: nextOpIndex) {
-                        if formatter.tokens[next] == .operator("||", .infix) {
+                        if formatter.tokens[next].token == .operator("||", .infix) {
                             index = endOfGroup
                             continue outer
                         }
                         nextOpIndex = next
                     }
                     formatter.replaceToken(at: index, with: .delimiter(","))
-                    if formatter.tokens[index - 1] == .space(" ") {
+                    if formatter.tokens[index - 1].token == .space(" ") {
                         formatter.removeToken(at: index - 1)
                         endIndex -= 1
                         index -= 1
                     } else if let prevIndex = formatter.index(of: .nonSpace, before: index),
-                        formatter.tokens[prevIndex].isLinebreak, let nonLinbreak =
+                        formatter.tokens[prevIndex].token.isLinebreak, let nonLinbreak =
                         formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex) {
                         formatter.removeToken(at: index)
                         formatter.insertToken(.delimiter(","), at: nonLinbreak + 1)
-                        if formatter.tokens[index + 1] == .space(" ") {
+                        if formatter.tokens[index + 1].token == .space(" ") {
                             formatter.removeToken(at: index + 1)
                             endIndex -= 1
                         }
@@ -3773,11 +3773,11 @@ public struct _FormatRules {
                 guard let prev = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: index) else {
                     break
                 }
-                switch formatter.tokens[prev] {
+                switch formatter.tokens[prev].token {
                 case .operator("!", _), .operator(".", _):
                     break // Ignored
                 case .operator("?", _):
-                    if formatter.tokens[prev - 1].isSpace {
+                    if formatter.tokens[prev - 1].token.isSpace {
                         break loop
                     }
                     isOptional = true
@@ -3809,7 +3809,7 @@ public struct _FormatRules {
                 index = prev
             }
             let isEmpty: Bool
-            switch formatter.tokens[opIndex] {
+            switch formatter.tokens[opIndex].token {
             case .operator("==", .infix): isEmpty = true
             case .operator("!=", .infix), .operator(">", .infix): isEmpty = false
             default: return
@@ -3891,7 +3891,7 @@ public struct _FormatRules {
                 return
             }
             formatter.removeTokens(inRange: i ..< endIndex)
-            if formatter.tokens[i].isLinebreak {
+            if formatter.tokens[i].token.isLinebreak {
                 let startIndex = formatter.startOfLine(at: i)
                 formatter.removeTokens(inRange: startIndex ... i)
             }
@@ -3933,7 +3933,7 @@ public struct _FormatRules {
             }
             var index = i
             loop: while var nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index) {
-                switch formatter.tokens[nextIndex] {
+                switch formatter.tokens[nextIndex].token {
                 case .keyword("class"), .keyword("enum"),
                      // Not actually allowed currently, but: future-proofing!
                      .keyword("protocol"), .keyword("struct"):
@@ -3975,7 +3975,7 @@ public struct _FormatRules {
                 let keywordIndex = formatter.index(of: .keyword, before: scopeStart) else {
                 return
             }
-            switch formatter.tokens[keywordIndex] {
+            switch formatter.tokens[keywordIndex].token {
             case .keyword("class"):
                 if formatter.specifiersForType(at: keywordIndex, contains: "@objcMembers") {
                     removeAttribute()
@@ -4009,20 +4009,20 @@ public struct _FormatRules {
             }) != nil {
                 return
             }
-            switch formatter.tokens[typeIndex] {
+            switch formatter.tokens[typeIndex].token {
             case .identifier("Array"):
                 formatter.replaceTokens(inRange: typeIndex ... endIndex, with:
-                    [.startOfScope("[")] + formatter.tokens[typeStart ... typeEnd] + [.endOfScope("]")])
+                    [.startOfScope("[")] + formatter.tokens[typeStart ... typeEnd].map { $0.token } + [.endOfScope("]")])
             case .identifier("Dictionary"):
                 guard let commaIndex = formatter.index(of: .delimiter(","), in: typeStart ..< typeEnd) else {
                     return
                 }
                 formatter.replaceToken(at: commaIndex, with: .delimiter(":"))
                 formatter.replaceTokens(inRange: typeIndex ... endIndex, with:
-                    [.startOfScope("[")] + formatter.tokens[typeStart ... typeEnd] + [.endOfScope("]")])
+                    [.startOfScope("[")] + formatter.tokens[typeStart ... typeEnd].map { $0.token } + [.endOfScope("]")])
             case .identifier("Optional"):
-                var typeTokens = formatter.tokens[typeStart ... typeEnd]
-                if formatter.tokens[typeStart] == .startOfScope("("),
+                var typeTokens = formatter.tokens[typeStart ... typeEnd].map { $0.token }
+                if formatter.tokens[typeStart].token == .startOfScope("("),
                     let commaEnd = formatter.index(of: .endOfScope(")"), after: typeStart),
                     commaEnd < typeEnd {
                     typeTokens.insert(.startOfScope("("), at: typeTokens.startIndex)
@@ -4102,7 +4102,7 @@ public struct _FormatRules {
         }
         func isTypeInitialized(_ name: String, in range: CountableRange<Int>) -> Bool {
             for i in range {
-                guard case .identifier(name) = formatter.tokens[i] else { continue }
+                guard case .identifier(name) = formatter.tokens[i].token else { continue }
                 if let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i, if: {
                     $0 == .operator(".", .infix)
                 }), formatter.next(.nonSpaceOrCommentOrLinebreak, after: dotIndex) == .identifier("init") {
@@ -4115,7 +4115,7 @@ public struct _FormatRules {
         }
         func isMemberReferenced(_ name: String, in range: CountableRange<Int>) -> Bool {
             for i in range {
-                guard case .identifier(name) = formatter.tokens[i] else { continue }
+                guard case .identifier(name) = formatter.tokens[i].token else { continue }
                 if let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i, if: {
                     $0 == .operator(".", .infix)
                 }), formatter.last(.nonSpaceOrCommentOrLinebreak, before: dotIndex)
@@ -4127,7 +4127,7 @@ public struct _FormatRules {
         }
         func isInitOverridden(for type: String, in range: CountableRange<Int>) -> Bool {
             for i in range {
-                guard case .keyword("init") = formatter.tokens[i],
+                guard case .keyword("init") = formatter.tokens[i].token,
                     formatter.specifiersForType(at: i, contains: "override"),
                     let scopeIndex = formatter.index(of: .startOfScope("{"), before: i),
                     let colonIndex = formatter.index(of: .delimiter(":"), before: scopeIndex),
@@ -4140,7 +4140,7 @@ public struct _FormatRules {
             return false
         }
         func membersAreReferenced(_: Set<String> /* unused */, inSubclassOf className: String) -> Bool {
-            for i in 0 ..< formatter.tokens.count where formatter.tokens[i] == .keyword("class") {
+            for i in 0 ..< formatter.tokens.count where formatter.tokens[i].token == .keyword("class") {
                 guard let nameIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i, if: {
                     $0.isIdentifier
                 }), let openBraceIndex = formatter.index(of: .startOfScope("{"), after: nameIndex),
@@ -4176,7 +4176,7 @@ public struct _FormatRules {
             }
             // Check that type doesn't (potentially) conform to a protocol
             // TODO: use a whitelist of known protocols to make this check less blunt
-            guard !formatter.tokens[typeIndex ..< scopeIndex].contains(.delimiter(":")) else {
+            guard !formatter.tokens[typeIndex ..< scopeIndex].contains(where: { $0.token == .delimiter(":") }) else {
                 return
             }
             // Check for code outside of main type definition
@@ -4192,7 +4192,7 @@ public struct _FormatRules {
             // Check if type name is initialized outside type, and if so don't
             // change any fileprivate members in case we break memberwise initializer
             // TODO: check if struct contains an overridden init; if so we can skip this check
-            if formatter.tokens[typeIndex] == .keyword("struct"),
+            if formatter.tokens[typeIndex].token == .keyword("struct"),
                 isTypeInitialized(typeName, in: 0 ..< startIndex) ||
                 isTypeInitialized(typeName, in: endIndex + 1 ..< formatter.tokens.count) {
                 return
@@ -4209,7 +4209,7 @@ public struct _FormatRules {
             } else if let names = formatter.namesInDeclaration(at: keywordIndex), !names.contains(where: {
                 isMemberReferenced($0, in: 0 ..< startIndex) ||
                     isMemberReferenced($0, in: endIndex + 1 ..< formatter.tokens.count)
-            }), formatter.tokens[typeIndex] != .keyword("class") ||
+            }), formatter.tokens[typeIndex].token != .keyword("class") ||
                 !membersAreReferenced(names, inSubclassOf: typeName) {
                 formatter.replaceToken(at: i, with: .keyword("private"))
             }
@@ -4229,7 +4229,7 @@ public struct _FormatRules {
         func valuesInRangeAreConstant(_ range: CountableRange<Int>) -> Bool {
             var index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, in: range)
             while var i = index {
-                switch formatter.tokens[i] {
+                switch formatter.tokens[i].token {
                 case .startOfScope where isConstant(at: i):
                     guard let endIndex = formatter.index(of: .endOfScope, after: i) else {
                         return false
@@ -4241,7 +4241,7 @@ public struct _FormatRules {
                 case .identifier:
                     guard let nextIndex =
                         formatter.index(of: .nonSpaceOrComment, in: i + 1 ..< range.upperBound),
-                        formatter.tokens[nextIndex] == .delimiter(":") else {
+                        formatter.tokens[nextIndex].token == .delimiter(":") else {
                         return false
                     }
                     // Identifier is a label
@@ -4254,7 +4254,7 @@ public struct _FormatRules {
         }
         func isConstant(at index: Int) -> Bool {
             var index = index
-            while case .operator(_, .postfix) = formatter.tokens[index] {
+            while case .operator(_, .postfix) = formatter.tokens[index].token {
                 index -= 1
             }
             guard let token = formatter.token(at: index) else {
@@ -4288,7 +4288,7 @@ public struct _FormatRules {
             guard let index = index else {
                 return false
             }
-            switch formatter.tokens[index] {
+            switch formatter.tokens[index].token {
             // Discount operators with higher precedence than ==
             case .operator("=", .infix),
                  .operator("&&", .infix), .operator("||", .infix),
@@ -4321,7 +4321,7 @@ public struct _FormatRules {
             var index: Int? = index
             var wasOperator = true
             while var i = index {
-                let token = formatter.tokens[i]
+                let token = formatter.tokens[i].token
                 switch token {
                 case .operator("&&", .infix), .operator("||", .infix),
                      .operator("?", .infix), .operator(":", .infix):
@@ -4377,8 +4377,8 @@ public struct _FormatRules {
             guard let endIndex = endOfExpression(at: nextIndex) else {
                 return
             }
-            let expression = Array(formatter.tokens[nextIndex ... endIndex])
-            let constant = Array(formatter.tokens[startIndex ... prevIndex])
+            let expression = formatter.tokens[nextIndex ... endIndex].map { $0.token }
+            let constant = formatter.tokens[startIndex ... prevIndex].map { $0.token }
             formatter.replaceTokens(inRange: nextIndex ... endIndex, with: constant)
             formatter.replaceToken(at: i, with: .operator(op, .infix))
             formatter.replaceTokens(inRange: startIndex ... prevIndex, with: expression)
@@ -4408,7 +4408,7 @@ public struct _FormatRules {
             }
             let startIndex = formatter.index(of: .nonSpaceOrComment, before: endOfLine) ?? -1
             formatter.removeTokens(inRange: endOfLine ..< i)
-            let comment = Array(formatter.tokens[startIndex + 1 ..< endOfLine])
+            let comment = formatter.tokens[startIndex + 1 ..< endOfLine].map { $0.token }
             formatter.insertTokens(comment, at: endOfLine + 1)
             formatter.removeTokens(inRange: startIndex + 1 ..< endOfLine)
         }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -37,15 +37,18 @@ public final class FormatRule {
     let help: String
     let options: [String]
     let sharedOptions: [String]
+    let isSilent: Bool
 
     fileprivate init(help: String,
                      options: [String] = [],
                      sharedOptions: [String] = [],
+                     isSilent: Bool = false,
                      _ fn: @escaping (Formatter) -> Void) {
         self.fn = fn
         self.help = help
         self.options = options
         self.sharedOptions = sharedOptions
+        self.isSilent = isSilent
     }
 
     public func apply(with formatter: Formatter) {
@@ -167,7 +170,7 @@ public struct _FormatRules {
         }
 
         func isCaptureList(at i: Int) -> Bool {
-            assert(formatter.tokens[i] == .endOfScope("].token"))
+            assert(formatter.tokens[i] == .endOfScope("]"))
             guard formatter.lastToken(before: i + 1, where: {
                 !$0.isSpaceOrCommentOrLinebreak && $0 != .endOfScope("]")
             }) == .startOfScope("{"),
@@ -828,7 +831,8 @@ public struct _FormatRules {
     public let indent = FormatRule(
         help: "Adjusts leading whitespace based on scope and line wrapping.",
         options: ["indent", "tabwidth", "indentcase", "ifdef", "xcodeindentation"],
-        sharedOptions: ["trimwhitespace", "linebreaks"]
+        sharedOptions: ["trimwhitespace", "linebreaks"],
+        isSilent: true
     ) { formatter in
         var scopeStack: [Token] = []
         var scopeStartLineIndexes: [Int] = []
@@ -1462,7 +1466,8 @@ public struct _FormatRules {
     /// Standardise linebreak characters as whatever is specified in the options (\n by default)
     public let linebreaks = FormatRule(
         help: "Normalizes all linebreaks to use the same character.",
-        options: ["linebreaks"]
+        options: ["linebreaks"],
+        isSilent: true
     ) { formatter in
         formatter.forEach(.linebreak) { i, _ in
             formatter.replaceToken(at: i, with: .linebreak(formatter.options.linebreak))
@@ -1474,7 +1479,8 @@ public struct _FormatRules {
         help: """
         Normalizes the order for property/function/class specifiers (public, weak,
         lazy, etc.)
-        """
+        """,
+        isSilent: true
     ) { formatter in
         formatter.forEach(.keyword) { i, token in
             switch token.string {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3555,7 +3555,7 @@ public struct _FormatRules {
         }
         guard !header.isEmpty else { return }
         let headerTokens = tokenize(header).map { $0.token }
-        if formatter.tokens.prefix(headerTokens.count).map({ $0.token }) == headerTokens {
+        if formatter.tokens.prefix(upTo: headerTokens.count).map({ $0.token }) == headerTokens {
             formatter.removeTokens(inRange: 0 ..< headerTokens.count)
         }
         if formatter.tokens.first?.token.isSpaceOrLinebreak == false {

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -419,14 +419,14 @@ public func applyRules(_ rules: [FormatRule],
     // Recursively apply rules until no changes are detected
     let group = DispatchGroup()
     let queue = DispatchQueue(label: "swiftformat.formatting", qos: .userInteractive)
-    let timeout = TimeInterval(tokens.count) / 1000
+    let timeout = !tokens.isEmpty ? TimeInterval(tokens.count) / 1000 : TimeInterval(1)
     for _ in 0 ..< 10 {
         let formatter = Formatter(tokens, fileName: fileName, options: options)
         for (i, rule) in rules.enumerated() {
+            formatter.help = rule.help
+            formatter.isSilent = rule.isSilent
+            formatter.ruleIndex = i
             queue.async(group: group) {
-                formatter.help = rule.help
-                formatter.isSilent = rule.isSilent
-                formatter.ruleIndex = i
                 rule.apply(with: formatter)
             }
             guard group.wait(timeout: .now() + timeout) != .timedOut else {

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -121,6 +121,31 @@ private struct StringDelimiterType {
     var hashCount: Int
 }
 
+public typealias TokenWL = (token: Token, lineNum: Int)
+
+public func == (lhs: [TokenWL], rhs: [TokenWL]) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+
+    for i in 0 ..< lhs.count {
+        if lhs[i].token != rhs[i].token {
+            return false
+        }
+    }
+    return true
+}
+
+public func != (lhs: [TokenWL], rhs: [TokenWL]) -> Bool {
+    return !(lhs == rhs)
+}
+
+public func IsEqual(lhs: [TokenWL], rhs: [TokenWL]) -> Bool {
+    return lhs == rhs
+}
+
+public func == (lhs: TokenWL, rhs: Token) -> Bool {
+    return lhs.token == rhs
+}
+
 /// All token types
 public enum Token: Equatable {
     case number(String, NumberType)
@@ -670,48 +695,61 @@ private extension UnicodeScalarView {
     }
 }
 
+private var _lines = 1
+private func _resetLine() { _lines = 1 }
+
 private extension UnicodeScalarView {
-    mutating func parseSpace() -> Token? {
-        return readCharacters(where: { $0.isSpace }).map { .space($0) }
+    mutating func parseSpace() -> TokenWL? {
+        return readCharacters(where: { $0.isSpace }).map { (.space($0), _lines) }
     }
 
-    mutating func parseLineBreak() -> Token? {
+    mutating func parseLineBreak() -> TokenWL? {
+        var ret: Token?
+
         if read("\r") {
             if read("\n") {
-                return .linebreak("\r\n")
+                ret = .linebreak("\r\n")
+            } else {
+                ret = .linebreak("\r")
             }
-            return .linebreak("\r")
+        } else {
+            ret = read("\n") ? .linebreak("\n") : nil
         }
-        return read("\n") ? .linebreak("\n") : nil
+
+        if let ret = ret {
+            _lines += 1
+            return TokenWL(token: ret, lineNum: _lines)
+        }
+        return nil
     }
 
-    mutating func parseDelimiter() -> Token? {
+    mutating func parseDelimiter() -> TokenWL? {
         return readCharacter(where: {
             ":;,".unicodeScalars.contains($0)
-        }).map { .delimiter(String($0)) }
+        }).map { (.delimiter(String($0)), _lines) }
     }
 
-    mutating func parseStartOfString() -> Token? {
+    mutating func parseStartOfString() -> TokenWL? {
         guard read("\"") else {
             return nil
         }
         let multiline = readString("\"\"")
-        return .startOfScope(multiline ? "\"\"\"" : "\"")
+        return (.startOfScope(multiline ? "\"\"\"" : "\""), _lines)
     }
 
-    mutating func parseStartOfScope() -> Token? {
+    mutating func parseStartOfScope() -> TokenWL? {
         return parseStartOfString() ?? readCharacter(where: {
             "<([{".unicodeScalars.contains($0)
-        }).map { .startOfScope(String($0)) }
+        }).map { (.startOfScope(String($0)), _lines) }
     }
 
-    mutating func parseEndOfScope() -> Token? {
+    mutating func parseEndOfScope() -> TokenWL? {
         return readCharacter(where: {
             "}])>".unicodeScalars.contains($0)
-        }).map { .endOfScope(String($0)) }
+        }).map { (.endOfScope(String($0)), _lines) }
     }
 
-    mutating func parseOperator() -> Token? {
+    mutating func parseOperator() -> TokenWL? {
         func isHead(_ c: UnicodeScalar) -> Bool {
             if "./\\=­-+!*%&|^~?".unicodeScalars.contains(c) {
                 return true
@@ -759,7 +797,7 @@ private extension UnicodeScalarView {
         if var tail = readCharacter(where: isHead) {
             switch tail {
             case "?", "!":
-                return .operator(String(tail), .none)
+                return (.operator(String(tail), .none), _lines)
             case "/":
                 break
             default:
@@ -767,23 +805,23 @@ private extension UnicodeScalarView {
             }
             var head = ""
             // Tail may only contain dot if head does
-            let headWasDot = (tail == ".")
+            let headWasDot = tail == "."
             while let c = readCharacter(where: { isTail($0) && (headWasDot || $0 != ".") }) {
                 if tail == "/" {
                     if c == "*" {
                         if head == "" {
-                            return .startOfScope("/*")
+                            return (.startOfScope("/*"), _lines)
                         }
                         // Can't return two tokens, so put /* back to be parsed next time
                         self = start
-                        return .operator(head, .none)
+                        return (.operator(head, .none), _lines)
                     } else if c == "/" {
                         if head == "" {
-                            return .startOfScope("//")
+                            return (.startOfScope("//"), _lines)
                         }
                         // Can't return two tokens, so put // back to be parsed next time
                         self = start
-                        return .operator(head, .none)
+                        return (.operator(head, .none), _lines)
                     }
                 }
                 if c != "/" {
@@ -793,12 +831,12 @@ private extension UnicodeScalarView {
                 tail = c
             }
             head.append(Character(tail))
-            return .operator(head, .none)
+            return (.operator(head, .none), _lines)
         }
         return nil
     }
 
-    mutating func parseIdentifier() -> Token? {
+    mutating func parseIdentifier() -> TokenWL? {
         func isHead(_ c: UnicodeScalar) -> Bool {
             switch c.value {
             case 0x41 ... 0x5A, // A-Z
@@ -876,36 +914,36 @@ private extension UnicodeScalarView {
         let start = self
         if read("`") {
             if let identifier = readIdentifier(), read("`") {
-                return .identifier("`" + identifier + "`")
+                return (.identifier("`" + identifier + "`"), _lines)
             }
             self = start
         } else if read("#") {
             if let identifier = readIdentifier() {
                 if identifier == "if" {
-                    return .startOfScope("#if")
+                    return (.startOfScope("#if"), _lines)
                 }
                 if identifier == "endif" {
-                    return .endOfScope("#endif")
+                    return (.endOfScope("#endif"), _lines)
                 }
-                return .keyword("#" + identifier)
+                return (.keyword("#" + identifier), _lines)
             }
             let hashes = readCharacters { $0 == "#" } ?? ""
-            if case let .startOfScope(quotes)? = parseStartOfString() {
-                return .startOfScope("#" + hashes + quotes)
+            if case let (.startOfScope(quotes), num)? = parseStartOfString() {
+                return (.startOfScope("#" + hashes + quotes), num)
             }
             self = start
         } else if read("@") {
             if let identifier = readIdentifier() {
-                return .keyword("@" + identifier)
+                return (.keyword("@" + identifier), _lines)
             }
             self = start
         } else if let identifier = readIdentifier() {
-            return identifier.isSwiftKeyword ? .keyword(identifier) : .identifier(identifier)
+            return (identifier.isSwiftKeyword ? .keyword(identifier) : .identifier(identifier), _lines)
         }
         return nil
     }
 
-    mutating func parseNumber() -> Token? {
+    mutating func parseNumber() -> TokenWL? {
         func readNumber(where head: @escaping (UnicodeScalar) -> Bool) -> String? {
             return read(head: head, tail: { head($0) || $0 == "_" })
         }
@@ -932,37 +970,37 @@ private extension UnicodeScalarView {
                     if let p = readCharacter(where: { "pP".unicodeScalars.contains($0) }) {
                         let sign = readSign()
                         if let power = readInteger() {
-                            return .number("0x\(hex)\(p)\(sign)\(power)", .hex)
+                            return (.number("0x\(hex)\(p)\(sign)\(power)", .hex), _lines)
                         }
-                        return .error("0x\(hex)\(p)\(readToEndOfToken())")
+                        return (.error("0x\(hex)\(p)\(readToEndOfToken())"), _lines)
                     }
                     let endOfHex = self
                     if read("."), let fraction = readHex() {
                         if let p = readCharacter(where: { "pP".unicodeScalars.contains($0) }) {
                             let sign = readSign()
                             if let power = readInteger() {
-                                return .number("0x\(hex).\(fraction)\(p)\(sign)\(power)", .hex)
+                                return (.number("0x\(hex).\(fraction)\(p)\(sign)\(power)", .hex), _lines)
                             }
-                            return .error("0x\(hex).\(fraction)\(p)\(readToEndOfToken())")
+                            return (.error("0x\(hex).\(fraction)\(p)\(readToEndOfToken())"), _lines)
                         }
                         if fraction.unicodeScalars.first?.isDigit == true {
-                            return .error("0x\(hex).\(fraction)\(readToEndOfToken())")
+                            return (.error("0x\(hex).\(fraction)\(readToEndOfToken())"), _lines)
                         }
                     }
                     self = endOfHex
-                    return .number("0x\(hex)", .hex)
+                    return (.number("0x\(hex)", .hex), _lines)
                 }
-                return .error("0x" + readToEndOfToken())
+                return (.error("0x" + readToEndOfToken()), _lines)
             } else if read("b") {
                 if let bin = readNumber(where: { "01".unicodeScalars.contains($0) }) {
-                    return .number("0b\(bin)", .binary)
+                    return (.number("0b\(bin)", .binary), _lines)
                 }
-                return .error("0b" + readToEndOfToken())
+                return (.error("0b" + readToEndOfToken()), _lines)
             } else if read("o") {
                 if let octal = readNumber(where: { ("0" ... "7").contains($0) }) {
-                    return .number("0o\(octal)", .octal)
+                    return (.number("0o\(octal)", .octal), _lines)
                 }
-                return .error("0o" + readToEndOfToken())
+                return (.error("0o" + readToEndOfToken()), _lines)
             }
         }
 
@@ -989,10 +1027,10 @@ private extension UnicodeScalarView {
             }
         }
 
-        return .number(number, type)
+        return (.number(number, type), _lines)
     }
 
-    mutating func parseToken() -> Token? {
+    mutating func parseToken() -> TokenWL? {
         // Have to split into groups for Swift to be able to process this
         if let token = parseSpace() ??
             parseLineBreak() ??
@@ -1007,15 +1045,15 @@ private extension UnicodeScalarView {
             return token
         }
         if !isEmpty {
-            return .error(readToEndOfToken())
+            return (.error(readToEndOfToken()), _lines)
         }
         return nil
     }
 }
 
-public func tokenize(_ source: String) -> [Token] {
+public func tokenize(_ source: String) -> [TokenWL] {
     var scopeIndexStack: [Int] = []
-    var tokens: [Token] = []
+    var tokens: [TokenWL] = []
     var characters = UnicodeScalarView(source.unicodeScalars)
     var closedGenericScopeIndexes: [Int] = []
 
@@ -1039,17 +1077,17 @@ public func tokenize(_ source: String) -> [Token] {
                 continue
             case "\"" where !escaped && characters.readString(hashes):
                 if string != "" {
-                    tokens.append(.stringBody(string))
+                    tokens.append((.stringBody(string), _lines))
                 }
-                tokens.append(.endOfScope("\"" + hashes))
+                tokens.append((.endOfScope("\"" + hashes), _lines))
                 scopeIndexStack.removeLast()
                 return
             case "(" where escaped:
                 if string != "" {
-                    tokens.append(.stringBody(string))
+                    tokens.append((.stringBody(string), _lines))
                 }
                 scopeIndexStack.append(tokens.count)
-                tokens.append(.startOfScope("("))
+                tokens.append((.startOfScope("("), _lines))
                 return
             default:
                 escaped = false
@@ -1057,7 +1095,7 @@ public func tokenize(_ source: String) -> [Token] {
             string.append(Character(c))
         }
         if string != "" {
-            tokens.append(.stringBody(string))
+            tokens.append((.stringBody(string), _lines))
         }
     }
 
@@ -1073,54 +1111,54 @@ public func tokenize(_ source: String) -> [Token] {
                 continue
             case "\"" where !escaped && characters.readString("\"\"" + hashes):
                 if !string.isEmpty {
-                    tokens.append(.error(string)) // Not permitted by the spec
+                    tokens.append((.error(string), _lines)) // Not permitted by the spec
                 }
                 var offset = ""
-                if case let .space(_offset) = tokens.last! {
+                if case let (.space(_offset), _) = tokens.last! {
                     offset = _offset
                 }
                 // Fix up indents
                 for index in (scopeIndexStack.last! ..< tokens.count - 1).reversed() {
-                    if case let .space(indent) = tokens[index], tokens[index - 1].isLinebreak {
+                    if case let (.space(indent), num) = tokens[index], tokens[index - 1].token.isLinebreak {
                         guard offset.isEmpty || indent.hasPrefix(offset) else {
-                            tokens[index] = .error(indent) // Mismatched whitespace
+                            tokens[index] = (.error(indent), num) // Mismatched whitespace
                             break
                         }
                         let remainder: String = String(indent[offset.endIndex ..< indent.endIndex])
-                        if case let .stringBody(body) = tokens[index + 1] {
-                            tokens[index + 1] = .stringBody(remainder + body)
+                        if case let (.stringBody(body), num) = tokens[index + 1] {
+                            tokens[index + 1] = (.stringBody(remainder + body), num)
                         } else {
-                            tokens.insert(.stringBody(remainder), at: index + 1)
+                            tokens.insert((.stringBody(remainder), tokens[index + 1].lineNum), at: index + 1)
                         }
                         if offset.isEmpty {
                             tokens.remove(at: index)
                         } else {
-                            tokens[index] = .space(offset)
+                            tokens[index].token = .space(offset)
                         }
                     }
                 }
-                tokens.append(.endOfScope("\"\"\"" + hashes))
+                tokens.append((.endOfScope("\"\"\"" + hashes), _lines))
                 scopeIndexStack.removeLast()
                 return
             case "(" where escaped:
                 if string != "" {
-                    tokens.append(.stringBody(string))
+                    tokens.append((.stringBody(string), _lines))
                 }
                 scopeIndexStack.append(tokens.count)
-                tokens.append(.startOfScope("("))
+                tokens.append((.startOfScope("("), _lines))
                 return
             case "\r", "\n":
                 if string != "" {
-                    tokens.append(.stringBody(string))
+                    tokens.append((.stringBody(string), _lines))
                     string = ""
                 }
                 if c == "\r", characters.read("\n") {
-                    tokens.append(.linebreak("\r\n"))
+                    tokens.append((.linebreak("\r\n"), _lines))
                 } else {
-                    tokens.append(.linebreak(String(c)))
+                    tokens.append((.linebreak(String(c)), _lines))
                 }
                 if let space = characters.parseSpace() {
-                    tokens.append(space)
+                    tokens.append((space.token, _lines))
                 }
                 escaped = false
                 continue
@@ -1130,7 +1168,7 @@ public func tokenize(_ source: String) -> [Token] {
             string.append(Character(c))
         }
         if string != "" {
-            tokens.append(.stringBody(string))
+            tokens.append((.stringBody(string), _lines))
         }
     }
 
@@ -1139,11 +1177,11 @@ public func tokenize(_ source: String) -> [Token] {
 
     func flushCommentBodyTokens() {
         if comment != "" {
-            tokens.append(.commentBody(comment))
+            tokens.append((.commentBody(comment), _lines))
             comment = ""
         }
         if space != "" {
-            tokens.append(.space(space))
+            tokens.append((.space(space), _lines))
             space = ""
         }
     }
@@ -1156,7 +1194,7 @@ public func tokenize(_ source: String) -> [Token] {
             }
             if space != "" {
                 if comment == "" {
-                    tokens.append(.space(space))
+                    tokens.append((.space(space), _lines))
                 } else {
                     comment += space
                 }
@@ -1173,43 +1211,44 @@ public func tokenize(_ source: String) -> [Token] {
             case "/" where characters.read("*"):
                 flushCommentBodyTokens()
                 scopeIndexStack.append(tokens.count)
-                tokens.append(.startOfScope("/*"))
+                tokens.append((.startOfScope("/*"), _lines))
                 continue
             case "*" where characters.read("/"):
                 flushCommentBodyTokens()
                 // Fix up indents
                 var baseIndent = ""
                 for index in scopeIndexStack.last! ..< tokens.count - 1 {
-                    if case let .space(indent) = tokens[index], tokens[index - 1].isLinebreak,
-                        tokens.count > index, case .commentBody = tokens[index + 1],
+                    if case let .space(indent) = tokens[index].token, tokens[index - 1].token.isLinebreak,
+                        tokens.count > index, case .commentBody = tokens[index + 1].token,
                         baseIndent.isEmpty || indent.count < baseIndent.count {
                         baseIndent = indent
                     }
                 }
                 for index in (scopeIndexStack.last! ..< tokens.count - 1).reversed() {
-                    if case let .space(indent) = tokens[index], tokens[index - 1].isLinebreak,
-                        tokens.count > index, case let .commentBody(body) = tokens[index + 1],
+                    if case let .space(indent) = tokens[index].token, tokens[index - 1].token.isLinebreak,
+                        tokens.count > index, case let .commentBody(body) = tokens[index + 1].token,
                         indent.hasPrefix(baseIndent) {
-                        tokens[index + 1] = .commentBody(indent.dropFirst(baseIndent.count) + body)
+                        tokens[index + 1].token = .commentBody(indent.dropFirst(baseIndent.count) + body)
                         if baseIndent.isEmpty {
                             tokens.remove(at: index)
                         } else {
-                            tokens[index] = .space(baseIndent)
+                            tokens[index].token = .space(baseIndent)
                         }
                     }
                 }
-                tokens.append(.endOfScope("*/"))
+                tokens.append((.endOfScope("*/"), _lines))
                 scopeIndexStack.removeLast()
-                if scopeIndexStack.last == nil || tokens[scopeIndexStack.last!] != .startOfScope("/*") {
+                if scopeIndexStack.last == nil || tokens[scopeIndexStack.last!].token != .startOfScope("/*") {
                     return
                 }
                 continue
             case "\n", "\r":
+                _lines += 1 // TODO: Check.
                 flushCommentBodyTokens()
                 if c == "\r", characters.read("\n") {
-                    tokens.append(.linebreak("\r\n"))
+                    tokens.append((.linebreak("\r\n"), _lines))
                 } else {
-                    tokens.append(.linebreak(String(c)))
+                    tokens.append((.linebreak(String(c)), _lines))
                 }
                 continue
             default:
@@ -1220,7 +1259,7 @@ public func tokenize(_ source: String) -> [Token] {
             }
             if space != "" {
                 if comment == "" {
-                    tokens.append(.space(space))
+                    tokens.append((.space(space), _lines))
                 } else {
                     comment += space
                 }
@@ -1233,20 +1272,20 @@ public func tokenize(_ source: String) -> [Token] {
     }
 
     func convertOpeningChevronToSymbol(at index: Int) {
-        assert(tokens[index] == .startOfScope("<"))
+        assert(tokens[index].token == .startOfScope("<"))
         if scopeIndexStack.last == index {
             scopeIndexStack.removeLast()
         }
-        tokens[index] = .operator("<", .none)
+        tokens[index].token = .operator("<", .none)
         stitchOperators(at: index)
     }
 
     func convertClosingChevronToSymbol(at i: Int, andOpeningChevron: Bool) {
-        assert(tokens[i] == .endOfScope(">"))
-        tokens[i] = .operator(">", .none)
+        assert(tokens[i].token == .endOfScope(">"))
+        tokens[i].token = .operator(">", .none)
         stitchOperators(at: i)
         if let previousIndex = index(of: .nonSpaceOrComment, before: i),
-            tokens[previousIndex] == .endOfScope(">") {
+            tokens[previousIndex].token == .endOfScope(">") {
             convertClosingChevronToSymbol(at: previousIndex, andOpeningChevron: true)
         }
         if andOpeningChevron, let scopeIndex = closedGenericScopeIndexes.last {
@@ -1256,20 +1295,20 @@ public func tokenize(_ source: String) -> [Token] {
     }
 
     func isUnwrapOperator(at index: Int) -> Bool {
-        let token = tokens[index]
+        let token = tokens[index].token
         if case let .operator(string, _) = token, ["?", "!"].contains(string), index > 0 {
-            let token = tokens[index - 1]
+            let token = tokens[index - 1].token
             return !token.isSpaceOrLinebreak && !token.isStartOfScope
         }
         return false
     }
 
     func stitchOperators(at index: Int) {
-        guard case var .operator(string, _) = tokens[index] else {
+        guard case var .operator(string, _) = tokens[index].token else {
             assertionFailure()
             return
         }
-        while let nextToken: Token = index + 1 < tokens.count ? tokens[index + 1] : nil,
+        while let nextToken: Token = index + 1 < tokens.count ? tokens[index + 1].token : nil,
             case let .operator(nextString, _) = nextToken,
             string.hasPrefix(".") || !nextString.contains(".") {
             if scopeIndexStack.last == index {
@@ -1277,11 +1316,11 @@ public func tokenize(_ source: String) -> [Token] {
                 scopeIndexStack.removeLast()
             }
             string += nextString
-            tokens[index] = .operator(string, .none)
+            tokens[index].token = .operator(string, .none)
             tokens.remove(at: index + 1)
         }
         var index = index
-        while let prevToken: Token = index > 1 ? tokens[index - 1] : nil,
+        while let prevToken: Token = index > 1 ? tokens[index - 1].token : nil,
             case let .operator(prevString, _) = prevToken, !isUnwrapOperator(at: index - 1),
             prevString.hasPrefix(".") || !string.contains(".") {
             if scopeIndexStack.last == index - 1 {
@@ -1289,15 +1328,15 @@ public func tokenize(_ source: String) -> [Token] {
                 scopeIndexStack.removeLast()
             }
             string = prevString + string
-            tokens[index - 1] = .operator(string, .none)
+            tokens[index - 1].token = .operator(string, .none)
             tokens.remove(at: index)
             index -= 1
         }
         setSymbolType(at: index)
         // Fix ternary that may not have been correctly closed in the first pass
-        if let scopeIndex = scopeIndexStack.last, tokens[scopeIndex] == .operator("?", .infix) {
-            for i in index ..< tokens.count where tokens[i] == .delimiter(":") {
-                tokens[i] = .operator(":", .infix)
+        if let scopeIndex = scopeIndexStack.last, tokens[scopeIndex].token == .operator("?", .infix) {
+            for i in index ..< tokens.count where tokens[i].token == .delimiter(":") {
+                tokens[i].token = .operator(":", .infix)
                 scopeIndexStack.removeLast()
                 break
             }
@@ -1305,26 +1344,26 @@ public func tokenize(_ source: String) -> [Token] {
     }
 
     func setSymbolType(at i: Int) {
-        let token = tokens[i]
+        let token = tokens[i].token
         guard case let .operator(string, currentType) = token else {
             assertionFailure()
             return
         }
         guard let prevNonSpaceToken =
-            index(of: .nonSpaceOrCommentOrLinebreak, before: i).map({ tokens[$0] }) else {
+            index(of: .nonSpaceOrCommentOrLinebreak, before: i).map({ tokens[$0].token }) else {
             if tokens.count > i + 1 {
-                tokens[i] = .operator(string, .prefix)
+                tokens[i].token = .operator(string, .prefix)
             }
             return
         }
         switch prevNonSpaceToken {
         case .keyword("func"), .keyword("operator"):
-            tokens[i] = .operator(string, .none)
+            tokens[i].token = .operator(string, .none)
             return
         default:
             break
         }
-        let prevToken: Token = tokens[i - 1]
+        let prevToken: Token = tokens[i - 1].token
         let type: OperatorType
         switch string {
         case ":", "=", "->":
@@ -1348,14 +1387,14 @@ public func tokenize(_ source: String) -> [Token] {
             type = .postfix
         default:
             guard let nextNonSpaceToken =
-                index(of: .nonSpaceOrCommentOrLinebreak, after: i).map({ tokens[$0] }) else {
+                index(of: .nonSpaceOrCommentOrLinebreak, after: i).map({ tokens[$0].token }) else {
                 if prevToken.isLvalue {
                     type = .postfix
                     break
                 }
                 return
             }
-            let nextToken: Token = tokens[i + 1]
+            let nextToken: Token = tokens[i + 1].token
             if nextToken.isRvalue {
                 type = prevToken.isLvalue ? .infix : .prefix
             } else if prevToken.isLvalue {
@@ -1368,13 +1407,13 @@ public func tokenize(_ source: String) -> [Token] {
                 return
             }
         }
-        tokens[i] = .operator(string, type)
+        tokens[i].token = .operator(string, type)
     }
 
     func index(of type: TokenType, before index: Int) -> Int? {
         var index = index - 1
         while index >= 0 {
-            if tokens[index].is(type) {
+            if tokens[index].token.is(type) {
                 return index
             }
             index -= 1
@@ -1385,7 +1424,7 @@ public func tokenize(_ source: String) -> [Token] {
     func index(of type: TokenType, after index: Int) -> Int? {
         var index = index + 1
         while index < tokens.count {
-            if tokens[index].is(type) {
+            if tokens[index].token.is(type) {
                 return index
             }
             index += 1
@@ -1396,36 +1435,36 @@ public func tokenize(_ source: String) -> [Token] {
     func processToken() {
         let token = tokens.last!
         let count = tokens.count
-        switch token {
+        switch token.token {
         case let .keyword(string):
             // Track switch/case statements
             if let prevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: count - 1),
-                case .operator(".", _) = tokens[prevIndex] {
-                tokens[tokens.count - 1] = .identifier(string)
+                case .operator(".", _) = tokens[prevIndex].token {
+                tokens[tokens.count - 1].token = .identifier(string)
                 processToken()
                 return
             }
             fallthrough
         case .identifier:
-            if count > 1, case .number = tokens[count - 2] {
-                tokens[count - 1] = .error(token.string)
+            if count > 1, case .number = tokens[count - 2].token {
+                tokens[count - 1].token = .error(token.token.string)
             }
         case let .number(string, _) where count > 1:
-            switch tokens[count - 2] {
+            switch tokens[count - 2].token {
             case .number:
-                tokens[count - 1] = .error(string)
+                tokens[count - 1].token = .error(string)
             case .operator(".", _):
-                tokens[count - 1] = .identifier(string)
+                tokens[count - 1].token = .identifier(string)
             default:
                 break
             }
         case .operator:
             stitchOperators(at: count - 1)
         case .startOfScope("<") where count >= 2:
-            if tokens[count - 2].isOperator,
+            if tokens[count - 2].token.isOperator,
                 let index = index(of: .nonSpaceOrCommentOrLinebreak, before: count - 2),
-                ![.keyword("func"), .keyword("init")].contains(tokens[index]) {
-                tokens[tokens.count - 1] = .operator("<", .none)
+                ![.keyword("func"), .keyword("init")].contains(tokens[index].token) {
+                tokens[tokens.count - 1].token = .operator("<", .none)
                 stitchOperators(at: count - 1)
                 processToken()
                 return
@@ -1436,22 +1475,22 @@ public func tokenize(_ source: String) -> [Token] {
         default:
             break
         }
-        if !token.isSpaceOrCommentOrLinebreak {
+        if !token.token.isSpaceOrCommentOrLinebreak {
             if let prevIndex = index(of: .nonSpaceOrComment, before: count - 1),
-                case .endOfScope(">") = tokens[prevIndex] {
+                case .endOfScope(">") = tokens[prevIndex].token {
                 // Fix up misidentified generic that is actually a pair of operators
-                switch token {
+                switch token.token {
                 case .operator("?", _), .operator("!", _), .operator("&", _),
                      .operator(".", _), .operator("...", _), .operator("->", _),
                      .operator("=", _) where prevIndex != count - 2:
                     break
                 case .operator("=", _) where prevIndex == count - 2:
                     guard let startIndex = index(of: .startOfScope, before: count - 1),
-                        tokens[startIndex] == .startOfScope("<"),
+                        tokens[startIndex].token == .startOfScope("<"),
                         let prevIndex = index(of: .nonSpaceOrComment, before: startIndex),
-                        case .identifier = tokens[prevIndex],
+                        case .identifier = tokens[prevIndex].token,
                         let prevPrevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex),
-                        tokens[prevPrevIndex] == .delimiter(":") else {
+                        tokens[prevPrevIndex].token == .delimiter(":") else {
                         fallthrough
                     }
                 case .operator, .identifier, .number, .startOfScope("\""), .startOfScope("\"\"\""):
@@ -1469,21 +1508,21 @@ public func tokenize(_ source: String) -> [Token] {
         }
         // Handle scope
         if let scopeIndex = scopeIndexStack.last {
-            let scope = tokens[scopeIndex]
-            if token.isEndOfScope(scope) {
+            let scope = tokens[scopeIndex].token
+            if token.token.isEndOfScope(scope) {
                 scopeIndexStack.removeLast()
-                switch token {
+                switch token.token {
                 case .delimiter(":"):
                     if case .operator("?", .infix) = scope {
-                        tokens[tokens.count - 1] = .operator(":", .infix)
+                        tokens[tokens.count - 1].token = .operator(":", .infix)
                     } else {
-                        tokens[tokens.count - 1] = .startOfScope(":")
+                        tokens[tokens.count - 1].token = .startOfScope(":")
                         scopeIndexStack.append(tokens.count - 1)
                     }
                 case .endOfScope("case"), .endOfScope("default"):
                     scopeIndexStack.append(tokens.count - 1)
                 case .endOfScope(")"):
-                    guard let scope = scopeIndexStack.last.map({ tokens[$0] }) else {
+                    guard let scope = scopeIndexStack.last.map({ tokens[$0].token }) else {
                         break
                     }
                     if let delimiterType = scope.stringDelimiterType {
@@ -1502,7 +1541,7 @@ public func tokenize(_ source: String) -> [Token] {
                 default:
                     break
                 }
-                if token == .endOfScope(">") {
+                if token.token == .endOfScope(">") {
                     closedGenericScopeIndexes.insert(scopeIndex, at: 0)
                 } else {
                     closedGenericScopeIndexes.removeAll()
@@ -1510,7 +1549,7 @@ public func tokenize(_ source: String) -> [Token] {
                 return
             } else if scope == .startOfScope("<") {
                 // We think it's a generic at this point, but could be wrong
-                switch token {
+                switch token.token {
                 case let .operator(string, _):
                     switch string {
                     case ".", "==", "?", "!", "&", "->":
@@ -1523,7 +1562,7 @@ public func tokenize(_ source: String) -> [Token] {
                         convertOpeningChevronToSymbol(at: scopeIndex)
                     }
                 case .delimiter(":") where scopeIndexStack.count > 1 &&
-                    tokens[scopeIndexStack[scopeIndexStack.count - 2]] == .endOfScope("case"):
+                    tokens[scopeIndexStack[scopeIndexStack.count - 2]].token == .endOfScope("case"):
                     // Not a generic scope
                     convertOpeningChevronToSymbol(at: scopeIndex)
                     processToken()
@@ -1539,45 +1578,45 @@ public func tokenize(_ source: String) -> [Token] {
                 default:
                     break
                 }
-            } else if token == .delimiter(":"),
+            } else if token.token == .delimiter(":"),
                 scope == .startOfScope("(") || scope == .startOfScope("["),
                 let prevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: count - 1),
-                tokens[prevIndex].isIdentifierOrKeyword,
+                tokens[prevIndex].token.isIdentifierOrKeyword,
                 let prevPrevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex) {
-                if case let .keyword(name) = tokens[prevIndex] {
-                    tokens[prevIndex] = .identifier(name)
+                if case let .keyword(name) = tokens[prevIndex].token {
+                    tokens[prevIndex].token = .identifier(name)
                 }
-                if case let .keyword(name) = tokens[prevPrevIndex] {
-                    tokens[prevPrevIndex] = .identifier(name)
+                if case let .keyword(name) = tokens[prevPrevIndex].token {
+                    tokens[prevPrevIndex].token = .identifier(name)
                 }
-            } else if case let .keyword(string) = token {
+            } else if case let .keyword(string) = token.token {
                 var scope = scope
                 var scopeIndex = scopeIndex
                 var scopeStackIndex = scopeIndexStack.count - 1
                 while scopeStackIndex > 0, scope == .startOfScope("#if") {
                     scopeStackIndex -= 1
                     scopeIndex = scopeIndexStack[scopeStackIndex]
-                    scope = tokens[scopeIndex]
+                    scope = tokens[scopeIndex].token
                 }
                 if [.startOfScope("{"), .startOfScope(":")].contains(scope) {
                     switch string {
                     case "default":
-                        tokens[tokens.count - 1] = .endOfScope(string)
+                        tokens[tokens.count - 1].token = .endOfScope(string)
                         processToken()
                         return
                     case "case":
                         if let keywordIndex = index(of: .keyword, before: scopeIndex) {
-                            var keyword = tokens[keywordIndex]
+                            var keyword = tokens[keywordIndex].token
                             if case .keyword("where") = keyword,
                                 let keywordIndex = index(of: .keyword, before: keywordIndex) {
-                                keyword = tokens[keywordIndex]
+                                keyword = tokens[keywordIndex].token
                             }
                             if case .keyword("enum") = keyword {
                                 break
                             }
                         }
                         if let prevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: count - 1) {
-                            switch tokens[prevIndex] {
+                            switch tokens[prevIndex].token {
                             case .keyword("if"),
                                  .keyword("guard"),
                                  .keyword("while"),
@@ -1585,7 +1624,7 @@ public func tokenize(_ source: String) -> [Token] {
                                  .delimiter(","):
                                 break
                             default:
-                                tokens[tokens.count - 1] = .endOfScope(string)
+                                tokens[tokens.count - 1].token = .endOfScope(string)
                                 processToken()
                                 return
                             }
@@ -1595,12 +1634,12 @@ public func tokenize(_ source: String) -> [Token] {
                     }
                 }
             } else if scope == .startOfScope(":") {
-                if [.keyword("#else"), .keyword("#elseif")].contains(token) {
+                if [.keyword("#else"), .keyword("#elseif")].contains(token.token) {
                     scopeIndexStack.removeLast()
                     return
-                } else if .endOfScope("#endif") == token {
+                } else if .endOfScope("#endif") == token.token {
                     scopeIndexStack.removeLast()
-                    if let index = scopeIndexStack.last, tokens[index] == .startOfScope("#if") {
+                    if let index = scopeIndexStack.last, tokens[index].token == .startOfScope("#if") {
                         scopeIndexStack.removeLast()
                     }
                     return
@@ -1608,7 +1647,7 @@ public func tokenize(_ source: String) -> [Token] {
             }
         }
         // Either there's no scope, or token didn't close it
-        switch token {
+        switch token.token {
         case let .startOfScope(string):
             scopeIndexStack.append(tokens.count - 1)
             switch string {
@@ -1617,7 +1656,7 @@ public func tokenize(_ source: String) -> [Token] {
             case "//":
                 processCommentBody()
             default:
-                if let delimiterType = token.stringDelimiterType {
+                if let delimiterType = token.token.stringDelimiterType {
                     if delimiterType.isMultiline {
                         processMultilineStringBody(hashCount: delimiterType.hashCount)
                     } else {
@@ -1631,12 +1670,12 @@ public func tokenize(_ source: String) -> [Token] {
             return
         case let .endOfScope(string):
             if ["case", "default"].contains(string), let scopeIndex = scopeIndexStack.last,
-                tokens[scopeIndex] == .startOfScope("#if") {
+                tokens[scopeIndex].token == .startOfScope("#if") {
                 scopeIndexStack.append(tokens.count - 1)
                 return
             }
             // Previous scope wasn't closed correctly
-            tokens[count - 1] = .error(string)
+            tokens[count - 1].token = .error(string)
             return
         default:
             break
@@ -1646,7 +1685,7 @@ public func tokenize(_ source: String) -> [Token] {
     // Ignore hashbang at start of file
     if source.hasPrefix("#!") {
         characters.removeFirst(2)
-        tokens.append(.startOfScope("#!"))
+        tokens.append((.startOfScope("#!"), 1))
         processCommentBody()
     }
 
@@ -1658,16 +1697,16 @@ public func tokenize(_ source: String) -> [Token] {
 
     loop: while let scopeIndex = scopeIndexStack.last {
         switch tokens[scopeIndex] {
-        case .startOfScope("<"):
+        case (.startOfScope("<"), _):
             // If we encountered an end-of-file while a generic scope was
             // still open, the opening < must have been an operator
             convertOpeningChevronToSymbol(at: scopeIndex)
-        case .startOfScope("//"):
+        case (.startOfScope("//"), _):
             scopeIndexStack.removeLast()
         default:
-            if tokens.last?.isError == false {
+            if tokens.last?.token.isError == false {
                 // File ended with scope still open
-                tokens.append(.error(""))
+                tokens.append((.error(""), tokens.last?.lineNum ?? 0))
             }
             break loop
         }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1051,6 +1051,10 @@ private extension UnicodeScalarView {
     }
 }
 
+public func pureTokenize(_ source: String) -> [Token] {
+    return tokenize(source).map { $0.token }
+}
+
 public func tokenize(_ source: String) -> [TokenWL] {
     var scopeIndexStack: [Int] = []
     var tokens: [TokenWL] = []

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1686,6 +1686,8 @@ public func tokenize(_ source: String) -> [TokenWL] {
         }
     }
 
+    _resetLine()
+
     // Ignore hashbang at start of file
     if source.hasPrefix("#!") {
         characters.removeFirst(2)

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -34,10 +34,10 @@ import XCTest
 
 class FormatterTests: XCTestCase {
     func testRemoveCurrentTokenWhileEnumerating() {
-        let input: [Token] = [
-            .identifier("foo"),
-            .identifier("bar"),
-            .identifier("baz"),
+        let input: [TokenWL] = [
+            (.identifier("foo"), 0),
+            (.identifier("bar"), 0),
+            (.identifier("baz"), 0),
         ]
         var output: [Token] = []
         let formatter = Formatter(input, options: .default)
@@ -47,14 +47,14 @@ class FormatterTests: XCTestCase {
                 formatter.removeToken(at: i)
             }
         }
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, input.map { $0.token })
     }
 
     func testRemovePreviousTokenWhileEnumerating() {
-        let input: [Token] = [
-            .identifier("foo"),
-            .identifier("bar"),
-            .identifier("baz"),
+        let input: [TokenWL] = [
+            (.identifier("foo"), 0),
+            (.identifier("bar"), 0),
+            (.identifier("baz"), 0),
         ]
         var output: [Token] = []
         let formatter = Formatter(input, options: .default)
@@ -64,14 +64,14 @@ class FormatterTests: XCTestCase {
                 formatter.removeToken(at: i - 1)
             }
         }
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, input.map { $0.token })
     }
 
     func testRemoveNextTokenWhileEnumerating() {
-        let input: [Token] = [
-            .identifier("foo"),
-            .identifier("bar"),
-            .identifier("baz"),
+        let input: [TokenWL] = [
+            (.identifier("foo"), 0),
+            (.identifier("bar"), 0),
+            (.identifier("baz"), 0),
         ]
         var output: [Token] = []
         let formatter = Formatter(input, options: .default)
@@ -81,16 +81,16 @@ class FormatterTests: XCTestCase {
                 formatter.removeToken(at: i + 1)
             }
         }
-        XCTAssertEqual(output, [Token](input.dropLast()))
+        XCTAssertEqual(output, input.dropLast().map { $0.token })
     }
 
     func testIndexBeforeComment() {
-        let input: [Token] = [
-            .identifier("foo"),
-            .startOfScope("//"),
-            .space(" "),
-            .commentBody("bar"),
-            .linebreak("\n"),
+        let input: [TokenWL] = [
+            (.identifier("foo"), 0),
+            (.startOfScope("//"), 0),
+            (.space(" "), 0),
+            (.commentBody("bar"), 0),
+            (.linebreak("\n"), 0),
         ]
         let formatter = Formatter(input, options: .default)
         let index = formatter.index(before: 4, where: { !$0.isSpaceOrComment })
@@ -98,14 +98,14 @@ class FormatterTests: XCTestCase {
     }
 
     func testIndexBeforeMultilineComment() {
-        let input: [Token] = [
-            .identifier("foo"),
-            .startOfScope("/*"),
-            .space(" "),
-            .commentBody("bar"),
-            .space(" "),
-            .endOfScope("*/"),
-            .linebreak("\n"),
+        let input: [TokenWL] = [
+            (.identifier("foo"), 0),
+            (.startOfScope("/*"), 0),
+            (.space(" "), 0),
+            (.commentBody("bar"), 0),
+            (.space(" "), 0),
+            (.endOfScope("*/"), 0),
+            (.linebreak("\n"), 0),
         ]
         let formatter = Formatter(input, options: .default)
         let index = formatter.index(before: 6, where: { !$0.isSpaceOrComment })

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -108,7 +108,7 @@ class MetadataTests: XCTestCase {
             }
             let allOptions = rule.options + rule.sharedOptions
             for index in scopeStart + 1 ..< scopeEnd {
-                switch formatter.tokens[index] {
+                switch formatter.tokens[index].token {
                 case let .identifier(name) where [
                     "spaceEquivalentToWidth",
                     "spaceEquivalentToTokens",

--- a/Tests/SwiftFormatTests.swift
+++ b/Tests/SwiftFormatTests.swift
@@ -151,7 +151,7 @@ class SwiftFormatTests: XCTestCase {
 
     func testOffsetForToken() {
         let source = "// a comment\n    let foo = 5\n"
-        let tokens = tokenize(source)
+        let tokens = pureTokenize(source)
         let (line, column) = offsetForToken(at: 7, in: tokens, tabWidth: 1)
         XCTAssertEqual(line, 2)
         XCTAssertEqual(column, 8)
@@ -159,7 +159,7 @@ class SwiftFormatTests: XCTestCase {
 
     func testOffsetForTokenWithTabs() {
         let source = "// a comment\n\tlet foo = 5\n"
-        let tokens = tokenize(source)
+        let tokens = pureTokenize(source)
         let (line, column) = offsetForToken(at: 7, in: tokens, tabWidth: 2)
         XCTAssertEqual(line, 2)
         XCTAssertEqual(column, 6)

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -46,7 +46,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnclosedBraces() {
@@ -61,7 +61,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .error(""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnclosedMultilineComment() {
@@ -72,7 +72,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("comment"),
             .error(""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnclosedString() {
@@ -82,7 +82,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("Hello World"),
             .error(""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnbalancedScopes() {
@@ -100,7 +100,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .error(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Hashbang
@@ -111,7 +111,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("#!"),
             .commentBody("/usr/bin/swift"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHashbangAtStartOfFile() {
@@ -122,7 +122,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .linebreak("\n"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHashbangAfterFirstLine() {
@@ -135,7 +135,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .linebreak("\n"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Unescaping
@@ -195,7 +195,7 @@ class TokenizerTests: XCTestCase {
         let output: [Token] = [
             .space("    "),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSpacesAndTabs() {
@@ -203,7 +203,7 @@ class TokenizerTests: XCTestCase {
         let output: [Token] = [
             .space("  \t  \t"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Strings
@@ -214,7 +214,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("\""),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSimpleString() {
@@ -224,7 +224,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("foo"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringWithEscape() {
@@ -234,7 +234,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("hello\\tworld"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringWithEscapedQuotes() {
@@ -244,7 +244,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\\"nice\\\" to meet you"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringWithEscapedLogic() {
@@ -257,7 +257,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(")"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringWithEscapedBackslash() {
@@ -267,7 +267,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\\\"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Multiline strings
@@ -286,7 +286,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testIndentedSimpleMultilineString() {
@@ -300,7 +300,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testEmptyMultilineString() {
@@ -310,7 +310,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineStringWithEscapedLinebreak() {
@@ -324,7 +324,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineStringStartingWithInterpolation() {
@@ -348,7 +348,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineStringWithEscapedTripleQuote() {
@@ -360,7 +360,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("\"\"\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Raw strings
@@ -371,7 +371,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("#\""),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testEmptyDoubleRawString() {
@@ -380,7 +380,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("##\""),
             .endOfScope("\"##"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnbalancedRawString() {
@@ -390,7 +390,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\"#"),
             .error(""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnbalancedRawString2() {
@@ -400,7 +400,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope("\"#"),
             .error("#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingUnescapedQuote() {
@@ -410,7 +410,7 @@ class TokenizerTests: XCTestCase {
             .stringBody(" \" "),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingJustASingleUnescapedQuote() {
@@ -420,7 +420,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("#"),
             .error(""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingUnhashedBackslash() {
@@ -430,7 +430,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\"),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingHashedEscapeSequence() {
@@ -440,7 +440,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\#n"),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingUnderhashedEscapeSequence() {
@@ -450,7 +450,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\#n"),
             .endOfScope("\"##"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingUnhashedInterpolation() {
@@ -460,7 +460,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\(5)"),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingHashedInterpolation() {
@@ -473,7 +473,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(")"),
             .endOfScope("\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRawStringContainingUnderhashedInterpolation() {
@@ -483,7 +483,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("\\#(5)"),
             .endOfScope("\"##"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Multiline raw strings
@@ -502,7 +502,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineRawStringContainingUnhashedInterpolation() {
@@ -516,7 +516,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineRawStringContainingHashedInterpolation() {
@@ -533,7 +533,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\"#"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineRawStringContainingUnderhashedInterpolation() {
@@ -547,7 +547,7 @@ class TokenizerTests: XCTestCase {
             .space("    "),
             .endOfScope("\"\"\"##"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Single-line comments
@@ -558,7 +558,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("//"),
             .commentBody("foo"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSingleLineCommentWithSpace() {
@@ -569,7 +569,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("foo"),
             .space(" "),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSingleLineCommentWithLinebreak() {
@@ -580,7 +580,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Multiline comments
@@ -592,7 +592,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("foo"),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSingleLineMultilineCommentWithSpace() {
@@ -604,7 +604,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineComment() {
@@ -616,7 +616,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("bar"),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineCommentWithSpace() {
@@ -629,7 +629,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("bar"),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNestedComments() {
@@ -643,7 +643,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("baz"),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNestedCommentsWithSpace() {
@@ -663,7 +663,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testPreformattedMultilineComment() {
@@ -697,7 +697,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Numbers
@@ -705,19 +705,19 @@ class TokenizerTests: XCTestCase {
     func testZero() {
         let input = "0"
         let output: [Token] = [.number("0", .integer)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSmallInteger() {
         let input = "5"
         let output: [Token] = [.number("5", .integer)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLargeInteger() {
         let input = "12345678901234567890"
         let output: [Token] = [.number("12345678901234567890", .integer)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNegativeInteger() {
@@ -726,7 +726,7 @@ class TokenizerTests: XCTestCase {
             .operator("-", .prefix),
             .number("7", .integer),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInvalidInteger() {
@@ -735,19 +735,19 @@ class TokenizerTests: XCTestCase {
             .number("123", .integer),
             .error("abc"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSmallFloat() {
         let input = "0.2"
         let output: [Token] = [.number("0.2", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLargeFloat() {
         let input = "1234.567890"
         let output: [Token] = [.number("1234.567890", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNegativeFloat() {
@@ -756,31 +756,31 @@ class TokenizerTests: XCTestCase {
             .operator("-", .prefix),
             .number("0.34", .decimal),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testExponential() {
         let input = "1234e5"
         let output: [Token] = [.number("1234e5", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testPositiveExponential() {
         let input = "0.123e+4"
         let output: [Token] = [.number("0.123e+4", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNegativeExponential() {
         let input = "0.123e-4"
         let output: [Token] = [.number("0.123e-4", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCapitalExponential() {
         let input = "0.123E-4"
         let output: [Token] = [.number("0.123E-4", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInvalidExponential() {
@@ -790,121 +790,121 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("e5"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLeadingZeros() {
         let input = "0005"
         let output: [Token] = [.number("0005", .integer)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testBinary() {
         let input = "0b101010"
         let output: [Token] = [.number("0b101010", .binary)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOctal() {
         let input = "0o52"
         let output: [Token] = [.number("0o52", .octal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHex() {
         let input = "0x2A"
         let output: [Token] = [.number("0x2A", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHexadecimalPower() {
         let input = "0xC3p0"
         let output: [Token] = [.number("0xC3p0", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCapitalHexadecimalPower() {
         let input = "0xC3P0"
         let output: [Token] = [.number("0xC3P0", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNegativeHexadecimalPower() {
         let input = "0xC3p-5"
         let output: [Token] = [.number("0xC3p-5", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testFloatHexadecimalPower() {
         let input = "0xC.3p0"
         let output: [Token] = [.number("0xC.3p0", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testFloatNegativeHexadecimalPower() {
         let input = "0xC.3p-5"
         let output: [Token] = [.number("0xC.3p-5", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInInteger() {
         let input = "1_23_4_"
         let output: [Token] = [.number("1_23_4_", .integer)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInFloat() {
         let input = "0_.1_2_"
         let output: [Token] = [.number("0_.1_2_", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInExponential() {
         let input = "0.1_2_e-3"
         let output: [Token] = [.number("0.1_2_e-3", .decimal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInBinary() {
         let input = "0b0000_0000_0001"
         let output: [Token] = [.number("0b0000_0000_0001", .binary)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInOctal() {
         let input = "0o123_456"
         let output: [Token] = [.number("0o123_456", .octal)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInHex() {
         let input = "0xabc_def"
         let output: [Token] = [.number("0xabc_def", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInHexadecimalPower() {
         let input = "0xabc_p5"
         let output: [Token] = [.number("0xabc_p5", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnderscoresInFloatHexadecimalPower() {
         let input = "0xa.bc_p5"
         let output: [Token] = [.number("0xa.bc_p5", .hex)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNoLeadingUnderscoreInInteger() {
         let input = "_12345"
         let output: [Token] = [.identifier("_12345")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNoLeadingUnderscoreInHex() {
         let input = "0x_12345"
         let output: [Token] = [.error("0x_12345")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHexPropertyAccess() {
@@ -914,7 +914,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("ee"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInvalidHexadecimal() {
@@ -922,7 +922,7 @@ class TokenizerTests: XCTestCase {
         let output: [Token] = [
             .error("0x123.0"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testAnotherInvalidHexadecimal() {
@@ -930,7 +930,7 @@ class TokenizerTests: XCTestCase {
         let output: [Token] = [
             .error("0x123.0p"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInvalidOctal() {
@@ -939,7 +939,7 @@ class TokenizerTests: XCTestCase {
             .number("0o123567", .octal),
             .error("8"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Identifiers & keywords
@@ -947,74 +947,74 @@ class TokenizerTests: XCTestCase {
     func testFoo() {
         let input = "foo"
         let output: [Token] = [.identifier("foo")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDollar0() {
         let input = "$0"
         let output: [Token] = [.identifier("$0")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDollar() {
         // Note: support for this is deprecated in Swift 3
         let input = "$"
         let output: [Token] = [.identifier("$")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testFooDollar() {
         let input = "foo$"
         let output: [Token] = [.identifier("foo$")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func test_() {
         let input = "_"
         let output: [Token] = [.identifier("_")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func test_foo() {
         let input = "_foo"
         let output: [Token] = [.identifier("_foo")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testFoo_bar() {
         let input = "foo_bar"
         let output: [Token] = [.identifier("foo_bar")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testAtFoo() {
         let input = "@foo"
         let output: [Token] = [.keyword("@foo")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHashFoo() {
         let input = "#foo"
         let output: [Token] = [.keyword("#foo")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnicode() {
         let input = "µsec"
         let output: [Token] = [.identifier("µsec")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testEmoji() {
         let input = "💩"
         let output: [Token] = [.identifier("💩")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testBacktickEscapedClass() {
         let input = "`class`"
         let output: [Token] = [.identifier("`class`")]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDotPrefixedKeyword() {
@@ -1023,7 +1023,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .prefix),
             .identifier("default"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordsAsArgumentLabelNames() {
@@ -1043,7 +1043,7 @@ class TokenizerTests: XCTestCase {
             .identifier("baz"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordsAsArgumentLabelNames2() {
@@ -1063,7 +1063,7 @@ class TokenizerTests: XCTestCase {
             .identifier("baz"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordsAsArgumentLabelNames3() {
@@ -1083,7 +1083,7 @@ class TokenizerTests: XCTestCase {
             .identifier("baz"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordAsInternalArgumentLabelName() {
@@ -1101,7 +1101,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Array"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordAsExternalArgumentLabelName() {
@@ -1119,7 +1119,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Array"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordAsBothArgumentLabelNames() {
@@ -1137,7 +1137,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Array"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testKeywordAsSubscriptLabels() {
@@ -1151,7 +1151,7 @@ class TokenizerTests: XCTestCase {
             .identifier("bar"),
             .endOfScope("]"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNumberedTupleVariableMember() {
@@ -1161,7 +1161,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("2"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNumberedTupleExpressionMember() {
@@ -1175,7 +1175,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("1"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: Operators
@@ -1183,7 +1183,7 @@ class TokenizerTests: XCTestCase {
     func testBasicOperator() {
         let input = "+="
         let output: [Token] = [.operator("+=", .none)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDivide() {
@@ -1195,13 +1195,13 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperator() {
         let input = "~="
         let output: [Token] = [.operator("~=", .none)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperator2() {
@@ -1213,7 +1213,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperator3() {
@@ -1225,7 +1225,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperator4() {
@@ -1237,7 +1237,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSequentialOperators() {
@@ -1250,19 +1250,19 @@ class TokenizerTests: XCTestCase {
             .operator("-", .prefix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDotPrefixedOperator() {
         let input = "..."
         let output: [Token] = [.operator("...", .none)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testUnicodeOperator() {
         let input = "≥"
         let output: [Token] = [.operator("≥", .none)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorFollowedByComment() {
@@ -1277,7 +1277,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope("*/"),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorPrecededBySpaceFollowedByComment() {
@@ -1293,7 +1293,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope("*/"),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorPrecededByComment() {
@@ -1308,7 +1308,7 @@ class TokenizerTests: XCTestCase {
             .operator("-", .prefix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorPrecededByCommentFollowedBySpace() {
@@ -1324,13 +1324,13 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorMayContainDotIfStartsWithDot() {
         let input = ".*.."
         let output: [Token] = [.operator(".*..", .none)]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorMayNotContainDotUnlessStartsWithDot() {
@@ -1339,7 +1339,7 @@ class TokenizerTests: XCTestCase {
             .operator("*", .prefix), // TODO: should be postfix
             .operator("..", .none),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOperatorStitchingDoesNotCreateIllegalToken() {
@@ -1350,7 +1350,7 @@ class TokenizerTests: XCTestCase {
             .operator("..", .infix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNullCoalescingOperator() {
@@ -1362,7 +1362,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTernary() {
@@ -1380,7 +1380,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("c"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTernaryWithOddSpacing() {
@@ -1396,7 +1396,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("c"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixOperatorBeforeLinebreak() {
@@ -1408,7 +1408,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixOperatorAfterLinebreak() {
@@ -1420,7 +1420,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixOperatorBeforeComment() {
@@ -1433,7 +1433,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope("*/"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixOperatorAfterComment() {
@@ -1446,7 +1446,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testPrefixMinusBeforeMember() {
@@ -1456,7 +1456,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .prefix),
             .identifier("foo"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixMinusBeforeMember() {
@@ -1469,7 +1469,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .prefix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testPostfixOperatorBeforeMember() {
@@ -1480,7 +1480,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNotOperator() {
@@ -1489,7 +1489,7 @@ class TokenizerTests: XCTestCase {
             .operator("!", .prefix),
             .identifier("foo"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNotOperatorAfterKeyword() {
@@ -1500,7 +1500,7 @@ class TokenizerTests: XCTestCase {
             .operator("!", .prefix),
             .identifier("foo"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringDotMethod() {
@@ -1512,7 +1512,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("isEmpty"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testStringAssignment() {
@@ -1526,7 +1526,7 @@ class TokenizerTests: XCTestCase {
             .stringBody("foo"),
             .endOfScope("\""),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixNotEqualsInParens() {
@@ -1536,7 +1536,7 @@ class TokenizerTests: XCTestCase {
             .operator("!=", .none),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: chevrons (might be operators or generics)
@@ -1554,7 +1554,7 @@ class TokenizerTests: XCTestCase {
             .operator(">", .infix),
             .identifier("c"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLessThanGreaterThanFollowedByOperator() {
@@ -1585,7 +1585,7 @@ class TokenizerTests: XCTestCase {
             .operator("<", .infix),
             .identifier("y"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericTypeAmpersandProtocol() {
@@ -1600,7 +1600,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("Bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomChevronOperatorFollowedByParen() {
@@ -1614,7 +1614,7 @@ class TokenizerTests: XCTestCase {
             .identifier("bar"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRightShift() {
@@ -1624,7 +1624,7 @@ class TokenizerTests: XCTestCase {
             .operator(">>", .infix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLeftShift() {
@@ -1634,7 +1634,7 @@ class TokenizerTests: XCTestCase {
             .operator("<<", .infix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTripleShift() {
@@ -1644,7 +1644,7 @@ class TokenizerTests: XCTestCase {
             .operator(">>>", .infix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testRightShiftEquals() {
@@ -1654,7 +1654,7 @@ class TokenizerTests: XCTestCase {
             .operator(">>=", .infix),
             .identifier("b"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLeftShiftInsideTernary() {
@@ -1672,7 +1672,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .number("0", .integer),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testBitshiftThatLooksLikeAGeneric() {
@@ -1692,7 +1692,7 @@ class TokenizerTests: XCTestCase {
             .operator(">>", .infix),
             .identifier("e"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testBasicGeneric() {
@@ -1706,7 +1706,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Baz"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNestedGenerics() {
@@ -1720,7 +1720,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(">"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testFunctionThatLooksLikeGenericType() {
@@ -1733,7 +1733,7 @@ class TokenizerTests: XCTestCase {
             .identifier("r"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericClassDeclaration() {
@@ -1751,7 +1751,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericSubclassDeclaration() {
@@ -1769,7 +1769,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("Bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFunctionDeclaration() {
@@ -1787,7 +1787,7 @@ class TokenizerTests: XCTestCase {
             .identifier("T"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericClassInit() {
@@ -1806,7 +1806,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFollowedByDot() {
@@ -1821,7 +1821,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testConstantThatLooksLikeGenericType() {
@@ -1833,7 +1833,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Pi"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTupleOfBoolsThatLooksLikeGeneric() {
@@ -1849,7 +1849,7 @@ class TokenizerTests: XCTestCase {
             .identifier("V"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTupleOfBoolsThatReallyLooksLikeGeneric() {
@@ -1865,7 +1865,7 @@ class TokenizerTests: XCTestCase {
             .identifier("V"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericDeclarationThatLooksLikeTwoExpressions() {
@@ -1891,7 +1891,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("c"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericDeclarationWithoutSpace() {
@@ -1912,7 +1912,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("["),
             .endOfScope("]"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericClassInitThatLooksLikeTuple() {
@@ -1930,7 +1930,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(")"),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomChevronOperatorThatLooksLikeGeneric() {
@@ -1944,7 +1944,7 @@ class TokenizerTests: XCTestCase {
             .operator(">>>", .infix),
             .number("5", .integer),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericAsFunctionType() {
@@ -1959,7 +1959,7 @@ class TokenizerTests: XCTestCase {
             .operator("->", .infix),
             .identifier("Void"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingFunctionType() {
@@ -1974,7 +1974,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Baz"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingFunctionTypeWithMultipleArguments() {
@@ -1991,7 +1991,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Quux"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingMultipleFunctionTypes() {
@@ -2012,7 +2012,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Void"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingArrayType() {
@@ -2027,7 +2027,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Baz"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingTupleType() {
@@ -2042,7 +2042,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(")"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericContainingArrayAndTupleType() {
@@ -2059,7 +2059,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(")"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFollowedByIn() {
@@ -2074,7 +2074,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .keyword("in"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOptionalGenericType() {
@@ -2088,7 +2088,7 @@ class TokenizerTests: XCTestCase {
             .identifier("U"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testTrailingOptionalGenericType() {
@@ -2100,7 +2100,7 @@ class TokenizerTests: XCTestCase {
             .operator("?", .postfix),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testNestedOptionalGenericType() {
@@ -2115,7 +2115,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(">"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDeeplyNestedGenericType() {
@@ -2132,7 +2132,7 @@ class TokenizerTests: XCTestCase {
             .endOfScope(">"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFollowedByGreaterThan() {
@@ -2149,7 +2149,7 @@ class TokenizerTests: XCTestCase {
             .operator(">", .infix),
             .identifier("c"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFollowedByElipsis() {
@@ -2170,7 +2170,7 @@ class TokenizerTests: XCTestCase {
             .operator("...", .postfix),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericOperatorFunction() {
@@ -2185,7 +2185,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericCustomOperatorFunction() {
@@ -2202,7 +2202,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericTypeContainingAmpersand() {
@@ -2220,7 +2220,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Quux"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperatorStartingWithOpenChevron() {
@@ -2230,7 +2230,7 @@ class TokenizerTests: XCTestCase {
             .operator("<--", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCustomOperatorEndingWithCloseChevron() {
@@ -2240,7 +2240,7 @@ class TokenizerTests: XCTestCase {
             .operator("-->", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGreaterThanLessThanOperator() {
@@ -2250,7 +2250,7 @@ class TokenizerTests: XCTestCase {
             .operator("><", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testLessThanGreaterThanOperator() {
@@ -2260,7 +2260,7 @@ class TokenizerTests: XCTestCase {
             .operator("<>", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericFollowedByAssign() {
@@ -2280,7 +2280,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .number("5", .integer),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericInFailableInit() {
@@ -2294,7 +2294,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixEqualsOperatorWithSpace() {
@@ -2307,7 +2307,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixEqualsOperatorWithoutSpace() {
@@ -2319,7 +2319,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixQuestionMarkChevronOperatorWithSpace() {
@@ -2332,7 +2332,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixQuestionMarkChevronOperatorWithoutSpace() {
@@ -2344,7 +2344,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixEqualsDoubleChevronOperator() {
@@ -2356,7 +2356,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .operator("=<<", .none),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testInfixEqualsDoubleChevronGenericFunction() {
@@ -2371,7 +2371,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("("),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testHalfOpenRangeFollowedByComment() {
@@ -2384,7 +2384,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("//"),
             .commentBody("comment"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSortAscending() {
@@ -2398,7 +2398,7 @@ class TokenizerTests: XCTestCase {
             .operator("<", .none),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSortDescending() {
@@ -2412,7 +2412,7 @@ class TokenizerTests: XCTestCase {
             .operator(">", .none),
             .endOfScope(")"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericsWithWhereClause() {
@@ -2432,7 +2432,7 @@ class TokenizerTests: XCTestCase {
             .identifier("C"),
             .endOfScope(">"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testIfLessThanIfGreaterThan() {
@@ -2462,7 +2462,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("{"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: optionals
@@ -2475,7 +2475,7 @@ class TokenizerTests: XCTestCase {
             .operator("=", .infix),
             .identifier("nil"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testQuestionMarkEqualOperator() {
@@ -2487,7 +2487,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testOptionalChaining() {
@@ -2498,7 +2498,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultipleOptionalChaining() {
@@ -2511,7 +2511,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSplitLineOptionalChaining() {
@@ -2524,7 +2524,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: case statements
@@ -2545,7 +2545,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Baz"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSingleLineGenericEnum() {
@@ -2567,7 +2567,7 @@ class TokenizerTests: XCTestCase {
             .identifier("Baz"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testMultilineLineEnum() {
@@ -2589,7 +2589,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchStatement() {
@@ -2622,7 +2622,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchStatementWithEnumCases() {
@@ -2652,7 +2652,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingDictionaryDefault() {
@@ -2685,7 +2685,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseIsDictionaryStatement() {
@@ -2720,7 +2720,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingCaseIdentifier() {
@@ -2748,7 +2748,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingDefaultIdentifier() {
@@ -2776,7 +2776,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingIfCase() {
@@ -2813,7 +2813,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingIfCaseCommaCase() {
@@ -2859,7 +2859,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingGuardCase() {
@@ -2898,7 +2898,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchFollowedByEnum() {
@@ -2936,7 +2936,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingSwitchIdentifierFollowedByEnum() {
@@ -2976,7 +2976,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchCaseContainingRangeOperator() {
@@ -3006,7 +3006,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testEnumDeclarationInsideSwitchCase() {
@@ -3044,7 +3044,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testDefaultAfterWhereCondition() {
@@ -3078,7 +3078,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testEnumWithConditionalCase() {
@@ -3106,7 +3106,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchWithConditionalCase() {
@@ -3138,7 +3138,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchWithConditionalCase2() {
@@ -3172,7 +3172,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testSwitchWithConditionalCase3() {
@@ -3206,7 +3206,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testGenericEnumCase() {
@@ -3237,7 +3237,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCaseEnumValueWithoutSpaces() {
@@ -3257,7 +3257,7 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .endOfScope("}"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: dot prefix
@@ -3273,7 +3273,7 @@ class TokenizerTests: XCTestCase {
             .identifier("bar"),
             .endOfScope("]"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: linebreaks
@@ -3285,7 +3285,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\n"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCR() {
@@ -3295,7 +3295,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\r"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCRLF() {
@@ -3305,7 +3305,7 @@ class TokenizerTests: XCTestCase {
             .linebreak("\r\n"),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCRLFAfterComment() {
@@ -3317,7 +3317,7 @@ class TokenizerTests: XCTestCase {
             .startOfScope("//"),
             .commentBody("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testCRLFInMultilineComment() {
@@ -3329,7 +3329,7 @@ class TokenizerTests: XCTestCase {
             .commentBody("bar"),
             .endOfScope("*/"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     // MARK: keypaths
@@ -3348,7 +3348,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testAnonymousKeyPath() {
@@ -3364,7 +3364,7 @@ class TokenizerTests: XCTestCase {
             .operator(".", .prefix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 
     func testAnonymousSubscriptKeyPath() {
@@ -3384,6 +3384,6 @@ class TokenizerTests: XCTestCase {
             .operator(".", .infix),
             .identifier("bar"),
         ]
-        XCTAssertEqual(tokenize(input), output)
+        XCTAssertEqual(pureTokenize(input), output)
     }
 }


### PR DESCRIPTION
I added some modifications which prints Xcode-compatible warning info and succeeded to use it in Xcode run phase before compilation:

<img width="2160" alt="Screen Shot 2019-06-18 at 21 31 09" src="https://user-images.githubusercontent.com/14824311/60037594-40fa4780-96b2-11e9-8221-45ccf8280e30.png">

@nicklockwood, These modifications are not ready for publishing in their current form, I think. As naming is not sophisticated in the proof-of-concept commits and many `.map { }` usage might be unnecessary but the main idea is acceptable, I think. And still the performance/run time is ok.
I count the line numbers in Tokenizer's `parseLineBreak()` and added the current line number to each token. Column info also would be fine.
