### PR TITLE
Fix bug where CLI would only consider first error in array

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -550,10 +550,6 @@ func processArguments(_ args: [String], in directory: String) -> ExitCode {
 
         if outputFlags.filesWritten == 0 {
             if outputFlags.filesChecked == 0 {
-                if let error = errors.first {
-                    errors.removeAll()
-                    throw error
-                }
                 if outputFlags.filesSkipped == 0 {
                     let inputPaths = inputURLs.map { $0.path }.joined(separator: ", ")
                     throw FormatError.options("No eligible files found at \(inputPaths)")


### PR DESCRIPTION
This is my (very naive) attempt at fixing the issues I raised in #467. I don't really have context on why the code is written this way (it seems to date back ~3 years, to 2894502df311e05aa9bac76b787fafb4a3e91582), so I'm not entirely confident this is safe to merge 😄.