### PR TITLE
Fix --quiet preventing .raw output

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -67,7 +67,7 @@ public struct CLI {
 
 private var quietMode = false
 private func print(_ message: String, as type: CLI.OutputType = .info) {
-    if !quietMode || [.content, .error].contains(type) {
+    if !quietMode || [.raw, .content, .error].contains(type) {
         CLI.print(message, type)
     }
 }


### PR DESCRIPTION
Fixes #476. 32ba97d added a new case `raw` to handle the non-EOL-appended output. However, this new case isn't bypassed for `--quiet` like `.content` was, leading to potential output issues.