### PR TITLE
Documentation fix: redundantObjc example code

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -838,7 +838,7 @@ Removes unnecessary `@objc` annotation from properties and functions.
 
 ```diff
 - @IBAction @objc func goBack() {}
-+ @IBOutlet func goBack() {}
++ @IBAction func goBack() {}
 ```
 
 ```diff


### PR DESCRIPTION
I don't think it was intended to change an IBOutlet to an IBAction.