### PR TITLE
Disables wrap parameters for image and color literals due to Xcode bug

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -922,9 +922,9 @@ extension Formatter {
             switch token.string {
             case "(":
                 /// Don't wrap color/image literals due to Xcode bug
-                guard i - 1 >= 0,
-                    tokens[i - 1].string != "#colorLiteral",
-                    tokens[i - 1].string != "#imageLiteral" else {
+                guard let prevToken = self.token(at: i - 1),
+                    prevToken != .keyword("#colorLiteral"),
+                    prevToken != .keyword("#imageLiteral") else {
                     return
                 }
                 guard hasMultipleArguments ||

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -921,6 +921,12 @@ extension Formatter {
             var isParameters = false
             switch token.string {
             case "(":
+                /// Don't wrap color/image literals due to Xcode bug
+                guard i - 1 >= 0,
+                    tokens[i - 1].string != "#colorLiteral",
+                    tokens[i - 1].string != "#imageLiteral" else {
+                    return
+                }
                 guard hasMultipleArguments ||
                     index(in: i + 1 ..< endOfScope, where: { $0.isComment }) != nil else {
                     // Not an argument list, or only one argument

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3144,11 +3144,6 @@ public struct _FormatRules {
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks", "tabwidth", "maxwidth"]
     ) { formatter in
-        /// Don't wrap color/image literals due to Xcode bug
-        guard !formatter.tokens.contains(.keyword("#colorLiteral")),
-            !formatter.tokens.contains(.keyword("#imageLiteral")) else {
-            return
-        }
         formatter.wrapCollectionsAndArguments(completePartialWrapping: true)
     }
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3144,6 +3144,11 @@ public struct _FormatRules {
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks", "tabwidth", "maxwidth"]
     ) { formatter in
+        /// Don't wrap color/image literals due to Xcode bug
+        guard !formatter.tokens.contains(.keyword("#colorLiteral")),
+            !formatter.tokens.contains(.keyword("#imageLiteral")) else {
+            return
+        }
         formatter.wrapCollectionsAndArguments(completePartialWrapping: true)
     }
 

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -8056,7 +8056,7 @@ class RulesTests: XCTestCase {
     }
 
     func testNoWrapColorLiteral() {
-        let input = "if let color = #colorLiteral(resourceName: \"abc\") {}"
+        let input = "if let color = #colorLiteral(red: 0.2392156863, green: 0.6470588235, blue: 0.3647058824, alpha: 1)"
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 30)
         testFormatting(for: input, rule: FormatRules.wrapArguments, options: options,
                        exclude: ["wrap"])


### PR DESCRIPTION
This PR fixes an issue where the wrapping of color literals produces an unexpected behavior in XCode

Result:

<img width="397" alt="Screen Shot 2020-01-28 at 11 28 45 AM" src="https://user-images.githubusercontent.com/48680587/73272622-6eb3eb80-41c1-11ea-9b27-6d819461055f.png">
