### PR TITLE
Fixed bug in `indexOfLastSignificantKeyword()` logic

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -448,9 +448,12 @@ extension Formatter {
             return nil
         }
         if let endBraceIndex = lastIndex(of: .endOfScope("}"), in: index ..< i),
-            let startIndex = self.index(of: .startOfScope("{"), before: endBraceIndex),
-            !isStartOfClosure(at: startIndex) {
-            return nil
+            let startIndex = self.index(of: .startOfScope("{"), before: endBraceIndex) {
+            if isStartOfClosure(at: startIndex) {
+                return indexOfLastSignificantKeyword(at: startIndex, excluding: excluding)
+            } else {
+                return nil
+            }
         }
         switch tokens[index].string {
         case let name where

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -2046,6 +2046,12 @@ class RulesTests: XCTestCase {
         testFormatting(for: input, output, rule: FormatRules.indent)
     }
 
+    func testChainedClosureIndentsAfterIfCondition() {
+        let input = "if foo {\nbar()\n.baz()\n}\n\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
+        let output = "if foo {\n    bar()\n        .baz()\n}\n\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"
+        testFormatting(for: input, output, rule: FormatRules.indent)
+    }
+
     func testChainedClosureIndentsAfterVarDeclaration() {
         let input = "var foo: Int\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
         let output = "var foo: Int\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -480,6 +480,7 @@ extension RulesTests {
         ("testCaseVarOuterParensRemoved", testCaseVarOuterParensRemoved),
         ("testCatchLetError", testCatchLetError),
         ("testChainedClosureIndents", testChainedClosureIndents),
+        ("testChainedClosureIndentsAfterIfCondition", testChainedClosureIndentsAfterIfCondition),
         ("testChainedClosureIndentsAfterLetDeclaration", testChainedClosureIndentsAfterLetDeclaration),
         ("testChainedClosureIndentsAfterVarDeclaration", testChainedClosureIndentsAfterVarDeclaration),
         ("testChainedFunctionEndingInOpenParenNotDoubleIndented", testChainedFunctionEndingInOpenParenNotDoubleIndented),


### PR DESCRIPTION
Fixed Issues https://github.com/nicklockwood/SwiftFormat/issues/570 .
Unit test is also added.
