### PR TITLE
Update hook for format only ".swift" files

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Git pre-commit hook
 
     ```bash
     #!/bin/bash
-    git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
+    git diff --diff-filter=d --staged --name-only | grep -e '\.swift$' | while read line; do
       swiftformat "${line}";
       git add "$line";
     done


### PR DESCRIPTION
There is a bug in the current git `pre-commit` hook. It tries to format files end with `swift`. For instance: `rswift` is a binary file and shouldn't be formatted.

Too test out:
```
echo rswift | grep -e '\(.*\).swift$' 
echo rswift | grep -e '\.swift$' 
```

I've also simplified the regex :) 