### PR TITLE
Fixed the cause of not performing `indexOfLastSignificantKeyword()` logic

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -104,7 +104,14 @@ public class Formatter: NSObject {
     public let options: FormatOptions
 
     /// The token array managed by the formatter (read-only)
-    public private(set) var tokens: [Token]
+    public private(set) var tokens: [Token] {
+        didSet {
+            cacheIndexOfLastSignificantKeywords = [Int?](repeating: nil, count: tokens.count)
+        }
+    }
+
+    /// The indexOfLastSignificantKeyword cache array
+    internal var cacheIndexOfLastSignificantKeywords = [Int?]()
 
     /// Create a new formatter instance from a token array
     public init(_ tokens: [Token], options: FormatOptions = FormatOptions(),
@@ -113,6 +120,7 @@ public class Formatter: NSObject {
         self.options = options
         self.trackChanges = trackChanges
         self.range = range
+        cacheIndexOfLastSignificantKeywords = [Int?](repeating: nil, count: tokens.count)
     }
 
     // MARK: changes made

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -106,7 +106,7 @@ public class Formatter: NSObject {
     /// The token array managed by the formatter (read-only)
     public private(set) var tokens: [Token] {
         didSet {
-            cacheIndexOfLastSignificantKeywords = [Int?](repeating: nil, count: tokens.count)
+            cacheIndexOfLastSignificantKeywords = [Int?](repeating: -1, count: tokens.count)
         }
     }
 
@@ -120,7 +120,7 @@ public class Formatter: NSObject {
         self.options = options
         self.trackChanges = trackChanges
         self.range = range
-        cacheIndexOfLastSignificantKeywords = [Int?](repeating: nil, count: tokens.count)
+        cacheIndexOfLastSignificantKeywords = [Int?](repeating: -1, count: tokens.count)
     }
 
     // MARK: changes made

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -447,6 +447,18 @@ extension Formatter {
     }
 
     func indexOfLastSignificantKeyword(at i: Int, excluding: [String] = []) -> Int? {
+        guard i > 0 else {
+            return calculateIndexOfLastSignificantKeyword(at: i, excluding: excluding)
+        }
+        if let cacheIndex = cacheIndexOfLastSignificantKeywords[i] {
+            return cacheIndex
+        }
+        let index = calculateIndexOfLastSignificantKeyword(at: i, excluding: excluding)
+        cacheIndexOfLastSignificantKeywords[i] = index
+        return index
+    }
+
+    private func calculateIndexOfLastSignificantKeyword(at i: Int, excluding: [String] = []) -> Int? {
         guard let token = token(at: i),
             let index = token.isKeyword ? i : index(of: .keyword, before: i) else {
             return nil

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -450,8 +450,8 @@ extension Formatter {
         guard i > 0 else {
             return calculateIndexOfLastSignificantKeyword(at: i, excluding: excluding)
         }
-        if let cacheIndex = cacheIndexOfLastSignificantKeywords[i] {
-            return cacheIndex
+        if cacheIndexOfLastSignificantKeywords[i] != -1 {
+            return cacheIndexOfLastSignificantKeywords[i]
         }
         let index = calculateIndexOfLastSignificantKeyword(at: i, excluding: excluding)
         cacheIndexOfLastSignificantKeywords[i] = index

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -331,4 +331,39 @@ class FormatterTests: XCTestCase {
         """))
         XCTAssertEqual(formatter.endOfScope(at: 4), 13)
     }
+
+    // MARK: closure
+
+    func testFunctionInLotsOfClosureNotFormatted() throws {
+        let repeatCount = 10
+        let input = """
+        override func foo() {
+        bar {
+        var baz = 5
+        \(String(repeating: """
+        fizz {
+        buzz {
+        fizzbuzz()
+        }
+        }
+        
+        """, count: repeatCount))}
+        }
+        """
+        let output = """
+        override func foo() {
+            bar {
+                var baz = 5
+        \(String(repeating: """
+                fizz {
+                    buzz {
+                        fizzbuzz()
+                    }
+                }
+        
+        """, count: repeatCount))    }
+        }
+        """
+        XCTAssertEqual(try format(input + "\n", rules: FormatRules.default), output + "\n")
+    }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -327,6 +327,30 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssert(formatter.isStartOfClosure(at: 21))
     }
 
+    func testFunctionInLotsOfClosure() {
+        let repeatCount = 2
+        let formatter = Formatter(tokenize("""
+        override func foo() {
+        bar {
+        var baz = 5
+        \(String(repeating: """
+        fizz {
+        buzz {
+        fizzbuzz()
+        }
+        }
+        
+        """, count: repeatCount))}
+        }
+        """))
+        XCTAssertFalse(formatter.isStartOfClosure(at: 8))
+        XCTAssert(formatter.isStartOfClosure(at: 12))
+        for i in stride(from: 0, to: repeatCount * 16, by: 16) {
+            XCTAssert(formatter.isStartOfClosure(at: 24 + i))
+            XCTAssert(formatter.isStartOfClosure(at: 28 + i))
+        }
+    }
+
     // MARK: isAccessorKeyword
 
     func testDidSet() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -129,6 +129,7 @@ extension FormatterTests {
         ("testEnableNext", testEnableNext),
         ("testEnableNextWithMultilineComment", testEnableNextWithMultilineComment),
         ("testEndOfScopeInSwitch", testEndOfScopeInSwitch),
+        ("testFunctionInLotsOfClosureNotFormatted", testFunctionInLotsOfClosureNotFormatted),
         ("testIndexBeforeComment", testIndexBeforeComment),
         ("testIndexBeforeMultilineComment", testIndexBeforeMultilineComment),
         ("testLinebreakAfterLinebreakReturnsCorrectIndex", testLinebreakAfterLinebreakReturnsCorrectIndex),

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -346,6 +346,7 @@ extension ParsingHelpersTests {
         ("testFunctionAllmanBracesNotTreatedAsClosure", testFunctionAllmanBracesNotTreatedAsClosure),
         ("testFunctionBracesNotTreatedAsClosure", testFunctionBracesNotTreatedAsClosure),
         ("testFunctionInGetterPosition", testFunctionInGetterPosition),
+        ("testFunctionInLotsOfClosure", testFunctionInLotsOfClosure),
         ("testGenericSubscriptSetGet", testGenericSubscriptSetGet),
         ("testGetSet", testGetSet),
         ("testGuardElseBracesNotTreatedAsClosure", testGuardElseBracesNotTreatedAsClosure),


### PR DESCRIPTION
In this PR, https://github.com/nicklockwood/SwiftFormat/issues/577 will be solved by speeding up with cache.
Unit test is also added.

The following is the result of executing SwiftFormat with the sample code described in https://github.com/nicklockwood/SwiftFormat/issues/577#issuecomment-599522922.

<details close>
<summary>sample code</summary>
<br>

```swift
enum ManagersAssembly {
    // swiftlint:disable:next closure_body_length
    static let container: DependencyContainer = {
        let container = DependencyContainer()

        // MARK: - Cocoa

        container.register {
            UserDefaults.standard
        }

        container.register { _ -> JSONDecoder in
            let jsonDecoder = JSONDecoder()
            jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
            jsonDecoder.dateDecodingStrategy = .secondsSince1970
            return jsonDecoder
        }

        container.register { JSONEncoder() }

        // MARK: - Managers

        container.register(.singleton) {
            CartManager(cartService: $0, storageManager: $1) as CartManagerProtocol
        }

        container.register {
            KeyboardManager(notificationCenter: .default) as KeyboardManagerProtocol
        }

        container.register {
            RequestProvider(decoder: $0, requestInterceptor: $1) as RequestProviderProtocol
        }

        container.register {
            UserDefaultsManager(defaults: $0, encoder: $1, decoder: $2) as StorageProtocol
        }

        container.register {
            FirstLaunchManager(defaults: $0) as FirstLaunchManagerProtocol
        }

        container.register {
            PrecacheManager(requestProvider: $0, storage: $1, firstLaunchManager: $2) as PrecacheManagerProtocol
        }

        container.register {
            GeocoderManager() as GeocoderManagerProtocol
        }

        container.register(.singleton) {
            StoriesManager(storiesService: $0, storiesListService: $1) as StoriesManagerProtocol
        }

        // MARK: - Services

        container.register {
            CartService(requestProvider: $0) as CartServiceProtocol
        }

        container.register {
            BackendListService<ProductList>(requestProvider: $0) as ProductsServiceProtocol
        }

        container.register {
            BackendListService<ShopList>(requestProvider: $0) as ShopsServiceProtocol
        }

        container.register {
            BackendListService<Stories>(requestProvider: $0) as StoriesListServiceProtocol
        }

        container.register {
            ContactService(requestProvider: $0) as ContactServiceProtocol
        }

        container.register {
            BackendListService<CollectionMetadata>(requestProvider: $0) as CollectionsServiceProtocol
        }

        container.register {
            MetadataService(requestProvider: $0) as MetadataServiceProtocol
        }

        container.register {
            ProductService(requestProvider: $0) as ProductServiceProtocol
        }

        container.register {
            ProfileService(requestProvider: $0) as ProfileServiceProtocol
        }

        container.register {
            AuthManager(requestProvider: $0, tokenHolder: $1) as AuthManagerProtocol
        }

        container.register(.singleton) {
            AuthTokenHolderManager() as AuthTokenHolder
        }

        container.register(.singleton) {
            AuthRequestAdapter(tokenHolder: $0, decoder: $1) as RequestInterceptor
        }

        container.register {
            MetadataGetService(requestProvider: $0, request: MetadataEndpoint.sizes) as SizesServiceProtocol
        }

        container.register {
            StoriesService(requestProvider: $0) as StoriesServiceProtocol
        }

        container.register {
            OrderManager(requestProvider: $0) as OrderManagerProtocol
        }

        container.register {
            MetadataGetService(requestProvider: $0, request: MetadataEndpoint.banners) as BannersManagerProtocol
        }

        container.register {
            MetadataGetService(requestProvider: $0, request: MetadataEndpoint.cities) as CitiesManagerProtocol
        }

        container.register {
            MetadataGetService(requestProvider: $0, request: MetadataEndpoint.faq) as FaqServiceProtocol
        }

        container.register {
            SavedStoreManager() as SavedStoreManagerProtocol
        }

        container.register {
            ReviewsService(requestProvider: $0) as ReviewsServiceProtocol
        }

        container.register {
            MetadataGetService(requestProvider: $0, request: MetadataEndpoint.about) as AboutCompanyServiceProtocol
        }

        container.register { WishlistService(requestProvider: $0) as WishlistServiceProtocol }

        container.register { ContactsTransitionGenerator() as ContactsTransitionGeneratorProtocol }

        container.register { SubscriptionService(requestProvider: $0) as SubscriptionServiceProtocol }

        container.register {
            BackendListService<Suggests>(requestProvider: $0) as SuggestServiceProtocol
        }

        container.register { FeedbackService(requestProvider: $0) as FeedbackServiceProtocol }

        return container
    }()
}
```
</details>

|SwiftFormat Version|Result|
|:-:|:-|
|This PR|Running SwiftFormat...<br>SwiftFormat completed in 0.04s.<br>0/1 files formatted.<br>Program ended with exit code: 0|
|0.44.5|Running SwiftFormat...<br>warning: indent rule timed out.<br>error: Failed to format any files.<br>Program ended with exit code: 70|
|0.44.4|Running SwiftFormat...<br>warning: indent rule timed out.<br>error: Failed to format any files.<br>Program ended with exit code: 70|
|0.44.3|Running SwiftFormat...<br>SwiftFormat completed in 0.05s.<br>0/1 files formatted.<br>Program ended with exit code: 0|


By the way, when the timeout value was changed as follows in **0.44.5**, the process was not completed even after several minutes.

```diff
- let timeout = 1 + TimeInterval(tokens.count) / 1000
+ let timeout = 1 + TimeInterval(tokens.count)
```
