### PR TITLE
redundantBackticks: Remove redundant raw values for escaped reserved words

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2014,7 +2014,7 @@ public struct _FormatRules {
                 }), let quoteIndex = formatter.index(of: .nonSpaceOrLinebreak, after: equalsIndex, if: {
                     $0 == .startOfScope("\"")
                 }), formatter.token(at: quoteIndex + 2) == .endOfScope("\"") {
-                    if formatter.tokens[nameIndex].string == formatter.token(at: quoteIndex + 1)?.string {
+                    if formatter.tokens[nameIndex].unescaped() == formatter.token(at: quoteIndex + 1)?.string {
                         formatter.removeTokens(inRange: nameIndex + 1 ... quoteIndex + 2)
                         index = nameIndex
                     } else {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -5168,6 +5168,12 @@ class RulesTests: XCTestCase {
         testFormatting(for: input, output, rule: FormatRules.redundantRawValues)
     }
 
+    func testRemoveBacktickCaseRawStringCases() {
+        let input = "enum Foo: String { case `as` = \"as\", `let` = \"let\" }"
+        let output = "enum Foo: String { case `as`, `let` }"
+        testFormatting(for: input, output, rule: FormatRules.redundantRawValues)
+    }
+
     func testNoRemoveRawStringIfNameDoesntMatch() {
         let input = "enum Foo: String {\n    case bar = \"foo\"\n}"
         testFormatting(for: input, rule: FormatRules.redundantRawValues)


### PR DESCRIPTION
```swift
enum Foo: String {
  case `as` = "as"
  case bs = "bs"
}
```

Currently, `redundantBackticks` will correctly strip the `"bs"` rawValue but will miss the `"as"`.

```swift
enum Foo: String {
  case `as` = "as"
  case bs
}
```

But the escaped `as` is also safe to cleanup.

This PR changes the token comparison to consider the unescaped value of the string to fix the issue.

```swift
enum Foo: String {
  case `as`
  case bs
}
```