### PR TITLE
Fixed an indentation issue that occurred in 0.44.8 and later.

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -434,7 +434,7 @@ extension Formatter {
             guard let braceIndex = lastIndex(of: .endOfScope("}"), in: index + 1 ..< i) else {
                 return false
             }
-            return self.index(of: .linebreak, in: braceIndex + 1 ..< i) != nil
+            return self.index(of: .nonSpaceOrCommentOrLinebreak, in: braceIndex + 1 ..< i) != nil
         }
 
         switch tokens[index].string {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -2132,6 +2132,12 @@ class RulesTests: XCTestCase {
         testFormatting(for: input, output, rule: FormatRules.indent)
     }
 
+    func testChainedClosureIndentsAfterIfCondition2() {
+        let input = "if foo {\nbar()\n.baz()\n}\n\nfoo\n.bar {\nbaz()\n}.bar {\nbaz()\n}"
+        let output = "if foo {\n    bar()\n        .baz()\n}\n\nfoo\n    .bar {\n        baz()\n    }.bar {\n        baz()\n    }"
+        testFormatting(for: input, output, rule: FormatRules.indent)
+    }
+
     func testChainedClosureIndentsAfterVarDeclaration() {
         let input = "var foo: Int\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
         let output = "var foo: Int\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -505,6 +505,7 @@ extension RulesTests {
         ("testCatchLetError", testCatchLetError),
         ("testChainedClosureIndents", testChainedClosureIndents),
         ("testChainedClosureIndentsAfterIfCondition", testChainedClosureIndentsAfterIfCondition),
+        ("testChainedClosureIndentsAfterIfCondition2", testChainedClosureIndentsAfterIfCondition2),
         ("testChainedClosureIndentsAfterLetDeclaration", testChainedClosureIndentsAfterLetDeclaration),
         ("testChainedClosureIndentsAfterVarDeclaration", testChainedClosureIndentsAfterVarDeclaration),
         ("testChainedFunctionEndingInOpenParenNotDoubleIndented", testChainedFunctionEndingInOpenParenNotDoubleIndented),


### PR DESCRIPTION
Fixed an indentation issue that occurred in 0.44.8 and later.

## Format target
```
if foo {
bar()
.baz()
}

foo
.bar {
baz()
}.bar {
baz()
}
```

## OK (Until 0.44.7)
```
if foo {
    bar()
        .baz()
}

foo
    .bar {
        baz()
    }.bar {
        baz()
    }
```

## NG (0.44.8 and later)
```
if foo {
    bar()
        .baz()
}

foo
    .bar {
        baz()
    }.bar {
    baz()
}
```