### PR TITLE
Keep internal / external parameter labels on the same line

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -866,10 +866,14 @@ extension Formatter {
             var linebreakIndiciesToRemove = [Int]()
             for index in i ..< endOfScope {
                 if tokens[index].is(.linebreak),
+                    // Check if this linebreak sits between two identifiers (e.g. the external and internal argument labels)
+                    let nextCommaOrClosingParen = self.index(of: .delimiter(","), after: index)
+                    ?? self.index(of: .endOfScope(")"), after: index),
                     let previousNonwhitespace = self.index(of: .nonSpaceOrCommentOrLinebreak, before: index),
                     tokens[previousNonwhitespace].is(.identifier),
                     let nextNonwhitespace = self.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
-                    tokens[nextNonwhitespace].is(.identifier) {
+                    tokens[nextNonwhitespace].is(.identifier),
+                    nextNonwhitespace < nextCommaOrClosingParen {
                     linebreakIndiciesToRemove.append(index)
                 }
             }

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -229,6 +229,6 @@ class CommandLineTests: XCTestCase {
             Swift.print(message)
         }
         // NOTE: to update regression suite, run again without `--lint` argument
-        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --cache ignore --lint"), .ok)
+        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --cache ignore"), .ok)
     }
 }

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -229,6 +229,6 @@ class CommandLineTests: XCTestCase {
             Swift.print(message)
         }
         // NOTE: to update regression suite, run again without `--lint` argument
-        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --cache ignore"), .ok)
+        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --cache ignore --lint"), .ok)
     }
 }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -8637,6 +8637,24 @@ class RulesTests: XCTestCase {
                        options: options, exclude: ["unusedArguments"])
     }
 
+    func testWrapParametersAfterFirstWithSeparatedArgumentLabels() {
+        let input = """
+        func foo(with
+            bar: Int, and
+            baz: String, and
+            quux: Bool
+        ) -> LongReturnType {}
+        """
+        let output = """
+        func foo(with bar: Int,
+                 and baz: String,
+                 and quux: Bool) -> LongReturnType {}
+        """
+        let options = FormatOptions(wrapParameters: .afterFirst)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments,
+                       options: options, exclude: ["unusedArguments"])
+    }
+
     // MARK: beforeFirst
 
     func testWrapAfterFirstConvertedToWrapBefore() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -8914,6 +8914,24 @@ class RulesTests: XCTestCase {
                        options: options, exclude: ["unusedArguments"])
     }
 
+    func testWrapParametersBeforeFirstWithSeparatedArgumentLabels() {
+        let input = """
+        func foo(with
+            bar: Int, and
+            baz: String
+        ) -> LongReturnType {}
+        """
+        let output = """
+        func foo(
+            with bar: Int,
+            and baz: String
+        ) -> LongReturnType {}
+        """
+        let options = FormatOptions(wrapParameters: .beforeFirst)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments,
+                       options: options, exclude: ["unusedArguments"])
+    }
+
     func testWrapParametersListBeforeFirstInClosureTypeWithMaxWidth() {
         let input = """
         var mathFunction: (Int, Int, String) -> Int = { _, _, _ in

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1795,6 +1795,7 @@ extension RulesTests {
         ("testWrapIfStatement", testWrapIfStatement),
         ("testWrapParametersAfterFirstIfMaxLengthExceededInReturnType", testWrapParametersAfterFirstIfMaxLengthExceededInReturnType),
         ("testWrapParametersBeforeFirstIfMaxLengthExceededInReturnType", testWrapParametersBeforeFirstIfMaxLengthExceededInReturnType),
+        ("testWrapParametersBeforeFirstWithSeparatedArgumentLabels", testWrapParametersBeforeFirstWithSeparatedArgumentLabels),
         ("testWrapParametersClosureAfterParameterListDoesNotWrapClosureArguments", testWrapParametersClosureAfterParameterListDoesNotWrapClosureArguments),
         ("testWrapParametersDoesNotAffectFunctionDeclaration", testWrapParametersDoesNotAffectFunctionDeclaration),
         ("testWrapParametersListBeforeFirstInClosureType", testWrapParametersListBeforeFirstInClosureType),

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1794,6 +1794,7 @@ extension RulesTests {
         ("testWrapIfElseStatement", testWrapIfElseStatement),
         ("testWrapIfStatement", testWrapIfStatement),
         ("testWrapParametersAfterFirstIfMaxLengthExceededInReturnType", testWrapParametersAfterFirstIfMaxLengthExceededInReturnType),
+        ("testWrapParametersAfterFirstWithSeparatedArgumentLabels", testWrapParametersAfterFirstWithSeparatedArgumentLabels),
         ("testWrapParametersBeforeFirstIfMaxLengthExceededInReturnType", testWrapParametersBeforeFirstIfMaxLengthExceededInReturnType),
         ("testWrapParametersBeforeFirstWithSeparatedArgumentLabels", testWrapParametersBeforeFirstWithSeparatedArgumentLabels),
         ("testWrapParametersClosureAfterParameterListDoesNotWrapClosureArguments", testWrapParametersClosureAfterParameterListDoesNotWrapClosureArguments),


### PR DESCRIPTION
This PR updates the `wrapArguments` rule to make sure internal and external parameter labels stay on the same line.

 - This is an enhancement related to #664

Example:

```swift
// Before
func foo(with
    bar: Int, and
    baz: String
) -> LongReturnType {}

// After formatting with `wrapArguments --beforeFirst`
func foo(
    with bar: Int,
    and baz: String
) -> LongReturnType {}

// After formatting with `wrapArguments --afterFirst`
func foo(with bar: Int, 
         and baz: String) -> LongReturnType {}