### PR TITLE
Add rule for multiline enum cases

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -20,6 +20,7 @@
 * [linebreakAtEndOfFile](#linebreakAtEndOfFile)
 * [linebreaks](#linebreaks)
 * [modifierOrder](#modifierOrder)
+* [multilineEnumCases](#multilineEnumCases)
 * [numberFormatting](#numberFormatting)
 * [preferKeyPath](#preferKeyPath)
 * [ranges *(deprecated)*](#ranges)
@@ -609,6 +610,10 @@ Option | Description
 
 </details>
 <br/>
+
+## multilineEnumCases
+
+Sort switch cases alphabetically.
 
 ## numberFormatting
 

--- a/Rules.md
+++ b/Rules.md
@@ -613,7 +613,7 @@ Option | Description
 
 ## multilineEnumCases
 
-Sort switch cases alphabetically.
+Writes one enum case per line
 
 ## numberFormatting
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3438,17 +3438,17 @@ public struct _FormatRules {
                 while let caseKeywordIndex = formatter.index(of: .keyword("case"), after: lastCase),
                     let breaklineIndex = formatter.index(of: .linebreak, after: caseKeywordIndex)
                 {
-                    var identifier: String = ""
-                    var associatedValue: String?
-
                     for jdx in (caseKeywordIndex + 1) ... breaklineIndex {
-                        if let token = formatter.token(at: jdx), token == .delimiter(",") {
-                            formatter.removeToken(at: jdx)
-                            formatter.insertLinebreak(at: jdx)
-                            formatter.insertSpace(formatter.indentForLine(at: jdx), at: jdx + 1)
-                            formatter.insertToken(.keyword("case"), at: jdx + 2)
-                            formatter.insertToken(.space(" "), at: jdx + 3)
-                        }
+                        guard
+                            let token = formatter.token(at: jdx),
+                            token == .delimiter(","),
+                            formatter.index(of: .startOfScope("("), in: lastCase ..< jdx) == nil else { continue }
+
+                        formatter.removeToken(at: jdx)
+                        formatter.insertLinebreak(at: jdx)
+                        formatter.insertSpace(formatter.indentForLine(at: jdx), at: jdx + 1)
+                        formatter.insertToken(.keyword("case"), at: jdx + 2)
+                        formatter.insertToken(.space(" "), at: jdx + 3)
                     }
 
                     lastCase = breaklineIndex

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3425,9 +3425,9 @@ public struct _FormatRules {
 
     /// Formats enum cases declaration into one case per line
     public let multilineEnumCases = FormatRule(
-        help: "Writes one enum case per line",
+        help: "Writes one enum case per line.",
         options: [],
-        sharedOptions: ["linebreaks"]
+        sharedOptions: ["linebreaks", "indent"]
     ) { formatter in
         formatter.forEach(.keyword("enum")) { idx, _ in
             if let start = formatter.index(of: .startOfScope("{"), after: idx),

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3423,9 +3423,9 @@ public struct _FormatRules {
         }
     }
 
-    /// Rewrites the enum cases one per line
+    /// Formats enum cases declaration into one case per line
     public let multilineEnumCases = FormatRule(
-        help: "Sort switch cases alphabetically.",
+        help: "Writes one enum case per line",
         options: [],
         sharedOptions: ["linebreaks"]
     ) { formatter in

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3423,6 +3423,40 @@ public struct _FormatRules {
         }
     }
 
+    /// Rewrites the enum cases one per line
+    public let multilineEnumCases = FormatRule(
+        help: "Sort switch cases alphabetically.",
+        options: [],
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.forEach(.keyword("enum")) { idx, _ in
+            if let start = formatter.index(of: .startOfScope("{"), after: idx),
+                let end = formatter.index(of: .endOfScope("}"), after: start)
+            {
+                var lastCase = start
+
+                while let caseKeywordIndex = formatter.index(of: .keyword("case"), after: lastCase),
+                    let breaklineIndex = formatter.index(of: .linebreak, after: caseKeywordIndex)
+                {
+                    var identifier: String = ""
+                    var associatedValue: String?
+
+                    for jdx in (caseKeywordIndex + 1) ... breaklineIndex {
+                        if let token = formatter.token(at: jdx), token == .delimiter(",") {
+                            formatter.removeToken(at: jdx)
+                            formatter.insertLinebreak(at: jdx)
+                            formatter.insertSpace(formatter.indentForLine(at: jdx), at: jdx + 1)
+                            formatter.insertToken(.keyword("case"), at: jdx + 2)
+                            formatter.insertToken(.space(" "), at: jdx + 3)
+                        }
+                    }
+
+                    lastCase = breaklineIndex
+                }
+            }
+        }
+    }
+
     /// Normalize the use of void in closure arguments and return values
     public let void = FormatRule(
         help: "Use `Void` for type declarations and `()` for values.",

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3427,7 +3427,7 @@ public struct _FormatRules {
     public let multilineEnumCases = FormatRule(
         help: "Writes one enum case per line.",
         options: [],
-        sharedOptions: ["linebreaks", "indent"]
+        sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.keyword("enum")) { idx, _ in
             if let start = formatter.index(of: .startOfScope("{"), after: idx),

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -4457,7 +4457,7 @@ class RulesTests: XCTestCase {
     func testMultilineEnumCases() {
         let input = """
         enum Enum1: Int {
-            case a = 0, p, c, d
+            case a = 0, p = 2, c, d
             case e, k
             case m(String, String)
         }
@@ -4465,7 +4465,7 @@ class RulesTests: XCTestCase {
         let output = """
         enum Enum1: Int {
             case a = 0
-            case p
+            case p = 2
             case c
             case d
             case e

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -4459,6 +4459,7 @@ class RulesTests: XCTestCase {
         enum Enum1: Int {
             case a = 0, p, c, d
             case e, k
+            case m(String, String)
         }
         """
         let output = """
@@ -4469,6 +4470,7 @@ class RulesTests: XCTestCase {
             case d
             case e
             case k
+            case m(String, String)
         }
         """
         testFormatting(for: input, output, rule: FormatRules.multilineEnumCases)

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -1664,14 +1664,14 @@ class RulesTests: XCTestCase {
     func testEnumCaseIndentingCommas() {
         let input = "enum Foo {\ncase Bar,\nBaz\n}"
         let output = "enum Foo {\n    case Bar,\n        Baz\n}"
-        testFormatting(for: input, output, rule: FormatRules.indent)
+        testFormatting(for: input, output, rule: FormatRules.indent, exclude: ["multilineEnumCases"])
     }
 
     func testEnumCaseIndentingCommasWithXcodeStyle() {
         let input = "enum Foo {\ncase Bar,\nBaz\n}"
         let output = "enum Foo {\n    case Bar,\n    Baz\n}"
         let options = FormatOptions(xcodeIndentation: true)
-        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options, exclude: ["multilineEnumCases"])
     }
 
     func testEnumCaseWrappedIfWithXcodeStyle() {
@@ -11694,7 +11694,10 @@ class RulesTests: XCTestCase {
         }
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: FormatRules.redundantFileprivate, options: options)
+        testFormatting(for: input,
+                       rule: FormatRules.redundantFileprivate,
+                       options: options,
+                       exclude: ["multilineEnumCases"])
     }
 
     func testFileprivateClassTypeMemberNotChangedToPrivate() {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -4452,6 +4452,28 @@ class RulesTests: XCTestCase {
         testFormatting(for: input, rule: FormatRules.modifierOrder)
     }
 
+    // MARK: multilineEnumCases
+
+    func testMultilineEnumCases() {
+        let input = """
+        enum Enum1: Int {
+            case a = 0, p, c, d
+            case e, k
+        }
+        """
+        let output = """
+        enum Enum1: Int {
+            case a = 0
+            case p
+            case c
+            case d
+            case e
+            case k
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.multilineEnumCases)
+    }
+
     // MARK: - void
 
     func testEmptyParensReturnValueConvertedToVoid() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -884,6 +884,7 @@ extension RulesTests {
         ("testMultilineCommentHeader", testMultilineCommentHeader),
         ("testMultilineDisableNextRemoveSelf", testMultilineDisableNextRemoveSelf),
         ("testMultilineDisableRemoveSelf", testMultilineDisableRemoveSelf),
+        ("testMultilineEnumCases", testMultilineEnumCases),
         ("testMultilineForLoopBraceOnNextLine", testMultilineForLoopBraceOnNextLine),
         ("testMultilineForLoopBraceOnNextLine2", testMultilineForLoopBraceOnNextLine2),
         ("testMultilineForWhereLoopBraceOnNextLine", testMultilineForWhereLoopBraceOnNextLine),


### PR DESCRIPTION
### Why?

Reviewing changes within big enum declarations can be quite messy and hard to follow:

```diff
enum Enum1: Int {
-   case a = 0, p = 2, c, d
+   case a = 0, p = 4, c, f
    case e, k
    case m(String, String)
}
```

### Rule

This PR adds a rule to rewrite enum declaration cases into one case per line. As you can see in the added test, it will go from this:

```swift
enum Enum1: Int {
     case a = 0, p = 2, c, d
     case e, k
     case m(String, String)
}
```

to this:

```swift
enum Enum1: Int {
     case a = 0
     case p = 2
     case c
     case d
     case e
     case k
     case m(String, String)
}
```

Improving the visibility of further changes in the enum declaration

```diff
enum Enum1: Int {
     case a = 0
-    case p = 2
+    case p = 4
     case c
     case d
-    case e
+    case f
     case k
     case m(String, String)
```

### Improvements
- The name of the rule can probably be improved.
- Sort the cases
- Extend the rule to handle switch cases.
