### PR TITLE
[Bug] Nested enums breaks with multiline cases

### DIFF
--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -4689,6 +4689,23 @@ class RulesTests: XCTestCase {
         """
         testFormatting(for: input, output, rule: FormatRules.multilineEnumCases)
     }
+    
+    func testMultilineEnumCasesWithNestedEnumsDoesNothing() {
+        let input = """
+        public enum SearchTerm: Decodable, Equatable {
+            case term(name: String)
+            case category(category: Category)
+
+            enum CodingKeys: String, CodingKey {
+                case name
+                case type
+                case categoryId = "category_id"
+                case attributes
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.multilineEnumCases)
+    }
 
     func testEnumCaseSplitOverMultipleLines() {
         let input = """


### PR DESCRIPTION
### What?

While testing another rule, I've found out that the current implementation of `multilineEnumCases` does not work for nested enums. I am adding a test that exposes the bug.

When running the rule to this code:

```swift
enum SearchTerm {
    case term(name: String)
    case category(category: Category)

    enum CodingKeys: String, CodingKey {
          case name
          case type
          case categoryId = "category_id"
          case attributes
    }
}
```

You end up with this:

```swift
enum SearchTerm {
    case term(name: String)
    case category(category: Category)

    enum CodingKeys: String
          case CodingKey 
          case name
          case type
          case categoryId = "category_id"
          case attributes
    }
}
```

A workaround in the meantime would be to add the 2nd enum in an extension:

```swift
enum SearchTerm {
    case term(name: String)
    case category(category: Category)
}

extension SearchTerm {
    enum CodingKeys: String, CodingKey {
        ...
    }
}
```

I am not sure what's the process for this, but I can take it if you want @nicklockwood .