### PR TITLE
Update organizeDeclarations to handle struct computed properties correctly

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4931,17 +4931,6 @@ public struct _FormatRules {
             case staticMethod
             case classMethod
             case instanceMethod
-
-            /// Whether or not this declaration potentially affects the
-            /// synthesized memberwise initializer of a `struct`
-            var canAffectStructMemberwiseInitializer: Bool {
-                switch self {
-                case .instanceProperty, .instancePropertyWithBody:
-                    return true
-                default:
-                    return false
-                }
-            }
         }
 
         let categoryOrdering: [Category] = [
@@ -5217,6 +5206,42 @@ public struct _FormatRules {
             if typeDeclaration.kind == "struct",
                 !typeDeclaration.body.contains(where: { $0.keyword == "init" })
             {
+                /// Whether or not this declaration is an instance property that can affect
+                /// the parameters struct's synthesized memberwise initializer
+                func affectsSynthesizedMemberwiseInitializer(
+                    _ declaration: Formatter.Declaration,
+                    _ type: DeclarationType?
+                ) -> Bool {
+                    switch type {
+                    case .instanceProperty:
+                        return true
+
+                    case .instancePropertyWithBody:
+                        // `instancePropertyWithBody` represents some stored properties,
+                        // but also computed properties. Only stored properties,
+                        // not computed properties, affect the synthesized init.
+                        //
+                        // This is a stored property if and only if
+                        // the declaration body has a `didSet` or `willSet` keyword,
+                        // based on the grammar for a variable declaration:
+                        // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_variable-declaration
+                        let parser = Formatter(declaration.tokens)
+                        var hasWillSetOrDidSetBlock = false
+
+                        if let bodyOpenBrace = parser.index(of: .startOfScope("{"), after: -1),
+                            let firstBodyToken = parser.next(.nonSpaceOrCommentOrLinebreak, after: bodyOpenBrace),
+                            firstBodyToken.string == "willSet" || firstBodyToken.string == "didSet"
+                        {
+                            hasWillSetOrDidSetBlock = true
+                        }
+
+                        return hasWillSetOrDidSetBlock
+
+                    default:
+                        return false
+                    }
+                }
+
                 // Whether or not the two given declaration orderings preserve
                 // the same synthesized memberwise initializer
                 func preservesSynthesizedMemberwiseInitiaizer(
@@ -5224,11 +5249,11 @@ public struct _FormatRules {
                     _ rhs: CategorizedDeclarations
                 ) -> Bool {
                     let lhsPropertiesOrder = lhs
-                        .filter { $0.type?.canAffectStructMemberwiseInitializer == true }
+                        .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.type) }
                         .map { $0.declaration }
 
                     let rhsPropertiesOrder = rhs
-                        .filter { $0.type?.canAffectStructMemberwiseInitializer == true }
+                        .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.type) }
                         .map { $0.declaration }
 
                     return lhsPropertiesOrder == rhsPropertiesOrder

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13991,13 +13991,19 @@ class RulesTests: XCTestCase {
         testFormatting(for: input, rule: FormatRules.organizeDeclarations)
     }
 
-    func testOrganizesStructPropertiesThatDoesntBreakMemberwiseInitializer() {
+    func testOrganizesStructPropertiesThatDontBreakMemberwiseInitializer() {
         let input = """
         struct Foo {
+            var computed: String {
+                let didSet = "didSet"
+                let willSet = "willSet"
+                return didSet + willSet
+            }
+
             private func instanceMethod() {}
-            public let quux: Int
+            public let bar: Int
             var baaz: Int
-            var bar: Int {
+            var quux: Int {
                 didSet {}
             }
         }
@@ -14010,13 +14016,19 @@ class RulesTests: XCTestCase {
 
             // MARK: Public
 
-            public let quux: Int
+            public let bar: Int
 
             // MARK: Internal
 
             var baaz: Int
 
-            var bar: Int {
+            var computed: String {
+                let didSet = "didSet"
+                let willSet = "willSet"
+                return didSet + willSet
+            }
+
+            var quux: Int {
                 didSet {}
             }
 

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1332,7 +1332,7 @@ extension RulesTests {
         ("testOrganizeEnumCasesFirst", testOrganizeEnumCasesFirst),
         ("testOrganizePrivateSet", testOrganizePrivateSet),
         ("testOrganizesNestedTypesWithinConditionalCompilationBlock", testOrganizesNestedTypesWithinConditionalCompilationBlock),
-        ("testOrganizesStructPropertiesThatDoesntBreakMemberwiseInitializer", testOrganizesStructPropertiesThatDoesntBreakMemberwiseInitializer),
+        ("testOrganizesStructPropertiesThatDontBreakMemberwiseInitializer", testOrganizesStructPropertiesThatDontBreakMemberwiseInitializer),
         ("testOrganizesTypeBelowSymbolImport", testOrganizesTypeBelowSymbolImport),
         ("testOrganizesTypesBelowConditionalCompilationBlock", testOrganizesTypesBelowConditionalCompilationBlock),
         ("testOrganizesTypesWithinConditionalCompilationBlock", testOrganizesTypesWithinConditionalCompilationBlock),


### PR DESCRIPTION
This is a follow-up to https://github.com/nicklockwood/SwiftFormat/pull/708#discussion_r475934954 that updates the new `organizeDeclarations` (#701) rule to handle struct computed properties correctly.