### PR TITLE
Update organizeDeclarations rule to support class properties

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4926,6 +4926,7 @@ public struct _FormatRules {
             case nestedType
             case staticProperty
             case staticPropertyWithBody
+            case classPropertyWithBody
             case instanceProperty
             case instancePropertyWithBody
             case staticMethod
@@ -4938,8 +4939,8 @@ public struct _FormatRules {
         ]
 
         let categorySubordering: [DeclarationType] = [
-            .nestedType, .staticProperty, .staticPropertyWithBody, .instanceProperty,
-            .instancePropertyWithBody, .staticMethod, .classMethod, .instanceMethod,
+            .nestedType, .staticProperty, .staticPropertyWithBody, .classPropertyWithBody,
+            .instanceProperty, .instancePropertyWithBody, .staticMethod, .classMethod, .instanceMethod,
         ]
 
         /// The `Category` of the given `Declaration`
@@ -5057,6 +5058,11 @@ public struct _FormatRules {
                         } else {
                             return .staticProperty
                         }
+                    } else if isClassDeclaration {
+                        // Interestingly, Swift does not support stored class properties
+                        // so there's no such thing as a class property without a body.
+                        // https://forums.swift.org/t/class-properties/16539/11
+                        return .classPropertyWithBody
                     } else {
                         if hasBody {
                             return .instancePropertyWithBody

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13380,6 +13380,10 @@ class RulesTests: XCTestCase {
                 3.141592653589
             }
 
+            class var b2: String {
+                "class computed property"
+            }
+
             func g() -> Int {
                 10
             }
@@ -13390,8 +13394,8 @@ class RulesTests: XCTestCase {
 
             static func e() {}
 
-            static var b: String {
-                "computed property"
+            static var b1: String {
+                "static computed property"
             }
 
             class func f() -> Foo {
@@ -13410,8 +13414,12 @@ class RulesTests: XCTestCase {
             static var a1: Int = 1
             static var a2: Int = 2
 
-            static var b: String {
-                "computed property"
+            static var b1: String {
+                "static computed property"
+            }
+
+            class var b2: String {
+                "class computed property"
             }
 
             let c: String = String {


### PR DESCRIPTION
This PR updates the `organizeDeclarations` rule to support `class` properties, as discussed in https://github.com/nicklockwood/SwiftFormat/pull/701#issuecomment-680323799