### PR TITLE
Xcode Extension - Fixes restoring of selections in Xcode 12

### DIFF
--- a/EditorExtension/Extension/FormatFileCommand.swift
+++ b/EditorExtension/Extension/FormatFileCommand.swift
@@ -64,7 +64,7 @@ class FormatFileCommand: NSObject, XCSourceEditorCommand {
         }
 
         // Remove all selections to avoid a crash when changing the contents of the buffer.
-        let selections = invocation.buffer.selections.copy() as? [XCSourceTextRange] ?? []
+        let selections = invocation.buffer.selections.compactMap { $0 as? XCSourceTextRange }
         invocation.buffer.selections.removeAllObjects()
 
         // Update buffer

--- a/EditorExtension/Extension/FormatSelectionCommand.swift
+++ b/EditorExtension/Extension/FormatSelectionCommand.swift
@@ -38,7 +38,8 @@ class FormatSelectionCommand: NSObject, XCSourceEditorCommand {
             return completionHandler(FormatCommandError.notSwiftLanguage)
         }
 
-        guard let selections = invocation.buffer.selections.copy() as? [XCSourceTextRange] else {
+        let selections = invocation.buffer.selections.compactMap { $0 as? XCSourceTextRange }
+        guard selections.count > 0 else {
             return completionHandler(FormatCommandError.noSelection)
         }
 


### PR DESCRIPTION
After formatting a file or selection in Xcode 12, the cursor position is lost and gets moved to the end of the file.

The problem is that this line always returns an empty array when the extension is used in Xcode 12:
```swift
let selections = invocation.buffer.selections.copy() as? [XCSourceTextRange] ?? []
```

Using `compactMap` to generate a typed copy of the selections resolves the issue.

