### PR TITLE
Clean up print statement that prints newlines while formatting

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1276,9 +1276,6 @@ public struct _FormatRules {
                         {
                             indent += formatter.options.indent
                         }
-                        if case let .space(s) = formatter.tokens[start], s != indent {
-                            print("")
-                        }
                         let stringIndent = stringBodyIndentStack.last!
                         i += formatter.insertSpaceIfEnabled(stringIndent + indent, at: start)
                     }


### PR DESCRIPTION
This `print("")` statement is printing a bunch of newlines while running the formatter (#721)

#### Before

```
cal@Cals-MacBook-Pro Sample % swiftformat .  
Running SwiftFormat...




















warning: No Swift version was specified, so some formatting features were disabled. Specify the version of Swift you are using with the --swiftversion option, or by adding a .swift-version file to your project.
SwiftFormat completed in 0.2s.
49/49 files formatted.
```

#### After

```
cal@Cals-MacBook-Pro Sample % swiftformat .                
Running SwiftFormat...
warning: No Swift version was specified, so some formatting features were disabled. Specify the version of Swift you are using with the --swiftversion option, or by adding a .swift-version file to your project.
SwiftFormat completed in 0.19s.
49/49 files formatted.
```
