### PR TITLE
More organizeDeclarations improvements

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -150,32 +150,12 @@ func preprocessArguments(_ args: [String], _ names: [String]) throws -> [String:
 
 // Find best match for a given string in a list of options
 func bestMatches(for query: String, in options: [String]) -> [String] {
-    func levenshtein(_ lhs: String, _ rhs: String) -> Int {
-        var dist = [[Int]]()
-        for i in 0 ... lhs.count {
-            dist.append([i])
-        }
-        for j in 1 ... rhs.count {
-            dist[0].append(j)
-        }
-        for i in 1 ... lhs.count {
-            let lhs = lhs[lhs.index(lhs.startIndex, offsetBy: i - 1)]
-            for j in 1 ... rhs.count {
-                if lhs == rhs[rhs.index(rhs.startIndex, offsetBy: j - 1)] {
-                    dist[i].append(dist[i - 1][j - 1])
-                } else {
-                    dist[i].append(min(min(dist[i - 1][j] + 1, dist[i][j - 1] + 1), dist[i - 1][j - 1] + 1))
-                }
-            }
-        }
-        return dist[lhs.count][rhs.count]
-    }
     let lowercaseQuery = query.lowercased()
-    // Sort matches by Levenshtein distance
+    // Sort matches by Levenshtein edit distance
     return options
         .compactMap { option -> (String, Int)? in
             let lowercaseOption = option.lowercased()
-            let distance = levenshtein(lowercaseOption, lowercaseQuery)
+            let distance = editDistance(lowercaseOption, lowercaseQuery)
             guard distance <= lowercaseQuery.count / 2 ||
                 !lowercaseOption.commonPrefix(with: lowercaseQuery).isEmpty
             else {
@@ -185,6 +165,28 @@ func bestMatches(for query: String, in options: [String]) -> [String] {
         }
         .sorted { $0.1 < $1.1 }
         .map { $0.0 }
+}
+
+/// The Levenshtein edit-distance between two strings
+func editDistance(_ lhs: String, _ rhs: String) -> Int {
+    var dist = [[Int]]()
+    for i in 0 ... lhs.count {
+        dist.append([i])
+    }
+    for j in 1 ... rhs.count {
+        dist[0].append(j)
+    }
+    for i in 1 ... lhs.count {
+        let lhs = lhs[lhs.index(lhs.startIndex, offsetBy: i - 1)]
+        for j in 1 ... rhs.count {
+            if lhs == rhs[rhs.index(rhs.startIndex, offsetBy: j - 1)] {
+                dist[i].append(dist[i - 1][j - 1])
+            } else {
+                dist[i].append(min(min(dist[i - 1][j] + 1, dist[i][j - 1] + 1), dist[i - 1][j - 1] + 1))
+            }
+        }
+    }
+    return dist[lhs.count][rhs.count]
 }
 
 // Parse a comma-delimited list of items

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5066,7 +5066,7 @@ private extension Formatter {
 
             switch declarationTypeToken {
             // Properties and property-like declarations
-            case .keyword("let"), .keyword("var"), .keyword("typealias"),
+            case .keyword("let"), .keyword("var"),
                  .keyword("case"), .keyword("operator"), .keyword("precedencegroup"):
 
                 var hasBody: Bool
@@ -5111,6 +5111,10 @@ private extension Formatter {
                 } else {
                     return .instanceMethod
                 }
+
+            // Type-like declarations
+            case .keyword("typealias"):
+                return .nestedType
 
             default:
                 return nil

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5454,19 +5454,20 @@ private extension Formatter {
                     (.declaration(kind: "comment", tokens: markDeclaration), category, nil),
                     at: indexOfFirstDeclaration
                 )
-            }
 
-            // If this declaration is the first declaration in the type scope,
-            // make sure the type's opening sequence of tokens ends with
-            // at least one blank line (so it appears balanced)
-            if indexOfFirstDeclaration == 0 {
-                typeOpeningTokens = endingWithBlankLine(typeOpeningTokens)
+                // If this declaration is the first declaration in the type scope,
+                // make sure the type's opening sequence of tokens ends with
+                // at least one blank line so the category separator appears balanced
+                if indexOfFirstDeclaration == 0 {
+                    typeOpeningTokens = endingWithBlankLine(typeOpeningTokens)
+                }
             }
 
             // Insert newlines to separate declaration types
             for declarationType in Formatter.categorySubordering {
                 guard let indexOfLastDeclarationWithType = sortedDeclarations
-                    .lastIndex(where: { $0.category == category && $0.type == declarationType })
+                    .lastIndex(where: { $0.category == category && $0.type == declarationType }),
+                    indexOfLastDeclarationWithType != sortedDeclarations.indices.last
                 else { continue }
 
                 switch sortedDeclarations[indexOfLastDeclarationWithType].declaration {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13518,6 +13518,8 @@ class RulesTests: XCTestCase {
 
             static func e() {}
 
+            typealias Bar = Int
+
             static var b1: String {
                 "static computed property"
             }
@@ -13536,6 +13538,8 @@ class RulesTests: XCTestCase {
 
         let output = """
         class Foo {
+
+            typealias Bar = Int
 
             enum NestedEnum {}
 

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13840,7 +13840,15 @@ class RulesTests: XCTestCase {
 
             // Public
 
-            public func instanceMethod() {}
+            public func bar() {}
+
+            // MARK: - Internal
+
+            func baaz() {}
+
+            // mrak: privat
+
+            private func quux() {}
 
         }
         """
@@ -13854,7 +13862,15 @@ class RulesTests: XCTestCase {
 
             // MARK: Public
 
-            public func instanceMethod() {}
+            public func bar() {}
+
+            // MARK: Internal
+
+            func baaz() {}
+
+            // MARK: Private
+
+            private func quux() {}
 
         }
         """

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13300,7 +13300,6 @@ class RulesTests: XCTestCase {
     func testOrganizeClassDeclarationsIntoCategories() {
         let input = """
         class Foo {
-
             private func privateMethod() {}
 
             private let bar = 1
@@ -13320,7 +13319,6 @@ class RulesTests: XCTestCase {
 
             /// Doc comment
             public func publicMethod() {}
-
         }
         """
 
@@ -13384,7 +13382,6 @@ class RulesTests: XCTestCase {
 
         let output = """
         public class Foo {
-
             public class Bar {
 
                 // MARK: Lifecycle
@@ -13399,16 +13396,14 @@ class RulesTests: XCTestCase {
                 // MARK: Fileprivate
 
                 fileprivate func baaz() {}
-
             }
-
         }
         """
 
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -13484,14 +13479,13 @@ class RulesTests: XCTestCase {
 
             private(set) var baz: Int
             internal private(set) var baz: Int
-
         }
         """
 
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -13538,7 +13532,6 @@ class RulesTests: XCTestCase {
 
         let output = """
         class Foo {
-
             typealias Bar = Int
 
             enum NestedEnum {}
@@ -13582,7 +13575,7 @@ class RulesTests: XCTestCase {
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "redundantType"]
+            exclude: ["blankLinesAtEndOfScope", "redundantType"]
         )
     }
 
@@ -13601,7 +13594,6 @@ class RulesTests: XCTestCase {
 
         let output = """
         enum Foo {
-
             case bar
             case baz
             case quux
@@ -13618,7 +13610,7 @@ class RulesTests: XCTestCase {
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "unusedArguments"]
+            exclude: ["blankLinesAtEndOfScope", "unusedArguments"]
         )
     }
 
@@ -13728,7 +13720,6 @@ class RulesTests: XCTestCase {
             // - Public
 
             public func publicInstanceMethod() {}
-
         }
         """
 
@@ -13736,7 +13727,7 @@ class RulesTests: XCTestCase {
             for: input, output,
             rule: FormatRules.organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "- %c"),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -13772,7 +13763,6 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public func instanceMethod() {}
-
         }
         """
 
@@ -13780,7 +13770,7 @@ class RulesTests: XCTestCase {
             for: input, output,
             rule: FormatRules.organizeDeclarations,
             options: FormatOptions(organizeStructThreshold: 2),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -13827,11 +13817,10 @@ class RulesTests: XCTestCase {
 
             let bar: String
             let baz: Int?
-
         }
         """
         testFormatting(for: input, rule: FormatRules.organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testUpdatesMalformedMarks() {
@@ -13853,7 +13842,6 @@ class RulesTests: XCTestCase {
             // mrak: privat
 
             private func quux() {}
-
         }
         """
 
@@ -13875,12 +13863,11 @@ class RulesTests: XCTestCase {
             // MARK: Private
 
             private func quux() {}
-
         }
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testHandlesTrailingCommentCorrectly() {
@@ -13905,12 +13892,11 @@ class RulesTests: XCTestCase {
 
             var bar = "bar"
             var quux = "quux"
-
         }
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testDoesntInsertMarkWhenOnlyOneCategory() {
@@ -13924,17 +13910,14 @@ class RulesTests: XCTestCase {
 
         let output = """
         class Foo {
-
             var bar: Int
             var baaz: Int
 
             func instanceMethod() {}
-
         }
         """
 
-        testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, output, rule: FormatRules.organizeDeclarations)
     }
 
     func testOrganizesTypesWithinConditionalCompilationBlock() {
@@ -13963,7 +13946,6 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public func instanceMethod() {}
-
         }
         #else
         struct ProductionFoo {
@@ -13975,14 +13957,13 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public func instanceMethod() {}
-
         }
         #endif
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testOrganizesTypesBelowConditionalCompilationBlock() {
@@ -14011,13 +13992,12 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public func instanceMethod() {}
-
         }
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testOrganizesNestedTypesWithinConditionalCompilationBlock() {
@@ -14041,7 +14021,6 @@ class RulesTests: XCTestCase {
             init() {}
 
             var quuz = "quux"
-
         }
         """
 
@@ -14066,7 +14045,6 @@ class RulesTests: XCTestCase {
                 // MARK: Internal
 
                 var debugBar = "debug"
-
             }
 
             static let debugFoo = DebugFoo()
@@ -14079,13 +14057,12 @@ class RulesTests: XCTestCase {
             var baaz = "baaz"
 
             var quuz = "quux"
-
         }
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: ["blankLinesAtStartOfScope"])
     }
 
     func testOrganizesTypeBelowSymbolImport() {
@@ -14124,13 +14101,12 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public func instanceMethod() {}
-
         }
         """
 
         testFormatting(
             for: input, output, rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortedImports"]
+            exclude: ["blankLinesAtStartOfScope", "sortedImports"]
         )
     }
 
@@ -14195,7 +14171,6 @@ class RulesTests: XCTestCase {
             // MARK: Private
 
             private func instanceMethod() {}
-
         }
 
         Foo(bar: 1, baaz: 2, quux: 3)
@@ -14203,7 +14178,7 @@ class RulesTests: XCTestCase {
 
         testFormatting(
             for: input, output, rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -14222,7 +14197,6 @@ class RulesTests: XCTestCase {
             }
 
             var baaz: Int
-
         }
 
         Foo(bar: 1, baaz: 2, quux: 3)
@@ -14230,7 +14204,7 @@ class RulesTests: XCTestCase {
 
         testFormatting(
             for: input, rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -14247,13 +14221,12 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public let bar = 1
-
         }
         """
 
         testFormatting(
             for: input, rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
@@ -14274,7 +14247,6 @@ class RulesTests: XCTestCase {
             var baaz = 1
 
             public let bar = 1
-
         }
         """
 
@@ -14317,7 +14289,6 @@ class RulesTests: XCTestCase {
             // MARK: Public
 
             public var bar = 10
-
         }
 
         extension Foo {
@@ -14329,21 +14300,19 @@ class RulesTests: XCTestCase {
             // MARK: Internal
 
             var quux: Int { 30 }
-
         }
         """
 
         testFormatting(
             for: input, rule: FormatRules.organizeDeclarations,
             options: FormatOptions(organizeStructThreshold: 20),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: ["blankLinesAtStartOfScope"]
         )
     }
 
     func testParsesPropertiesWithBodies() {
         let input = """
         class Foo {
-
             // Instance properties without bodies:
 
             let propertyWithoutBody1 = 10
@@ -14381,13 +14350,9 @@ class RulesTests: XCTestCase {
             var withBody6: String = { "bar" }() {
                 didSet { print("didSet") }
             }
-
         }
         """
 
-        testFormatting(
-            for: input, rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
-        )
+        testFormatting(for: input, rule: FormatRules.organizeDeclarations)
     }
 }


### PR DESCRIPTION
This PR makes a few improvements to the `organizeDeclarations` rule (#701) based on discussions from airbnb/swift#102:

 - Correct misspelled mark comments (instead of duplicating them) by comparing the edit distance
 - Group `typealias` declarations with types instead of with properties 
    - Previously they were being treated as `instanceProperty` declarations, but they are actually more type-like)
 - Stop inserting blank lines at the top and bottom of type bodies
    - This resolves linting conflicts with the `blankLinesAtEndOfScope` rule