### PR TITLE
Update organzieDeclarations rule to only validate comments at the top level of a type body

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5195,10 +5195,11 @@ private extension Formatter {
                     // valid category separators for this category. If they are similar or identical,
                     // we'll want to replace the existing comment with the correct comment.
                     let existingComment = sourceCode(for: Array(parser.tokens[potentialSeparatorRange]))
+                    let minimumEditDistance = Int(0.2 * Float(existingComment.count))
 
-                    guard editDistance(existingComment.lowercased(), potentialSeparatorComment.lowercased()) <= 3 else {
-                        continue
-                    }
+                    guard editDistance(existingComment.lowercased(), potentialSeparatorComment.lowercased())
+                        <= minimumEditDistance
+                    else { continue }
 
                     // If we found a matching comment, remove it and all subsequent empty lines
                     let startOfCommentLine = parser.startOfLine(at: commentStartIndex)

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13878,6 +13878,37 @@ class RulesTests: XCTestCase {
                        exclude: ["blankLinesAtStartOfScope"])
     }
 
+    func testDoesntAttemptToUpdateMarksNotAtTopLevel() {
+        let input = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            public init() {
+                foo = ["foo"]
+            }
+
+            // Comment at bottom of lifecycle category
+
+            // MARK: Private
+
+            @annotation // Private
+            // Private
+            private var foo: [String] = []
+
+            private func bar() {
+                // Private
+                guard let baz = bar else {
+                    return
+                }
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.organizeDeclarations,
+                       exclude: ["blankLinesAtStartOfScope"])
+    }
+
     func testHandlesTrailingCommentCorrectly() {
         let input = """
         class Foo {

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -13829,9 +13829,13 @@ class RulesTests: XCTestCase {
 
             // MARK: lifecycle
 
+            // MARK: Lifeycle
+
             init() {}
 
             // Public
+
+            // - Public
 
             public func bar() {}
 
@@ -13840,6 +13844,8 @@ class RulesTests: XCTestCase {
             func baaz() {}
 
             // mrak: privat
+
+            // Pulse
 
             private func quux() {}
         }
@@ -13861,6 +13867,8 @@ class RulesTests: XCTestCase {
             func baaz() {}
 
             // MARK: Private
+
+            // Pulse
 
             private func quux() {}
         }

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -651,6 +651,7 @@ extension RulesTests {
         ("testDispatchAsyncGroupClosureArgumentMadeTrailing", testDispatchAsyncGroupClosureArgumentMadeTrailing),
         ("testDispatchSyncClosureArgumentMadeTrailing", testDispatchSyncClosureArgumentMadeTrailing),
         ("testDispatchSyncFlagsClosureArgumentMadeTrailing", testDispatchSyncFlagsClosureArgumentMadeTrailing),
+        ("testDoesntAttemptToUpdateMarksNotAtTopLevel", testDoesntAttemptToUpdateMarksNotAtTopLevel),
         ("testDoesntBreakStructSynthesizedMemberwiseInitializer", testDoesntBreakStructSynthesizedMemberwiseInitializer),
         ("testDoesntInsertMarkWhenOnlyOneCategory", testDoesntInsertMarkWhenOnlyOneCategory),
         ("testDoesntRemoveCategorySeparatorsFromBodyNotBeingOrganized", testDoesntRemoveCategorySeparatorsFromBodyNotBeingOrganized),


### PR DESCRIPTION
Previously, the `organizeDeclarations` rule (#701) was validating all comments within a type body. This would mangle a type that had a matching comment inside a function body (#725).

Now we validate that the comment sits at the top level of a type body before we try to update it to the correct category separator. This fixes #725.