### PR TITLE
Update pre-commit hook to work with spaces in file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Git pre-commit hook
 
     ```bash
     #!/bin/bash
-    git-format-staged --formatter "swiftformat stdin --stdinpath {}" "*.swift"
+    git-format-staged --formatter "swiftformat stdin --stdinpath '{}'" "*.swift"
     ```
     
     (Note that this example uses your locally installed version of SwiftFormat, not a separate copy in your project repository. You can replace `swiftformat` with the path to a copy inside your project if you prefer.)


### PR DESCRIPTION
Related: https://github.com/nicklockwood/SwiftFormat/issues/730

Test:
- [x] Committing a file with a file path that contains spaces does not result in error:
Ex: `/my/file path with spaces/file.swift`
