### PR TITLE
Fix issue where extensionAccessControl would place visibility keywords before annotations

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1187,7 +1187,22 @@ extension Formatter {
                 $0.string == declaration.keyword
             }) else { return openTokens }
 
-            let startOfModifiers = openTokensFormatter.startOfModifiers(at: indexOfKeyword)
+            var startOfModifiers = openTokensFormatter.startOfModifiers(at: indexOfKeyword)
+
+            // If there are any annotations, skip past them
+            while startOfModifiers < indexOfKeyword,
+                openTokensFormatter.tokens[startOfModifiers].string.hasPrefix("@")
+                || openTokensFormatter.tokens[startOfModifiers].isSpaceOrCommentOrLinebreak
+            {
+                startOfModifiers += 1
+
+                // Also skip through annotation bodies, like in `@available(iOS 14.0, *)`
+                if openTokensFormatter.tokens[startOfModifiers] == .startOfScope("("),
+                    let endOfScope = openTokensFormatter.endOfScope(at: startOfModifiers)
+                {
+                    startOfModifiers = endOfScope + 1
+                }
+            }
 
             openTokensFormatter.insert(
                 tokenize("\(visibilityKeyword.rawValue) "),

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1304,6 +1304,43 @@ extension RulesTests {
         )
     }
 
+    func testPlacesVisibilityKeywordAfterAnnotations() {
+        let input = """
+        public extension Foo {
+            @discardableResult
+            func bar() -> Int { 10 }
+
+            /// Doc comment
+            @discardableResult
+            @available(iOS 10.0, *)
+            func baaz() -> Int { 10 }
+
+            @objc func quux() {}
+            @available(iOS 10.0, *) func quixotic() {}
+        }
+        """
+
+        let output = """
+        extension Foo {
+            @discardableResult
+            public func bar() -> Int { 10 }
+
+            /// Doc comment
+            @discardableResult
+            @available(iOS 10.0, *)
+            public func baaz() -> Int { 10 }
+
+            @objc public func quux() {}
+            @available(iOS 10.0, *) public func quixotic() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output, rule: FormatRules.extensionAccessControl,
+            options: FormatOptions(extensionACLPlacement: .onDeclarations)
+        )
+    }
+
     // MARK: extensionAccessControl .onExtension
 
     func testUpdatedVisibilityOfExtension() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1472,6 +1472,7 @@ extension RulesTests {
         ("testPerformBatchUpdatesNotMadeTrailing", testPerformBatchUpdatesNotMadeTrailing),
         ("testPInExponentialNotConvertedToLower", testPInExponentialNotConvertedToLower),
         ("testPInExponentialNotConvertedToUpper", testPInExponentialNotConvertedToUpper),
+        ("testPlacesVisibilityKeywordAfterAnnotations", testPlacesVisibilityKeywordAfterAnnotations),
         ("testPlacingCustomDeclarationsBeforeMarks", testPlacingCustomDeclarationsBeforeMarks),
         ("testPostfixExpressionNonYodaCondition", testPostfixExpressionNonYodaCondition),
         ("testPostfixExpressionNonYodaCondition2", testPostfixExpressionNonYodaCondition2),


### PR DESCRIPTION
This PR fixes an issue where the new `extensionAccessControl` rule (#742) would place visibility keywords before annotations. This fixes #757.

### Before

```diff
-public extension Foo {
+extension Foo {
-    @discardableResult
+    public @discardableResult
     func bar() {}
 }
```

### After

```diff
-public extension Foo {
+extension Foo {
     @discardableResult
-    func bar() {}
+    public func bar() {}
 }
```
