### PR TITLE
More markTypes fixes and improvements

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1067,21 +1067,31 @@ extension Formatter {
                 $0.string == keyword
             }) else { return nil }
 
-            guard var typeNameIndex = openingFormatter.index(of: .identifier, after: keywordIndex) else {
+            guard let typeNameIndex = openingFormatter.index(of: .identifier, after: keywordIndex) else {
                 return nil
             }
 
-            // If the identifier is followed by a dot, it's actually the first
-            // part of the fully-qualified name and we should skip through
-            // to the last component of the name.
-            while openingFormatter.token(at: typeNameIndex + 1)?.string == ".",
-                openingFormatter.token(at: typeNameIndex + 2)?.is(.identifier) == true
-            {
-                typeNameIndex += 2
-            }
-
-            return openingFormatter.token(at: typeNameIndex)?.string
+            return openingFormatter.fullyQualifiedName(startingAt: typeNameIndex).name
         }
+    }
+
+    /// The fully qualified name starting at the given index
+    func fullyQualifiedName(startingAt index: Int) -> (name: String, endIndex: Int) {
+        // If the identifier is followed by a dot, it's actually the first
+        // part of the fully-qualified name and we should skip through
+        // to the last component of the name.
+        var name = tokens[index].string
+        var index = index
+
+        while token(at: index + 1)?.string == ".",
+            let nextIdentifier = token(at: index + 2),
+            nextIdentifier.is(.identifier) == true
+        {
+            name = "\(name).\(nextIdentifier.string)"
+            index += 2
+        }
+
+        return (name, index)
     }
 
     // get type of declaration starting at index of declaration keyword

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5180,7 +5180,7 @@ public struct _FormatRules {
 
                     // If the type being extended was defined further up in this same file,
                     // it would be repetitive to include the type name in the scope name for this extension.
-                    if declarations[..<index].contains(where: { $0.name == typeName }) {
+                    if declarations[..<index].contains(where: { $0.name == typeName && $0.keyword != "extension" }) {
                         scopeName = "\(conformances.joined(separator: ", "))"
                     } else {
                         scopeName = "\(typeName) + \(conformances.joined(separator: ", "))"

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5165,12 +5165,10 @@ public struct _FormatRules {
                     while let token = openingFormatter.token(at: conformanceSearchIndex),
                         conformanceSearchIndex < endOfConformances
                     {
-                        if token.isIdentifier,
-                            // Ignore identifiers followed by dots, which are components
-                            // of a fully-qualified name but not the protocol name itself.
-                            openingFormatter.token(at: conformanceSearchIndex + 1)?.string != "."
-                        {
-                            conformances.append(token.string)
+                        if token.isIdentifier {
+                            let (fullyQualifiedName, next) = openingFormatter.fullyQualifiedName(startingAt: conformanceSearchIndex)
+                            conformances.append(fullyQualifiedName)
+                            conformanceSearchIndex = next
                         }
 
                         conformanceSearchIndex += 1

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1994,4 +1994,23 @@ extension RulesTests {
 
         testFormatting(for: input, rule: FormatRules.markTypes)
     }
+
+    func testMultipleExtensionsOfSameType() {
+        let input = """
+        extension Foo: BarProtocol {}
+        extension Foo: QuuxProtocol {}
+        """
+
+        let output = """
+        // MARK: Foo + BarProtocol
+
+        extension Foo: BarProtocol {}
+
+        // MARK: Foo + QuuxProtocol
+
+        extension Foo: QuuxProtocol {}
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.markTypes)
+    }
 }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1836,18 +1836,15 @@ extension RulesTests {
 
     func testFullyQualifiedTypeNames() {
         let input = """
-        struct Foo {}
-        extension MyModule.Foo: MyModule.MyNamespace.BarProtocol {}
+        extension MyModule.Foo: MyModule.MyNamespace.BarProtocol, QuuxProtocol {}
+        extension MyModule.Foo {}
         """
 
         let output = """
-        // MARK: - Foo
+        // MARK: MyModule.Foo + MyModule.MyNamespace.BarProtocol, QuuxProtocol
 
-        struct Foo {}
-
-        // MARK: BarProtocol
-
-        extension MyModule.Foo: MyModule.MyNamespace.BarProtocol {}
+        extension MyModule.Foo: MyModule.MyNamespace.BarProtocol, QuuxProtocol {}
+        extension MyModule.Foo {}
         """
 
         testFormatting(for: input, output, rule: FormatRules.markTypes)

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1021,6 +1021,7 @@ extension RulesTests {
         ("testMultilineSwitchCases", testMultilineSwitchCases),
         ("testMultipleAttributesNotSeparated", testMultipleAttributesNotSeparated),
         ("testMultipleClosureArgumentUnwrapped", testMultipleClosureArgumentUnwrapped),
+        ("testMultipleExtensionsOfSameType", testMultipleExtensionsOfSameType),
         ("testMultipleNestedClosures", testMultipleNestedClosures),
         ("testNamedClosureArgumentNotMadeTrailing", testNamedClosureArgumentNotMadeTrailing),
         ("testNamespacedVoidLiteralNotConverted", testNamespacedVoidLiteralNotConverted),


### PR DESCRIPTION
This PR fixes two more issues with the new `markTypes` rule (#747):

 - Fixes an issue where marks would be incorrect when following another extension of the same type:
   ```diff
    // MARK: Foo + BarProtocol

    extension Foo: BarProtocol {}

   -// MARK: QuuxProtocol
   +// MARK: Foo + QuuxProtocol

    extension Foo: QuuxProtocol {}
   ```

- Update the marks to use the entire fully-qualified name
   ```diff
   -// MARK: Foo + BarProtocol
   +// MARK: MyModule.Foo + MyModule.MyNamespace.BarProtocol

    extension MyModule.Foo: MyModule.MyNamespace.BarProtocol {}
   ```