### PR TITLE
Add --wrapconditions option

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1749,6 +1749,7 @@ Option | Description
 `--wrapcollections` | Wrap array/dict: "before-first", "after-first", "preserve"
 `--closingparen` | Closing paren position: "balanced" (default) or "same-line"
 `--wrapreturntype` | Wrap return type: "if-multiline", "preserve" (default)
+`--wrapconditions` | Wrap conditions: "before-first", "after-first", "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -389,6 +389,49 @@ extension Formatter {
 
             lastIndex = i
         }
+
+        // -- wrapconditions
+        forEach(.keyword) { index, token in
+            guard ["if", "guard", "while"].contains(token.string) else {
+                return
+            }
+
+            // Only wrap when this is a control flow condition that spans multiple lines
+            guard
+                let nextOpenBracketIndex = self.index(of: .startOfScope("{"), after: index),
+                let nextTokenIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
+                !onSameLine(index, nextOpenBracketIndex)
+            else { return }
+
+            switch options.wrapConditions {
+            case .preserve, .disabled, .default:
+                break
+
+            case .beforeFirst:
+                // Wrap if the next non-whitespace-or-comment
+                // is on the same line as the control flow keyword
+                if onSameLine(index, nextTokenIndex) {
+                    insertLinebreak(at: index + 1)
+                }
+
+            case .afterFirst:
+                // Unwrap if the next non-whitespace-or-comment
+                // is not on the same line as the control flow keyword
+                if !onSameLine(index, nextTokenIndex),
+                   let linebreakIndex = self.index(of: .linebreak, in: index ..< nextTokenIndex)
+                {
+                    removeToken(at: linebreakIndex)
+                }
+
+                // Make sure there is still exactly one space after the control flow keyword
+                if let space = self.token(at: index + 1),
+                   space.isSpace,
+                   space.string.count != 1
+                {
+                    self.replaceToken(at: index + 1, with: .space(" "))
+                }
+            }
+        }
     }
 
     func removeParen(at index: Int) {

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -452,6 +452,12 @@ struct _Descriptors {
         help: "Wrap return type: \"if-multiline\", \"preserve\" (default)",
         keyPath: \.wrapReturnType
     )
+    let wrapConditions = OptionDescriptor(
+        argumentName: "wrapconditions",
+        displayName: "Wrap Conditions",
+        help: "Wrap conditions: \"before-first\", \"after-first\", \"preserve\"",
+        keyPath: \.wrapCollections
+    )
     let closingParenOnSameLine = OptionDescriptor(
         argumentName: "closingparen",
         displayName: "Closing Paren Position",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -307,6 +307,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapCollections: WrapMode
     public var closingParenOnSameLine: Bool
     public var wrapReturnType: WrapReturnType
+    public var wrapConditions: WrapMode
     public var uppercaseHex: Bool
     public var uppercaseExponent: Bool
     public var decimalGrouping: Grouping
@@ -383,6 +384,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapCollections: WrapMode = .preserve,
                 closingParenOnSameLine: Bool = false,
                 wrapReturnType: WrapReturnType = .preserve,
+                wrapConditions: WrapMode = .preserve,
                 uppercaseHex: Bool = true,
                 uppercaseExponent: Bool = false,
                 decimalGrouping: Grouping = .group(3, 6),
@@ -453,6 +455,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapCollections = wrapCollections
         self.closingParenOnSameLine = closingParenOnSameLine
         self.wrapReturnType = wrapReturnType
+        self.wrapConditions = wrapConditions
         self.uppercaseHex = uppercaseHex
         self.uppercaseExponent = uppercaseExponent
         self.decimalGrouping = decimalGrouping

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -37,7 +37,7 @@ public extension Formatter {
 
     /// Whether or not the two indicies represent tokens on the same line
     func onSameLine(_ lhs: Int, _ rhs: Int) -> Bool {
-        startOfLine(at: lhs) == startOfLine(at: rhs)
+        return startOfLine(at: lhs) == startOfLine(at: rhs)
     }
 
     /// Returns the space at the start of the line containing the specified index

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -35,6 +35,11 @@ public extension Formatter {
         return index
     }
 
+    /// Whether or not the two indicies represent tokens on the same line
+    func onSameLine(_ lhs: Int, _ rhs: Int) -> Bool {
+        startOfLine(at: lhs) == startOfLine(at: rhs)
+    }
+
     /// Returns the space at the start of the line containing the specified index
     func indentForLine(at index: Int) -> String {
         if case let .space(string)? = token(at: startOfLine(at: index)) {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3409,7 +3409,7 @@ public struct _FormatRules {
         help: "Wrap lines that exceed the specified maximum width.",
         options: ["maxwidth", "nowrapoperators", "assetliterals"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "indent",
-                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype"]
+                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }
@@ -3465,7 +3465,8 @@ public struct _FormatRules {
     public let wrapArguments = FormatRule(
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: ["wrap"],
-        options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "wrapreturntype"],
+        options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen",
+                  "wrapreturntype", "wrapconditions"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
                         "tabwidth", "maxwidth", "smarttabs", "assetliterals"]
     ) { formatter in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -146,6 +146,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.closingParenOnSameLine, Descriptors.linebreak, Descriptors.truncateBlankLines,
                         Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs,
                         Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType,
+                        Descriptors.wrapConditions,
                     ]
                 case .identifier("indexWhereLineShouldWrapInLine"), .identifier("indexWhereLineShouldWrap"):
                     referencedOptions += [

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2206,6 +2206,106 @@ extension RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapMultilineStatementBraces, options: options)
     }
 
+    // MARK: wrapConditions before-first
+
+    func testWrapConditionsBeforeFirst() {
+        let input = """
+        if let foo = foo,
+           let bar = bar,
+           foo == bar {}
+
+        else if foo != bar,
+                let quux = quux {}
+
+        else {}
+
+        if let baaz = baaz {}
+
+        guard baaz.filter({ $0 == foo }),
+              let bar = bar else {}
+
+        while let foo = foo,
+              let bar = bar {}
+        """
+
+        let output = """
+        if
+          let foo = foo,
+          let bar = bar,
+          foo == bar {}
+
+        else if
+          foo != bar,
+          let quux = quux {}
+
+        else {}
+
+        if let baaz = baaz {}
+
+        guard
+          baaz.filter({ $0 == foo }),
+          let bar = bar else {}
+
+        while
+          let foo = foo,
+          let bar = bar {}
+        """
+
+        testFormatting(
+            for: input, [output], rules: [FormatRules.wrapArguments, FormatRules.indent],
+            options: FormatOptions(indent: "  ", wrapConditions: .beforeFirst)
+        )
+    }
+
+    func testWrapConditionsAfterFirst() {
+        let input = """
+        if
+          let foo = foo,
+          let bar = bar,
+          foo == bar {}
+
+        else if
+          foo != bar,
+          let quux = quux {}
+
+        else {}
+
+        if let baaz = baaz {}
+
+        guard
+          baaz.filter({ $0 == foo }),
+          let bar = bar else {}
+
+        while
+          let foo = foo,
+          let bar = bar {}
+        """
+
+        let output = """
+        if let foo = foo,
+           let bar = bar,
+           foo == bar {}
+
+        else if foo != bar,
+                let quux = quux {}
+
+        else {}
+
+        if let baaz = baaz {}
+
+        guard baaz.filter({ $0 == foo }),
+              let bar = bar else {}
+
+        while let foo = foo,
+              let bar = bar {}
+        """
+
+        testFormatting(
+            for: input, [output], rules: [FormatRules.wrapArguments, FormatRules.indent],
+            options: FormatOptions(indent: "  ", wrapConditions: .afterFirst)
+        )
+    }
+
     // MARK: - wrapAttributes
 
     func testPreserveWrappedFuncAttributeByDefault() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -2031,6 +2031,8 @@ extension RulesTests {
         ("testWrapCollectionsConsecutiveCodeCommentsNotIndented", testWrapCollectionsConsecutiveCodeCommentsNotIndented),
         ("testWrapCollectionsConsecutiveCodeCommentsNotIndentedInWrapBeforeFirst", testWrapCollectionsConsecutiveCodeCommentsNotIndentedInWrapBeforeFirst),
         ("testWrapColorLiteral", testWrapColorLiteral),
+        ("testWrapConditionsAfterFirst", testWrapConditionsAfterFirst),
+        ("testWrapConditionsBeforeFirst", testWrapConditionsBeforeFirst),
         ("testWrapFuncAttribute", testWrapFuncAttribute),
         ("testWrapFunctionArrow", testWrapFunctionArrow),
         ("testWrapFunctionIfReturnTypeExceedsMaxWidth", testWrapFunctionIfReturnTypeExceedsMaxWidth),


### PR DESCRIPTION
This PR adds a `--wrapconditions` option to the wrapArguments rule as discussed in #772. This lets users choose between the two following wrap styles for multiline control flow statements:

### `--wrapconditions after-first`

```swift
if let foo = foo,
   let bar = bar {}

guard let foo = foo,
      let bar = bar else {}
```

### `--wrapconditions before-first`

```swift
if 
  let foo = foo,
  let bar = bar {}

guard 
  let foo = foo,
  let bar = bar else {}
```