### PR TITLE
Fix a potential index out of range crash

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3868,7 +3868,7 @@ public struct _FormatRules {
         }
         var headerTokens = tokenize(header)
         let endIndex = lastHeaderTokenIndex + headerTokens.count
-        if formatter.tokens.endIndex >= endIndex, headerTokens == Array(formatter.tokens[
+        if formatter.tokens.endIndex > endIndex, headerTokens == Array(formatter.tokens[
             lastHeaderTokenIndex + 1 ... endIndex
         ]) {
             lastHeaderTokenIndex += headerTokens.count


### PR DESCRIPTION
If `endIndex == formatter.tokens.endIndex`, 
```swift
formatter.tokens[lastHeaderTokenIndex + 1 ... endIndex]
```
could crash.