### PR TITLE
Fix a potential index out of range crash

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3868,7 +3868,7 @@ public struct _FormatRules {
         }
         var headerTokens = tokenize(header)
         let endIndex = lastHeaderTokenIndex + headerTokens.count
-        if formatter.tokens.endIndex >= endIndex, headerTokens == Array(formatter.tokens[
+        if formatter.tokens.endIndex > endIndex, headerTokens == Array(formatter.tokens[
             lastHeaderTokenIndex + 1 ... endIndex
         ]) {
             lastHeaderTokenIndex += headerTokens.count

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -1886,6 +1886,13 @@ class RulesTests: XCTestCase {
         XCTAssertThrowsError(try format(input, rules: [FormatRules.fileHeader], options: options))
     }
 
+    func testEdgeCaseHeaderEndIndexPlusNewHeaderTokensCountEqualsFileTokensEndIndex() {
+        let input = "// Header comment\n\nclass Foo {}"
+        let output = "// Header line1\n// Header line2\n\nclass Foo {}"
+        let options = FormatOptions(fileHeader: "// Header line1\n// Header line2")
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
     // MARK: - sortedSwitchCases
 
     func testSortedSwitchCaseMultilineWithComments() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -708,6 +708,7 @@ extension RulesTests {
         ("testDoubleIndentWhenScopesSeparatedByWrap", testDoubleIndentWhenScopesSeparatedByWrap),
         ("testDoubleNestedIndentedIfElseifEndifOutdenting", testDoubleNestedIndentedIfElseifEndifOutdenting),
         ("testDoublePostfixExpressionYodaCondition", testDoublePostfixExpressionYodaCondition),
+        ("testEdgeCaseHeaderEndIndexPlusNewHeaderTokensCountEqualsFileTokensEndIndex", testEdgeCaseHeaderEndIndexPlusNewHeaderTokensCountEqualsFileTokensEndIndex),
         ("testElseClauseIndenting", testElseClauseIndenting),
         ("testElseNotOnSameLineForAllman", testElseNotOnSameLineForAllman),
         ("testElseOnNextLineOption", testElseOnNextLineOption),


### PR DESCRIPTION
If `endIndex == formatter.tokens.endIndex`, 
```swift
formatter.tokens[lastHeaderTokenIndex + 1 ... endIndex]
```
could crash.