### PR TITLE
--wrapconditions fixes and improvements

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -397,11 +397,19 @@ extension Formatter {
                 return
             }
 
+            let endOfConditionsToken: Token
+            if token.string == "guard" {
+                endOfConditionsToken = .keyword("else")
+            } else {
+                endOfConditionsToken = .startOfScope("{")
+            }
+
             // Only wrap when this is a control flow condition that spans multiple lines
             guard
-                let nextOpenBracketIndex = self.index(of: .startOfScope("{"), after: index),
+                let endOfConditionsTokenIndex = self.index(of: endOfConditionsToken, after: index),
                 let nextTokenIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
-                !onSameLine(index, nextOpenBracketIndex)
+                !(onSameLine(index, endOfConditionsTokenIndex)
+                    || self.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfLine(at: index)) == endOfConditionsTokenIndex)
             else { return }
 
             switch options.wrapConditions {

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -456,7 +456,7 @@ struct _Descriptors {
         argumentName: "wrapconditions",
         displayName: "Wrap Conditions",
         help: "Wrap conditions: \"before-first\", \"after-first\", \"preserve\"",
-        keyPath: \.wrapCollections
+        keyPath: \.wrapConditions
     )
     let closingParenOnSameLine = OptionDescriptor(
         argumentName: "closingparen",

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2230,8 +2230,6 @@ extension RulesTests {
         else if foo != bar,
                 let quux = quux {}
 
-        else {}
-
         if let baaz = baaz {}
 
         guard baaz.filter({ $0 == foo }),
@@ -2251,8 +2249,6 @@ extension RulesTests {
           foo != bar,
           let quux = quux {}
 
-        else {}
-
         if let baaz = baaz {}
 
         guard
@@ -2267,6 +2263,30 @@ extension RulesTests {
         testFormatting(
             for: input, [output], rules: [FormatRules.wrapArguments, FormatRules.indent],
             options: FormatOptions(indent: "  ", wrapConditions: .beforeFirst)
+        )
+    }
+
+    func testWrapConditionsBeforeFirstWhereShouldPreserveExisting() {
+        let input = """
+        else {}
+
+        else
+        {}
+
+        if foo == bar
+        {}
+
+        guard let foo = bar else
+        {}
+
+        guard let foo = bar
+        else {}
+        """
+
+        testFormatting(
+            for: input, rules: [FormatRules.wrapArguments, FormatRules.indent],
+            options: FormatOptions(indent: "  ", wrapConditions: .beforeFirst),
+            exclude: ["elseOnSameLine"]
         )
     }
 

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -2035,6 +2035,7 @@ extension RulesTests {
         ("testWrapColorLiteral", testWrapColorLiteral),
         ("testWrapConditionsAfterFirst", testWrapConditionsAfterFirst),
         ("testWrapConditionsBeforeFirst", testWrapConditionsBeforeFirst),
+        ("testWrapConditionsBeforeFirstWhereShouldPreserveExisting", testWrapConditionsBeforeFirstWhereShouldPreserveExisting),
         ("testWrapFuncAttribute", testWrapFuncAttribute),
         ("testWrapFunctionArrow", testWrapFunctionArrow),
         ("testWrapFunctionIfReturnTypeExceedsMaxWidth", testWrapFunctionIfReturnTypeExceedsMaxWidth),


### PR DESCRIPTION
This PR adds some fixes and improvements for the new `--wrapconditions` rule added in #775

1. The command line option didn't work because the `OptionDescriptor` was using the wrong keypath
2. Fixed some instances where `--wrapconditions` was adding unnecessary newlines