### PR TITLE
Redundant type -- add explicit type option

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1185,6 +1185,10 @@ by using `--self init-only`:
 
 Remove redundant type from variable declarations.
 
+Option | Description
+--- | ---
+`--redundanttype` | Keep "inferred" (default) or "explicit" type annotation
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -787,6 +787,12 @@ struct _Descriptors {
         help: "Place ACL \"on-extension\" (default) or \"on-declarations\"",
         keyPath: \.extensionACLPlacement
     )
+    let redundantType = OptionDescriptor(
+        argumentName: "redundanttype",
+        displayName: "Redundant Type",
+        help: "Keep \"inferred\" (default) or \"explicit\" type annotation",
+        keyPath: \.redundantType
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -110,9 +110,10 @@ public enum WrapReturnType: String, CaseIterable {
     case preserve
 }
 
+/// Annotation which should be kept when removing a redundant type
 public enum RedundantType: String, CaseIterable {
-    case explicitType = "explicit-type"
-    case assignment
+    case explicit
+    case inferred
 }
 
 /// Version number wrapper
@@ -435,7 +436,7 @@ public struct FormatOptions: CustomStringConvertible {
                 organizeExtensionThreshold: Int = 0,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
-                redundantType: RedundantType = .assignment,
+                redundantType: RedundantType = .inferred,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -110,6 +110,11 @@ public enum WrapReturnType: String, CaseIterable {
     case preserve
 }
 
+public enum RedundantType: String, CaseIterable {
+    case explicitType = "explicit-type"
+    case assignment
+}
+
 /// Version number wrapper
 public struct Version: RawRepresentable, Comparable, ExpressibleByStringLiteral, CustomStringConvertible {
     public let rawValue: String
@@ -352,6 +357,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var organizeExtensionThreshold: Int
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
+    public var redundantType: RedundantType
 
     // Deprecated
     public var indentComments: Bool
@@ -429,6 +435,7 @@ public struct FormatOptions: CustomStringConvertible {
                 organizeExtensionThreshold: Int = 0,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
+                redundantType: RedundantType = .assignment,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -500,6 +507,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.organizeExtensionThreshold = organizeExtensionThreshold
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
+        self.redundantType = redundantType
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -650,7 +650,7 @@ public struct _FormatRules {
             let equalsIndex = formatter.index(of: .operator("=", .infix), after: colonIndex),
             let endIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: equalsIndex),
             let assignmentTypeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
-            let openParensIndex = formatter.index(of: .delimiter("("), after: assignmentTypeStartIndex)
+            let openParensIndex = formatter.index(of: .startOfScope("("), after: assignmentTypeStartIndex)
             else { return }
 
             // Check types match
@@ -677,13 +677,14 @@ public struct _FormatRules {
             }
 
             switch formatter.options.redundantType {
-            case .assignment:
+            case .inferred:
                 formatter.removeTokens(in: colonIndex ... endIndex)
                 if formatter.tokens[colonIndex - 1].isSpace {
                     formatter.removeToken(at: colonIndex - 1)
                 }
-            case .explicitType:
+            case .explicit:
                 formatter.removeTokens(in: assignmentTypeStartIndex ..< openParensIndex)
+                formatter.insert([.identifier(".init")], at: assignmentTypeStartIndex)
             }
         }
     }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -639,7 +639,8 @@ public struct _FormatRules {
 
     /// Removes explicit type declarations from initialization declarations
     public let redundantType = FormatRule(
-        help: "Remove redundant type from variable declarations."
+        help: "Remove redundant type from variable declarations.",
+        options: ["redundanttype"]
     ) { formatter in
         formatter.forEachToken(where: { (token) -> Bool in
             token == .keyword("var") || token == .keyword("let")

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -648,7 +648,9 @@ public struct _FormatRules {
                 [.delimiter(":"), .operator("=", .infix)].contains($0)
             }), formatter.tokens[colonIndex] == .delimiter(":"),
             let equalsIndex = formatter.index(of: .operator("=", .infix), after: colonIndex),
-            let endIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: equalsIndex)
+            let endIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: equalsIndex),
+            let assignmentTypeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+            let openParensIndex = formatter.index(of: .delimiter("("), after: assignmentTypeStartIndex)
             else { return }
 
             // Check types match
@@ -674,9 +676,14 @@ public struct _FormatRules {
                 return
             }
 
-            formatter.removeTokens(in: colonIndex ... endIndex)
-            if formatter.tokens[colonIndex - 1].isSpace {
-                formatter.removeToken(at: colonIndex - 1)
+            switch formatter.options.redundantType {
+            case .assignment:
+                formatter.removeTokens(in: colonIndex ... endIndex)
+                if formatter.tokens[colonIndex - 1].isSpace {
+                    formatter.removeToken(at: colonIndex - 1)
+                }
+            case .explicitType:
+                formatter.removeTokens(in: assignmentTypeStartIndex ..< openParensIndex)
             }
         }
     }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -789,6 +789,18 @@ extension RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantType)
     }
 
+//    func testVarNonRedundantTypeDoesNothingExplicitType() {
+//        let input = "var view: UIView = UINavigationBar()"
+//        testFormatting(for: input, rule: FormatRules.redundantType)
+//    }
+//
+    func testLetRedundantTypeRemovalExplicitType() {
+        let input = "let view: UIView = UIView()"
+        let output = "let view: UIView = .init()"
+        let options = FormatOptions(redundantType: .explicitType, swiftVersion: "5.1")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
     func testLetNonRedundantTypeDoesNothing() {
         let input = "let view: UIView = UINavigationBar()"
         testFormatting(for: input, rule: FormatRules.redundantType)

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -789,18 +789,6 @@ extension RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantType)
     }
 
-//    func testVarNonRedundantTypeDoesNothingExplicitType() {
-//        let input = "var view: UIView = UINavigationBar()"
-//        testFormatting(for: input, rule: FormatRules.redundantType)
-//    }
-//
-    func testLetRedundantTypeRemovalExplicitType() {
-        let input = "let view: UIView = UIView()"
-        let output = "let view: UIView = .init()"
-        let options = FormatOptions(redundantType: .explicitType, swiftVersion: "5.1")
-        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
-    }
-
     func testLetNonRedundantTypeDoesNothing() {
         let input = "let view: UIView = UINavigationBar()"
         testFormatting(for: input, rule: FormatRules.redundantType)
@@ -872,6 +860,72 @@ extension RulesTests {
         baz ? bar2() : bar2()
         """
         testFormatting(for: input, output, rule: FormatRules.redundantType)
+    }
+
+    func testVarRedundantTypeRemovalExplicitType() {
+        let input = "var view: UIView = UIView()"
+        let output = "var view: UIView = .init()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testLetRedundantGenericTypeRemovalExplicitType() {
+        let input = "let relay: BehaviourRelay<Int?> = BehaviourRelay<Int?>(value: nil)"
+        let output = "let relay: BehaviourRelay<Int?> = .init(value: nil)"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testVarNonRedundantTypeDoesNothingExplicitType() {
+        let input = "var view: UIView = UINavigationBar()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testLetRedundantTypeRemovalExplicitType() {
+        let input = "let view: UIView = UIView()"
+        let output = "let view: UIView = .init()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeRemovedIfValueOnNextLineExplicitType() {
+        let input = """
+        let view: UIView
+            = UIView()
+        """
+        let output = """
+        let view: UIView
+            = .init()
+        """
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeRemovedIfValueOnNextLine2ExplicitType() {
+        let input = """
+        let view: UIView =
+            UIView()
+        """
+        let output = """
+        let view: UIView =
+            .init()
+        """
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeRemovalWithCommentExplicitType() {
+        let input = "var view: UIView /* view */ = UIView()"
+        let output = "var view: UIView /* view */ = .init()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)    }
+
+    func testRedundantTypeRemovalWithComment2ExplicitType() {
+        let input = "var view: UIView = /* view */ UIView()"
+        let output = "var view: UIView = /* view */ .init()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
     // MARK: - redundantNilInit


### PR DESCRIPTION
Addresses #816 by adding options for `inferred` and `explicit` to Redundant Type rule