### PR TITLE
Better handle Redundant Type static or class members/funcs

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -682,15 +682,16 @@ public struct _FormatRules {
                     formatter.removeToken(at: colonIndex - 1)
                 }
             case .explicit:
+                guard let valueStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex) else { break }
                 if formatter.nextToken(after: j) == .startOfScope("(") {
-                    formatter.replaceToken(at: j, with: [.operator(".", .infix), .identifier("init")])
+                    formatter.replaceTokens(in: valueStartIndex ... j, with: [.operator(".", .infix), .identifier("init")])
                 } else if
                     // check for `= Type.identifier` or `= Type.identifier()`
                     formatter.token(at: j + 1) == .operator(".", .infix),
                     formatter.endOfExpression(at: j + 1, upTo: []) == j + 2 ||
                     (formatter.token(at: j + 3) == .startOfScope("(") && formatter.token(at: j + 4) == .endOfScope(")"))
                 {
-                    formatter.removeToken(at: j)
+                    formatter.removeTokens(in: valueStartIndex ... j)
                 }
             }
         }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -945,6 +945,54 @@ extension RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
+    func testRedundantTypeRemovalWithStaticMember() {
+        let input = """
+        let session: URLSession = URLSession.default
+
+        init(foo: Foo, bar: Bar) {
+            self.foo = foo
+            self.bar = bar
+        }
+        """
+        let output = """
+        let session: URLSession = .default
+
+        init(foo: Foo, bar: Bar) {
+            self.foo = foo
+            self.bar = bar
+        }
+        """
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeRemovalWithStaticFunc() {
+        let input = """
+        let session: URLSession = URLSession.default()
+
+        init(foo: Foo, bar: Bar) {
+            self.foo = foo
+            self.bar = bar
+        }
+        """
+        let output = """
+        let session: URLSession = .default()
+
+        init(foo: Foo, bar: Bar) {
+            self.foo = foo
+            self.bar = bar
+        }
+        """
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeDoesNothingWithStaticMemberMakingCopy() {
+        let input = "let session: URLSession = URLSession.default.makeCopy()"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
     // MARK: - redundantNilInit
 
     func testRemoveRedundantNilInit() {


### PR DESCRIPTION
I noticed that the current implementation of `--redundanttype explicit` is too greedy if it encounters static or class members/funcs. This PR should help this rule better handle these cases.