### PR TITLE
Ignore comments in lines connected by a continuation character

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -340,16 +340,24 @@ private func cumulate(successiveLines: [String]) throws -> [String] {
     var cumulatedLines = [String]()
     var iterator = successiveLines.makeIterator()
     while let currentLine = iterator.next() {
-        var cumulatedLine = currentLine.trimmingCharacters(in: .whitespaces)
+        var cumulatedLine = effectiveContent(of: currentLine)
         while cumulatedLine.hasSuffix("\\") {
             guard let nextLine = iterator.next() else {
                 throw FormatError.reading("Configuration file ends with an illegal line continuation character '\'")
             }
-            cumulatedLine = cumulatedLine.dropLast() + nextLine
+            if !nextLine.trimmingCharacters(in: .whitespaces).starts(with: "#") {
+                cumulatedLine = cumulatedLine.dropLast() + effectiveContent(of: nextLine)
+            }
         }
-        cumulatedLines.append(cumulatedLine)
+        cumulatedLines.append(String(cumulatedLine))
     }
     return cumulatedLines
+}
+
+private func effectiveContent(of line: String) -> String {
+    return line
+        .prefix { $0 != "#" }
+        .trimmingCharacters(in: .whitespaces)
 }
 
 // Serialize a set of options into either an arguments string or a file

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -338,6 +338,24 @@ class ArgumentsTests: XCTestCase {
         XCTAssertEqual(args["hexgrouping"], "4, 8")
     }
 
+    func testCommentsInConsecutiveLines() throws {
+        let config = """
+        --rules braces, \\
+                # some comment
+                fileHeader, \\
+                # another comment invalidating this line separator \\
+                # yet another comment
+                andOperator
+        --hexgrouping   \\
+                4,      \\  # comment after line separator
+                8           # comment invalidating this line separator \\
+        """
+        let data = Data(config.utf8)
+        let args = try parseConfigFile(data)
+        XCTAssertEqual(args["rules"], "braces, fileHeader, andOperator")
+        XCTAssertEqual(args["hexgrouping"], "4, 8")
+    }
+
     func testLineContinuationCharacterOnLastLine() throws {
         let config = """
         --rules braces,\\

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -16,6 +16,7 @@ extension ArgumentsTests {
         ("testCommentContainingSpace", testCommentContainingSpace),
         ("testCommentedLine", testCommentedLine),
         ("testCommentInLine", testCommentInLine),
+        ("testCommentsInConsecutiveLines", testCommentsInConsecutiveLines),
         ("testDisableArgumentOverridesConfigRules", testDisableArgumentOverridesConfigRules),
         ("testDuplicateDisableArgumentsAreMerged", testDuplicateDisableArgumentsAreMerged),
         ("testDuplicateExcludeArgumentsAreMerged", testDuplicateExcludeArgumentsAreMerged),


### PR DESCRIPTION
Currently, in the configuration file, if a comment follows a line continuation character, the comment and all the subsequent lines are ignored. This should be considered a bug. 

With this change the parser just ignores the comments, but not the lines which follow after the comment. So the continuation only applies to the first line after the continuation character which is not a comment.