### PR TITLE
Exit early if redundanttype is from Optional binding

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -680,7 +680,11 @@ public struct _FormatRules {
                     formatter.removeToken(at: colonIndex - 1)
                 }
             case .explicit:
-                guard let valueStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex) else { break }
+                guard
+                    let valueStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                    // ensure is not optional binding
+                    formatter.lastToken(before: i, where: { [.delimiter(","), .keyword("if"), .keyword("guard")].contains($0) }) == nil
+                else { break }
                 if formatter.nextToken(after: j) == .startOfScope("(") {
                     formatter.replaceTokens(in: valueStartIndex ... j, with: [.operator(".", .infix), .identifier("init")])
                 } else if

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1059,6 +1059,24 @@ extension RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantType, options: options)
     }
 
+    func testRedundantTypeDoesNothingIfLet() {
+        let input = "if let foo: Foo = Foo() {}"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeDoesNothingGuardLet() {
+        let input = "guard let foo: Foo = Foo() else {}"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeDoesNothingIfLetAfterComma() {
+        let input = "if check == true, let foo: Foo = Foo() {}"
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
     // MARK: - redundantNilInit
 
     func testRemoveRedundantNilInit() {


### PR DESCRIPTION
The `explicit` option of the redundanttype rule is still a bit too eager — it will remove "redundant" types, moving to `.init` style even for Optional binding, which will fail to compile. This breaks early if it's discovered that the current `let/var` token is from Optional binding.