### PR TITLE
Update swiftformat-for-xcode install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Xcode source editor extension
 Like the command-line tool, you can install the SwiftFormat for Xcode extension application via [Homebrew](http://brew.sh/). Assuming you already have Homebrew installed, type:
 
 ```bash
-$ brew cask install swiftformat-for-xcode
+$ brew install --cask swiftformat-for-xcode
 ```
 
 This will install SwiftFormat for Xcode in your Applications folder. Double-click the app to launch it, and then follow the on-screen instructions.


### PR DESCRIPTION
Homebrew recently disabled `brew cask install` in favor of `brew install --cask`. It was deprecated in 2.6.0 (release notes [here](https://brew.sh/2020/12/01/homebrew-2.6.0/) and disabled in 2.7.0.