### PR TITLE
Fix issue where single line method after array would wrap unexpectedly

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -80,7 +80,14 @@ extension Formatter {
             }
         }
 
-        func wrapReturnIfNecessary(endOfFunctionScope: Int) {
+        func wrapReturnIfNecessary(
+            startOfScope: Int,
+            endOfFunctionScope: Int
+        ) {
+            guard token(at: startOfScope) == .startOfScope("(") else {
+                return
+            }
+
             switch options.wrapReturnType {
             case .preserve:
                 break
@@ -171,7 +178,10 @@ extension Formatter {
                 }
             }
 
-            wrapReturnIfNecessary(endOfFunctionScope: endOfScope)
+            wrapReturnIfNecessary(
+                startOfScope: i,
+                endOfFunctionScope: endOfScope
+            )
         }
         func wrapArgumentsAfterFirst(startOfScope i: Int, endOfScope: Int, allowGrouping: Bool) {
             guard var firstArgumentIndex = self.index(of: .nonSpaceOrLinebreak, in: i + 1 ..< endOfScope) else {
@@ -223,7 +233,10 @@ extension Formatter {
                 insertLinebreak(at: breakIndex)
             }
 
-            wrapReturnIfNecessary(endOfFunctionScope: endOfScope)
+            wrapReturnIfNecessary(
+                startOfScope: i,
+                endOfFunctionScope: endOfScope
+            )
         }
 
         var lastIndex = -1

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2032,6 +2032,26 @@ extension RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
     }
 
+    func testDoesntWrapReturnOnSingleLineFunctionDeclarationAfterMultilineArray() {
+        let input = """
+        final class Foo {
+            private static let array = [
+                "one",
+            ]
+
+            private func singleLine() -> String {}
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline
+        )
+
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+    }
+
     func testPreserveReturnOnMultilineFunctionDeclarationByDefault() {
         let input = """
         func multilineFunction(

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -711,6 +711,7 @@ extension RulesTests {
         ("testDoesntUseGroupedMarkTemplateWhenSeparatedByExtensionOfOtherType", testDoesntUseGroupedMarkTemplateWhenSeparatedByExtensionOfOtherType),
         ("testDoesntUseGroupedMarkTemplateWhenSeparatedByOtherType", testDoesntUseGroupedMarkTemplateWhenSeparatedByOtherType),
         ("testDoesntWrapReturnOnSingleLineFunctionDeclaration", testDoesntWrapReturnOnSingleLineFunctionDeclaration),
+        ("testDoesntWrapReturnOnSingleLineFunctionDeclarationAfterMultilineArray", testDoesntWrapReturnOnSingleLineFunctionDeclarationAfterMultilineArray),
         ("testDontChangePrivateExtensionToFileprivate", testDontChangePrivateExtensionToFileprivate),
         ("testDontCorruptPartialFragment", testDontCorruptPartialFragment),
         ("testDontCorruptPartialFragment2", testDontCorruptPartialFragment2),


### PR DESCRIPTION
This PR fixes a bug where `--wrapreturntype if-multiline` would unexpectedly wrap a single-line method that follows a multi-line array declaration

## Before

```swift
final class Foo {
  private static let array = [
    "one",
  ]

  private func singleLine() 
    -> String 
  {}
}
```

## After

```swift
final class Foo {
  private static let array = [
    "one",
  ]

  private func singleLine() -> String {}
}
```
