### PR TITLE
(DRAFT) fix: `hoistPatternLet` with wrapped switch cases puts `let` on previous line

### DIFF
--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -567,6 +567,25 @@ extension RulesTests {
                        exclude: ["wrapSwitchCases", "sortedSwitchCases"])
     }
 
+    func testHoistNewlineSeparatedSwitchCaseLets() {
+        let input = """
+        switch foo {
+        case .foo(let bar),
+             .bar(let bar):
+        }
+        """
+
+        let output = """
+        switch foo {
+        case let .foo(bar),
+             let .bar(bar):
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.hoistPatternLet,
+                       exclude: ["wrapSwitchCases", "sortedSwitchCases"])
+    }
+
     func testHoistCatchLet() {
         let input = "do {} catch Foo.foo(bar: let bar) {}"
         let output = "do {} catch let Foo.foo(bar: bar) {}"

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -868,6 +868,7 @@ extension RulesTests {
         ("testHoistIfSecondArgIsUnderscore", testHoistIfSecondArgIsUnderscore),
         ("testHoistLabelledCaseLet", testHoistLabelledCaseLet),
         ("testHoistLetWithNoSpaceAfterCase", testHoistLetWithNoSpaceAfterCase),
+        ("testHoistNewlineSeparatedSwitchCaseLets", testHoistNewlineSeparatedSwitchCaseLets),
         ("testHoistSwitchCaseWithNestedParens", testHoistSwitchCaseWithNestedParens),
         ("testHoistWrappedGuardCaseLet", testHoistWrappedGuardCaseLet),
         ("testIfAfterSwitchCaseNotWrapped", testIfAfterSwitchCaseNotWrapped),


### PR DESCRIPTION
This pull request doesn't fix the bug, but adds a failing test demonstrating the issue. I'm looking for guidance on the recommended way to address this issue, and will be happy to make the fix myself.

### Input

```swift
switch foo {
case .foo(let bar),
     .bar(let bar):
}
```

### Expected output

```swift
case let .foo(bar),
     let .bar(bar):
}
```

### Actual output

```swift
switch foo {
case let .foo(bar), let
    .bar(bar):
}
```