### PR TITLE
Adds support for tokenizing Xcode placeholder tokens

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -443,7 +443,8 @@ Option | Description
 
 ## enumNamespaces
 
-Converts types used for hosting only static members into enums.
+Converts types used for hosting only static members into enums (an empty enum is
+the canonical way to create a namespace in Swift as it can't be instantiated).
 
 ## extensionAccessControl
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -736,7 +736,10 @@ public struct _FormatRules {
 
     // Converts types used for hosting only static members into enums to avoid instantiation.
     public let enumNamespaces = FormatRule(
-        help: "Converts types used for hosting only static members into enums."
+        help: """
+        Converts types used for hosting only static members into enums (an empty enum is
+        the canonical way to create a namespace in Swift as it can't be instantiated).
+        """
     ) { formatter in
         func rangeHostsOnlyStaticMembersAtTopLevel(_ range: Range<Int>) -> Bool {
             // exit for empty declarations

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -911,6 +911,31 @@ private extension UnicodeScalarView {
                 return .identifier("`" + identifier + "`")
             }
             self = start
+        } else if read("<") {
+            if read("#") {
+                // look for closing Xcode token
+                var previousWasHash = false
+                var index = startIndex
+                var found = false
+                while index < endIndex {
+                    let idx = index
+                    index = self.index(after: index)
+                    if self[idx] == ">" {
+                        if previousWasHash {
+                            found = true
+                            break
+                        }
+                    } else {
+                        previousWasHash = self[idx] == "#"
+                    }
+                }
+                if found {
+                    let string = String(prefix(upTo: index))
+                    self = suffix(from: index)
+                    return .identifier("<#\(string)")
+                }
+            }
+            self = start
         } else if read("#") {
             if let identifier = readIdentifier() {
                 if identifier == "if" {

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -1212,29 +1212,45 @@ extension RulesTests {
 
     func testSingleIndentTrailingClosureBody() {
         let input = """
-        method(
-            withParameter: 1,
-            otherParameter: 2
-        ) { [weak self] in
-            guard let error = error else { return }
-            print("and a trailing closure")
+        func foo() {
+            method(
+                withParameter: 1,
+                otherParameter: 2
+            ) { [weak self] in
+                guard let error = error else { return }
+                print("and a trailing closure")
+            }
         }
         """
-
         let options = FormatOptions(wrapArguments: .disabled, closingParenOnSameLine: false)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
+
+    func testSingleIndentTrailingClosureBody2() {
+        let input = """
+        func foo() {
+            method(withParameter: 1,
+                   otherParameter: 2) { [weak self] in
+                guard let error = error else { return }
+                print("and a trailing closure")
+            }
+        }
+        """
+        let options = FormatOptions(wrapArguments: .disabled, closingParenOnSameLine: true)
         testFormatting(for: input, rule: FormatRules.indent, options: options)
     }
 
     func testDoubleIndentTrailingClosureBody() {
         let input = """
-        method(
-            withParameter: 1,
-            otherParameter: 2) { [weak self] in
-                guard let error = error else { return }
-                print("and a trailing closure")
+        func foo() {
+            method(
+                withParameter: 1,
+                otherParameter: 2) { [weak self] in
+                    guard let error = error else { return }
+                    print("and a trailing closure")
+            }
         }
         """
-
         let options = FormatOptions(wrapArguments: .disabled, closingParenOnSameLine: true)
         testFormatting(for: input, rule: FormatRules.indent, options: options)
     }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -827,6 +827,20 @@ extension RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
     }
 
+    func testHandleXcodeTokenApplyingWrap() {
+        let input = """
+        test(image: <#T##UIImage#>, name: "Name")
+        """
+        let output = """
+        test(
+            image: <#T##UIImage#>,
+            name: "Name"
+        )
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, maxWidth: 20)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
     // MARK: wrapParameters
 
     // MARK: preserve

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -1367,6 +1367,56 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
+    func testXcodeToken() {
+        let input = """
+        test(image: <#T##UIImage#>)
+        """
+        let output: [Token] = [
+            .identifier("test"),
+            .startOfScope("("),
+            .identifier("image"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("<#T##UIImage#>"),
+            .endOfScope(")"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
+    func testXcodeWithArrayAndClosureToken() {
+        let input = """
+        monkey(smelly: <#T##Bool#>, happy: <#T##Bool#>, names: <#T##[String]#>, throw💩: <#T##((Int) -> Void)##((Int) -> Void)##(Int) -> Void#>)
+        """
+        let output: [Token] = [
+            .identifier("monkey"),
+            .startOfScope("("),
+            .identifier("smelly"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("<#T##Bool#>"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("happy"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("<#T##Bool#>"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("names"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("<#T##[String]#>"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("throw💩"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("<#T##((Int) -> Void)##((Int) -> Void)##(Int) -> Void#>"),
+            .endOfScope(")"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
     // MARK: Operators
 
     func testBasicOperator() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -879,6 +879,7 @@ extension RulesTests {
         ("testHandleAndAtStartOfLine", testHandleAndAtStartOfLine),
         ("testHandleAndAtStartOfLineAfterComment", testHandleAndAtStartOfLineAfterComment),
         ("testHandlesTrailingCommentCorrectly", testHandlesTrailingCommentCorrectly),
+        ("testHandleXcodeTokenApplyingWrap", testHandleXcodeTokenApplyingWrap),
         ("testHexFractionGrouping", testHexFractionGrouping),
         ("testHoistCaseLet", testHoistCaseLet),
         ("testHoistCaseVar", testHoistCaseVar),
@@ -2590,6 +2591,8 @@ extension TokenizerTests {
         ("testUnescapeUnicodeLiterals", testUnescapeUnicodeLiterals),
         ("testUnicode", testUnicode),
         ("testUnicodeOperator", testUnicodeOperator),
+        ("testXcodeToken", testXcodeToken),
+        ("testXcodeWithArrayAndClosureToken", testXcodeWithArrayAndClosureToken),
         ("testZero", testZero),
     ]
 }

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1860,6 +1860,7 @@ extension RulesTests {
         ("testSingleClosureArgumentUnwrapped", testSingleClosureArgumentUnwrapped),
         ("testSingleClosureArgumentWithReturnValueUnwrapped", testSingleClosureArgumentWithReturnValueUnwrapped),
         ("testSingleIndentTrailingClosureBody", testSingleIndentTrailingClosureBody),
+        ("testSingleIndentTrailingClosureBody2", testSingleIndentTrailingClosureBody2),
         ("testSingleIndentTrailingClosureBodyOfShortMethod", testSingleIndentTrailingClosureBodyOfShortMethod),
         ("testSingleIndentTrailingClosureBodyThatStartsOnFollowingLine", testSingleIndentTrailingClosureBodyThatStartsOnFollowingLine),
         ("testSingleLineGuardBrace", testSingleLineGuardBrace),


### PR DESCRIPTION
# What's Here

On our team we wrap arguments / parameters that reach a certain length (120 char). While editing, I find it really tedious to go through and move them to their own lines, but at the same time it's much more soothing to my mind to newline them before replacing the tokens. Especially if the method signature contains a callback or more. 

Enter SwiftFormat for Xcode. _Almost_. Turns out it didn't parse Xcode placeholder tokens, so it couldn't wrap things for me until I filled them out.

So I added support for recognizing placeholder tokens, along with a few tests.

I could probably update the implementation to do less index work, and keep that control statement more high level, but I wanted to see if this is even a thing anyone else wants.

![format-tokens](https://user-images.githubusercontent.com/32696/115969996-c7318000-a50d-11eb-8500-8ce4c0803572.gif)
