### PR TITLE
Added Linux build GitHub action

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -1,0 +1,29 @@
+name: Build for Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to build (branch, tag or SHA)'
+        required: false
+        default: 'master'
+
+jobs:
+  build:
+    name: Build SwiftFormat for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Build it
+        run: |
+          swift build --configuration release
+          SWIFTFORMAT_BIN_PATH=`swift build --configuration release --show-bin-path`
+          mv $SWIFTFORMAT_BIN_PATH/swiftformat "${HOME}/swiftformat_linux"
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: swiftformat_linux
+          path: ~/swiftformat_linux
+          retention-days: 5


### PR DESCRIPTION
We talked a bit about this on https://github.com/nicklockwood/SwiftFormat/issues/860

This is a GitHub Action workflow that will build SwiftFormat on Linux then upload the resulting binary as an artifact that can be downloaded from GitHub.

The workflow would be accessible from the Actions tab and has to be run manually. You can specify the branch/tag/SHA that you want to build.

<img width="1443" alt="Screen Shot 2021-04-28 at 11 43 16 AM" src="https://user-images.githubusercontent.com/679224/116338891-707ebb80-a817-11eb-9593-b3a6ddc430ee.png">

Once that's done, in the summary section you should be able to see the "Artifacts" that were produced by the workflow. You can download `swiftformat_linux` by clicking on it, and then simply include it in your release commit

<img width="1164" alt="Screen Shot 2021-04-28 at 11 43 33 AM" src="https://user-images.githubusercontent.com/679224/116338967-960bc500-a817-11eb-886b-cecf94af9213.png">

Thank you for considering this!

