### PR TITLE
[Linux] Binary fixes

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -23,7 +23,7 @@ jobs:
           SWIFTFORMAT_BIN_PATH=`swift build --configuration release --show-bin-path`
           mv $SWIFTFORMAT_BIN_PATH/swiftformat "${HOME}/swiftformat_linux"
           apt update && apt install zip -y
-          cd ${HOME}/swiftformat_linux
+          cd ${HOME}
           zip swiftformat_linux.zip swiftformat_linux
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This makes possible to use the binary on slim swift images, which doesn't contain the full swift toolchain.
With the current binary I get the following error trying to run it on `swift:5.3-focal-slim`:
```
swiftformat: error while loading shared libraries: libswiftCore.so: cannot open shared object file: No such file or directory
```

Minor: I see that when downloading the binary it is not marked as executable, but I don't think it is a problem of how we compile it, as being it compiled by SPM should already have the executable flag. Maybe it is something related to how you have uploaded the binary to github?