### PR TITLE
Add wrapMultilineStatementBraces support for more cases

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1558,6 +1558,30 @@ extension Formatter {
         }
         return spaceEquivalentToTokens(from: firstToken, upTo: nextTokenIndex)
     }
+
+    func startOfMultilineStatement(at openBraceIndex: Int) -> Int? {
+        assert(tokens[openBraceIndex] == .startOfScope("{"))
+
+        if let indexBeforeOpenBrace = index(of: .nonSpaceOrCommentOrLinebreak, before: openBraceIndex),
+           tokens[indexBeforeOpenBrace] == .endOfScope(")"),
+           let startOfMethodParameters = index(of: .startOfScope("("), before: indexBeforeOpenBrace),
+           let indexBeforeStartOfParameters = index(of: .nonSpaceOrCommentOrLinebreak, before: startOfMethodParameters),
+           let indexTwoBeforeStartOfParameters = index(of: .nonSpaceOrCommentOrLinebreak, before: indexBeforeStartOfParameters),
+           tokens[indexBeforeStartOfParameters].isIdentifier && tokens[indexTwoBeforeStartOfParameters].string == "."
+           || tokens[indexBeforeStartOfParameters].string == "="
+        {
+            return startOfMethodParameters
+        } else if let keywordIndex = indexOfLastSignificantKeyword(at: openBraceIndex, excluding: ["where"]),
+                  [
+                      "if", "for", "guard", "while", "switch", "func", "init", "subscript",
+                      "extension", "class", "actor", "struct", "enum", "protocol",
+                  ].contains(tokens[keywordIndex].string)
+        {
+            return keywordIndex
+        } else {
+            return nil
+        }
+    }
 }
 
 extension _FormatRules {

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1558,30 +1558,6 @@ extension Formatter {
         }
         return spaceEquivalentToTokens(from: firstToken, upTo: nextTokenIndex)
     }
-
-    func startOfMultilineStatement(at openBraceIndex: Int) -> Int? {
-        assert(tokens[openBraceIndex] == .startOfScope("{"))
-
-        if let indexBeforeOpenBrace = index(of: .nonSpaceOrCommentOrLinebreak, before: openBraceIndex),
-           tokens[indexBeforeOpenBrace] == .endOfScope(")"),
-           let startOfMethodParameters = index(of: .startOfScope("("), before: indexBeforeOpenBrace),
-           let indexBeforeStartOfParameters = index(of: .nonSpaceOrCommentOrLinebreak, before: startOfMethodParameters),
-           let indexTwoBeforeStartOfParameters = index(of: .nonSpaceOrCommentOrLinebreak, before: indexBeforeStartOfParameters),
-           tokens[indexBeforeStartOfParameters].isIdentifier && tokens[indexTwoBeforeStartOfParameters].string == "."
-           || tokens[indexBeforeStartOfParameters].string == "="
-        {
-            return startOfMethodParameters
-        } else if let keywordIndex = indexOfLastSignificantKeyword(at: openBraceIndex, excluding: ["where"]),
-                  [
-                      "if", "for", "guard", "while", "switch", "func", "init", "subscript",
-                      "extension", "class", "actor", "struct", "enum", "protocol",
-                  ].contains(tokens[keywordIndex].string)
-        {
-            return keywordIndex
-        } else {
-            return nil
-        }
-    }
 }
 
 extension _FormatRules {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1090,7 +1090,7 @@ public struct _FormatRules {
     /// indenting can be configured with the `options` parameter of the formatter.
     public let indent = FormatRule(
         help: "Indent code in accordance with the scope level.",
-        orderAfter: ["trailingSpace", "wrap", "wrapArguments"],
+        orderAfter: ["trailingSpace", "wrap", "wrapArguments", "wrapMultilineStatementBraces"],
         options: ["indent", "tabwidth", "smarttabs", "indentcase", "ifdef", "xcodeindentation"],
         sharedOptions: ["trimwhitespace", "allman", "wrapconditions"]
     ) { formatter in
@@ -3670,44 +3670,39 @@ public struct _FormatRules {
 
     public let wrapMultilineStatementBraces = FormatRule(
         help: "Wrap the opening brace of multiline statements.",
-        orderAfter: ["indent", "braces", "wrapArguments"],
+        orderAfter: ["braces", "wrapArguments"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
-        formatter.forEachToken { i, token in
-            guard case let .keyword(keyword) = token, [
-                "if", "for", "guard", "while", "switch", "func", "init", "subscript",
-                "extension", "class", "actor", "struct", "enum", "protocol",
-            ].contains(keyword),
-                let openBraceIndex = formatter.index(of: .startOfScope("{"), after: i)
-            else {
+        formatter.forEachToken { openBraceIndex, openBraceToken in
+            guard openBraceToken == .startOfScope("{") else {
                 return
             }
-            let startOfLine = formatter.startOfLine(at: openBraceIndex)
-            // Make sure the brace is on a separate line from the if / guard
-            guard i < startOfLine,
-                  // If token before the brace isn't a newline or guard else then insert a newline
-                  let prevIndex = formatter.index(of: .nonSpace, before: openBraceIndex),
-                  let prevToken = formatter.token(at: prevIndex),
-                  !prevToken.isLinebreak, !(prevToken == .keyword("else") &&
-                      prevIndex == formatter.index(of: .nonSpace, after: startOfLine)),
-                  // Only wrap when the brace's line is more indented than the if / guard
-                  formatter.indentForLine(at: i) < formatter.indentForLine(at: openBraceIndex),
-                  // And only when closing brace is not on same line
-                  let closingIndex = formatter.endOfScope(at: openBraceIndex),
-                  formatter.tokens[openBraceIndex ..< closingIndex].contains(where: { $0.isLinebreak })
-            else {
-                return
-            }
-            formatter.insertLinebreak(at: openBraceIndex)
 
-            // Insert a space to align the opening brace with the if / guard keyword
-            let indentation = formatter.indentForLine(at: i)
-            formatter.insertSpace(indentation, at: openBraceIndex + 1)
+            if let startOfMultilineStatement = formatter.startOfMultilineStatement(at: openBraceIndex),
+               // Make sure the brace is on a separate line from the if / guard
+               startOfMultilineStatement < formatter.startOfLine(at: openBraceIndex),
+               // If token before the brace isn't a newline or guard else then insert a newline
+               let prevIndex = formatter.index(of: .nonSpace, before: openBraceIndex),
+               let prevToken = formatter.token(at: prevIndex),
+               !prevToken.isLinebreak, !(prevToken == .keyword("else") &&
+                   prevIndex == formatter.index(of: .nonSpace, after: formatter.startOfLine(at: openBraceIndex))),
+               // Only wrap when the brace's line is more indented than the if / guard
+               formatter.indentForLine(at: startOfMultilineStatement) < formatter.indentForLine(at: openBraceIndex),
+               // And only when closing brace is not on same line
+               let closingIndex = formatter.endOfScope(at: openBraceIndex),
+               formatter.tokens[openBraceIndex ..< closingIndex].contains(where: { $0.isLinebreak })
+            {
+                formatter.insertLinebreak(at: openBraceIndex)
 
-            // If we left behind a trailing space on the previous line, clean it up
-            let previousTokenIndex = openBraceIndex - 1
-            if formatter.tokens[previousTokenIndex].isSpace {
-                formatter.removeToken(at: previousTokenIndex)
+                // Insert a space to align the opening brace with the if / guard keyword
+                let indentation = formatter.indentForLine(at: startOfMultilineStatement)
+                formatter.insertSpace(indentation, at: openBraceIndex + 1)
+
+                // If we left behind a trailing space on the previous line, clean it up
+                let previousTokenIndex = openBraceIndex - 1
+                if formatter.tokens[previousTokenIndex].isSpace {
+                    formatter.removeToken(at: previousTokenIndex)
+                }
             }
         }
     }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2371,6 +2371,50 @@ extension RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapMultilineStatementBraces, options: options)
     }
 
+    func testMultilineBraceAppliedToTrailingClosure() {
+        let input = """
+        UIView.animate(
+            duration: 10,
+            options: []) {
+                print()
+        }
+        """
+
+        let output = """
+        UIView.animate(
+            duration: 10,
+            options: [])
+        {
+            print()
+        }
+        """
+
+        let options = FormatOptions(closingParenOnSameLine: true)
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineStatementBraces, FormatRules.indent], options: options)
+    }
+
+    func testMultilineBraceAppliedToGetterBody() {
+        let input = """
+        var items: Adaptive<CGFloat> = .adaptive(
+            compact: Sizes.horizontalPaddingTiny_8,
+            regular: Sizes.horizontalPaddingLarge_64) {
+                didSet { updateAccessoryViewSpacing() }
+        }
+        """
+
+        let output = """
+        var items: Adaptive<CGFloat> = .adaptive(
+            compact: Sizes.horizontalPaddingTiny_8,
+            regular: Sizes.horizontalPaddingLarge_64)
+        {
+            didSet { updateAccessoryViewSpacing() }
+        }
+        """
+
+        let options = FormatOptions(closingParenOnSameLine: true)
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineStatementBraces, FormatRules.indent], options: options)
+    }
+
     // MARK: wrapConditions before-first
 
     func testWrapConditionsBeforeFirstPreservesMultilineStatements() {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2376,7 +2376,7 @@ extension RulesTests {
         UIView.animate(
             duration: 10,
             options: []) {
-                print()
+            print()
         }
         """
 
@@ -2390,7 +2390,7 @@ extension RulesTests {
         """
 
         let options = FormatOptions(closingParenOnSameLine: true)
-        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineStatementBraces, FormatRules.indent], options: options)
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineStatementBraces], options: options, exclude: ["indent"])
     }
 
     func testMultilineBraceAppliedToGetterBody() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1117,6 +1117,8 @@ extension RulesTests {
         ("testMixedCaseMarkIsNotUpdated", testMixedCaseMarkIsNotUpdated),
         ("testModifierOrder", testModifierOrder),
         ("testModifiersDontAffectAttributeWrapping", testModifiersDontAffectAttributeWrapping),
+        ("testMultilineBraceAppliedToGetterBody", testMultilineBraceAppliedToGetterBody),
+        ("testMultilineBraceAppliedToTrailingClosure", testMultilineBraceAppliedToTrailingClosure),
         ("testMultilineClassBrace", testMultilineClassBrace),
         ("testMultilineClassBraceNotAppliedForXcodeIndentationMode", testMultilineClassBraceNotAppliedForXcodeIndentationMode),
         ("testMultilineCommentHeader", testMultilineCommentHeader),


### PR DESCRIPTION
This PR adds `wrapMultilineStatementBraces` support to more types of multiline statements

### Before

```
UIView.animate(
    duration: 10,
    options: []) {
    print()
}

var items: Adaptive<CGFloat> = .adaptive(
    compact: Sizes.horizontalPaddingTiny_8,
    regular: Sizes.horizontalPaddingLarge_64) {
        didSet { updateAccessoryViewSpacing() }
}
```

### After

```
UIView.animate(
    duration: 10,
    options: []) 
{
    print()
}

var items: Adaptive<CGFloat> = .adaptive(
    compact: Sizes.horizontalPaddingTiny_8,
    regular: Sizes.horizontalPaddingLarge_64) 
{
    didSet { updateAccessoryViewSpacing() }
}
```