### PR TITLE
Update README Instructions for Build Phase SDKROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ let package = Package(
 
     ```bash
     cd BuildTools
-    SDKROOT=macosx
+    SDKROOT=(xcrun --sdk macosx --show-sdk-path)
     #swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file
     swift run -c release swiftformat "$SRCROOT"
     ```


### PR DESCRIPTION
In Xcode 13 using `SDKROOT=macosx` will generate a warning: `no such SDK: macosx`.  This can be fixed by updating the Build Phase to use the following instead:

`SDKROOT=(xcrun --sdk macosx --show-sdk-path)`

This should allow `xcrun` to dynamically fetch the SDK path instead.  This pull request simply updates the README with that change.

Thanks to @kishikawakatsumi for the [tip](https://twitter.com/k_katsumi/status/1431574995445026824).

Closes #1009