### PR TITLE
Add --redundanttype infer-locals-only option

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1365,14 +1365,30 @@ Remove redundant type from variable declarations.
 
 Option | Description
 --- | ---
-`--redundanttype` | Keep "inferred" (default) or "explicit" type annotation
+`--redundanttype` | "inferred" (default), "explicit", or "infer-locals-only"
 
 <details>
 <summary>Examples</summary>
 
 ```diff
+// inferred
 - let view: UIView = UIView()
 + let view = UIView()
+
+// explicit
+- let view: UIView = UIView()
++ let view: UIView = .init()
+
+// infer-locals-only
+  class Foo {
+-     let view: UIView = UIView()
++     let view: UIView = .init()
+
+      func method() {
+-         let view: UIView = UIView()
++         let view = UIView()
+      }
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -806,8 +806,24 @@ private struct Examples {
 
     let redundantType = """
     ```diff
+    // inferred
     - let view: UIView = UIView()
     + let view = UIView()
+
+    // explicit
+    - let view: UIView = UIView()
+    + let view: UIView = .init()
+
+    // infer-locals-only
+      class Foo {
+    -     let view: UIView = UIView()
+    +     let view: UIView = .init()
+
+          func method() {
+    -         let view: UIView = UIView()
+    +         let view = UIView()
+          }
+      }
     ```
     """
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -815,7 +815,7 @@ struct _Descriptors {
     let redundantType = OptionDescriptor(
         argumentName: "redundanttype",
         displayName: "Redundant Type",
-        help: "Keep \"inferred\" (default) or \"explicit\" type annotation",
+        help: "\"inferred\" (default), \"explicit\", or \"infer-locals-only\"",
         keyPath: \.redundantType
     )
     let emptyBracesSpacing = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -112,8 +112,20 @@ public enum WrapReturnType: String, CaseIterable {
 
 /// Annotation which should be kept when removing a redundant type
 public enum RedundantType: String, CaseIterable {
+    /// Preserves the type as a part of the property definition:
+    /// `let foo: Foo = Foo()` becomes `let foo: Foo = .init()`
     case explicit
+
+    /// Uses type inference to omit the type in the property definition:
+    /// `let foo: Foo = Foo()` becomes `let foo = Foo()`
     case inferred
+
+    /// Uses `.inferred` for properties within local scopes (method bodies, etc.),
+    /// but `.explicit` for globals and properties within types.
+    ///  - This is because type checking for globals and type properties
+    ///    using inferred types can be more expensive.
+    ///    https://twitter.com/uint_min/status/1441448033988722691?s=21
+    case inferLocalsOnly = "infer-locals-only"
 }
 
 /// Argument type for empty brace spacing behavior

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1412,6 +1412,67 @@ extension Formatter {
         }
     }
 
+    /// The type of scope that a declaration is contained within
+    enum DeclarationScope {
+        /// The declaration is a top-level global
+        case global
+
+        /// The declaration is a member of some type
+        case type
+
+        /// The declaration is within some local scope,
+        /// like a function body.
+        case local
+    }
+
+    /// The declaration scope (global, type, or local) that the
+    /// given token index is contained by.
+    func declarationScope(at i: Int) -> DeclarationScope {
+        /// Declarations which have `DeclarationScope.type`
+        let typeDeclararions = Set(["class", "struct", "enum", "actor", "extension"])
+
+        /// Declarations which have `DeclarationScope.local`
+        let localDeclararions = Set(["let", "var", "func", "subscript", "init", "deinit"])
+
+        let allDeclarationScopes = typeDeclararions.union(localDeclararions)
+
+        // back track through tokens until we find a startOfScope("{") that isDeclarationTypeKeyword
+        //  - we have to skip scopes that sit between this token and the its actual start of scope,
+        //    so we have to keep track of the number of unpaired end scope tokens we have encountered
+        var unpairedEndScopeCount = 0
+        var currentIndex = i
+        var startOfScope: Int?
+
+        while startOfScope == nil, currentIndex > 0 {
+            currentIndex -= 1
+
+            if tokens[currentIndex] == .endOfScope("}") {
+                unpairedEndScopeCount += 1
+            } else if tokens[currentIndex] == .startOfScope("{") {
+                if unpairedEndScopeCount == 0 {
+                    startOfScope = currentIndex
+                } else {
+                    unpairedEndScopeCount -= 1
+                }
+            }
+        }
+
+        // If this declaration isn't within any scope,
+        // it must be a global.
+        guard
+            let startOfScopeIndex = startOfScope,
+            let declarationTypeKeyword = lastToken(before: startOfScopeIndex, where: { allDeclarationScopes.contains($0.string) })
+        else {
+            return .global
+        }
+
+        if typeDeclararions.contains(declarationTypeKeyword.string) {
+            return .type
+        } else {
+            return .local
+        }
+    }
+
     // Swift modifier keywords, in preferred order
     var modifierOrder: [String] {
         var priorities = [String: Int]()

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -682,7 +682,30 @@ public struct _FormatRules {
                 return
             }
 
+            /// The implementation of RedundantType uses inferred or explicit,
+            /// potentially depending on the context.
+            enum RedundantTypeImplementation {
+                case inferred
+                case explicit
+            }
+
+            let implementation: RedundantTypeImplementation
+
             switch formatter.options.redundantType {
+            case .inferred:
+                implementation = .inferred
+            case .explicit:
+                implementation = .explicit
+            case .inferLocalsOnly:
+                switch formatter.declarationScope(at: i) {
+                case .global, .type:
+                    implementation = .explicit
+                case .local:
+                    implementation = .inferred
+                }
+            }
+
+            switch implementation {
             case .inferred:
                 formatter.removeTokens(in: colonIndex ... typeEndIndex)
                 if formatter.tokens[colonIndex - 1].isSpace {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1226,6 +1226,45 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
+    func testRedundantTypeinferLocalsOnly() {
+        let input = """
+        let globalFoo: Foo = Foo()
+
+        struct SomeType {
+            let instanceFoo: Foo = Foo()
+
+            func method() {
+                let localFoo: Foo = Foo()
+                let localString: String = "foo"
+            }
+
+            let instanceString: String = "foo"
+        }
+
+        let globalString: String = "foo"
+        """
+
+        let output = """
+        let globalFoo: Foo = .init()
+
+        struct SomeType {
+            let instanceFoo: Foo = .init()
+
+            func method() {
+                let localFoo = Foo()
+                let localString = "foo"
+            }
+
+            let instanceString: String = "foo"
+        }
+
+        let globalString: String = "foo"
+        """
+
+        let options = FormatOptions(redundantType: .inferLocalsOnly)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
     // MARK: - redundantNilInit
 
     func testRemoveRedundantNilInit() {


### PR DESCRIPTION
This PR adds a `--redundanttype infer-locals-only` option that uses `inferred` for local properties within method bodies (etc) but uses `explicit` for globals or instance properties.

```diff
  class Foo {
-     let view: UIView = UIView()
+     let view: UIView = .init()

      func method() {
-         let view: UIView = UIView()
+         let view = UIView()
      }
  }
```

This is because type checking for globals and type properties using inferred types can be more expensive: https://twitter.com/uint_min/status/1441448033988722691?s=21