### PR TITLE
Add --markcategories true/false option for organizeDeclarations rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -899,11 +899,12 @@ Option | Description
 
 ## organizeDeclarations
 
-Organizes declarations within class, struct, and enum bodies.
+Organizes declarations within class, struct, enum, actor, and extension bodies.
 
 Option | Description
 --- | ---
 `--categorymark` | Template for category mark comments. Defaults to "MARK: %c"
+`--markcategories` | Insert MARK comments between categories (true by default)
 `--beforemarks` | Declarations placed before first mark (e.g. `typealias,struct`)
 `--lifecycle` | Names of additional Lifecycle methods (e.g. `viewDidLoad`)
 `--organizetypes` | Declarations to organize (default: `class,actor,struct,enum`)

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1299,7 +1299,8 @@ extension Formatter {
             else { continue }
 
             // Build the MARK declaration, but only when there is more than one category present.
-            if numberOfCategories > 1,
+            if options.markCategories,
+               numberOfCategories > 1,
                let markComment = category.markComment(from: options.categoryMarkComment)
             {
                 let firstDeclaration = sortedDeclarations[indexOfFirstDeclaration].declaration

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -732,6 +732,14 @@ struct _Descriptors {
         fromArgument: { $0 },
         toArgument: { $0 }
     )
+    let markCategories = OptionDescriptor(
+        argumentName: "markcategories",
+        displayName: "Mark Categories",
+        help: "Insert MARK comments between categories (true by default)",
+        keyPath: \.markCategories,
+        trueValues: ["true"],
+        falseValues: ["false"]
+    )
     let categoryMarkComment = OptionDescriptor(
         argumentName: "categorymark",
         displayName: "Category Mark Comment",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -358,6 +358,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var markExtensions: MarkMode
     public var extensionMarkComment: String
     public var groupedExtensionMarkComment: String
+    public var markCategories: Bool
     public var categoryMarkComment: String
     public var beforeMarks: Set<String>
     public var lifecycleMethods: Set<String>
@@ -440,6 +441,7 @@ public struct FormatOptions: CustomStringConvertible {
                 markExtensions: MarkMode = .always,
                 extensionMarkComment: String = "MARK: - %t + %c",
                 groupedExtensionMarkComment: String = "MARK: %c",
+                markCategories: Bool = true,
                 categoryMarkComment: String = "MARK: %c",
                 beforeMarks: Set<String> = [],
                 lifecycleMethods: Set<String> = [],
@@ -516,6 +518,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.markExtensions = markExtensions
         self.extensionMarkComment = extensionMarkComment
         self.groupedExtensionMarkComment = groupedExtensionMarkComment
+        self.markCategories = markCategories
         self.categoryMarkComment = categoryMarkComment
         self.beforeMarks = beforeMarks
         self.lifecycleMethods = lifecycleMethods

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5480,11 +5480,11 @@ public struct _FormatRules {
     }
 
     public let organizeDeclarations = FormatRule(
-        help: "Organizes declarations within class, struct, and enum bodies.",
+        help: "Organizes declarations within class, struct, enum, actor, and extension bodies.",
         runOnceOnly: true,
         disabledByDefault: true,
         orderAfter: ["extensionAccessControl", "redundantFileprivate"],
-        options: ["categorymark", "beforemarks", "lifecycle", "organizetypes",
+        options: ["categorymark", "markcategories", "beforemarks", "lifecycle", "organizetypes",
                   "structthreshold", "classthreshold", "enumthreshold", "extensionlength"],
         sharedOptions: ["lineaftermarks"]
     ) { formatter in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -170,6 +170,7 @@ class MetadataTests: XCTestCase {
                 case .identifier("organizeType"):
                     referencedOptions += [
                         Descriptors.categoryMarkComment,
+                        Descriptors.markCategories,
                         Descriptors.beforeMarks,
                         Descriptors.lifecycleMethods,
                         Descriptors.organizeTypes,

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1271,6 +1271,64 @@ class OrganizationTests: RulesTests {
         )
     }
 
+    func testOrganizeWithNoCategoryMarks_noSpacesBetweenDeclarations() {
+        let input = """
+        class Foo {
+            private func privateMethod() {}
+            private let bar = 1
+            public let baz = 1
+        }
+        """
+
+        let output = """
+        class Foo {
+            public let baz = 1
+
+            private let bar = 1
+
+            private func privateMethod() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(markCategories: false)
+        )
+    }
+
+    func testOrganizeWithNoCategoryMarks_withSpacesBetweenDeclarations() {
+        let input = """
+        class Foo {
+            private func privateMethod() {}
+
+            private let bar = 1
+
+            public let baz = 1
+
+            private func anotherPrivateMethod() {}
+        }
+        """
+
+        let output = """
+        class Foo {
+            public let baz = 1
+
+            private let bar = 1
+
+            private func privateMethod() {}
+
+            private func anotherPrivateMethod() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(markCategories: false)
+        )
+    }
+
     // MARK: extensionAccessControl .onDeclarations
 
     func testUpdatesVisibilityOfExtensionMembers() {


### PR DESCRIPTION
This PR adds a `--markcategories` option for the `organizeDeclarations` rule, which configures whether or not to insert `// MARK:` comments between categories.

### Sample

```swift
class Foo {
    private func privateMethod() {}
    private let bar = 1
    public let baz = 1
}
```

### with `--markcategories true` (the default)

```swift
class Foo {

    // MARK: - Public

    public let baz = 1
    
    // MARK: - Private

    private let bar = 1
    
    private func privateMethod() {}
    
}
```

### with `--markcategories false` (new!)

```swift
class Foo {
    public let baz = 1

    private let bar = 1

    private func privateMethod() {}
}
```