### PR TITLE
Fix test failure due to redundantClosure rule

### DIFF
--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -241,15 +241,13 @@ class IndentTests: RulesTests {
 
     func testIndentTrailingClosureArgumentsAfterFunction() {
         let input = """
-        var epoxyViewportLogger: EpoxyViewportLogger = {
-            EpoxyViewportLogger(
-                debounceInterval: 0.5,
-                viewportStartImpressionHandler: { [weak self] _, viewportLoggingContext in
-                    self?.viewportLoggingRegistry.logViewportSessionStart(with: viewportLoggingContext)
-                }) { [weak self] _, viewportLoggingContext in
-                    self?.viewportLoggingRegistry.logViewportSessionEnd(with: viewportLoggingContext)
-                }
-        }()
+        var epoxyViewportLogger = EpoxyViewportLogger(
+            debounceInterval: 0.5,
+            viewportStartImpressionHandler: { [weak self] _, viewportLoggingContext in
+                self?.viewportLoggingRegistry.logViewportSessionStart(with: viewportLoggingContext)
+            }) { [weak self] _, viewportLoggingContext in
+                self?.viewportLoggingRegistry.logViewportSessionEnd(with: viewportLoggingContext)
+            }
         """
         let options = FormatOptions(closingParenOnSameLine: true)
         testFormatting(for: input, rule: FormatRules.indent, options: options)


### PR DESCRIPTION
This PR fixes a test failure due to the `redundantClosure` rule