### PR TITLE
Fix issue where redundantInit rule could cause build failure

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4447,6 +4447,23 @@ public struct _FormatRules {
             firstChar != "$", String(firstChar).uppercased() == String(firstChar) else {
                 return
             }
+
+            // If there's a linebreak between the `init` and the open paren,
+            // we have to remove it or this init call will no lomger compile
+            if let newlineIndex = formatter.index(of: .linebreak, before: openParenIndex),
+               newlineIndex > i
+            {
+                formatter.removeToken(at: newlineIndex)
+
+                // Remove any spaces around the linebreak
+                // (e.g. any extra indentation spaces that are no longer necessary)
+                for index in (i ... newlineIndex).reversed() {
+                    if formatter.token(at: index)?.isSpace == true {
+                        formatter.removeToken(at: index)
+                    }
+                }
+            }
+
             formatter.removeTokens(in: dotIndex ... i)
         }
     }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -728,6 +728,27 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantInit)
     }
 
+    func testRemoveInitWithOpenParenOnFollowingLine() {
+        let input = """
+        var foo: Foo {
+            Foo.init
+            (
+                bar: bar,
+                baaz: baaz
+            )
+        }
+        """
+        let output = """
+        var foo: Foo {
+            Foo(
+                bar: bar,
+                baaz: baaz
+            )
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantInit)
+    }
+
     // MARK: - redundantLetError
 
     func testCatchLetError() {


### PR DESCRIPTION
This PR fixes an issue where the `redundantInit` failure could cause a build failure if the `.init` and open paren aren't on the same line. This seems to be because parsing for method calls / `.init` is more lenient than parsing for the sugared initializer syntax.

### Input

```swift
var foo: Foo {
    Foo.init
    (
        bar: bar,
        baaz: baaz
    )
}
```

### Output before fix

```swift
var foo: Foo {
    Foo          // 🛑 expected member name or constructor call after type name
    (
        bar: bar,
        baaz: baaz
    )
}
```

### Output after fix

```swift
var foo: Foo {
    Foo(
        bar: bar,
        baaz: baaz
    )
}
```