### PR TITLE
Add --wraptypealiases option

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1950,6 +1950,7 @@ Option | Description
 `--closingparen` | Closing paren position: "balanced" (default) or "same-line"
 `--wrapreturntype` | Wrap return type: "if-multiline", "preserve" (default)
 `--wrapconditions` | Wrap conditions: "before-first", "after-first", "preserve"
+`--wraptypealiases` | Wrap typealiases: "before-first", "after-first", "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -459,6 +459,12 @@ struct _Descriptors {
         help: "Wrap array/dict: \"before-first\", \"after-first\", \"preserve\"",
         keyPath: \.wrapCollections
     )
+    let wrapTypealiases = OptionDescriptor(
+        argumentName: "wraptypealiases",
+        displayName: "Wrap Typealiases",
+        help: "Wrap typealiases: \"before-first\", \"after-first\", \"preserve\"",
+        keyPath: \.wrapTypealiases
+    )
     let wrapReturnType = OptionDescriptor(
         argumentName: "wrapreturntype",
         displayName: "Wrap Return Type",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -332,6 +332,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapArguments: WrapMode
     public var wrapParameters: WrapMode
     public var wrapCollections: WrapMode
+    public var wrapTypealiases: WrapMode
     public var closingParenOnSameLine: Bool
     public var wrapReturnType: WrapReturnType
     public var wrapConditions: WrapMode
@@ -415,6 +416,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapArguments: WrapMode = .preserve,
                 wrapParameters: WrapMode = .default,
                 wrapCollections: WrapMode = .preserve,
+                wrapTypealiases: WrapMode = .preserve,
                 closingParenOnSameLine: Bool = false,
                 wrapReturnType: WrapReturnType = .preserve,
                 wrapConditions: WrapMode = .preserve,
@@ -492,6 +494,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapArguments = wrapArguments
         self.wrapParameters = wrapParameters
         self.wrapCollections = wrapCollections
+        self.wrapTypealiases = wrapTypealiases
         self.closingParenOnSameLine = closingParenOnSameLine
         self.wrapReturnType = wrapReturnType
         self.wrapConditions = wrapConditions

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3900,7 +3900,7 @@ public struct _FormatRules {
         help: "Wrap lines that exceed the specified maximum width.",
         options: ["maxwidth", "nowrapoperators", "assetliterals"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "indent",
-                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions"]
+                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }
@@ -3957,7 +3957,7 @@ public struct _FormatRules {
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: ["wrap"],
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen",
-                  "wrapreturntype", "wrapconditions"],
+                  "wrapreturntype", "wrapconditions", "wraptypealiases"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
                         "tabwidth", "maxwidth", "smarttabs", "assetliterals"]
     ) { formatter in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -152,7 +152,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.closingParenOnSameLine, Descriptors.linebreak, Descriptors.truncateBlankLines,
                         Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs,
                         Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType,
-                        Descriptors.wrapConditions,
+                        Descriptors.wrapConditions, Descriptors.wrapTypealiases,
                     ]
                 case .identifier("indexWhereLineShouldWrapInLine"), .identifier("indexWhereLineShouldWrap"):
                     referencedOptions += [

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -891,8 +891,8 @@ class SyntaxTests: RulesTests {
         guard
             let first = response?.first,
             let last = response?.last,
-            case .foo(token: let foo, Providing: let bar) = first,
-            case .foo(token: let baz, Providing: let quux) = last
+            case .foo(token: let foo, provider: let bar) = first,
+            case .foo(token: let baz, provider: let quux) = last
         else {
             return
         }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -891,8 +891,8 @@ class SyntaxTests: RulesTests {
         guard
             let first = response?.first,
             let last = response?.last,
-            case .foo(token: let foo, provider: let bar) = first,
-            case .foo(token: let baz, provider: let quux) = last
+            case .foo(token: let foo, Providing: let bar) = first,
+            case .foo(token: let baz, Providing: let quux) = last
         else {
             return
         }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2226,6 +2226,225 @@ class WrappingTests: RulesTests {
                        rules: [FormatRules.wrapArguments, FormatRules.wrap], options: options)
     }
 
+    func testWrapArguments_typealias_beforeFirst() {
+        let input = """
+        typealias Dependencies = FooProviding & BarProviding & BaazProviding & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies
+            = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 40)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_multipleTypealiases_beforeFirst() {
+        let input = """
+        enum Namespace {
+            typealias DependenciesA = FooProviding & BarProviding
+            typealias DependenciesB = BaazProviding & QuuxProviding
+        }
+        """
+
+        let output = """
+        enum Namespace {
+            typealias DependenciesA
+                = FooProviding
+                & BarProviding
+            typealias DependenciesB
+                = BaazProviding
+                & QuuxProviding
+        }
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 45)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_afterFirst() {
+        let input = """
+        typealias Dependencies = FooProviding & BarProviding & BaazProviding & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 40)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_multipleTypealiases_afterFirst() {
+        let input = """
+        enum Namespace {
+            typealias DependenciesA = FooProviding & BarProviding
+            typealias DependenciesB = BaazProviding & QuuxProviding
+        }
+        """
+
+        let output = """
+        enum Namespace {
+            typealias DependenciesA = FooProviding
+                & BarProviding
+            typealias DependenciesB = BaazProviding
+                & QuuxProviding
+        }
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 45)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth() {
+        let input = """
+        typealias Dependencies = FooProviding & BarProviding & BaazProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 100)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently() {
+        let input = """
+        typealias Dependencies = FooProviding & BarProviding &
+            BaazProviding & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently2() {
+        let input = """
+        enum Namespace {
+            typealias Dependencies = FooProviding & BarProviding
+                & BaazProviding & QuuxProviding
+        }
+        """
+
+        let output = """
+        enum Namespace {
+            typealias Dependencies
+                = FooProviding
+                & BarProviding
+                & BaazProviding
+                & QuuxProviding
+        }
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently3() {
+        let input = """
+        typealias Dependencies
+            = FooProviding & BarProviding &
+            BaazProviding & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently4() {
+        let input = """
+        typealias Dependencies
+            = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistentlyWithComment() {
+        let input = """
+        typealias Dependencies = FooProviding & BarProviding // trailing comment 1
+            // Inline Comment 1
+            & BaazProviding & QuuxProviding // trailing comment 2
+        """
+
+        let output = """
+        typealias Dependencies
+            = FooProviding
+            & BarProviding // trailing comment 1
+            // Inline Comment 1
+            & BaazProviding
+            & QuuxProviding // trailing comment 2
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_singleTypePreserved() {
+        let input = """
+        typealias Dependencies = FooProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 10)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["wrap"])
+    }
+
+    func testWrapArguments_typealias_preservesCommentsBetweenTypes() {
+        let input = """
+        typealias Dependencies
+            // We use `FooProviding` because `FooFeature` depends on `Foo`
+            = FooProviding
+            // We use `BarProviding` because `BarFeature` depends on `Bar`
+            & BarProviding
+            // We use `BaazProviding` because `BaazFeature` depends on `Baaz`
+            & BaazProviding
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArguments_typealias_preservesCommentsAfterTypes() {
+        let input = """
+        typealias Dependencies
+            = FooProviding // We use `FooProviding` because `FooFeature` depends on `Foo`
+            & BarProviding // We use `BarProviding` because `BarFeature` depends on `Bar`
+            & BaazProviding // We use `BaazProviding` because `BaazFeature` depends on `Baaz`
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+    }
+
     // MARK: - -return wrap-if-multiline
 
     func testWrapReturnOnMultilineFunctionDeclaration() {


### PR DESCRIPTION
This PR adds a new `--wraptypealiases` option, that supports both `beforeFirst` and `afterFirst` wrapping.

----

At Airbnb, our DI system uses "provider" protocols. Features/components typically express their dependencies as a `typealias` containing all of the types that they need to access. For example:

```swift
typealias Dependencies = FooProviding & BarProviding & BaazProviding & QuuxProviding

// then later you can do `dependencies.foo`, `dependencies.bar` etc -- it's quite nice!
```

The current `wrap` implementation inserts the minimum number of newlines necessary to make the declaration fit within the line limit. For example:

```swift
typealias Dependencies = FooProviding & BarProviding & BaazProviding 
    & QuuxProviding
```

We typically prefer wrapping so that each type is on a separate line, which is how the new `--wraptypealiases` works:

#### `--wraptypealiases beforeFirst`

```swift
typealias Dependencies 
    = FooProviding 
    & BarProviding 
    & BaazProviding 
    & QuuxProviding
```

#### `--wraptypealiases afterFirst`

```swift
typealias Dependencies = FooProviding 
    & BarProviding
    & BaazProviding 
    & QuuxProviding
```