### PR TITLE
Improve wrapping for ternary operators

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1937,6 +1937,7 @@ Option | Description
 `--maxwidth` | Maximum length of a line before wrapping. defaults to "none"
 `--nowrapoperators` | Comma-delimited list of operators that shouldn't be wrapped
 `--assetliterals` | Color/image literal width. "actual-width" or "visual-width"
+`--wrapternary` | Wrap ternary operators: "default", "before-operators"
 
 ## wrapArguments
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -477,6 +477,12 @@ struct _Descriptors {
         help: "Wrap conditions: \"before-first\", \"after-first\", \"preserve\"",
         keyPath: \.wrapConditions
     )
+    let wrapTernaryOperators = OptionDescriptor(
+        argumentName: "wrapternary",
+        displayName: "Wrap Ternary Operators",
+        help: "Wrap ternary operators: \"default\", \"before-operators\"",
+        keyPath: \.wrapTernaryOperators
+    )
     let closingParenOnSameLine = OptionDescriptor(
         argumentName: "closingparen",
         displayName: "Closing Paren Position",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -135,6 +135,15 @@ public enum EmptyBracesSpacing: String, CaseIterable {
     case linebreak
 }
 
+/// Wrapping behavior for multi-line ternary operators
+public enum TernaryOperatorWrapMode: String, CaseIterable {
+    /// Wraps ternary operators using the default `wrap` behavior,
+    /// which performs the minimum amount of wrapping necessary.
+    case `default`
+    /// Wraps long / multi-line ternary operators before each of the component operators
+    case beforeOperators = "before-operators"
+}
+
 /// Version number wrapper
 public struct Version: RawRepresentable, Comparable, ExpressibleByStringLiteral, CustomStringConvertible {
     public let rawValue: String
@@ -336,6 +345,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var closingParenOnSameLine: Bool
     public var wrapReturnType: WrapReturnType
     public var wrapConditions: WrapMode
+    public var wrapTernaryOperators: TernaryOperatorWrapMode
     public var uppercaseHex: Bool
     public var uppercaseExponent: Bool
     public var decimalGrouping: Grouping
@@ -420,6 +430,7 @@ public struct FormatOptions: CustomStringConvertible {
                 closingParenOnSameLine: Bool = false,
                 wrapReturnType: WrapReturnType = .preserve,
                 wrapConditions: WrapMode = .preserve,
+                wrapTernaryOperators: TernaryOperatorWrapMode = .default,
                 uppercaseHex: Bool = true,
                 uppercaseExponent: Bool = false,
                 decimalGrouping: Grouping = .group(3, 6),
@@ -498,6 +509,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.closingParenOnSameLine = closingParenOnSameLine
         self.wrapReturnType = wrapReturnType
         self.wrapConditions = wrapConditions
+        self.wrapTernaryOperators = wrapTernaryOperators
         self.uppercaseHex = uppercaseHex
         self.uppercaseExponent = uppercaseExponent
         self.decimalGrouping = decimalGrouping

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3898,9 +3898,9 @@ public struct _FormatRules {
 
     public let wrap = FormatRule(
         help: "Wrap lines that exceed the specified maximum width.",
-        options: ["maxwidth", "nowrapoperators", "assetliterals"],
+        options: ["maxwidth", "nowrapoperators", "assetliterals", "wrapternary"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "indent",
-                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases"]
+                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapternary"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }
@@ -3959,7 +3959,7 @@ public struct _FormatRules {
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen",
                   "wrapreturntype", "wrapconditions", "wraptypealiases"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
-                        "tabwidth", "maxwidth", "smarttabs", "assetliterals"]
+                        "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
     ) { formatter in
         formatter.wrapCollectionsAndArguments(completePartialWrapping: true,
                                               wrapSingleArguments: false)

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -152,7 +152,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.closingParenOnSameLine, Descriptors.linebreak, Descriptors.truncateBlankLines,
                         Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs,
                         Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType,
-                        Descriptors.wrapConditions, Descriptors.wrapTypealiases,
+                        Descriptors.wrapConditions, Descriptors.wrapTypealiases, Descriptors.wrapTernaryOperators,
                     ]
                 case .identifier("indexWhereLineShouldWrapInLine"), .identifier("indexWhereLineShouldWrap"):
                     referencedOptions += [

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -975,6 +975,102 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.wrap, options: options)
     }
 
+    func testWrapSimpleTernaryOperator() {
+        let input = """
+        let foo = fooCondition ? longValueThatContainsFoo : longValueThatContainsBar
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? longValueThatContainsFoo
+            : longValueThatContainsBar
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testRewrapsSimpleTernaryOperator() {
+        let input = """
+        let foo = fooCondition ? longValueThatContainsFoo :
+            longValueThatContainsBar
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? longValueThatContainsFoo
+            : longValueThatContainsBar
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testWrapComplexTernaryOperator() {
+        let input = """
+        let foo = fooCondition ? Foo(property: value) : barContainer.getBar(using: barProvider)
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? Foo(property: value)
+            : barContainer.getBar(using: barProvider)
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testRewrapsComplexTernaryOperator() {
+        let input = """
+        let foo = fooCondition ? Foo(property: value) :
+            barContainer.getBar(using: barProvider)
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? Foo(property: value)
+            : barContainer.getBar(using: barProvider)
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testWrapsSimpleNestedTernaryOperator() {
+        let input = """
+        let foo = fooCondition ? (barCondition ? a : b) : (baazCondition ? c : d)
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? (barCondition ? a : b)
+            : (baazCondition ? c : d)
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testWrapsComplexNestedTernaryOperation() {
+        let input = """
+        let foo = fooCondition ? barCondition ? longTrueBarResult : longFalseBarResult : baazCondition ? longTrueBaazResult : longFalseBaazResult
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? barCondition
+                ? longTrueBarResult
+                : longFalseBarResult
+            : baazCondition
+                ? longTrueBaazResult
+                : longFalseBaazResult
+        """
+
+        let options = FormatOptions(maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options, exclude: ["indent"])
+    }
+
     // MARK: - wrapArguments
 
     func testIndentFirstElementWhenApplyingWrap() {
@@ -1903,9 +1999,9 @@ class WrappingTests: RulesTests {
 
     func testNoMistakeTernaryExpressionForArguments() {
         let input = """
-        (foo ?
-            bar :
-            baz)
+        (foo
+            ? bar
+            : baz)
         """
         let options = FormatOptions(wrapArguments: .beforeFirst, wrapParameters: .beforeFirst)
         testFormatting(for: input, rule: FormatRules.wrapArguments, options: options,

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -986,7 +986,7 @@ class WrappingTests: RulesTests {
             : longValueThatContainsBar
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -1002,7 +1002,7 @@ class WrappingTests: RulesTests {
             : longValueThatContainsBar
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -1017,7 +1017,7 @@ class WrappingTests: RulesTests {
             : barContainer.getBar(using: barProvider)
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -1033,7 +1033,7 @@ class WrappingTests: RulesTests {
             : barContainer.getBar(using: barProvider)
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -1048,7 +1048,7 @@ class WrappingTests: RulesTests {
             : (baazCondition ? c : d)
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -1067,8 +1067,35 @@ class WrappingTests: RulesTests {
                 : longFalseBaazResult
         """
 
-        let options = FormatOptions(maxWidth: 60)
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options, exclude: ["indent"])
+    }
+
+    func testNoWrapTernaryWrappedWithinChildExpression() {
+        let input = """
+        func foo() {
+            return _skipString(string) ? .token(
+                string, Location(source: input, range: startIndex ..< index)
+            ) : nil
+        }
+        """
+
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 0)
+        testFormatting(for: input, rule: FormatRules.wrap, options: options)
+    }
+
+    func testNoWrapTernaryWrappedWithinChildExpression2() {
+        let input = """
+        let types: [PolygonType] = plane.isEqual(to: plane) ? [] : vertices.map {
+            let t = plane.normal.dot($0.position) - plane.w
+            let type: PolygonType = (t < -epsilon) ? .back : (t > epsilon) ? .front : .coplanar
+            polygonType = PolygonType(rawValue: polygonType.rawValue | type.rawValue)!
+            return type
+        }
+        """
+
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 0)
+        testFormatting(for: input, rule: FormatRules.wrap, options: options)
     }
 
     // MARK: - wrapArguments
@@ -1999,9 +2026,9 @@ class WrappingTests: RulesTests {
 
     func testNoMistakeTernaryExpressionForArguments() {
         let input = """
-        (foo
-            ? bar
-            : baz)
+        (foo ?
+            bar :
+            baz)
         """
         let options = FormatOptions(wrapArguments: .beforeFirst, wrapParameters: .beforeFirst)
         testFormatting(for: input, rule: FormatRules.wrapArguments, options: options,


### PR DESCRIPTION
This PR improves wrapping for ternary operators. This implements #888.

### Before

Previously, ternary operators were wrapped the minimum number of times to fit them within the limit.

```swift
// For example, if slightly over the length limit, this:
let foo = fooCondition ? longValueThatContainsFoo : longValueThatContainsBar

// would be wrapped to:
let foo = fooCondition ? longValueThatContainsFoo : 
    longValueThatContainsBar
```

### After (with `--wrapternary before-operators`)

Now, ternary operators wrap intelligently at both the `?` and `:`:

```swift
// For example, if slightly over the length limit, this:
let foo = fooCondition ? longValueThatContainsFoo : longValueThatContainsBar

// is now wrapped to:
let foo = fooCondition 
    ? longValueThatContainsFoo 
    : longValueThatContainsBar
```
