### PR TITLE
Improve multiline string indentation when string is on its own line

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1753,13 +1753,11 @@ public struct _FormatRules {
                 let baseIndent = formatter.indentForLine(at: stringStartIndex)
                 let expectedIndent = baseIndent + formatter.options.indent
 
-                guard let stringEndIndex = formatter.endOfScope(at: stringStartIndex) else {
-                    return
-                }
-
-                if formatter.indentForLine(at: stringEndIndex) == expectedIndent {
-                    return
-                }
+                guard
+                    let stringEndIndex = formatter.endOfScope(at: stringStartIndex),
+                    // Preserve the default indentation if the opening """ is on a line by itself
+                    formatter.startOfLine(at: stringStartIndex, excludingIndent: true) != stringStartIndex
+                else { return }
 
                 for linebreakIndex in (stringStartIndex ..< stringEndIndex).reversed()
                     where formatter.tokens[linebreakIndex].isLinebreak

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2319,6 +2319,51 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.indent, options: options)
     }
 
+    func testNoIndentMultilineStringWithOmittedReturn() {
+        let input = #"""
+        var string: String {
+            """
+            SELECT *
+            FROM authors
+            WHERE authors.name LIKE '%David%'
+            """
+        }
+        """#
+        let options = FormatOptions(indentStrings: true)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
+
+    func testNoIndentMultilineStringOnOwnLineInMethodCall() {
+        let input = #"""
+        XCTAssertEqual(
+            loggingService.assertions,
+            """
+            My long mutli-line assertion.
+            This error was not recoverable.
+            """
+        )
+        """#
+        let options = FormatOptions(indentStrings: true)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
+
+    func testIndentMultilineStringInMethodCall() {
+        let input = #"""
+        XCTAssertEqual(loggingService.assertions, """
+        My long mutli-line assertion.
+        This error was not recoverable.
+        """)
+        """#
+        let output = #"""
+        XCTAssertEqual(loggingService.assertions, """
+            My long mutli-line assertion.
+            This error was not recoverable.
+            """)
+        """#
+        let options = FormatOptions(indentStrings: true)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+    }
+
     func testIndentMultilineStringAtTopLevel() {
         let input = #"""
         let sql = """


### PR DESCRIPTION
This PR improves the behavior of the `indentStrings` option (added in #1049) when the string's opening `"""` are on their own line. In this case we probably shouldn't require the string body to be indented.

### Before

```swift
var string: String {
    """
        SELECT *
        FROM authors
        WHERE authors.name LIKE '%David%'
        """
}

XCTAssertEqual(
    loggingService.assertions,
    """
        My long mutli-line assertion.
        This error was not recoverable.
        """
)
```

### After

```swift
var string: String {
    """
    SELECT *
    FROM authors
    WHERE authors.name LIKE '%David%'
    """
}

XCTAssertEqual(
    loggingService.assertions,
    """
    My long mutli-line assertion.
    This error was not recoverable.
    """
)
```