### PR TITLE
Update redundantVoidReturnType to apply to closures

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1400,6 +1400,10 @@ Option | Description
 
 Remove explicit `Void` return type.
 
+Option | Description
+--- | ---
+`--closurevoid` | Closure void returns: "remove" (default) or "preserve"
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -858,6 +858,12 @@ struct _Descriptors {
         trueValues: ["true", "enabled"],
         falseValues: ["false", "disabled"]
     )
+    let closureVoidReturn = OptionDescriptor(
+        argumentName: "closurevoid",
+        displayName: "Closure Void Return",
+        help: "Closure void returns: \"remove\" (default) or \"preserve\"",
+        keyPath: \.closureVoidReturn
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -144,6 +144,12 @@ public enum TernaryOperatorWrapMode: String, CaseIterable {
     case beforeOperators = "before-operators"
 }
 
+/// Whether or not to remove `-> Void` from closures
+public enum ClosureVoidReturn: String, CaseIterable {
+    case remove
+    case preserve
+}
+
 /// Version number wrapper
 public struct Version: RawRepresentable, Comparable, ExpressibleByStringLiteral, CustomStringConvertible {
     public let rawValue: String
@@ -396,6 +402,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var emptyBracesSpacing: EmptyBracesSpacing
     public var acronyms: Set<String>
     public var indentStrings: Bool
+    public var closureVoidReturn: ClosureVoidReturn
 
     // Deprecated
     public var indentComments: Bool
@@ -482,6 +489,7 @@ public struct FormatOptions: CustomStringConvertible {
                 emptyBracesSpacing: EmptyBracesSpacing = .noSpace,
                 acronyms: Set<String> = ["ID", "URL", "UUID"],
                 indentStrings: Bool = false,
+                closureVoidReturn: ClosureVoidReturn = .remove,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -562,6 +570,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.emptyBracesSpacing = emptyBracesSpacing
         self.acronyms = acronyms
         self.indentStrings = indentStrings
+        self.closureVoidReturn = closureVoidReturn
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2750,7 +2750,8 @@ public struct _FormatRules {
 
     /// Remove redundant void return values for function and closure declarations
     public let redundantVoidReturnType = FormatRule(
-        help: "Remove explicit `Void` return type."
+        help: "Remove explicit `Void` return type.",
+        options: ["closurevoid"]
     ) { formatter in
         formatter.forEach(.operator("->", .infix)) { i, _ in
             guard var endIndex = formatter.index(of: .nonSpace, after: i) else { return }
@@ -2775,7 +2776,9 @@ public struct _FormatRules {
 
             // If this is the explicit return type of a closure, it should
             // always be safe to remove
-            if formatter.next(.nonSpaceOrCommentOrLinebreak, after: endIndex) == .keyword("in") {
+            if formatter.options.closureVoidReturn == .remove,
+               formatter.next(.nonSpaceOrCommentOrLinebreak, after: endIndex) == .keyword("in")
+            {
                 formatter.removeTokens(in: i ..< formatter.index(of: .nonSpace, after: endIndex)!)
                 return
             }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1611,9 +1611,16 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantVoidReturnType)
     }
 
-    func testNoRemoveRedundantVoidInClosureArguments() {
+    func testRemoveRedundantVoidInClosureArguments() {
         let input = "{ (foo: Bar) -> Void in foo() }"
-        testFormatting(for: input, rule: FormatRules.redundantVoidReturnType)
+        let output = "{ (foo: Bar) in foo() }"
+        testFormatting(for: input, output, rule: FormatRules.redundantVoidReturnType)
+    }
+
+    func testRemoveRedundantVoidInClosureArguments2() {
+        let input = "methodWithTrailingClosure { foo -> Void in foo() }"
+        let output = "methodWithTrailingClosure { foo in foo() }"
+        testFormatting(for: input, output, rule: FormatRules.redundantVoidReturnType)
     }
 
     // MARK: - redundantReturn

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1623,6 +1623,12 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantVoidReturnType)
     }
 
+    func testNoRemoveRedundantVoidInClosureArgument() {
+        let input = "{ (foo: Bar) -> Void in foo() }"
+        let options = FormatOptions(closureVoidReturn: .preserve)
+        testFormatting(for: input, rule: FormatRules.redundantVoidReturnType, options: options)
+    }
+
     // MARK: - redundantReturn
 
     func testRemoveRedundantReturnInClosure() {

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -119,13 +119,13 @@ class SpacingTests: RulesTests {
     func testAddSpaceBetweenCaptureListAndArguments2() {
         let input = "{ [weak self]() -> Void in }"
         let output = "{ [weak self] () -> Void in }"
-        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens)
+        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens, exclude: ["redundantVoidReturnType"])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments3() {
         let input = "{ [weak self]() throws -> Void in }"
         let output = "{ [weak self] () throws -> Void in }"
-        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens)
+        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens, exclude: ["redundantVoidReturnType"])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments4() {
@@ -149,7 +149,7 @@ class SpacingTests: RulesTests {
     func testAddSpaceBetweenCaptureListAndArguments7() {
         let input = "Foo<Bar>(0) { [weak self]() -> Void in }"
         let output = "Foo<Bar>(0) { [weak self] () -> Void in }"
-        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens)
+        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens, exclude: ["redundantVoidReturnType"])
     }
 
     func testSpaceBetweenClosingParenAndOpenBrace() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -188,7 +188,7 @@ class SyntaxTests: RulesTests {
 
     func testAnonymousVoidArgumentNotConvertedToEmptyParens() {
         let input = "{ (_: Void) -> Void in }"
-        testFormatting(for: input, rule: FormatRules.void)
+        testFormatting(for: input, rule: FormatRules.void, exclude: ["redundantVoidReturnType"])
     }
 
     func testFuncWithAnonymousVoidArgumentNotStripped() {
@@ -231,7 +231,7 @@ class SyntaxTests: RulesTests {
     func testEmptyClosureReturnValueConvertedToVoid() {
         let input = "{ () -> () in }"
         let output = "{ () -> Void in }"
-        testFormatting(for: input, output, rule: FormatRules.void)
+        testFormatting(for: input, output, rule: FormatRules.void, exclude: ["redundantVoidReturnType"])
     }
 
     func testAnonymousVoidClosureNotChanged() {
@@ -317,7 +317,7 @@ class SyntaxTests: RulesTests {
         let input = "{ () -> Void in }"
         let output = "{ () -> () in }"
         let options = FormatOptions(useVoid: false)
-        testFormatting(for: input, output, rule: FormatRules.void, options: options)
+        testFormatting(for: input, output, rule: FormatRules.void, options: options, exclude: ["redundantVoidReturnType"])
     }
 
     func testNoConvertVoidSelfToTuple() {


### PR DESCRIPTION
This PR updates `redundantVoidReturnType` to apply to closures as well

e.g. 

```swift
{ foo -> Void in foo() }
```

becomes

```swift
{ foo in foo() }
```

I notice this seemed to be intentionally not supported in the existing implementation (there was a `testNoRemoveRedundantVoidInClosureArguments()` test case testing that this didn't happen). Was this just a regression test for the existing behavior, or was this an intentional design decision / style preference? I [checked on swiftfiddle.com](https://swiftfiddle.com/?c=H4sIAAAAAAAAA6tWSlayUspJLVFIy89XsFWoVtAAMqwUgkuKMvPSNRUy8xQKgKwSkKimQm1MXkwekKURo5SRmpOTH6OkqaSjVAY0wUjPSKkWAD6BO55NAAAA) and the examples with `-> Void` removed compile successfully in all Swift versions (back to 2.2). 

We could add an option for this if you don't think it should be enabled by default or think this should be configurable -- let me know what you think.