### PR TITLE
Improve indentation of wrapped ternary operators

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1138,7 +1138,7 @@ public struct _FormatRules {
         help: "Indent code in accordance with the scope level.",
         orderAfter: ["trailingSpace", "wrap", "wrapArguments"],
         options: ["indent", "tabwidth", "smarttabs", "indentcase", "ifdef", "xcodeindentation", "indentstrings"],
-        sharedOptions: ["trimwhitespace", "allman", "wrapconditions"]
+        sharedOptions: ["trimwhitespace", "allman", "wrapconditions", "wrapternary"]
     ) { formatter in
         var scopeStack: [Token] = []
         var scopeStartLineIndexes: [Int] = []
@@ -1621,6 +1621,48 @@ public struct _FormatRules {
                            .count < indent.count + formatter.options.indent.count
                         {
                             indent = formatter.indentForLine(at: conditionBeginIndex) + formatter.options.indent
+                            indentStack[indentStack.count - 1] = indent
+                        }
+
+                        let startOfLineIndex = formatter.startOfLine(at: i, excludingIndent: true)
+                        let startOfLine = formatter.tokens[startOfLineIndex]
+
+                        if formatter.options.wrapTernaryOperators == .beforeOperators,
+                           startOfLine == .operator(":", .infix) || startOfLine == .operator("?", .infix)
+                        {
+                            // Push a ? scope onto the stack so we can easily know
+                            // that the next : is the closing operator of this ternary
+                            if startOfLine.string == "?" {
+                                // We smuggle the index of this operator in the scope stack
+                                // so we can recover it trivially when handling the
+                                // corresponding : operator.
+                                scopeStack.append(.operator("?-\(startOfLineIndex)", .infix))
+                            }
+
+                            // Indent any operator-leading lines following a compomnent operator
+                            // of a wrapped ternary operator expression, except for the :
+                            // following a ?
+                            if
+                                let nextToken = formatter.next(.nonSpace, after: i),
+                                nextToken.isOperator(ofType: .infix),
+                                nextToken != .operator(":", .infix)
+                            {
+                                indent += formatter.options.indent
+                                indentStack[indentStack.count - 1] = indent
+                            }
+                        }
+
+                        // Make sure the indentation for this : operator matches
+                        // the indentation of the previous ? operator
+                        if formatter.options.wrapTernaryOperators == .beforeOperators,
+                           formatter.next(.nonSpace, after: i) == .operator(":", .infix),
+                           let scope = scopeStack.last,
+                           scope.string.hasPrefix("?"),
+                           scope.isOperator(ofType: .infix),
+                           let previousOperatorIndex = scope.string.components(separatedBy: "-").last.flatMap({ Int($0) })
+                        {
+                            scopeStack.removeLast()
+                            indent = formatter.indentForLine(at: previousOperatorIndex)
                             indentStack[indentStack.count - 1] = indent
                         }
                     }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -1037,6 +1037,23 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
+    func testWrappedTernaryOperatorIndentsChainedCalls() {
+        let input = """
+        let ternary = condition
+            ? values
+                .map { $0.bar }
+                .filter { $0.hasFoo }
+                .last
+            : other.values
+                .compactMap { $0 }
+                .first?
+                .with(property: updatedValue)
+        """
+
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
+
     func testWrapsSimpleNestedTernaryOperator() {
         let input = """
         let foo = fooCondition ? (barCondition ? a : b) : (baazCondition ? c : d)
@@ -1052,7 +1069,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
-    func testWrapsComplexNestedTernaryOperation() {
+    func testWrapsDoubleNestedTernaryOperation() {
         let input = """
         let foo = fooCondition ? barCondition ? longTrueBarResult : longFalseBarResult : baazCondition ? longTrueBaazResult : longFalseBaazResult
         """
@@ -1068,7 +1085,30 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
-        testFormatting(for: input, output, rule: FormatRules.wrap, options: options, exclude: ["indent"])
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
+    }
+
+    func testWrapsTripleNestedTernaryOperation() {
+        let input = """
+        let foo = fooCondition ? barCondition ? quuxCondition ? longTrueQuuxResult : longFalseQuuxResult : barCondition2 ? longTrueBarResult : longFalseBarResult : baazCondition ? longTrueBaazResult : longFalseBaazResult
+        """
+
+        let output = """
+        let foo = fooCondition
+            ? barCondition
+                ? quuxCondition
+                    ? longTrueQuuxResult
+                    : longFalseQuuxResult
+                : barCondition2
+                    ? longTrueBarResult
+                    : longFalseBarResult
+            : baazCondition
+                ? longTrueBaazResult
+                : longFalseBaazResult
+        """
+
+        let options = FormatOptions(wrapTernaryOperators: .beforeOperators, maxWidth: 60)
+        testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
     func testNoWrapTernaryWrappedWithinChildExpression() {


### PR DESCRIPTION
This PR improves the indentation of wrapped ternary operators (when using `--wrapternary before-operators`)

### Before

```swift
let ternary = condition
    ? values
    .map { $0.bar }
    .filter { $0.hasFoo }
    .last
    : otherValues

let foo = fooCondition
    ? barCondition
    ? longTrueBarResult
    : longFalseBarResult
    : baazCondition
    ? longTrueBaazResult
    : longFalseBaazResult
```

### After

```swift
let ternary = condition
    ? values
        .map { $0.bar }
        .filter { $0.hasFoo }
        .last
    : otherValues

let foo = fooCondition
    ? barCondition
        ? longTrueBarResult
        : longFalseBarResult
    : baazCondition
        ? longTrueBaazResult
        : longFalseBaazResult
```