### PR TITLE
Fix issue where multiline string indentation conflicted with trailingSpace rule

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1762,6 +1762,12 @@ public struct _FormatRules {
                 for linebreakIndex in (stringStartIndex ..< stringEndIndex).reversed()
                     where formatter.tokens[linebreakIndex].isLinebreak
                 {
+                    // If this line is completely blank, do nothing
+                    //  - This prevents conflicts with the trailingSpace rule
+                    if formatter.nextToken(after: linebreakIndex)?.isLinebreak == true {
+                        continue
+                    }
+
                     let indentIndex = linebreakIndex + 1
                     if formatter.tokens[indentIndex].is(.space) {
                         formatter.replaceToken(at: indentIndex, with: .space(expectedIndent))

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2387,6 +2387,38 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.indent, options: options)
     }
 
+    func testIndentMultilineStringWithBlankLine() {
+        let input = #"""
+        let generatedClass = """
+        import UIKit
+
+        class ViewController: UIViewController { }
+        """
+        """#
+
+        let output = #"""
+        let generatedClass = """
+            import UIKit
+
+            class ViewController: UIViewController { }
+            """
+        """#
+        let options = FormatOptions(indentStrings: true)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+    }
+
+    func testIndentMultilineStringPreservesBlankLines() {
+        let input = #"""
+        let generatedClass = """
+            import UIKit
+
+            class ViewController: UIViewController { }
+            """
+        """#
+        let options = FormatOptions(indentStrings: true)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
+
     func testUnindentMultilineStringAtTopLevel() {
         let input = #"""
         let sql = """


### PR DESCRIPTION
The PR fixes an issue where the `--indentstrings true` mutliline string indentation would conflict with the `trailingSpace` rule if the multiline string had a blank line.