### PR TITLE
Develop rudifa

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -627,3 +627,12 @@ extension String {
         }
     }
 #endif
+
+extension Formatter {
+    func isCurrentScopeMultilineString(at tokenIndex: Int) -> Bool {
+        guard let scope = currentScope(at: tokenIndex), scope.isMultilineStringDelimiter else {
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -892,7 +892,9 @@ public struct _FormatRules {
                 case .startOfScope where prevToken.isStringDelimiter, .stringBody:
                     return
                 default:
-                    break
+                    if formatter.isCurrentScopeMultilineString(at: i) {
+                        return
+                    }
                 }
             }
             if let nextIndex = formatter.index(of: .nonSpace, after: i) {

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -111,7 +111,6 @@ class LinebreakTests: RulesTests {
 
         \"\"\"
         """
-        print("testConsecutiveBlankLinesNoInterpolation input=\(input)")
         testFormatting(for: input, rule: FormatRules.consecutiveBlankLines)
     }
 
@@ -125,7 +124,6 @@ class LinebreakTests: RulesTests {
 
         \"\"\"
         """
-        print("testConsecutiveBlankLinesAfterInterpolation input=\(input)")
         testFormatting(for: input, rule: FormatRules.consecutiveBlankLines)
     }
 

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -101,6 +101,34 @@ class LinebreakTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.consecutiveBlankLines, options: options)
     }
 
+    func testConsecutiveBlankLinesNoInterpolation() {
+        let input = """
+        \"\"\"
+        AAA
+        ZZZ
+
+
+
+        \"\"\"
+        """
+        print("testConsecutiveBlankLinesNoInterpolation input=\(input)")
+        testFormatting(for: input, rule: FormatRules.consecutiveBlankLines)
+    }
+
+    func testConsecutiveBlankLinesAfterInterpolation() {
+        let input = """
+        \"\"\"
+        AAA
+        \\(interpolated)
+
+
+
+        \"\"\"
+        """
+        print("testConsecutiveBlankLinesAfterInterpolation input=\(input)")
+        testFormatting(for: input, rule: FormatRules.consecutiveBlankLines)
+    }
+
     func testLintingConsecutiveBlankLinesReportsCorrectLine() {
         let input = "foo\n   \n\nbar"
         XCTAssertEqual(try lint(input, rules: [FormatRules.consecutiveBlankLines]), [


### PR DESCRIPTION
Hello @nicklockwood

Please consider my fix for the issue #1078 'In a triple-quoted string containing contiguous blank lines, an interpolated value causes loss of blank lines'.

