### PR TITLE
Fix brace wrapping regression for throwing methods

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1906,7 +1906,10 @@ public struct _FormatRules {
                case let .keyword(keyword) = formatter.tokens[keywordIndex],
                ["if", "for", "guard", "while", "switch", "func", "init", "subscript",
                 "extension", "class", "actor", "struct", "enum", "protocol"].contains(keyword),
-               formatter.indentForLine(at: prevIndex) > formatter.indentForLine(at: keywordIndex)
+               formatter.indentForLine(at: prevIndex) > formatter.indentForLine(at: keywordIndex),
+               // Verify that the open brace a `index` is actually the open brace paired with this keyword
+               let openBraceIndexAfterKeyword = formatter.index(of: .startOfScope("{"), after: keywordIndex),
+               i == openBraceIndexAfterKeyword
             {
                 useAllmanBraces = true
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1902,7 +1902,7 @@ public struct _FormatRules {
             // where the brace is on a separate line from the keyword.
             if formatter.options.wrapMultilineStatementBraces,
                let prevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: i),
-               let keywordIndex = formatter.indexOfLastSignificantKeyword(at: prevIndex + 1, excluding: ["where", "else", "case", "let", "var"]),
+               let keywordIndex = formatter.indexOfLastSignificantKeyword(at: prevIndex + 1, excluding: ["where", "else", "case", "let", "var", "throws"]),
                case let .keyword(keyword) = formatter.tokens[keywordIndex],
                ["if", "for", "guard", "while", "switch", "func", "init", "subscript",
                 "extension", "class", "actor", "struct", "enum", "protocol"].contains(keyword),

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -849,7 +849,7 @@ class WrappingTests: RulesTests {
             doSomething()
         }
         """
-        let options = FormatOptions(maxWidth: 42)
+        let options = FormatOptions(wrapMultilineStatementBraces: false, maxWidth: 42)
         testFormatting(for: input, output, rule: FormatRules.wrap, options: options)
     }
 
@@ -2823,6 +2823,27 @@ class WrappingTests: RulesTests {
         func method(
             foo: Int,
             bar: Int)
+        {
+            print("function body")
+        }
+        """
+        let options = FormatOptions(wrapMultilineStatementBraces: true)
+        testFormatting(for: input, [output], rules: [FormatRules.braces, FormatRules.indent], options: options,
+                       exclude: ["wrapArguments", "unusedArguments"])
+    }
+
+    func testMultilineThrowingFuncBraceOnNextLine() {
+        let input = """
+        func method(
+            foo: Int,
+            bar: Int) throws {
+            print("function body")
+        }
+        """
+        let output = """
+        func method(
+            foo: Int,
+            bar: Int) throws
         {
             print("function body")
         }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -3154,6 +3154,53 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output], rules: [FormatRules.braces, FormatRules.indent])
     }
 
+    func testDoesntWrapTrailingClosureAfterSingleLineChainedMethodCall1() {
+        let input = """
+        guard foo else {
+            return
+        }
+
+        when(fulfilled: promise)
+            .then {
+                // chained closure body 1
+            }
+            .done {
+                // chained closure body 2
+            }
+            .catch {
+                // chained closure body 3
+            }
+            .finally {
+                // chained closure body 4
+            }
+        """
+
+        testFormatting(for: input, rules: [FormatRules.braces, FormatRules.indent])
+    }
+
+    func testDoesntWrapTrailingClosureAfterSingleLineChainedMethodCall2() {
+        let input = """
+        when(
+            fulfilled: promise,
+            otherArgument: foo)
+            .then {
+                // chained closure body 1
+            }
+            .done {
+                // chained closure body 2
+            }
+            .catch {
+                // chained closure body 3
+            }
+            .finally {
+                // chained closure body 4
+            }
+        """
+
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: true)
+        testFormatting(for: input, rules: [FormatRules.braces, FormatRules.indent], options: options)
+    }
+
     // MARK: wrapConditions before-first
 
     func testWrapConditionsBeforeFirstPreservesMultilineStatements() {


### PR DESCRIPTION
This PR fixes a regression introduced in #1071 where braces of throwing methods would wrap incorrectly

### Before

```swift
func method(
    foo: Int,
    bar: Int) throws {
    print("function body")
}
```

### After

```swift
func method(
    foo: Int,
    bar: Int) throws 
{
    print("function body")
}
```

----

I also fixed a regression (also introduced in #1071) where trailing closure braces could be wrapped incorrectly:

### Before

```swift
guard foo else {
    return
}

when(fulfilled: promise)
    .then 
    {
        // chained closure body 1
    }
    .done 
    {
        // chained closure body 2
    }
```

### After

```swift
guard foo else {
    return
}

when(fulfilled: promise)
    .then {
        // chained closure body 1
    }
    .done {
        // chained closure body 2
    }
```