### PR TITLE
Add support for the `unowned(safe)` and `unowned(unsafe)` modifiers in `--modifierorder`.

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1726,6 +1726,9 @@ extension _FormatRules {
     // ACL setter modifiers
     static let aclSetterModifiers = aclModifiers.map { "\($0)(set)" }
 
+    // Ownership modifiers
+    static let ownershipModifiers = ["weak", "unowned", "unowned(safe)", "unowned(unsafe)"]
+
     // Modifier mapping (designed to match SwiftLint)
     static func mapModifiers(_ input: String) -> [String]? {
         switch input.lowercased() {
@@ -1738,7 +1741,7 @@ extension _FormatRules {
         case "typemethods":
             return [] // Not clear what this is for - legacy?
         case "owned":
-            return ["weak", "unowned"]
+            return ownershipModifiers
         default:
             return allModifiers.contains(input) ? [input] : nil
         }
@@ -1755,7 +1758,7 @@ extension _FormatRules {
         ["indirect"],
         ["isolated", "nonisolated"],
         ["lazy"],
-        ["weak", "unowned"],
+        ownershipModifiers,
         ["static", "class"],
         ["mutating", "nonmutating"],
         ["prefix", "infix", "postfix"],

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2354,6 +2354,17 @@ public struct _FormatRules {
                         lastModifier = (string + "(set)", [Token](formatter.tokens[index ..< lastIndex]))
                         previousIndex = lastIndex
                         lastIndex = index
+                    } else if let containedToken = formatter.last(.nonSpaceOrCommentOrLinebreak, before: index),
+                              case let .identifier(ident) = containedToken,
+                              ["safe", "unsafe"].contains(ident),
+                              let openParenIndex = formatter.index(of: .startOfScope("("), before: index),
+                              let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: openParenIndex),
+                              case let .identifier(string)? = formatter.token(at: index), string == "unowned"
+                    {
+                        lastModifier.map { modifiers[$0] = $1 }
+                        lastModifier = ("\(string)(\(ident))", [Token](formatter.tokens[index ..< lastIndex]))
+                        previousIndex = lastIndex
+                        lastIndex = index
                     } else {
                         break loop
                     }

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -42,7 +42,10 @@ public let swiftFormatConfigurationFile = ".swiftformat"
 public let swiftVersionFile = ".swift-version"
 
 /// Supported Swift versions
-public let swiftVersions = ["3.x", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2", "5.3"]
+public let swiftVersions = [
+    "3.x", "4.0", "4.1", "4.2",
+    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5",
+]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat
 public enum FormatError: Error, CustomStringConvertible, LocalizedError, CustomNSError {

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -690,13 +690,13 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testParseModifierOrderOption() throws {
-        let options = try Options(["modifierorder": "private(set),public"], in: "")
-        XCTAssertEqual(options.formatOptions?.modifierOrder, ["private(set)", "public"])
+        let options = try Options(["modifierorder": "private(set),public,unowned(unsafe)"], in: "")
+        XCTAssertEqual(options.formatOptions?.modifierOrder, ["private(set)", "public", "unowned(unsafe)"])
     }
 
     func testParseSpecifierOrderOption() throws {
-        let options = try Options(["specifierorder": "private(set),public"], in: "")
-        XCTAssertEqual(options.formatOptions?.modifierOrder, ["private(set)", "public"])
+        let options = try Options(["specifierorder": "private(set),public,unowned(unsafe)"], in: "")
+        XCTAssertEqual(options.formatOptions?.modifierOrder, ["private(set)", "public", "unowned(unsafe)"])
     }
 
     func testParseSwiftVersionOption() throws {

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -661,7 +661,7 @@ class ParsingHelpersTests: XCTestCase {
             "indirect",
             "isolated", "nonisolated",
             "lazy",
-            "weak", "unowned",
+            "weak", "unowned", "unowned(safe)", "unowned(unsafe)",
             "static", "class",
             "mutating", "nonmutating",
             "prefix", "infix", "postfix",
@@ -687,7 +687,7 @@ class ParsingHelpersTests: XCTestCase {
             "final",
             "optional", "required",
             "convenience",
-            "weak", "unowned",
+            "weak", "unowned", "unowned(safe)", "unowned(unsafe)",
             "prefix", "infix", "postfix",
         ])
     }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -2852,6 +2852,12 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.modifierOrder)
     }
 
+    func testUnownedUnsafeModifierNotMangled() {
+        let input = "unowned(unsafe) lazy var foo"
+        let output = "lazy unowned(unsafe) var foo"
+        testFormatting(for: input, output, rule: FormatRules.modifierOrder)
+    }
+
     func testPrivateRequiredStaticFuncModifiers() {
         let input = "required static private func foo()"
         let output = "private required static func foo()"


### PR DESCRIPTION
The `--modifierorder` option does not currently recognize these two modifiers (documented at https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_declaration-modifiers).