### PR TITLE
Add missing `endIndex` handling in `blockComments` rule implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,25 +5,67 @@ on:
   pull_request:
 jobs:
   macos:
-    runs-on: macos-10.14
+    strategy:
+      fail-fast: false
+      matrix:
+        macos:
+          - 10.14
+          - 10.15
+          - 11
+        xcode:
+          - latest-stable
+        include:
+          - macos: 11
+            xcode: latest
+    runs-on: macos-${{ matrix.macos }}
     steps:
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build and Test
         run:
           xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat (Framework)" -sdk macosx clean build test
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_11.2.1.app/Contents/Developer
       - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t a47579fa-9a2a-4c48-b557-aa725c6b5f92
+        uses: codecov/codecov-action@v2
+        with:
+          # the token is optional for a public repo, but including it anyway
+          token: a47579fa-9a2a-4c48-b557-aa725c6b5f92
+          env_vars: MD_APPLE_SDK_ROOT,RUNNER_OS,RUNNER_ARCH
+
   linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swift:5.4
+          - swift:5.5
+          - swiftlang/swift:nightly-main
+        swiftos:
+          - focal
     runs-on: ubuntu-latest
-    container:
-      image: swift:5.2
+    container: 
+      image: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build and Test
-        run: swift test --enable-test-discovery
-
+        run: swift test --enable-test-discovery --enable-code-coverage
+      - name: Convert profdata to LCOV
+        run: |
+          llvm-cov export -format lcov \
+            --ignore-filename-regex='/(\.build|Tests|Sources|Snapshots|PerformanceTests)/' \
+            -instr-profile=$(dirname $(swift test --show-codecov-path))/default.profdata \
+            $(swift build --show-bin-path)/SwiftFormatPackageTests.xctest \
+            >SwiftFormat.lcov
+      - name: Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: a47579fa-9a2a-4c48-b557-aa725c6b5f92
+          files: SwiftFormat.lcov
+          env_vars: SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6233,7 +6233,7 @@ public struct _FormatRules {
                     formatter.removeTokens(in: range)
                     endIndex -= range.count
                     startIndex = i + 1
-                    _ = replaceCommentBody(at: startIndex)
+                    endIndex += replaceCommentBody(at: startIndex)
                 }
 
                 // Replace ending delimiter
@@ -6242,7 +6242,7 @@ public struct _FormatRules {
                 }) {
                     let range = i ... endIndex
                     formatter.removeTokens(in: range)
-                    endIndex -= (range.count - 1)
+                    endIndex -= range.count
                 }
 
                 // remove /* and */
@@ -6275,6 +6275,7 @@ public struct _FormatRules {
                         formatter.insert(.startOfScope("//"), at: index)
                         var delta = 1 + replaceCommentBody(at: index + 1)
                         index += delta
+                        endIndex += delta
                     default:
                         index += 1
                     }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2376,4 +2376,28 @@ class SyntaxTests: RulesTests {
         """
         testFormatting(for: input, output, rule: FormatRules.blockComments)
     }
+
+    func testLongBlockCommentsWithoutPerLineMarkersFullyConverted() {
+        let input = """
+        /*
+            The beginnings of the lines in this multiline comment body
+            have only spaces in them. There are no asterisks, only spaces.
+
+            This should not cause the blockComments rule to convert only
+            part of the comment body and leave the rest hanging.
+
+            The comment must have at least this many lines to trigger the bug.
+        */
+        """
+        let output = """
+        // The beginnings of the lines in this multiline comment body
+        // have only spaces in them. There are no asterisks, only spaces.
+        //
+        // This should not cause the blockComments rule to convert only
+        // part of the comment body and leave the rest hanging.
+        //
+        // The comment must have at least this many lines to trigger the bug.
+        """
+        testFormatting(for: input, output, rule: FormatRules.blockComments)
+    }
 }


### PR DESCRIPTION
This fixes two issues:

1. The following comment no longer causes an assertion failure in the `redundantSelf` rule:
   ```swift
    /*
        asdf
           */
    ```

2. A multiline comment with a nonzero indent and at least 7 lines long is no longer only partially rewritten:
    
    Input:
    ```swift
    /*
        One
        Two
        Three
        Four
        Five
        Six
        Seven
    */
    ```
    Output (before):
    ```swift
    // One
    // Two
    // Three
    // Four
    // Five
    // Six
       Seven
    ```
    Output (after):
    ```swift
    // One
    // Two
    // Three
    // Four
    // Five
    // Six
    // Seven
    ```
