### PR TITLE
Don't apply redundantClosure rule if closure calls function that returns Never

### DIFF
--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -112,7 +112,7 @@ private struct Inference {
     }
 
     let linebreak = OptionInferrer { formatter, options in
-        var cr: Int = 0, lf: Int = 0, crlf: Int = 0
+        var cr = 0, lf: Int = 0, crlf: Int = 0
         formatter.forEachToken { _, token in
             switch token {
             case .linebreak("\n", _):

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -309,9 +309,7 @@ private var _allDescriptors: [OptionDescriptor] = {
     return descriptors
 }()
 
-private var _descriptorsByName: [String: OptionDescriptor] = {
-    Dictionary(uniqueKeysWithValues: _allDescriptors.map { ($0.argumentName, $0) })
-}()
+private var _descriptorsByName: [String: OptionDescriptor] = Dictionary(uniqueKeysWithValues: _allDescriptors.map { ($0.argumentName, $0) })
 
 private let _formattingDescriptors: [OptionDescriptor] = {
     let internalDescriptors = Descriptors.internal.map { $0.argumentName }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1713,9 +1713,7 @@ extension _FormatRules {
     }()
 
     // Current year. Used by fileHeader rule
-    static var currentYear: String = {
-        yearFormatter(Date())
-    }()
+    static var currentYear: String = yearFormatter(Date())
 
     // Swiftlint semantic modifier groups
     static let semanticModifierGroups = ["acl", "setteracl", "mutators", "typemethods", "owned"]

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6398,6 +6398,27 @@ public struct _FormatRules {
                     }
                 }
 
+                // If the closure calls a single function, which returns `Never`,
+                // then removing the closure will cause a compilation failure.
+                //  - We maintain a list of known functions that return `Never`.
+                //    We could expand this to be user-provided if necessary.
+                let knownFunctionsThatReturnNever: Set<String> = [
+                    "fatalError",
+                    "preconditionFailure",
+                ]
+
+                for identifierIndex in closureStartIndex ... closureEndIndex
+                    where formatter.token(at: identifierIndex)?.isIdentifier == true
+                {
+                    if
+                        indexIsWithinMainClosure(identifierIndex),
+                        let identifier = formatter.token(at: identifierIndex)?.string,
+                        knownFunctionsThatReturnNever.contains(identifier)
+                    {
+                        return
+                    }
+                }
+
                 // First we remove the spaces and linebreaks between the { } and the remainder of the closure body
                 //  - This requires a bit of bookkeeping, but makes sure we don't remove any
                 //    whitespace characters outside of the closure itself

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -5424,4 +5424,28 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.redundantClosure)
     }
+
+    func testKeepsClosureThatCallsMethodThatReturnsNever() {
+        let input = """
+        lazy var foo: String = { fatalError("no default value has been set") }()
+        lazy var bar: String = { return preconditionFailure("no default value has been set") }()
+        """
+
+        testFormatting(for: input, rule: FormatRules.redundantClosure,
+                       exclude: ["redundantReturn"])
+    }
+
+    func testRemovesClosureThatHasNestedFatalError() {
+        let input = """
+        lazy var foo = {
+            Foo(handle: { fatalError() })
+        }()
+        """
+
+        let output = """
+        lazy var foo = Foo(handle: { fatalError() })
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantClosure)
+    }
 }


### PR DESCRIPTION
This PR fixes #1096

We can't apply the `redundantClosure` rule if the closure calls a function that returns `Never`, like:

```swift
// before
lazy var foo: String = { fatalError("no default value has been set") }()

// after, fails to compile:
lazy var foo: String = fatalError("no default value has been set")
```

For now the rule implementation just maintains a list of known functions that return `Never`:

```swift
let knownFunctionsThatReturnNever: Set<String> = [
    "fatalError",
    "preconditionFailure",
]
```

I get the impression that custom user-defined methods that return `Never` are on the uncommon side, so it may not be worth adding a user-configurable option for this at this time (since it seems like quite the edge case). If this comes up in the future, though, it should be a pretty easy change to make if necessary.
