### PR TITLE
Fix issue where redundantClosure rule could break build for certain Void closures

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6385,6 +6385,28 @@ public struct _FormatRules {
                     }
                 }
 
+                // (5) if there is a method call immediately followed an identidier, as in:
+                //
+                //   method()
+                //   otherMethod()
+                //
+                // This can only be an issue in Void closures, because any non-Void closure
+                // would have to have a `return` statement following one of these method calls,
+                // which would be covered by heuristic #2 above.
+                for closingParenIndex in closureStartIndex ... closureEndIndex
+                    where formatter.token(at: closingParenIndex)?.string == ")"
+                {
+                    if indexIsWithinMainClosure(closingParenIndex),
+                       let nextNonWhitespace = formatter.index(
+                           of: .nonSpaceOrCommentOrLinebreak,
+                           after: closingParenIndex
+                       ),
+                       formatter.token(at: nextNonWhitespace)?.isIdentifier == true
+                    {
+                        return
+                    }
+                }
+
                 // This rule also doesn't support closures with an `in` token.
                 //  - We can't just remove this, because it could have important type information.
                 //    For example, `let double = { () -> Double in 100 }()` and `let double = 100` have different types.

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -5457,4 +5457,38 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.redundantClosure)
     }
+
+    func testPreservesClosureWithMultipleVoidMethodCalls() {
+        let input = """
+        lazy var triggerSomething: Void = {
+            logger.trace("log some stuff before Triggering")
+            TriggerClass.triggerTheThing()
+            logger.trace("Finished triggering the thing")
+        }()
+        """
+
+        testFormatting(for: input, rule: FormatRules.redundantClosure)
+    }
+
+    func testRemovesClosureWithMultipleNestedVoidMethodCalls() {
+        let input = """
+        lazy var foo: Foo = {
+            Foo(handle: {
+                logger.trace("log some stuff before Triggering")
+                TriggerClass.triggerTheThing()
+                logger.trace("Finished triggering the thing")
+            })
+        }()
+        """
+
+        let output = """
+        lazy var foo: Foo = Foo(handle: {
+            logger.trace("log some stuff before Triggering")
+            TriggerClass.triggerTheThing()
+            logger.trace("Finished triggering the thing")
+        })
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.redundantClosure, FormatRules.indent], exclude: ["redundantType"])
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the `redundantClosure` rule could break the build for certain `Void`-returning closures. This fixes the issue [discussed here](https://github.com/nicklockwood/SwiftFormat/issues/1096#issuecomment-1012231386).

Previously, this closure:

```swift
lazy var triggerSomething: Void = {
    logger.trace("log some stuff before Triggering")
    TriggerClass.triggerTheThing()
    logger.trace("Finished triggering the thing")
 }()
```

was incorrectly being removed and reformatted to: 

```swift
lazy var triggerSomething: Void = logger.trace("log some stuff before Triggering")
TriggerClass.triggerTheThing()
logger.trace("Finished triggering the thing")
```