### PR TITLE
Add rule to capture self explicitly to enable implicit self in closure body

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -11,6 +11,7 @@
 * [blankLinesBetweenScopes](#blankLinesBetweenScopes)
 * [blockComments](#blockComments)
 * [braces](#braces)
+* [closureImplicitSelf](#closureImplicitSelf)
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
 * [duplicateImports](#duplicateImports)
@@ -459,6 +460,32 @@ Option | Description
 +   BarProtocol
 + {
     // ...
+  }
+```
+
+</details>
+<br/>
+
+## closureImplicitSelf
+
+Capture self explicitly to enable implicit self in the closure body.
+
+Option | Description
+--- | ---
+`--selfcount` | Threshold for when to prefer [self] capture. Defaults to 2.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- DispatchQueue.main.async {
+-     self.performFoo()
+-     self.performBar()
+-     self.performBaaz()
++ DispatchQueue.main.async { [self] in
++     performFoo()
++     performBar()
++     performBaaz()
   }
 ```
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1326,6 +1326,20 @@ private struct Examples {
     ```
     """
 
+    let closureImplicitSelf = """
+    ```diff
+    - DispatchQueue.main.async {
+    -     self.performFoo()
+    -     self.performBar()
+    -     self.performBaaz()
+    + DispatchQueue.main.async { [self] in
+    +     performFoo()
+    +     performBar()
+    +     performBaaz()
+      }
+    ```
+    """
+
     let redundantClosure = """
     ```diff
     - let foo = { Foo() }()

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -876,6 +876,12 @@ struct _Descriptors {
         help: "Closure void returns: \"remove\" (default) or \"preserve\"",
         keyPath: \.closureVoidReturn
     )
+    let explicitSelfCount = OptionDescriptor(
+        argumentName: "selfcount",
+        displayName: "Explicit Self Count",
+        help: "Threshold for when to prefer [self] capture. Defaults to 2.",
+        keyPath: \.explicitSelfCount
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -404,6 +404,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var acronyms: Set<String>
     public var indentStrings: Bool
     public var closureVoidReturn: ClosureVoidReturn
+    public var explicitSelfCount: Int
     public var enabledRules: Set<String>
 
     // Deprecated
@@ -493,6 +494,7 @@ public struct FormatOptions: CustomStringConvertible {
                 acronyms: Set<String> = ["ID", "URL", "UUID"],
                 indentStrings: Bool = false,
                 closureVoidReturn: ClosureVoidReturn = .remove,
+                explicitSelfCount: Int = 2,
                 organizeDeclarationsEnabled _: Bool = false,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
@@ -576,6 +578,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.acronyms = acronyms
         self.indentStrings = indentStrings
         self.closureVoidReturn = closureVoidReturn
+        self.explicitSelfCount = explicitSelfCount
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -556,6 +556,25 @@ extension Formatter {
         return false
     }
 
+    /// Whether or not the given index is within the main closure body (e.g. _not_
+    /// in a nested closure) of the closure that starts at the given index
+    func isInMainClosureBody(index: Int, closureStartIndex: Int) -> Bool {
+        let startOfScopeAtIndex: Int
+        if token(at: index)?.isStartOfScope == true {
+            startOfScopeAtIndex = index
+        } else {
+            startOfScopeAtIndex = self.index(of: .startOfScope, before: index) ?? closureStartIndex
+        }
+
+        if isStartOfClosure(at: startOfScopeAtIndex) {
+            return startOfScopeAtIndex == closureStartIndex
+        } else if token(at: startOfScopeAtIndex)?.isStartOfScope == true {
+            return isInMainClosureBody(index: startOfScopeAtIndex - 1, closureStartIndex: closureStartIndex)
+        } else {
+            return false
+        }
+    }
+
     func isAccessorKeyword(at i: Int, checkKeyword: Bool = true) -> Bool {
         guard !checkKeyword ||
             ["get", "set", "willSet", "didSet"].contains(token(at: i)?.string ?? ""),

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6354,24 +6354,6 @@ public struct _FormatRules {
                // because removing them could break the build.
                formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex) != closureEndIndex
             {
-                // Whether this is within the closure, but not within a child closure of the main closure
-                func indexIsWithinMainClosure(_ index: Int) -> Bool {
-                    let startOfScopeAtIndex: Int
-                    if formatter.token(at: index)?.isStartOfScope == true {
-                        startOfScopeAtIndex = index
-                    } else {
-                        startOfScopeAtIndex = formatter.index(of: .startOfScope, before: index) ?? closureStartIndex
-                    }
-
-                    if formatter.isStartOfClosure(at: startOfScopeAtIndex) {
-                        return startOfScopeAtIndex == closureStartIndex
-                    } else if formatter.token(at: startOfScopeAtIndex)?.isStartOfScope == true {
-                        return indexIsWithinMainClosure(startOfScopeAtIndex - 1)
-                    } else {
-                        return false
-                    }
-                }
-
                 // Some heuristics to determine if this is a multi-statement closure:
 
                 // (1) any statement-forming scope (mostly just { and #if)
@@ -6385,7 +6367,7 @@ public struct _FormatRules {
                     if startOfScope != .startOfScope("("), // Method calls / other parents are fine
                        startOfScope != .startOfScope("\""), // Strings are fine
                        startOfScope != .startOfScope("\"\"\""), // Strings are fine
-                       indexIsWithinMainClosure(startOfScopeIndex),
+                       formatter.isInMainClosureBody(index: startOfScopeIndex, closureStartIndex: closureStartIndex),
                        !formatter.isStartOfClosure(at: startOfScopeIndex)
                     {
                         return
@@ -6399,7 +6381,7 @@ public struct _FormatRules {
                 {
                     let isAtStartOfClosure = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: returnIndex) == closureStartIndex
 
-                    if indexIsWithinMainClosure(returnIndex),
+                    if formatter.isInMainClosureBody(index: returnIndex, closureStartIndex: closureStartIndex),
                        !isAtStartOfClosure
                     {
                         return
@@ -6414,7 +6396,7 @@ public struct _FormatRules {
                     let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: semicolonIndex) ?? semicolonIndex
                     let isAtEndOfLine = formatter.startOfLine(at: semicolonIndex) != formatter.startOfLine(at: nextTokenIndex)
 
-                    if indexIsWithinMainClosure(semicolonIndex), !isAtEndOfLine {
+                    if formatter.isInMainClosureBody(index: semicolonIndex, closureStartIndex: closureStartIndex), !isAtEndOfLine {
                         return
                     }
                 }
@@ -6423,7 +6405,7 @@ public struct _FormatRules {
                 for equalsIndex in closureStartIndex ... closureEndIndex
                     where formatter.token(at: equalsIndex)?.string == "="
                 {
-                    if indexIsWithinMainClosure(equalsIndex) {
+                    if formatter.isInMainClosureBody(index: equalsIndex, closureStartIndex: closureStartIndex) {
                         return
                     }
                 }
@@ -6439,7 +6421,7 @@ public struct _FormatRules {
                 for closingParenIndex in closureStartIndex ... closureEndIndex
                     where formatter.token(at: closingParenIndex)?.string == ")"
                 {
-                    if indexIsWithinMainClosure(closingParenIndex),
+                    if formatter.isInMainClosureBody(index: closingParenIndex, closureStartIndex: closureStartIndex),
                        let nextNonWhitespace = formatter.index(
                            of: .nonSpaceOrCommentOrLinebreak,
                            after: closingParenIndex
@@ -6458,7 +6440,7 @@ public struct _FormatRules {
                 for inIndex in closureStartIndex ... closureEndIndex
                     where formatter.token(at: inIndex) == .keyword("in")
                 {
-                    if indexIsWithinMainClosure(inIndex) {
+                    if formatter.isInMainClosureBody(index: inIndex, closureStartIndex: closureStartIndex) {
                         return
                     }
                 }
@@ -6475,7 +6457,7 @@ public struct _FormatRules {
                 for i in closureStartIndex ... closureEndIndex {
                     if case let .identifier(identifier) = formatter.tokens[i],
                        knownFunctionsThatReturnNever.contains(identifier),
-                       indexIsWithinMainClosure(i)
+                       formatter.isInMainClosureBody(index: i, closureStartIndex: closureStartIndex)
                     {
                         return
                     }
@@ -6516,6 +6498,103 @@ public struct _FormatRules {
 
                     formatter.removeToken(at: returnIndex)
                 }
+            }
+        }
+    }
+
+    public let closureImplicitSelf = FormatRule(
+        help: """
+        Capture self explicitly to enable implicit self in the closure body.
+        """,
+        disabledByDefault: true,
+        options: ["selfcount"]
+    ) { formatter in
+        formatter.forEach(.startOfScope("{")) { closureStartIndex, _ in
+            guard
+                formatter.options.swiftVersion >= "5.3",
+                formatter.isStartOfClosure(at: closureStartIndex),
+                let closureEndIndex = formatter.endOfScope(at: closureStartIndex)
+            else { return }
+
+            // Check whether or not there's already a self capture in the capture list
+            var alreadyHasSelfCapture = false
+
+            if let startOfCaptureList = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex),
+               formatter.token(at: startOfCaptureList) == .startOfScope("["),
+               let endOfCaptureList = formatter.endOfScope(at: startOfCaptureList),
+               let selfCaptureIndex = formatter.index(of: .identifier("self"), after: startOfCaptureList),
+               selfCaptureIndex < endOfCaptureList
+            {
+                if formatter.last(.nonSpaceOrCommentOrLinebreak, before: selfCaptureIndex)?.string == "weak" {
+                    // weak self captures don't enable implicit self, so if the closure
+                    // is already using `weak self` then there's nothing to do here.
+                    // Maybe one day...... https://github.com/apple/swift-evolution/pull/1506
+                    return
+                } else {
+                    alreadyHasSelfCapture = true
+                }
+            }
+
+            // Find instances of `self.` in the closure body
+            var explicitSelfIndicies = [(selfKeyword: Int, dot: Int)]()
+            for explicitSelfIndex in closureStartIndex ... closureEndIndex {
+                if
+                    formatter.token(at: explicitSelfIndex)?.string == "self",
+                    formatter.isInMainClosureBody(index: explicitSelfIndex, closureStartIndex: closureStartIndex),
+                    let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: explicitSelfIndex),
+                    formatter.token(at: dotIndex)?.string == "."
+                {
+                    explicitSelfIndicies.append((explicitSelfIndex, dotIndex))
+                }
+            }
+
+            guard
+                !explicitSelfIndicies.isEmpty,
+                // By default we only add an explicit self capture
+                // if there are multiple `self.`s in the closure body
+                explicitSelfIndicies.count >= formatter.options.explicitSelfCount
+            else { return }
+
+            // remove all of the `self.`s
+            for (explicitSelfIndex, dotIndex) in explicitSelfIndicies.reversed() {
+                formatter.removeToken(at: dotIndex)
+                formatter.removeToken(at: explicitSelfIndex)
+            }
+
+            /// If the closure already has a self capture that enables implcit self,
+            /// then there's no more work to do
+            if alreadyHasSelfCapture {
+                return
+            }
+
+            // If the closure already has a capture list, add self to it
+            if let startOfCaptureList = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex),
+               formatter.token(at: startOfCaptureList) == .startOfScope("[")
+            {
+                let closureImplicitSelf = tokenize("self, ")
+                formatter.insert(closureImplicitSelf, at: startOfCaptureList + 1)
+                return
+            }
+
+            // Otherwise we have to add a capture list.
+            // If the closure doesn't have any arguments (and doesn't have an `in` keyword yet),
+            // then we also have to add that.
+            var closureHasInKeyword = false
+            for inIndex in closureStartIndex ... closureEndIndex {
+                if formatter.token(at: inIndex) == .keyword("in"),
+                   formatter.isInMainClosureBody(index: inIndex, closureStartIndex: closureStartIndex)
+                {
+                    closureHasInKeyword = true
+                    break
+                }
+            }
+
+            if closureHasInKeyword {
+                let captureList = tokenize(" [self]")
+                formatter.insert(captureList, at: closureStartIndex + 1)
+            } else {
+                let captureList = tokenize(" [self] in")
+                formatter.insert(captureList, at: closureStartIndex + 1)
             }
         }
     }

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -178,7 +178,7 @@ class IndentTests: RulesTests {
             self.bar()
         })
         """
-        testFormatting(for: input, output, rule: FormatRules.indent)
+        testFormatting(for: input, output, rule: FormatRules.indent, exclude: ["closureImplicitSelf"])
     }
 
     func testIndentDoubleParenthesizedClosures() {
@@ -189,7 +189,7 @@ class IndentTests: RulesTests {
             self.baz()
         }))
         """
-        testFormatting(for: input, rule: FormatRules.indent)
+        testFormatting(for: input, rule: FormatRules.indent, exclude: ["closureImplicitSelf"])
     }
 
     func testIndentUnbalancedBraces() {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -3018,7 +3018,7 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.redundantSelf)
+        testFormatting(for: input, rule: FormatRules.redundantSelf, exclude: ["closureImplicitSelf"])
     }
 
     func testSelfNotRemovedWhenPropertyIsKeyword() {
@@ -5572,5 +5572,207 @@ class RedundancyTests: RulesTests {
         """
 
         testFormatting(for: input, [output], rules: [FormatRules.redundantClosure, FormatRules.indent], exclude: ["redundantType"])
+    }
+
+    // MARK: - closureImplicitSelf
+
+    func testRemovesExplicitSelf() {
+        let input = """
+        methodWithClosureArgument {
+            self.foo = newValue
+            self.bar = newValue
+            print(self.baaz)
+        }
+        """
+
+        let output = """
+        methodWithClosureArgument { [self] in
+            foo = newValue
+            bar = newValue
+            print(baaz)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testRemovesExplicitSelfInClosureWithArguments() {
+        let input = """
+        methodWithClosureArgument { foo, bar in
+            self.foo = newValue
+            self.bar = newValue
+            print(self.baaz)
+        }
+        """
+
+        let output = """
+        methodWithClosureArgument { [self] foo, bar in
+            foo = newValue
+            bar = newValue
+            print(baaz)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testKeepsExplicitSelfWhenNotRedundant() {
+        let input = """
+        methodWithClosureArgument {
+            print(self)
+            print(self)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testUpdatesExistingCaptureList() {
+        let input = """
+        methodWithClosureArgument { [foo] in
+            print(foo)
+            self.bar = newValue
+            self.baaz = newValue
+        }
+        """
+
+        let output = """
+        methodWithClosureArgument { [self, foo] in
+            print(foo)
+            bar = newValue
+            baaz = newValue
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testNoUpdateCaptureListIfWeakSelfAlreadyPresent() {
+        let input = """
+        methodWithClosureArgument { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.bar = newValue
+            self.baaz = newValue
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testNoUpdateCaptureListIfStrongSelfAlreadyPresent() {
+        let input = """
+        methodWithClosureArgument { [self] in
+            self.bar = newValue
+            self.baaz = newValue
+        }
+        """
+
+        let output = """
+        methodWithClosureArgument { [self] in
+            bar = newValue
+            baaz = newValue
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testNoUpdateCaptureListIfUnownedSelfAlreadyPresent() {
+        let input = """
+        methodWithClosureArgument { [unowned self] in
+            self.bar = newValue
+            self.baaz = newValue
+        }
+
+        methodWithClosureArgument { [unowned(unsafe) self] in
+            self.bar = newValue
+            self.baaz = newValue
+        }
+        """
+
+        let output = """
+        methodWithClosureArgument { [unowned self] in
+            bar = newValue
+            baaz = newValue
+        }
+
+        methodWithClosureArgument { [unowned(unsafe) self] in
+            bar = newValue
+            baaz = newValue
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testAddsSelfCaptureToInnerClosure() {
+        let input = """
+        outerMethodWithClosureArgument {
+            innerMethodWithClosureArgument {
+                self.foo = newValue
+                self.bar = newValue
+            }
+        }
+        """
+
+        let output = """
+        outerMethodWithClosureArgument {
+            innerMethodWithClosureArgument { [self] in
+                foo = newValue
+                bar = newValue
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, output, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testCustomSelfCountThreshold() {
+        let input = """
+        methodWithClosureArgument {
+            self.foo = newValue
+            self.bar = newValue
+            self.baaz = newValue
+        }
+        """
+
+        let options = FormatOptions(explicitSelfCount: 5, swiftVersion: "5.3")
+        testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testKeepsSingleExplicitSelfByDefault() {
+        let input = """
+        methodWithClosureArgument {
+            self.foo = newValue
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
+    }
+
+    func testDisabledInSwift5_2() {
+        let input = """
+        methodWithClosureArgument {
+            self.foo = newValue
+            self.bar = newValue
+            print(self.baaz)
+        }
+        """
+
+        // The behavior used by this rule was added in 5.3 https://github.com/apple/swift-evolution/blob/main/proposals/0269-implicit-self-explicit-capture.md
+        let options = FormatOptions(swiftVersion: "5.2")
+        testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
     }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -1556,7 +1556,7 @@ class SyntaxTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.andOperator)
+        testFormatting(for: input, rule: FormatRules.andOperator, exclude: ["closureImplicitSelf"])
     }
 
     func testReplaceAndInViewBuilderInSwift5_3() {


### PR DESCRIPTION
This PR adds a new rule implementation to capture `self` explicitly to enable implicit `self` in closure bodies (from [SE-0269](https://github.com/apple/swift-evolution/blob/main/proposals/0269-implicit-self-explicit-capture.md), added in Swift 5.3).

When this rule is enabled, by default it only applies to closures that use explicit `self` repeatedly (e.g. more than once).

### Before

```swift
DispatchQueue.main.async {
  self.performFoo()
  self.performBar()
  self.performBaaz()
}
```

### After

```swift
DispatchQueue.main.async { [self] in
  performFoo()
  performBar()
  performBaaz()
}
```

On the other hand, this example is unchanged by default:

```swift
DispatchQueue.main.async {
  self.performFoo()
}
```

but with `--selfcount 1` it would be changed to:

```swift
DispatchQueue.main.async { [self] in
  performFoo()
}
```