### PR TITLE
Support Windows

### DIFF
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -33,6 +33,8 @@ import Foundation
 
 #if os(macOS)
     import Darwin.POSIX
+#elseif os(Windows)
+    import ucrt
 #else
     import Glibc
 #endif

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -553,7 +553,7 @@ func processArguments(_ args: [String], in directory: String) -> ExitCode {
                         return URL(fileURLWithPath: cachePath)
                     }
                 #endif
-                return URL(fileURLWithPath: "/var/tmp/")
+                return FileManager.default.temporaryDirectory
             }().appendingPathComponent("com.charcoaldesign.swiftformat")
             do {
                 try manager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
Fixes #990

Switched out glibc for ucrt on Windows. Unsure of how compatible it is, but all the tests pass and the tool has worked fine for my needs.

There are some compiler warnings which I am unsure of how to resolve:

1. >  warning: 'isatty' is deprecated: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _isatty.

    This can be ignored with the compiler option `/D_CRT_NONSTDC_NO_WARNINGS`, but I don't know how to pass compiler options using Swift. Alternatively I could use compiler directives to switch to `_isatty` when it's Windows, but I think it'd be nicer to just ignore it if possible.
2. > lld-link: warning: SwiftFormat\.build\x86_64-unknown-windows-msvc\release\CommandLineTool.build\main.swift.o: locally defined symbol imported: $s11SwiftFormat3CLIO5printyySS_AC10OutputTypeOtcvau (defined in SwiftFormat\.build\x86_64-unknown-windows-msvc\release\SwiftFormat.build\CommandLine.swift.o) [LNK4217]

    No idea.
4. > lld-link: warning: section name .debug_abbrev is longer than 8 characters and will use a non-standard string table

    Apparently because DWARF is used for debug information. Only happens for release config. Not sure how to fix or if it matters.