### PR TITLE
Add `wrapSingleLineComments` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -84,6 +84,7 @@
 * [sortedSwitchCases](#sortedSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
+* [wrapSingleLineComments](#wrapSingleLineComments)
 * [wrapSwitchCases](#wrapSwitchCases)
 
 # Deprecated Rules (do not use)
@@ -2213,6 +2214,10 @@ Wrap the opening brace of multiline statements.
 
 </details>
 <br/>
+
+## wrapSingleLineComments
+
+Wraps single line `//` comments that don't fit specified `--maxwidth` option.
 
 ## wrapSwitchCases
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -3917,19 +3917,19 @@ class WrappingTests: RulesTests {
     func testWrapSingleLineCommentsIndentation() {
         let input = """
         func f() {
-          // a b cde fgh
-          let x = 1
+            // a b cde fgh
+            let x = 1
         }
         """
         let output = """
         func f() {
-          // a b
-          // cde
-          // fgh
-          let x = 1
+            // a b
+            // cde
+            // fgh
+            let x = 1
         }
         """
 
-        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 6))
+        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 13))
     }
 }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -3900,4 +3900,36 @@ class WrappingTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.wrapSwitchCases)
     }
+
+    func testWrapSingleLineComments() {
+        let input = """
+        // a b cde fgh
+        """
+        let output = """
+        // a b
+        // cde
+        // fgh
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 6))
+    }
+
+    func testWrapSingleLineCommentsIndentation() {
+        let input = """
+        func f() {
+          // a b cde fgh
+          let x = 1
+        }
+        """
+        let output = """
+        func f() {
+          // a b
+          // cde
+          // fgh
+          let x = 1
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 6))
+    }
 }


### PR DESCRIPTION
This rule reformats single-line comments that exceed `--maxwidth` option value into multiple single-line comments.
E.g.

```swift
// a b cde fgh
```

is reformatted as

```swift
// a b
// cde
// fgh
```

if `--maxwidth` is set to 6 columns.