### PR TITLE
Avoid crashing when trying to sort an enum that has only one case

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6087,18 +6087,21 @@ public struct _FormatRules {
                 })
                 .map { $0.element }
 
-            // Make sure there's at least one newline between each declaration
-            for i in 0 ... max(0, declarations.count - 2) {
-                let declaration = declarations[i]
-                let nextDeclaration = declarations[i + 1]
+            // Avoid crashing when an enum only has one case
+            if (declarations.count - 2) >= 0 {
+                // Make sure there's at least one newline between each declaration
+                for i in 0 ... (declarations.count - 2) {
+                    let declaration = declarations[i]
+                    let nextDeclaration = declarations[i + 1]
 
-                if declaration.tokens.last?.isLinebreak == false,
-                   nextDeclaration.tokens.first?.isLinebreak == false
-                {
-                    declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
-                        let openFormatter = Formatter(openTokens)
-                        openFormatter.insertLinebreak(at: 0)
-                        return openFormatter.tokens
+                    if declaration.tokens.last?.isLinebreak == false,
+                       nextDeclaration.tokens.first?.isLinebreak == false
+                    {
+                        declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
+                            let openFormatter = Formatter(openTokens)
+                            openFormatter.insertLinebreak(at: 0)
+                            return openFormatter.tokens
+                        }
                     }
                 }
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6087,21 +6087,18 @@ public struct _FormatRules {
                 })
                 .map { $0.element }
 
-            // Avoid crashing when an enum only has one case
-            if (declarations.count - 2) >= 0 {
-                // Make sure there's at least one newline between each declaration
-                for i in 0 ... (declarations.count - 2) {
-                    let declaration = declarations[i]
-                    let nextDeclaration = declarations[i + 1]
+            // Make sure there's at least one newline between each declaration
+            for i in 0 ..< max(0, declarations.count - 1) {
+                let declaration = declarations[i]
+                let nextDeclaration = declarations[i + 1]
 
-                    if declaration.tokens.last?.isLinebreak == false,
-                       nextDeclaration.tokens.first?.isLinebreak == false
-                    {
-                        declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
-                            let openFormatter = Formatter(openTokens)
-                            openFormatter.insertLinebreak(at: 0)
-                            return openFormatter.tokens
-                        }
+                if declaration.tokens.last?.isLinebreak == false,
+                   nextDeclaration.tokens.first?.isLinebreak == false
+                {
+                    declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
+                        let openFormatter = Formatter(openTokens)
+                        openFormatter.insertLinebreak(at: 0)
+                        return openFormatter.tokens
                     }
                 }
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6087,21 +6087,18 @@ public struct _FormatRules {
                 })
                 .map { $0.element }
 
-            // Avoid crashing when an enum only has one case
-            if (declarations.count - 2) >= 0 {
-                // Make sure there's at least one newline between each declaration
-                for i in 0 ... (declarations.count - 2) {
-                    let declaration = declarations[i]
-                    let nextDeclaration = declarations[i + 1]
+            // Make sure there's at least one newline between each declaration
+            for i in 0 ... max(0, declarations.count - 2) {
+                let declaration = declarations[i]
+                let nextDeclaration = declarations[i + 1]
 
-                    if declaration.tokens.last?.isLinebreak == false,
-                       nextDeclaration.tokens.first?.isLinebreak == false
-                    {
-                        declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
-                            let openFormatter = Formatter(openTokens)
-                            openFormatter.insertLinebreak(at: 0)
-                            return openFormatter.tokens
-                        }
+                if declaration.tokens.last?.isLinebreak == false,
+                   nextDeclaration.tokens.first?.isLinebreak == false
+                {
+                    declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
+                        let openFormatter = Formatter(openTokens)
+                        openFormatter.insertLinebreak(at: 0)
+                        return openFormatter.tokens
                     }
                 }
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6087,18 +6087,21 @@ public struct _FormatRules {
                 })
                 .map { $0.element }
 
-            // Make sure there's at least one newline between each declaration
-            for i in 0 ... (declarations.count - 2) {
-                let declaration = declarations[i]
-                let nextDeclaration = declarations[i + 1]
+            // Avoid crashing when an enum only has one case
+            if (declarations.count - 2) >= 0 {
+                // Make sure there's at least one newline between each declaration
+                for i in 0 ... (declarations.count - 2) {
+                    let declaration = declarations[i]
+                    let nextDeclaration = declarations[i + 1]
 
-                if declaration.tokens.last?.isLinebreak == false,
-                   nextDeclaration.tokens.first?.isLinebreak == false
-                {
-                    declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
-                        let openFormatter = Formatter(openTokens)
-                        openFormatter.insertLinebreak(at: 0)
-                        return openFormatter.tokens
+                    if declaration.tokens.last?.isLinebreak == false,
+                       nextDeclaration.tokens.first?.isLinebreak == false
+                    {
+                        declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
+                            let openFormatter = Formatter(openTokens)
+                            openFormatter.insertLinebreak(at: 0)
+                            return openFormatter.tokens
+                        }
                     }
                 }
             }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -2962,24 +2962,16 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.sortDeclarations)
     }
 
-// Test does not succeed, as input equals output
-//    func testSortEnumBodyWithOnlyOneCase() {
-//        let input = """
-//        // swiftformat:sort
-//        enum FeatureFlags {
-//            case upsellB
-//        }
-//        """
-//
-//        let output = """
-//        // swiftformat:sort
-//        enum FeatureFlags {
-//            case upsellB
-//        }
-//        """
-//
-//        testFormatting(for: input, output, rule: FormatRules.sortDeclarations)
-//    }
+    func testSortEnumBodyWithOnlyOneCase() {
+        let input = """
+        // swiftformat:sort
+        enum FeatureFlags {
+            case upsellB
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.sortDeclarations)
+    }
 
     func testNoSortUnannotatedType() {
         let input = """

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -2962,6 +2962,25 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.sortDeclarations)
     }
 
+// Test does not succeed, as input equals output
+//    func testSortEnumBodyWithOnlyOneCase() {
+//        let input = """
+//        // swiftformat:sort
+//        enum FeatureFlags {
+//            case upsellB
+//        }
+//        """
+//
+//        let output = """
+//        // swiftformat:sort
+//        enum FeatureFlags {
+//            case upsellB
+//        }
+//        """
+//
+//        testFormatting(for: input, output, rule: FormatRules.sortDeclarations)
+//    }
+
     func testNoSortUnannotatedType() {
         let input = """
         enum FeatureFlags {

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -2973,6 +2973,16 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.sortDeclarations)
     }
 
+    func testSortEnumBodyWithoutCase() {
+        let input = """
+        // swiftformat:sort
+        enum FeatureFlags {
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.sortDeclarations)
+    }
+
     func testNoSortUnannotatedType() {
         let input = """
         enum FeatureFlags {


### PR DESCRIPTION
Problem:

trying to format

```swift
// swiftformat:sort
enum Test {
  case only
}
```

crashes with

```
$ swiftformat test.swift 
Running SwiftFormat...
Reading config file at <Redacted>/.swiftformat
[1]    88603 trace trap  swiftformat test.swift
```

The workaround is obvious if you know the cause (remove the annotation from single-case enums), but I think we should avoid the crash.