### PR TITLE
[SE-0345] Add redundantOptionalBinding rule for Swift 5.7+

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -36,6 +36,7 @@
 * [redundantLetError](#redundantLetError)
 * [redundantNilInit](#redundantNilInit)
 * [redundantObjc](#redundantObjc)
+* [redundantOptionalBinding](#redundantOptionalBinding)
 * [redundantParens](#redundantParens)
 * [redundantPattern](#redundantPattern)
 * [redundantRawValues](#redundantRawValues)
@@ -1220,6 +1221,28 @@ Remove redundant `@objc` annotations.
 ```diff
 - @objc @NSManaged private var foo: String?
 + @NSManaged private var foo: String?
+```
+
+</details>
+<br/>
+
+## redundantOptionalBinding
+
+Removes redundant identifiers in optional binding conditions.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- if let foo = foo {
++ if let foo {
+      print(foo)
+  }
+
+- guard let self = self else {
++ guard let self else {
+      return
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1396,4 +1396,18 @@ private struct Examples {
       }
     ```
     """
+
+    let redundantOptionalBinding = """
+    ```diff
+    - if let foo = foo {
+    + if let foo {
+          print(foo)
+      }
+
+    - guard let self = self else {
+    + guard let self else {
+          return
+      }
+    ```
+    """
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6558,6 +6558,38 @@ public struct _FormatRules {
         }
     }
 
+    public let redundantOptionalBinding = FormatRule(
+        help: "Removes redundant identifiers in optional binding conditions.",
+        // We can convert `if let foo = self.foo` to just `if let foo`,
+        // but only if `redundantSelf` can first remove the `self.`.
+        orderAfter: ["redundantSelf"]
+    ) { formatter in
+        formatter.forEachToken { i, introducer in
+            guard
+                // `if let foo` conditions were added in Swift 5.7 (SE-0345)
+                formatter.options.swiftVersion >= "5.7",
+
+                introducer == .keyword("let") || introducer == .keyword("var"),
+                formatter.isConditionalStatement(at: i),
+
+                let identiferIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i),
+                let identifier = formatter.token(at: identiferIndex),
+
+                let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: identiferIndex),
+                formatter.token(at: equalsIndex) == .operator("=", .infix),
+
+                let unwrappedIdentifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                let unwrappedIdentifier = formatter.token(at: unwrappedIdentifierIndex),
+                identifier.string == unwrappedIdentifier.string,
+
+                let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: unwrappedIdentifierIndex),
+                nextToken == .startOfScope("{") || nextToken == .delimiter(",") || nextToken == .keyword("else")
+            else { return }
+
+            formatter.removeTokens(in: identiferIndex + 1 ... unwrappedIdentifierIndex)
+        }
+    }
+
     public let closureImplicitSelf = FormatRule(
         help: """
         Capture self explicitly to enable implicit self in the closure body.

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -44,7 +44,7 @@ public let swiftVersionFile = ".swift-version"
 /// Supported Swift versions
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
-    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5",
+    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7",
 ]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -5780,4 +5780,177 @@ class RedundancyTests: RulesTests {
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: FormatRules.closureImplicitSelf, options: options)
     }
+
+    // MARK: Redundant optional
+
+    func testRemovesRedundantOptionalInSwift5_7() {
+        let input = """
+        if let foo = foo {
+            print(foo)
+        }
+
+        else if var bar = bar {
+            print(bar)
+        }
+
+        guard let self = self else {
+            return
+        }
+
+        while var quux = quux {
+            break
+        }
+        """
+
+        let output = """
+        if let foo {
+            print(foo)
+        }
+
+        else if var bar {
+            print(bar)
+        }
+
+        guard let self else {
+            return
+        }
+
+        while var quux {
+            break
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.redundantOptionalBinding, options: options, exclude: ["elseOnSameLine"])
+    }
+
+    func testRemovesMultipleOptionalBindings() {
+        let input = """
+        if let foo = foo, let bar = bar, let baaz = baaz {
+            print(foo, bar, baaz)
+        }
+
+        guard let foo = foo, let bar = bar, let baaz = baaz else {
+            return
+        }
+        """
+
+        let output = """
+        if let foo, let bar, let baaz {
+            print(foo, bar, baaz)
+        }
+
+        guard let foo, let bar, let baaz else {
+            return
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.redundantOptionalBinding, options: options)
+    }
+
+    func testRemovesMultipleOptionalBindingsOnSeparateLines() {
+        let input = """
+        if
+          let foo = foo,
+          let bar = bar,
+          let baaz = baaz
+        {
+          print(foo, bar, baaz)
+        }
+
+        guard
+          let foo = foo,
+          let bar = bar,
+          let baaz = baaz
+        else {
+          return
+        }
+        """
+
+        let output = """
+        if
+          let foo,
+          let bar,
+          let baaz
+        {
+          print(foo, bar, baaz)
+        }
+
+        guard
+          let foo,
+          let bar,
+          let baaz
+        else {
+          return
+        }
+        """
+
+        let options = FormatOptions(indent: "  ", swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.redundantOptionalBinding, options: options)
+    }
+
+    func testKeepsRedundantOptionalBeforeSwift5_7() {
+        let input = """
+        if let foo = foo {
+            print(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.6")
+        testFormatting(for: input, rule: FormatRules.redundantOptionalBinding, options: options)
+    }
+
+    func testKeepsNonRedundantOptional() {
+        let input = """
+        if let foo = bar {
+            print(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.redundantOptionalBinding, options: options)
+    }
+
+    func testKeepsOptionalNotEligibleForShorthand() {
+        let input = """
+        if let foo = self.foo, let bar = bar(), let baaz = baaz[0] {
+            print(foo, bar, baaz)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.redundantOptionalBinding, options: options, exclude: ["redundantSelf"])
+    }
+
+    func testRedundantSelfAndRedundantOptionalTogether() {
+        let input = """
+        if let foo = self.foo {
+            print(foo)
+        }
+        """
+
+        let output = """
+        if let foo {
+            print(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, [output], rules: [FormatRules.redundantOptionalBinding, FormatRules.redundantSelf], options: options)
+    }
+
+    func testDoesntRemoveShadowingOutsideOfOptionalBinding() {
+        let input = """
+        let foo = foo
+
+        if let bar = baaz({
+            let foo = foo
+            print(foo)
+        }) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.redundantOptionalBinding, options: options)
+    }
 }


### PR DESCRIPTION
This PR adds a new `redundantOptionalBinding` for Swift 5.7+ that applies the new shorthand optional binding syntax added in [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md) (😄)

```diff
- if let foo = foo {
+ if let foo {
      print(foo)
  }

- guard let self = self else {
+ guard let self else {
      return
  }
```