### PR TITLE
Add rule that marks methods that unconditionally call fatalError as unavailable

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -18,7 +18,6 @@
 * [fileHeader](#fileHeader)
 * [hoistPatternLet](#hoistPatternLet)
 * [indent](#indent)
-* [initCoderUnavailable](#initCoderUnavailable)
 * [leadingDelimiters](#leadingDelimiters)
 * [linebreakAtEndOfFile](#linebreakAtEndOfFile)
 * [linebreaks](#linebreaks)
@@ -65,6 +64,7 @@
 * [trailingCommas](#trailingCommas)
 * [trailingSpace](#trailingSpace)
 * [typeSugar](#typeSugar)
+* [unavailableMethod](#unavailableMethod)
 * [unusedArguments](#unusedArguments)
 * [void](#void)
 * [wrap](#wrap)
@@ -79,6 +79,7 @@
 * [blankLinesBetweenImports](#blankLinesBetweenImports)
 * [blockComments](#blockComments)
 * [closureImplicitSelf](#closureImplicitSelf)
+* [initCoderUnavailable](#initCoderUnavailable)
 * [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
 * [organizeDeclarations](#organizeDeclarations)
@@ -1925,6 +1926,29 @@ Option | Description
 ```diff
 - var foo: Optional<(Int) -> Void>
 + var foo: ((Int) -> Void)?
+```
+
+</details>
+<br/>
+
+## unavailableMethod
+
+Add `@available(*, unavailable)` attribute to methods that
+unconditionally call `fataError(...)`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
++ @available(*, unavailable)
+  func foo() {
+    fatalError()
+  }
+
++ @available(*, unavailable)
+  required init() {
+    fatalError()
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -399,6 +399,20 @@ private struct Examples {
     ```
     """
 
+    let unavailableMethod = """
+    ```diff
+    + @available(*, unavailable)
+      func foo() {
+        fatalError()
+      }
+
+    + @available(*, unavailable)
+      required init() {
+        fatalError()
+      }
+    ```
+    """
+
     let numberFormatting = """
     ```diff
     - let color = 0xFF77A5

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -117,6 +117,108 @@ class GeneralTests: RulesTests {
                        exclude: ["modifierOrder", "specifiers"])
     }
 
+    // MARK: - unavailableMethod
+
+    func testFatalErrorMethodMarkedAsUnavailable() {
+        let input = """
+        public class Foo {
+            public func bar() {
+                fatalError()
+            }
+        }
+        """
+        let output = """
+        public class Foo {
+            @available(*, unavailable)
+            public func bar() {
+                fatalError()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unavailableMethod)
+    }
+
+    func testFatalErrorMethodWithParamsMarkedAsUnavailable() {
+        let input = """
+        func bar(baaz _: Int, quuz _: String) {
+            fatalError()
+        }
+        """
+        let output = """
+        @available(*, unavailable)
+        func bar(baaz _: Int, quuz _: String) {
+            fatalError()
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unavailableMethod)
+    }
+
+    func testMethodWithAttributeMarkedAsUnavailable() {
+        let input = """
+        @objc
+        func bar() {
+            fatalError()
+        }
+        """
+        let output = """
+        @available(*, unavailable)
+        @objc
+        func bar() {
+            fatalError()
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unavailableMethod)
+    }
+
+    func testMethodWithFatalErrorClosureParamNotMarkedAsUnavailable() {
+        let input = """
+        public func bar(closure: () -> Int = { fatalError() }) -> Int {
+            closure()
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unavailableMethod)
+    }
+
+    func testInitializerMarkedAsUnavailable() {
+        let input = """
+        class Foo {
+            init() {
+                fatalError()
+            }
+        }
+        """
+
+        let output = """
+        class Foo {
+            @available(*, unavailable)
+            init() {
+                fatalError()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unavailableMethod)
+    }
+
+    func testUnavailableMethodRuleMarksInitCoderUnavailable() {
+        let input = """
+        class FooView: UIView {
+            required init?(coder _: NSCoder) {
+                fatalError()
+            }
+        }
+        """
+        let output = """
+        class FooView: UIView {
+            @available(*, unavailable)
+            required init?(coder _: NSCoder) {
+                fatalError()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unavailableMethod,
+                       exclude: ["initCoderUnavailable"])
+    }
+
     // MARK: - trailingCommas
 
     func testCommaAddedToSingleItem() {


### PR DESCRIPTION
This PR adds a rule that marks methods that unconditionally call `fatalError` as `@available(*, unavailable)`.

```diff
+ @available(*, unavailable)
  func foo() {
    fatalError()
  }
    
+ @available(*, unavailable)
  required init() {
    fatalError()
  }
```

This is effectively a superset of the existing `initCoderUnavailable` rule.
