### PR TITLE
add  `blankLineAfterImports`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -75,6 +75,7 @@
 # Opt-in Rules (disabled by default)
 
 * [acronyms](#acronyms)
+* [blankLineAfterImports](#blankLineAfterImports)
 * [blankLinesBetweenImports](#blankLinesBetweenImports)
 * [blockComments](#blockComments)
 * [isEmpty](#isEmpty)
@@ -188,6 +189,26 @@ and precondition(false, ...) to preconditionFailure(...).
 ```diff
 - precondition(false, "message", 2, 1)
 + preconditionFailure("message", 2, 1)
+```
+
+</details>
+<br/>
+
+## blankLineAfterImports
+
+Insert blank line After Imports declarations.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  import A
+  import B
+  @testable import D
++
+  class Foo {
+    // foo
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -133,6 +133,18 @@ private struct Examples {
       import E
     ```
     """
+    
+    let blankLineAfterImports = """
+    ```diff
+      import A
+      import B
+      @testable import D
+    +
+      class Foo {
+        // foo
+      }
+    ```
+    """
 
     let blankLinesBetweenScopes = """
     ```diff

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1011,6 +1011,31 @@ public struct _FormatRules {
             formatter.replaceTokens(in: endOfLine ..< nextImportIndex, with: formatter.linebreakToken(for: currentImportIndex + 1))
         }
     }
+    ///
+    public let blankLineAfterImports = FormatRule(
+        help: """
+        Insert blank line After Imports declarations.
+        """,
+        disabledByDefault: true,
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.forEach(.keyword("import")) { currentImportIndex, token in
+            
+            guard let endOfLine = formatter.index(of: .linebreak, after: currentImportIndex),
+                  let nextlineIndex = formatter.index(after: endOfLine, where: {_ in true})
+            else {
+                return
+            }
+            print(formatter.tokens[nextlineIndex])
+            switch formatter.tokens[nextlineIndex] {
+                case .linebreak: break
+                case .keyword("import"), .keyword("@testable"):break
+                default:
+                    formatter.insertLinebreak(at: nextlineIndex-1)
+            }
+            
+        }
+    }
 
     /// Adds a blank line immediately after a closing brace, unless followed by another closing brace
     public let blankLinesBetweenScopes = FormatRule(

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -252,6 +252,31 @@ class LinebreakTests: RulesTests {
     }
 
     // MARK: - blankLinesBetweenScopes
+    func testBlankLineAfterImport() {
+        let input = """
+        import ModuleA
+        @testable import ModuleB
+        import ModuleC
+        @testable import ModuleD
+        @testable import ModuleE
+        @testable import ModuleF
+        class foo {
+        }
+        """
+        let output = """
+        import ModuleA
+        @testable import ModuleB
+        import ModuleC
+        @testable import ModuleD
+        @testable import ModuleE
+        @testable import ModuleF
+        
+        class foo {
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.blankLineAfterImports,
+                       exclude: ["emptyBraces"])
+    }
 
     func testBlankLineBetweenFunctions() {
         let input = "func foo() {\n}\nfunc bar() {\n}"

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -71,6 +71,7 @@ class RulesTests: XCTestCase {
             + (rules.first?.name == "extensionAccessControl" ? [] : ["extensionAccessControl"])
             + (rules.first?.name == "markTypes" ? [] : ["markTypes"])
             + (rules.first?.name == "blockComments" ? [] : ["blockComments"])
+        + (rules.first?.name == "blankLineAfterImports" ? [] : ["blankLineAfterImports"])
         XCTAssertEqual(try format(input, rules: rules, options: options), output, file: file, line: line)
         XCTAssertEqual(try format(input, rules: FormatRules.all(except: exclude), options: options),
                        output2, file: file, line: line)


### PR DESCRIPTION
Summary:
Add blankLineAfterImports rule which insert a blank line after imports statements.

Test Plan:
Add unit tests and run all tests.