### PR TITLE
Add new rule to update generic methods to use opaque generic parameter syntax where equivalent

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -24,6 +24,7 @@
 * [linebreaks](#linebreaks)
 * [modifierOrder](#modifierOrder)
 * [numberFormatting](#numberFormatting)
+* [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferKeyPath](#preferKeyPath)
 * [redundantBackticks](#redundantBackticks)
 * [redundantBreak](#redundantBreak)
@@ -925,6 +926,36 @@ Option | Description
 ```diff
 - let big = 123456.123
 + let big = 123_456.123
+```
+
+</details>
+<br/>
+
+## opaqueGenericParameters
+
+Use opaque generic parameters (`some Protocol`) instead of generic parameters
+with constraints (`T where T: Protocol`, etc) where equivalent. Also supports
+primary associated types for common standard library types, so definitions like
+`T where T: Collection, T.Element == Foo` are upated to `some Collection<Foo>`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- func handle<T: Fooable>(_ value: T) {
++ func handle(_ value: some Fooable) {
+      print(value)
+  }
+
+- func handle<T>(_ value: T) where T: Fooable, T: Barable {
++ func handle(_ value: some Fooable & Barable) {
+      print(value)
+  }
+
+- func handle<T: Collection>(_ value: T) where T.Element == Foo {
++ func handle(_ value: some Collection<Foo>) {
+      print(value)
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1422,4 +1422,23 @@ private struct Examples {
       }
     ```
     """
+
+    let opaqueGenericParameters = """
+    ```diff
+    - func handle<T: Fooable>(_ value: T) {
+    + func handle(_ value: some Fooable) {
+          print(value)
+      }
+
+    - func handle<T>(_ value: T) where T: Fooable, T: Barable {
+    + func handle(_ value: some Fooable & Barable) {
+          print(value)
+      }
+
+    - func handle<T: Collection>(_ value: T) where T.Element == Foo {
+    + func handle(_ value: some Collection<Foo>) {
+          print(value)
+      }
+    ```
+    """
 }

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -322,6 +322,19 @@ public extension Formatter {
         removeTokens(in: range.lowerBound ..< range.upperBound + 1)
     }
 
+    /// Removes the tokens in the specified set of ranges, that must not overlay
+    func removeTokens(in rangesToRemove: [ClosedRange<Int>]) {
+        // We remove the ranges in reverse order, so that removing
+        // one range doesn't invalidate the existings of the other ranges
+        let rangeRemovalOrder = rangesToRemove
+            .sorted(by: { $0.startIndex < $1.startIndex })
+            .reversed()
+
+        for rangeToRemove in rangeRemovalOrder {
+            removeTokens(in: rangeToRemove)
+        }
+    }
+
     /// Removes the last token
     func removeLastToken() {
         trackChange(at: tokens.endIndex - 1)

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6821,8 +6821,10 @@ public struct _FormatRules {
 
     public let opaqueGenericParameters = FormatRule(
         help: """
-        Use opaque generic parameters (`some Protocol`) instead of expanded generic
-        signatures (`<T: Protocol> (T)`) where equivalent.
+        Use opaque generic parameters (`some Protocol`) instead of generic parameters
+        with constraints (`T where T: Protocol`, etc) where equivalent. Also supports
+        primary associated types for common standard library types, so definitions like
+        `T where T: Collection, T.Element == Foo` are upated to `some Collection<Foo>`.
         """,
         options: []
     ) { formatter in

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2580,14 +2580,14 @@ class SyntaxTests: RulesTests {
 
     func testOpaqueGenericParameterWithConstraintsInWhereClause() {
         let input = """
-        func foo<T>(_ value: T) where T: Fooable, T: Barable {
-            print(value)
+        func foo<T, U>(_ t: T, _ u: U) where T: Fooable, T: Barable, U: Baazable {
+            print(t, u)
         }
         """
 
         let output = """
-        func foo(_ value: some Fooable & Barable) {
-            print(value)
+        func foo(_ t: some Fooable & Barable, _ u: some Baazable) {
+            print(t, u)
         }
         """
 
@@ -2630,7 +2630,6 @@ class SyntaxTests: RulesTests {
         let output = """
         func foo<
             S: Baazable,
-            T: Fooable,
             U: Barable
         >(_ foo: some Fooable & Quuxable, bar1: U, bar2: U) where
             S.AssociatedType == Baaz,

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2530,4 +2530,159 @@ class SyntaxTests: RulesTests {
         """
         testFormatting(for: input, output, rule: FormatRules.blockComments)
     }
+
+    // MARK: - opaqueGenericParameters
+
+    func testGenericNotModifiedBelowSwift5_7() {
+        let input = """
+        func foo<T>(_ value: T) {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.6")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterWithNoConstraint() {
+        let input = """
+        func foo<T>(_ value: T) {
+            print(value)
+        }
+        """
+
+        let output = """
+        func foo(_ value: some Any) {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterWithConstraintInBracket() {
+        let input = """
+        func foo<T: Fooable, U: Barable>(_ fooable: T, barable: U) {
+            print(fooable, barable)
+        }
+        """
+
+        let output = """
+        func foo(_ fooable: some Fooable, barable: some Barable) {
+            print(fooable, barable)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterWithConstraintsInWhereClause() {
+        let input = """
+        func foo<T>(_ value: T) where T: Fooable, T: Barable {
+            print(value)
+        }
+        """
+
+        let output = """
+        func foo(_ value: some Fooable & Barable) {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterCanRemoveOneButNotOther() {
+        let input = """
+        func foo<T: Fooable, U: Barable>(_ foo: T, bar1: U, bar2: U) where T: Quuxable, U: Qaaxable {
+            print(foo, bar1, bar2)
+        }
+        """
+
+        let output = """
+        func foo<U: Barable>(_ foo: some Fooable & Quuxable, bar1: U, bar2: U) where U: Qaaxable {
+            print(foo, bar1, bar2)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterWithUnknownAssociatedTypeConstraint() {
+        // If we knew that `T.AssociatedType` was the protocol's primary
+        // associated type we could update this to `value: some Fooable<Bar>`,
+        // but we don't necessarily have that type information available.
+        //  - If primary associated types become very widespread, it may make
+        //    sense to assume (or have an option to assume) that this would work.
+        let input = """
+        func foo<T: Fooable>(_ value: T) where T.AssociatedType == Bar {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testOpaqueGenericParameterWithKnownAssociatedTypeConstraint() {
+        // For known types (like those in the standard library),
+        // we are able to know their primary associated types
+        let input = """
+        func foo<T: Collection>(_ value: T) where T.Element == Foo {
+            print(value)
+        }
+        """
+
+        let output = """
+        func foo(_ value: some Collection<Foo>) where T.Element == Foo {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericTypeUsedInMultipleParameters() {
+        let input = """
+        func foo<T: Fooable>(_ first: T, second: T) {
+            print(first, second)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericTypeUsedInClosure() {
+        let input = """
+        func foo<T: Fooable>(_ closure: (T) -> Void) {
+            closure(foo)
+        }
+        """
+
+        let output = """
+        func foo(_ closure: (some Fooable) -> Void) {
+            closure(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericTypeUsedInClosureMultipleTimes() {
+        let input = """
+        func foo<T: Fooable>(_ closure: (T) -> T) {
+            closure(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
 }


### PR DESCRIPTION
This PR adds a new `opaqueGenericParameter` rule that updates generic methods to use Swift 5.7's new simpler syntax where possible / equivalent. For example:

```diff
- func handle<T: Fooable>(_ value: T) {
+ func handle(_ value: some Fooable) {
      print(value)
  }

- func handle<T>(_ value: T) where T: Fooable, T: Barable {
+ func handle(_ value: some Fooable & Barable) {
      print(value)
  }

- func handle<T: Collection>(_ value: T) where T.Element == Foo {
+ func handle(_ value: some Collection<Foo>) {
      print(value)
  }
```