### PR TITLE
Create script to create an SPM artifact bundle

### DIFF
--- a/Scripts/get-version.sh
+++ b/Scripts/get-version.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+REGEX="let swiftFormatVersion = \"([0-9]+.[0-9]+.[0-9]+)\""
+while IFS= read -r line; do
+    if [[ $line =~ $REGEX ]]
+    then
+        echo "${BASH_REMATCH[1]}"
+        break
+    fi
+done < Sources/SwiftFormat.swift

--- a/Scripts/spm-artifact-bundle.sh
+++ b/Scripts/spm-artifact-bundle.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+ARTIFACT_BUNDLE=swiftformat.artifactbundle
+INFO_TEMPLATE=Scripts/spm-macos-artifact-bundle-info.template
+VERSION=$(./Scripts/get-version.sh)
+BINARY_OUTPUT_DIR=$ARTIFACT_BUNDLE/swiftformat-$VERSION-macos/bin
+
+mkdir $ARTIFACT_BUNDLE
+
+# Copy license into bundle
+cp LICENSE.md $ARTIFACT_BUNDLE
+
+# Create bundle info.json from template, replacing version
+sed 's/__VERSION__/'"${VERSION}"'/g' $INFO_TEMPLATE > "${ARTIFACT_BUNDLE}/info.json"
+
+# Copy MacOS SwiftFormat binary into bundle
+mkdir -p $BINARY_OUTPUT_DIR
+cp CommandLineTool/swiftformat $BINARY_OUTPUT_DIR
+
+# Create ZIP
+zip -yr - $ARTIFACT_BUNDLE > "${ARTIFACT_BUNDLE}.zip"
+
+rm -rf $ARTIFACT_BUNDLE

--- a/Scripts/spm-macos-artifact-bundle-info.template
+++ b/Scripts/spm-macos-artifact-bundle-info.template
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftlint": {
+            "version": "__VERSION__",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "swiftformat-__VERSION__-macos/bin/swiftformat",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
* Add a script to 'Scripts' to get the current SwiftFormat version 'get-version.sh'.
* Add a script to 'Scripts' to build an SPM artifact bundle to attach to a release 'spm-artifact-bundle.sh'.

Closes #1213.