### PR TITLE
Update `opaqueGenericParameters` rule to handle generic return types properly

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7018,22 +7018,51 @@ public struct _FormatRules {
 
             // Parse additional conformances and constraints after the `where` keyword if present
             // (e.g. `where Foo: Fooable, Foo.Bar: Barable, Foo.Baaz == Baazable`)
+            var whereTokenIndex: Int?
             if let whereIndex = formatter.index(of: .keyword("where"), after: paramListEndIndex),
                whereIndex < openBraceIndex
             {
+                whereTokenIndex = whereIndex
                 parseGenericTypes(from: whereIndex, to: openBraceIndex)
+            }
+
+            // Parse the return type if present
+            var returnTypeTokens: [Token]?
+            if let returnIndex = formatter.index(of: .operator("->", .infix), after: paramListEndIndex),
+               returnIndex < openBraceIndex
+            {
+                let returnTypeRange = (returnIndex + 1) ..< (whereTokenIndex ?? openBraceIndex)
+                returnTypeTokens = Array(formatter.tokens[returnTypeRange])
             }
 
             let parameterListRange = (paramListStartIndex + 1) ..< paramListEndIndex
             let parameterListTokens = formatter.tokens[parameterListRange]
 
-            // If the generic type occurs multiple times in the parameter list,
-            // it isnt eligible to be removed. For example `(T, T) where T: Foo`
-            // requires the two params to be the same underlying type, but
-            // `(some Foo, some Foo)` does not.
             for genericType in genericTypes {
-                let occurenceCount = parameterListTokens.filter { $0.string == genericType.name }.count
-                if occurenceCount > 1 || genericType.asOpaqueParameter == nil {
+                // If the generic type occurs multiple times in the parameter list,
+                // it isnt eligible to be removed. For example `(T, T) where T: Foo`
+                // requires the two params to be the same underlying type, but
+                // `(some Foo, some Foo)` does not.
+                let countInParameterList = parameterListTokens.filter { $0.string == genericType.name }.count
+                if countInParameterList > 1 {
+                    genericType.eligbleToRemove = false
+                }
+
+                // A generic used as a return type is different from an opaque result type (SE-244).
+                // For example in `-> T where T: Fooable`, the generic type is caller-specified,
+                // but with `-> some Fooable` the generic type is specified by the function implementation.
+                // Because those represent different concepts, we can't convert between them,
+                // so have to mark the generic type as ineligible if it appears in the return type.
+                if let returnTypeTokens = returnTypeTokens,
+                   returnTypeTokens.contains(where: { $0.string == genericType.name })
+                {
+                    genericType.eligbleToRemove = false
+                }
+
+                // If the method that generates the opaque parameter syntax doesn't succeed,
+                // then this type is ineligible (because it used a generic constraint that
+                // can't be represented using this syntax).
+                if genericType.asOpaqueParameter == nil {
                     genericType.eligbleToRemove = false
                 }
             }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2563,13 +2563,13 @@ class SyntaxTests: RulesTests {
 
     func testOpaqueGenericParameterWithConstraintInBracket() {
         let input = """
-        func foo<T: Fooable, U: Barable>(_ fooable: T, barable: U) {
+        func foo<T: Fooable, U: Barable>(_ fooable: T, barable: U) -> Baaz {
             print(fooable, barable)
         }
         """
 
         let output = """
-        func foo(_ fooable: some Fooable, barable: some Barable) {
+        func foo(_ fooable: some Fooable, barable: some Barable) -> Baaz {
             print(fooable, barable)
         }
         """
@@ -2580,13 +2580,13 @@ class SyntaxTests: RulesTests {
 
     func testOpaqueGenericParameterWithConstraintsInWhereClause() {
         let input = """
-        func foo<T, U>(_ t: T, _ u: U) where T: Fooable, T: Barable, U: Baazable {
+        func foo<T, U>(_ t: T, _ u: U) -> Baaz where T: Fooable, T: Barable, U: Baazable {
             print(t, u)
         }
         """
 
         let output = """
-        func foo(_ t: some Fooable & Barable, _ u: some Baazable) {
+        func foo(_ t: some Fooable & Barable, _ u: some Baazable) -> Baaz {
             print(t, u)
         }
         """
@@ -2722,6 +2722,45 @@ class SyntaxTests: RulesTests {
         let input = """
         func foo<T: Fooable>(_ closure: (T) -> T) {
             closure(foo)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericTypeUsedAsReturnType() {
+        // A generic used as a return type is different from an opaque result type (SE-244).
+        // In `-> T where T: Fooable`, the generic type is caller-specified, but with
+        // `-> some Fooable` the generic type is specified by the function implementation.
+        // Because those represent different concepts, we can't convert between them.
+        let input = """
+        func foo<T: Fooable>() -> T {
+            // ...
+        }
+
+        func bar<T>() -> T where T: Barable {
+            // ...
+        }
+
+        func baaz<T: Baazable>() -> Set<SomeComplicatedNestedGeneric<T, Bar>> {
+            // ...
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericTypeUsedAsReturnTypeAndParameter() {
+        // Since we can't change the return value, we can't change any of the use cases of T
+        let input = """
+        func foo<T: Fooable>(_ value: T) -> T {
+            value
+        }
+
+        func bar<T>(_ value: T) -> T where T: Barable {
+            value
         }
         """
 


### PR DESCRIPTION
This PR updates the `opaqueGenericParameters` rule to handle generic return types properly.

Previously it just didn't parse return types at all, so it would do silly things like:

```swift
// Before
func foo<T: Fooable>(_ value: T) -> T { ... }

// After
func foo(_ value: some Fooable) -> T { ... } // oops!
```

Return types are also special, because `some Fooable` in a parameter position is different from `some Fooble` in a return position ([SE-244](https://github.com/apple/swift-evolution/blob/main/proposals/0244-opaque-result-types.md)). In `-> T where T: Fooable`, the generic type is caller-specified, but with `-> some Fooable` the generic type is specified by the function implementation. Because those represent different concepts we can't convert between them.

Now the signature of this example is not modified by the rule, since `T` is used as a return type:

```swift
// Before and after
func foo<T: Fooable>(_ value: T) -> T { ... }
```