### PR TITLE
Fix assertion after applying typeSugar rule to array/dictionary extensions

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3285,7 +3285,7 @@ public struct _FormatRules {
                     guard let nameToken = formatter.next(.identifier, after: index),
                           case let .identifier(name) = nameToken
                     else {
-                        return formatter.fatalError("Expected identifier", at: index)
+                        return
                     }
                     var usingDynamicLookup = formatter.modifiersForDeclaration(
                         at: index,

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -1837,6 +1837,23 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.typeSugar)
     }
 
+    func testExtensionTypeSugar() {
+        let input = """
+        extension Array<Foo> {}
+        extension Optional<Foo> {}
+        extension Dictionary<Foo, Bar> {}
+        extension Optional<Array<Dictionary<Foo, Array<Bar>>>> {}
+        """
+
+        let output = """
+        extension [Foo] {}
+        extension Foo? {}
+        extension [Foo: Bar] {}
+        extension [[Foo: [Bar]]]? {}
+        """
+        testFormatting(for: input, output, rule: FormatRules.typeSugar)
+    }
+
     // dictionaries
 
     func testDictionaryTypeConvertedToSugar() {


### PR DESCRIPTION
This PR fixes #1221, so these `typeSugar`ed extensions no longer cause an assertion failure:

```swift
extension [Foo] {}
extension Foo? {}
extension [Foo: Bar] {}
extension [[Foo: [Bar]]]? {}
```