### PR TITLE
Add support for `--swiftversion latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,8 @@ The `.swift-version` file applies hierarchically; If you have submodules in your
 
 The other option to specify the Swift version using the `--swiftversion` command line argument. Note that this will be overridden by any `.swift-version` files encountered while processing.
 
+When specifying a Swift version, you can use a version number (e.g. `5.6`), or use `latest` to always automatically use the most recently released Swift version supported by SwiftFormat.   
+
 
 Config file
 -----------

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -912,7 +912,11 @@ struct _Descriptors {
     let swiftVersion = OptionDescriptor(
         argumentName: "swiftversion",
         displayName: "Swift Version",
-        help: "The version of Swift used in the files being formatted",
+        help: """
+        The version of Swift used in the files being formatted.
+        Can be a verison number (e.g. "5.6") or "latest" to use
+        the most recent Swift language version.
+        """,
         keyPath: \.swiftVersion
     )
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -162,6 +162,12 @@ public struct Version: RawRepresentable, Comparable, ExpressibleByStringLiteral,
 
     public init?(rawValue: String) {
         let rawValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if rawValue == "latest" {
+            self.rawValue = latestSwiftVersion
+            return
+        }
+
         guard CharacterSet.decimalDigits.contains(rawValue.unicodeScalars.first ?? " ") else {
             return nil
         }

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -47,6 +47,10 @@ public let swiftVersions = [
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7",
 ]
 
+/// The Swift Version to use if the user specifies `--swiftversion latest`.
+/// This should be the most recent production release of Swift.
+public let latestSwiftVersion = "5.6"
+
 /// An enumeration of the types of error that may be thrown by SwiftFormat
 public enum FormatError: Error, CustomStringConvertible, LocalizedError, CustomNSError {
     case reading(String)

--- a/Tests/VersionTests.swift
+++ b/Tests/VersionTests.swift
@@ -57,4 +57,15 @@ class VersionTests: XCTestCase {
         XCTAssertLessThan(version ?? "0", "4.0")
         XCTAssertGreaterThan(version ?? "0", "2.0")
     }
+
+    func testLatestSwiftVersion() throws {
+        let version = Version(rawValue: "latest")
+        let latestVersion = Version(rawValue: latestSwiftVersion)
+        XCTAssertEqual(version, latestVersion)
+    }
+
+    func testSpecifyLatestSwiftVersion() throws {
+        let options = FormatOptions(swiftVersion: "latest")
+        XCTAssertEqual(options.swiftVersion, Version(rawValue: latestSwiftVersion))
+    }
 }


### PR DESCRIPTION
This PR adds support for specifying `--swiftversion latest`, to automatically use the most recent language version supported by SwiftFormat. Implements #1226.