### PR TITLE
Fix issue where `async throws` was indented differently than just `throws`

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -852,8 +852,10 @@ extension Formatter {
         guard let token = token(at: i) else { return true }
         switch token {
         case let .keyword(string) where [
-            "where", "dynamicType", "rethrows", "throws", "async",
+            "where", "dynamicType", "rethrows", "throws",
         ].contains(string):
+            return false
+        case .identifier("async"):
             return false
         case .keyword("as"):
             // For case statements, we already indent

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1613,7 +1613,7 @@ public struct _FormatRules {
                             .endOfScope("}"), .endOfScope("]"), .endOfScope(")"),
                         ].contains(formatter.tokens[nextTokenIndex!]) ||
                             formatter.isStartOfStatement(at: nextTokenIndex!, in: scopeStack.last) || (
-                                (formatter.tokens[nextTokenIndex!].isIdentifier || [
+                                ((formatter.tokens[nextTokenIndex!].isIdentifier && formatter.tokens[nextTokenIndex!] != .identifier("async")) || [
                                     .keyword("try"), .keyword("await"),
                                 ].contains(formatter.tokens[nextTokenIndex!])) &&
                                     formatter.last(.nonSpaceOrCommentOrLinebreak, before: nextTokenIndex!).map {

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -38,7 +38,7 @@ import Foundation
 // Used to speed up matching
 // Note: Any, Self, self, super, nil, true and false have been omitted deliberately, as they
 // behave like identifiers. So too have context-specific keywords such as the following:
-// any, associativity, convenience, didSet, dynamic, final, get, indirect, infix, lazy,
+// any, associativity, async, convenience, didSet, dynamic, final, get, indirect, infix, lazy,
 // left, mutating, none, nonmutating, open, optional, override, postfix, precedence,
 // prefix, Protocol, required, right, set, some, any, Type, unowned, weak, willSet
 private let swiftKeywords = Set([

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -3232,4 +3232,16 @@ class IndentTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.indent, options: options,
                        exclude: ["consecutiveBlankLines", "wrapConditionalBodies"])
     }
+
+    func testAsyncThrowsNotUnindented() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String)
+            async throws -> String {}
+        """
+
+        let options = FormatOptions(closingParenOnSameLine: true)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where a function with `async throws` was indented differently than a function with just `throws`. Fixes  #1242.

This was because `async` is parsed as an `identifier` but `throws` is parsed as a `keyword`, so the indent rule wasn't handling the `async` in the same way as it would handle `throws`. I tried updating the parser to treat `async` as a `keyword` instead, but this caused other test failures (since `async` is merely a context-specific keyword, unlike `throws`).

```swift
// before
func multilineFunction(
    foo _: String,
    bar _: String)
async throws -> String {}

// after
func multilineFunction(
    foo _: String,
    bar _: String)
    async throws -> String {}
```