### PR TITLE
Add Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+# Swift official image with arm64 support
+# https://hub.docker.com/r/arm64v8/swift/
+ARG SWIFT_IMAGE=swift:focal
+
+FROM $SWIFT_IMAGE AS builder
+COPY . /workspace
+WORKDIR /workspace
+RUN swift build -c release && mv `swift build -c release --show-bin-path`/swiftformat /workspace
+
+FROM $SWIFT_IMAGE-slim AS runner
+COPY --from=builder /workspace/swiftformat /usr/bin
+ENTRYPOINT [ "swiftformat" ]
+CMD ["."]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Table of Contents
     - [Git pre-commit hook](#git-pre-commit-hook)
     - [On CI using Danger](#on-ci-using-danger)
     - [Bazel build](#bazel-build)
+    - [Docker](#docker)
 - [Configuration](#configuration)
     - [Options](#options)
     - [Rules](#rules)
@@ -388,6 +389,39 @@ Bazel Build
 
 If you use [Bazel](https://bazel.build/) to build your Swift projects and want to ensure that only properly formatted code is merged to your main branch, try [rules_swiftformat](https://github.com/cgrindel/rules_swiftformat). The repository contains Bazel rules and macros that format Swift source files using SwiftFormat, test that the formatted files exist in the workspace directory, and copy the formatted files to the workspace directory.
 
+
+Docker
+-----------
+
+SwiftFormat publishes releases into [GitHub Packages](https://github.com/features/packages) Docker registry. To pull the image call:
+
+```bash
+$ docker pull ghcr.io/nicklockwood/swiftformat:latest
+```
+
+By default, the container runs `swiftformat .` Therefore, you need to provide a path either via an argument:
+
+```bash
+docker run --rm -v /local/source/path:/work ghcr.io/nicklockwood/swiftformat:latest /work
+```
+
+or by changing the working dir:
+
+```bash
+docker run --rm -v /local/source/path:/work -w /work ghcr.io/nicklockwood/swiftformat:latest
+```
+
+To check the installed SwiftFormat version:
+
+```bash
+docker run --rm ghcr.io/nicklockwood/swiftformat:latest --version
+```
+
+Linting example:
+
+```bash
+docker run --rm -v /local/source/path:/work ghcr.io/nicklockwood/swiftformat:latest /work --lint
+```
 
 Configuration
 -------------


### PR DESCRIPTION
Resolves #1067 

Newly "Create and publish a Docker image" action in this PR:
1. Is triggered on every tag push (`docker/metadata-action` uses this tag for Docker image metadata).
2. Builds arm64 and amd64 slices.
3. Publishes images to GitHub Packages linked to the repository.
4. Doesn't require any additional setup for this repo.

I "moved" the latest 0.49.16 tag in the source repo after my changes so you can see how it will look like [in the repo Packages section](https://github.com/vox-humana/SwiftFormat/pkgs/container/swiftformat)
<img width="211" alt="image" src="https://user-images.githubusercontent.com/53595/184630689-bb16c79e-632a-4c49-a748-aa8cec620b0f.png">
<img width="965" alt="image" src="https://user-images.githubusercontent.com/53595/184630692-921aee48-5562-4fc8-8f90-33fb106d9c29.png">


Also, added a section to README file. Not sure whether I need to mention anything else, it just works 😄 
I don't know how the release process for this repo works, happy to adjust the action to make it easier if needed. 