### PR TITLE
Fix issue where function argument label named `async:` would unexpectedly be indented

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1613,7 +1613,7 @@ public struct _FormatRules {
                             .endOfScope("}"), .endOfScope("]"), .endOfScope(")"),
                         ].contains(formatter.tokens[nextTokenIndex!]) ||
                             formatter.isStartOfStatement(at: nextTokenIndex!, in: scopeStack.last) || (
-                                ((formatter.tokens[nextTokenIndex!].isIdentifier && formatter.tokens[nextTokenIndex!] != .identifier("async")) || [
+                                ((formatter.tokens[nextTokenIndex!].isIdentifier && !(formatter.tokens[nextTokenIndex!] == .identifier("async") && formatter.currentScope(at: nextTokenIndex!) != .startOfScope("("))) || [
                                     .keyword("try"), .keyword("await"),
                                 ].contains(formatter.tokens[nextTokenIndex!])) &&
                                     formatter.last(.nonSpaceOrCommentOrLinebreak, before: nextTokenIndex!).map {

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -3284,4 +3284,15 @@ class IndentTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.indent)
     }
+
+    func testAsyncFunctionArgumentLabelNotIndented() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            async _: String)
+            -> String {}
+        """
+        let options = FormatOptions(closingParenOnSameLine: true)
+        testFormatting(for: input, rule: FormatRules.indent, options: options)
+    }
 }


### PR DESCRIPTION
This PR fixes a regression caused by #1247 where a function argument label named `async:` would unexpectedly be indented.

### Before

```swift
func multilineFunction(
    foo _: String,
        async _: String)
    -> String {}
```

### After

```swift
func multilineFunction(
    foo _: String,
    async _: String)
    -> String {}
```