### PR TITLE
Fix edge cases with `opaqueGenericParameters` rule

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1882,7 +1882,18 @@ extension Formatter {
                 }
             }
 
-            return tokenize("some \(constraintRepresentations.joined(separator: " & "))")
+            if !constraintRepresentations.isEmpty {
+                return tokenize("some \(constraintRepresentations.joined(separator: " & "))")
+            }
+
+            // If there aren't any constraints but we have exactly one concrete type,
+            // we can just use that concrete type directly
+            let concreteTypes = conformances.filter { $0.type == .conceteType }
+            if concreteTypes.count == 1 {
+                return tokenize(concreteTypes[0].name)
+            }
+
+            return nil
         }
     }
 

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1970,12 +1970,12 @@ extension Formatter {
                 let constrainedTypeName = tokens[genericTypeNameIndex ..< delineatorIndex]
                     .map { $0.string }
                     .joined()
-                    .trimmingCharacters(in: .init(charactersIn: " \n,<>{}"))
+                    .trimmingCharacters(in: .init(charactersIn: " \n,{}"))
 
                 let conformanceName = tokens[(delineatorIndex + 1) ... typeEndIndex]
                     .map { $0.string }
                     .joined()
-                    .trimmingCharacters(in: .init(charactersIn: " \n,<>{}"))
+                    .trimmingCharacters(in: .init(charactersIn: " \n,{}"))
 
                 genericType.conformances.append(.init(
                     name: conformanceName,

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7087,9 +7087,11 @@ public struct _FormatRules {
                     let matchingGenericType = genericsEligibleToRemove.first(where: { $0.name == formatter.tokens[index].string }),
                     var opaqueParameter = matchingGenericType.asOpaqueParameter
                 {
-                    // If this instance of the type is followed by a `.` then we have to wrap the new type in parens
+                    // If this instance of the type is followed by a `.` or `?` then we have to wrap the new type in parens
                     // (e.g. changing `Foo.Type` to `some Any.Type` breaks the build, it needs to be `(some Any).Type`)
-                    if formatter.next(.nonSpaceOrCommentOrLinebreak, after: index) == .operator(".", .infix) {
+                    if let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: index),
+                       [.operator(".", .infix), .operator("?", .postfix)].contains(nextToken)
+                    {
                         opaqueParameter.insert(.startOfScope("("), at: 0)
                         opaqueParameter.append(.endOfScope(")"))
                     }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6937,10 +6937,12 @@ public struct _FormatRules {
                 formatter.options.swiftVersion >= "5.7",
                 // Validate that this is a generic method using angle bracket syntax,
                 // and find the indices for all of the key tokens
+                let paramListStartIndex = formatter.index(of: .startOfScope("("), after: funcIndex),
+                let paramListEndIndex = formatter.endOfScope(at: paramListStartIndex),
                 let genericSignatureStartIndex = formatter.index(of: .startOfScope("<"), after: funcIndex),
                 let genericSignatureEndIndex = formatter.endOfScope(at: genericSignatureStartIndex),
-                let paramListStartIndex = formatter.index(of: .startOfScope("("), after: genericSignatureEndIndex),
-                let paramListEndIndex = formatter.endOfScope(at: paramListStartIndex),
+                genericSignatureStartIndex < paramListStartIndex,
+                genericSignatureEndIndex < paramListStartIndex,
                 let openBraceIndex = formatter.index(of: .startOfScope("{"), after: paramListEndIndex)
             else { return }
 
@@ -7037,7 +7039,7 @@ public struct _FormatRules {
                 }
             }
 
-            // Remove types from the generic paremeter list
+            // Remove types from the generic parameter list
             let genericParameterListSourceRanges = sourceRangesToRemove.filter { $0.lowerBound < genericSignatureEndIndex }
             formatter.removeTokens(in: Array(genericParameterListSourceRanges))
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7080,7 +7080,7 @@ public struct _FormatRules {
                 }
             }
 
-            // Replace all of the uses of generic types that are elible to remove
+            // Replace all of the uses of generic types that are eligible to remove
             // with the corresponding opaque parameter declaration
             for index in parameterListRange.reversed() {
                 if
@@ -7094,6 +7094,14 @@ public struct _FormatRules {
             // Remove types from the generic parameter list
             let genericParameterListSourceRanges = sourceRangesToRemove.filter { $0.lowerBound < genericSignatureEndIndex }
             formatter.removeTokens(in: Array(genericParameterListSourceRanges))
+
+            // If we left a dangling comma at the end of the generic parameter list, we need to clean it up
+            if let newGenericSignatureEndIndex = formatter.endOfScope(at: genericSignatureStartIndex),
+               let trailingCommaIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: newGenericSignatureEndIndex),
+               formatter.tokens[trailingCommaIndex] == .delimiter(",")
+            {
+                formatter.removeTokens(in: trailingCommaIndex ..< newGenericSignatureEndIndex)
+            }
 
             // If we removed all of the generic types, we also have to remove the angle brackets
             if let newGenericSignatureEndIndex = formatter.index(of: .nonSpaceOrLinebreak, after: genericSignatureStartIndex),

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7020,6 +7020,15 @@ public struct _FormatRules {
                     }
                 }
 
+                // In some weird cases you can also have a generic constraint that references a generic
+                // type from the parent context with the same name. We can't change these, since it
+                // can cause the build to break
+                for conformance in genericType.conformances {
+                    if tokenize(conformance.name).contains(where: { $0.string == genericType.name }) {
+                        genericType.eligbleToRemove = false
+                    }
+                }
+
                 // A generic used as a return type is different from an opaque result type (SE-244).
                 // For example in `-> T where T: Fooable`, the generic type is caller-specified,
                 // but with `-> some Fooable` the generic type is specified by the function implementation.

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2909,6 +2909,19 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testHandlesSingleExactTypeGenericConstraint() {
+        let input = """
+        func foo<T>(with _: T) -> Foo where T == Dependencies {}
+        """
+
+        let output = """
+        func foo(with _: Dependencies) -> Foo {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2837,6 +2837,21 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testReturnedTupleUsingTypeAlsoUsedInParams() {
+        let input = """
+        func combineResults<ASuccess, AFailure, BSuccess, BFailure>(
+            _: Potential<ASuccess, AFailure>,
+            _: Potential<BSuccess, BFailure>
+        ) -> Potential<Success, Never> where
+            Success == (Result<ASuccess, AFailure>, Result<BSuccess, BFailure>),
+            Failure == Never
+        {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2897,10 +2897,12 @@ class SyntaxTests: RulesTests {
     func testAddsParensAroundTypeIfNecessary() {
         let input = """
         func foo<Foo>(_: Foo.Type) {}
+        func bar<Foo>(_: Foo?) {}
         """
 
         let output = """
         func foo(_: (some Any).Type) {}
+        func bar(_: (some Any)?) {}
         """
 
         let options = FormatOptions(swiftVersion: "5.7")

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2867,6 +2867,8 @@ class SyntaxTests: RulesTests {
         func bar<Foo>(_: (Foo) throws -> Void) {}
         func baaz<Foo>(_: (Foo) async -> Void) {}
         func quux<Foo>(_: (Foo) async throws -> Void) {}
+        func qaax<Foo>(_: ([Foo]) -> Void) {}
+        func qaax<Foo>(_: ((Foo, Bar)) -> Void) {}
         """
 
         let options = FormatOptions(swiftVersion: "5.7")

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2922,6 +2922,27 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testGenericConstraintThatIsGeneric() {
+        let input = """
+        class Foo<Bar, Baaz> {}
+        func foo<T: Foo<String, String>>(_: T) {}
+
+        class Bar<Baaz> {}
+        func bar<T: Bar<String>>(_: T) {}
+        """
+
+        let output = """
+        class Foo<Bar, Baaz> {}
+        func foo(_: some Foo<String, String>) {}
+
+        class Bar<Baaz> {}
+        func bar(_: some Bar<String>) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2865,6 +2865,19 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testGenericParameterUsedInBodyNotRemoved() {
+        let input = """
+        func foo<T>(_ value: T) {
+            typealias TTT = T
+            let casted = value as TTT
+            print(casted)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2815,6 +2815,28 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testOpaqueGenericParametersRuleSuccessfullyTerminatesInSampleCode() {
+        let input = """
+        class Service {
+            public func run() {}
+            private let foo: Foo<Void, Void>
+
+            private func a() -> Eventual<Void> {}
+            private func b() -> Eventual<Void> {}
+            private func c() -> Eventual<Void> {}
+            private func d() -> Eventual<Void> {}
+            private func e() -> Eventual<Void> {}
+            private func f() -> Eventual<Void> {}
+            private func g() -> Eventual<Void> {}
+            private func h() -> Eventual<Void> {}
+            private func i() {}
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2894,6 +2894,19 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testAddsParensAroundTypeIfNecessary() {
+        let input = """
+        func foo<Foo>(_: Foo.Type) {}
+        """
+
+        let output = """
+        func foo(_: (some Any).Type) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2748,23 +2748,6 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
-    func testGenericTypeUsedInClosure() {
-        let input = """
-        func foo<T: Fooable>(_ closure: (T) -> Void) {
-            closure(foo)
-        }
-        """
-
-        let output = """
-        func foo(_ closure: (some Fooable) -> Void) {
-            closure(foo)
-        }
-        """
-
-        let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
-    }
-
     func testGenericTypeUsedInClosureMultipleTimes() {
         let input = """
         func foo<T: Fooable>(_ closure: (T) -> T) {
@@ -2872,6 +2855,18 @@ class SyntaxTests: RulesTests {
             let casted = value as TTT
             print(casted)
         }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterUsedAsClosureParameterNotRemoved() {
+        let input = """
+        func foo<Foo>(_: (Foo) -> Void) {}
+        func bar<Foo>(_: (Foo) throws -> Void) {}
+        func baaz<Foo>(_: (Foo) async -> Void) {}
+        func quux<Foo>(_: (Foo) async throws -> Void) {}
         """
 
         let options = FormatOptions(swiftVersion: "5.7")

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2837,7 +2837,7 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
-    func testReturnedTupleUsingTypeAlsoUsedInParams() {
+    func testGenericParameterUsedInConstraintOfOtherTypeNotChanged() {
         let input = """
         func combineResults<ASuccess, AFailure, BSuccess, BFailure>(
             _: Potential<ASuccess, AFailure>,
@@ -2846,6 +2846,19 @@ class SyntaxTests: RulesTests {
             Success == (Result<ASuccess, AFailure>, Result<BSuccess, BFailure>),
             Failure == Never
         {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterInheritedFromContextNotRemoved() {
+        let input = """
+        func assign<Target>(
+            on _: DispatchQueue,
+            to _: AssignTarget<Target>,
+            at _: ReferenceWritableKeyPath<Target, Value>
+        ) where Value: Equatable {}
         """
 
         let options = FormatOptions(swiftVersion: "5.7")

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2943,6 +2943,19 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testDoesntChangeTypeWithConstraintThatReferencesItself() {
+        // This is a weird one but in the actual code this comes from `ViewModelContext` is both defined
+        // on the parent type of this declaration (where it has additional important constraints),
+        // and again in the method itself. Changing this to an opaque parameter breaks the build, because
+        // it loses the generic constraints applied by the parent type.
+        let input = """
+        func makeSections<ViewModelContext: RoutingBehaviors<ViewModelContext.Dependencies>>(_: ViewModelContext) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2875,6 +2875,25 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testFinalGenericParamRemovedProperlyWithoutHangingComma() {
+        let input = """
+        func foo<Bar, Baaz>(
+            bar _: (Bar) -> Void,
+            baaz _: Baaz
+        ) {}
+        """
+
+        let output = """
+        func foo<Bar>(
+            bar _: (Bar) -> Void,
+            baaz _: some Any
+        ) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {


### PR DESCRIPTION
This PR fixes a bunch of edge cases with the `opaqueGenericParameters` rule. With these fixes, our app repo complies successfully after applying this rule.