### PR TITLE
Add `--someAny` option to `opaqueGenericParameters` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -963,6 +963,10 @@ with constraints (`T where T: Protocol`, etc) where equivalent. Also supports
 primary associated types for common standard library types, so definitions like
 `T where T: Collection, T.Element == Foo` are upated to `some Collection<Foo>`.
 
+Option | Description
+--- | ---
+`--someAny` | Use `some Any` types: "true" (default) or "false"
+
 <details>
 <summary>Examples</summary>
 
@@ -979,6 +983,12 @@ primary associated types for common standard library types, so definitions like
 
 - func handle<T: Collection>(_ value: T) where T.Element == Foo {
 + func handle(_ value: some Collection<Foo>) {
+      print(value)
+  }
+
+// With `--someAny enabled` (the default)
+- func handle<T>(_ value: T) {
++ func handle(_ value: some Any) {
       print(value)
   }
 ```

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1436,6 +1436,12 @@ private struct Examples {
     + func handle(_ value: some Collection<Foo>) {
           print(value)
       }
+
+    // With `--someAny enabled` (the default)
+    - func handle<T>(_ value: T) {
+    + func handle(_ value: some Any) {
+          print(value)
+      }
     ```
     """
 

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1822,8 +1822,9 @@ extension Formatter {
 
         // The opaque parameter syntax that represents this generic type,
         // if the constraints can be expressed using this syntax
-        var asOpaqueParameter: [Token]? {
+        func asOpaqueParameter(useSomeAny: Bool) -> [Token]? {
             if conformances.isEmpty {
+                guard useSomeAny else { return nil }
                 return tokenize("some Any")
             }
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -902,6 +902,14 @@ struct _Descriptors {
         fromArgument: { $0 },
         toArgument: { $0 }
     )
+    let useSomeAny = OptionDescriptor(
+        argumentName: "someAny",
+        displayName: "Use `some Any`",
+        help: "Use `some Any` types: \"true\" (default) or \"false\"",
+        keyPath: \.useSomeAny,
+        trueValues: ["true", "enabled"],
+        falseValues: ["false", "disabled"]
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -419,6 +419,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var enumNamespaces: EnumNamespacesMode
     public var removeStartOrEndBlankLinesFromTypes: Bool
     public var genericTypes: String
+    public var useSomeAny: Bool
 
     // Deprecated
     public var indentComments: Bool
@@ -514,6 +515,7 @@ public struct FormatOptions: CustomStringConvertible {
                 enumNamespaces: EnumNamespacesMode = .always,
                 removeStartOrEndBlankLinesFromTypes: Bool = true,
                 genericTypes: String = "",
+                useSomeAny: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -600,6 +602,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.enumNamespaces = enumNamespaces
         self.removeStartOrEndBlankLinesFromTypes = removeStartOrEndBlankLinesFromTypes
         self.genericTypes = genericTypes
+        self.useSomeAny = useSomeAny
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6892,8 +6892,6 @@ public struct _FormatRules {
 
     public let redundantOptionalBinding = FormatRule(
         help: "Removes redundant identifiers in optional binding conditions.",
-        // We can convert `if let foo = self.foo` to just `if let foo`,
-        // but only if `redundantSelf` can first remove the `self.`.
         orderAfter: ["redundantSelf"]
     ) { formatter in
         formatter.forEachToken { i, introducer in
@@ -6929,7 +6927,7 @@ public struct _FormatRules {
         primary associated types for common standard library types, so definitions like
         `T where T: Collection, T.Element == Foo` are upated to `some Collection<Foo>`.
         """,
-        options: []
+        options: ["someAny"]
     ) { formatter in
         formatter.forEach(.keyword("func")) { funcIndex, _ in
             guard
@@ -6999,7 +6997,7 @@ public struct _FormatRules {
                 // If the method that generates the opaque parameter syntax doesn't succeed,
                 // then this type is ineligible (because it used a generic constraint that
                 // can't be represented using this syntax).
-                if genericType.asOpaqueParameter == nil {
+                if genericType.asOpaqueParameter(useSomeAny: formatter.options.useSomeAny) == nil {
                     genericType.eligbleToRemove = false
                 }
             }
@@ -7031,7 +7029,7 @@ public struct _FormatRules {
             for index in parameterListRange.reversed() {
                 if
                     let matchingGenericType = genericsEligibleToRemove.first(where: { $0.name == formatter.tokens[index].string }),
-                    let opaqueParameter = matchingGenericType.asOpaqueParameter
+                    let opaqueParameter = matchingGenericType.asOpaqueParameter(useSomeAny: formatter.options.useSomeAny)
                 {
                     formatter.replaceToken(at: index, with: opaqueParameter)
                 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2608,6 +2608,17 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testDisableSomeAnyGenericType() {
+        let input = """
+        func foo<T>(_ value: T) {
+            print(value)
+        }
+        """
+
+        let options = FormatOptions(useSomeAny: false, swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     func testOpaqueGenericParameterWithConstraintInBracket() {
         let input = """
         func foo<T: Fooable, U: Barable>(_ fooable: T, barable: U) -> Baaz {


### PR DESCRIPTION
This PR adds a `--someAny` option to `opaqueGenericParameters` rule.

By default the rule converts all eligible generic parameters to opaque `some` types. For types with no constraints, the opaque form is simply `some Any`:

```diff
- func handle<T>(_ value: T) {
+ func handle(_ value: some Any) {
      print(value)
  }
```

I'm not really convinced that this is more idiomatic than the previous spelling, and I think it's reasonable to support disabling this specific conversion while still using the rule in other eligible cases (where I think the shorthand opaque generic spelling is definitely more idiomatic).