### PR TITLE
Add `docComments` rule to convert between standard comments and doc comments

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -10,6 +10,7 @@
 * [braces](#braces)
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
+* [docComments](#docComments)
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
@@ -479,6 +480,29 @@ Replace consecutive spaces with a single space.
 ```diff
 - let     foo = 5
 + let foo = 5
+```
+
+</details>
+<br/>
+
+## docComments
+
+Use doc comments for comments preceding declarations.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- // A placeholder type used to demonstrate syntax rules
++ /// A placeholder type used to demonstrate syntax rules
+  class Foo {
+-     // This function doesn't really do anything
++     /// This function doesn't really do anything
+      func bar() {
+-         /// TODO: implement Foo.bar() algorithm
++         // TODO: implement Foo.bar() algorithm
+      }
+  }
 ```
 
 </details>

--- a/Snapshots/Consumer/Examples/JSON/json.swift
+++ b/Snapshots/Consumer/Examples/JSON/json.swift
@@ -17,7 +17,7 @@ public func compileJSONParser() -> String {
     return json.compile("parseJSON3", transformFunction: "jsonTransform")
 }
 
-// JSON grammar
+/// JSON grammar
 private let space: Consumer<JSONLabel> = .discard(.zeroOrMore(.character(in: " \t\n\r")))
 private let null: Consumer<JSONLabel> = .label(.null, "null")
 private let boolean: Consumer<JSONLabel> = .label(.boolean, "true" | "false")

--- a/Snapshots/Consumer/Examples/JSON/main.swift
+++ b/Snapshots/Consumer/Examples/JSON/main.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// Example input
+/// Example input
 let input = """
 {
     "foo": true,
@@ -41,7 +41,7 @@ time { print("handwritten:", try parseJSON2(input)) }
 // Evaluate json using compiled parser
 time { print("compiled:", try parseJSON3(input)!) }
 
-// Update compiled parser
+/// Update compiled parser
 print("Recompiling parser...")
 let compiledSwiftFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent().appendingPathComponent("compiled.swift")

--- a/Snapshots/Consumer/Examples/JSON/shared.swift
+++ b/Snapshots/Consumer/Examples/JSON/shared.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Nick Lockwood. All rights reserved.
 //
 
-/// This code is shared between the interpreted and compiled versions of the JSON parser
+// This code is shared between the interpreted and compiled versions of the JSON parser
 
 /// JSON parsing errors
 enum JSONError: Swift.Error {
@@ -24,7 +24,7 @@ enum JSONLabel: String {
     case array
     case object
 
-    // Internal types
+    /// Internal types
     case unichar
     case keyValue
 }

--- a/Snapshots/Consumer/Examples/REPL/main.swift
+++ b/Snapshots/Consumer/Examples/REPL/main.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-// Prevent control characters confusing parser
+/// Prevent control characters confusing parser
 private let start = UnicodeScalar(63232)!
 private let end = UnicodeScalar(63235)!
 private let cursorCharacters = CharacterSet(charactersIn: start ... end)
 
-// Persistent state
+/// Persistent state
 private let state = State()
 
 while true {

--- a/Snapshots/Consumer/Examples/REPL/repl.swift
+++ b/Snapshots/Consumer/Examples/REPL/repl.swift
@@ -84,17 +84,17 @@ private enum Label: String {
     case command
 }
 
-// boolean
+/// boolean
 private let bool: Consumer<Label> = .label(.bool, "true" | "false")
 
-// number
+/// number
 private let zeroToNine: Consumer<Label> = .character(in: "0" ... "9")
 private let oneToNine: Consumer<Label> = .character(in: "1" ... "9")
 private let integer: Consumer<Label> = "0" | [oneToNine, .zeroOrMore(zeroToNine)]
 private let decimal: Consumer<Label> = [integer, .optional([".", .oneOrMore(zeroToNine)])]
 private let number: Consumer<Label> = .label(.number, .flatten(decimal))
 
-// string
+/// string
 private let string: Consumer<Label> = .label(.string, .flatten([
     .discard("\""),
     .zeroOrMore(.any([
@@ -109,12 +109,12 @@ private let string: Consumer<Label> = .label(.string, .flatten([
     .discard("\""),
 ]))
 
-// identifier
+/// identifier
 private let alpha: Consumer<Label> = .character(in: .letters)
 private let alphanumeric: Consumer<Label> = .character(in: .alphanumerics)
 private let identifier: Consumer<Label> = .flatten([alpha, .zeroOrMore(alphanumeric)])
 
-// rvalues
+/// rvalues
 private let literal: Consumer<Label> = number | bool | string
 private let variable: Consumer<Label> = .label(.variable, identifier)
 private let subexpression: Consumer<Label> = [
@@ -130,17 +130,17 @@ private let expression: Consumer<Label> = .label(.expression, [
     term, .optional(["+" | "-", .reference(.expression)]),
 ])
 
-// assignment
+/// assignment
 private let assignment: Consumer<Label> = .label(.assignment, [
     identifier, .discard("="), expression,
 ])
 
-// comments and white space
+/// comments and white space
 private let space: Consumer<Label> = .character(in: .whitespacesAndNewlines)
 private let comment1: Consumer<Label> = ["//", .zeroOrMore(.anyCharacter(except: "\r", "\n"))]
 private let comment2: Consumer<Label> = ["/*", .zeroOrMore([.not("*/"), .anyCharacter()]), "*/"]
 private let spaceOrComment: Consumer<Label> = .discard(.zeroOrMore(space | comment1 | comment2))
 
-// root
+/// root
 private let command: Consumer<Label> =
     .label(.command, .ignore(spaceOrComment, in: assignment | expression))

--- a/Snapshots/Consumer/Sources/Consumer.swift
+++ b/Snapshots/Consumer/Sources/Consumer.swift
@@ -651,12 +651,12 @@ extension Consumer.Location: CustomStringConvertible {
         return lhs.range == rhs.range
     }
 
-    // Convenience constructor, used by compiled parsers
+    /// Convenience constructor, used by compiled parsers
     public static func at(_ range: Range<String.Index>, in source: String.UnicodeScalarView) -> Consumer.Location {
         return Consumer.Location(source: source, range: range)
     }
 
-    // Convenience constructor, used for testing
+    /// Convenience constructor, used for testing
     public static func at(_ range: CountableRange<Int>) -> Consumer.Location {
         let source = String(repeating: " ", count: range.upperBound).unicodeScalars
         let range = source.index(source.startIndex, offsetBy: range.lowerBound) ..< source.endIndex
@@ -688,7 +688,7 @@ private extension Consumer.Location {
 // MARK: Charset implementation
 
 public extension Consumer.Charset {
-    // Note: this can be expensive to calculate
+    /// Note: this can be expensive to calculate
     var ranges: [CountableClosedRange<UInt32>] {
         var ranges = [CountableClosedRange<UInt32>]()
         let bitmap: Data = characterSet.bitmapRepresentation
@@ -862,7 +862,7 @@ private extension Consumer.Error {
     }
 }
 
-// Human-readable character
+/// Human-readable character
 private func escapeCodePoint(_ codePoint: UInt32, inString _: Bool = false) -> String {
     guard let char = UnicodeScalar(codePoint), [0, 9, 10, 13].contains(codePoint) ||
         !CharacterSet.controlCharacters.contains(char)
@@ -873,7 +873,7 @@ private func escapeCodePoint(_ codePoint: UInt32, inString _: Bool = false) -> S
     return escapeString(String(char))
 }
 
-// Human-readable string
+/// Human-readable string
 private func escapeString<T: StringProtocol>(_ string: T) -> String {
     var result = "'"
     for char in string.unicodeScalars {

--- a/Snapshots/Consumer/Sources/ConsumerCompiler.swift
+++ b/Snapshots/Consumer/Sources/ConsumerCompiler.swift
@@ -31,17 +31,17 @@
 
 import Foundation
 
-/// Compiles the consumer into the source code for a Swift function.
-/// Currently only works if the `Label` type is `String` or `RawRepresentable<String>`
+// Compiles the consumer into the source code for a Swift function.
+// Currently only works if the `Label` type is `String` or `RawRepresentable<String>`
 
-/// The optional `functionName` argument specifies a name for the compiled transform function.
+// The optional `functionName` argument specifies a name for the compiled transform function.
 
-/// The optional `transformFunction` argument is the name of a function that will be
-/// called by the parser to transform the generic AST into an app-specific data structure.
+// The optional `transformFunction` argument is the name of a function that will be
+// called by the parser to transform the generic AST into an app-specific data structure.
 
-/// The `transformFunction` should have the same signature as the `Consumer<Label>.Transform` callback.
-/// If `transformFunction` is omitted, the function will generate a `Consumer<Label>.Match`,
-/// and the resultant function will require the target application to include the Consumer framework.
+// The `transformFunction` should have the same signature as the `Consumer<Label>.Transform` callback.
+// If `transformFunction` is omitted, the function will generate a `Consumer<Label>.Match`,
+// and the resultant function will require the target application to include the Consumer framework.
 
 public extension Consumer where Label: RawRepresentable, Label.RawValue == String {
     func compile(_ functionName: String = "parse", transformFunction: String? = nil) -> String {
@@ -1229,7 +1229,7 @@ private extension Consumer {
         return result
     }
 
-    // Source-safe string
+    /// Source-safe string
     func escapeString<T: StringProtocol>(_ string: T) -> String {
         var result = "\""
         for char in string.unicodeScalars {

--- a/Snapshots/Consumer/Tests/PerformanceTests.swift
+++ b/Snapshots/Consumer/Tests/PerformanceTests.swift
@@ -103,7 +103,7 @@ class PerformanceTests: XCTestCase {
     }
 }
 
-// http://json.org/example.html
+/// http://json.org/example.html
 private let json = """
 {"web-app": {
   "servlet": [

--- a/Snapshots/Euclid/Sources/CSG.swift
+++ b/Snapshots/Euclid/Sources/CSG.swift
@@ -207,7 +207,7 @@ private func boundsTest(
     }
 }
 
-// Merge all the meshes into a single mesh using fn
+/// Merge all the meshes into a single mesh using fn
 private func multimerge(_ meshes: [Mesh], using fn: (Mesh, Mesh) -> Mesh) -> Mesh {
     var mesh = Mesh([])
     var meshesAndBounds = meshes.map { ($0, $0.bounds) }
@@ -220,7 +220,7 @@ private func multimerge(_ meshes: [Mesh], using fn: (Mesh, Mesh) -> Mesh) -> Mes
     return mesh
 }
 
-// Merge each intersecting mesh after i into the mesh at index i using fn
+/// Merge each intersecting mesh after i into the mesh at index i using fn
 private func reduce(_ meshes: [Mesh], using fn: (Mesh, Mesh) -> Mesh) -> Mesh {
     var meshesAndBounds = meshes.map { ($0, $0.bounds) }
     return reduce(&meshesAndBounds, at: 0, using: fn)

--- a/Snapshots/Euclid/Sources/CoreText.swift
+++ b/Snapshots/Euclid/Sources/CoreText.swift
@@ -13,7 +13,7 @@ import Foundation
 
 #if os(watchOS)
 
-// Workaround for missing constants on watchOS
+/// Workaround for missing constants on watchOS
 extension NSAttributedString.Key {
     static let font = NSAttributedString.Key(rawValue: "NSFont")
 }

--- a/Snapshots/Euclid/Sources/Paths.swift
+++ b/Snapshots/Euclid/Sources/Paths.swift
@@ -138,7 +138,7 @@ public extension Path {
     /// Get vertices suitable for constructing a polygon from the path
     /// vertices include normals and uv coordinates normalized to the
     /// bounding rectangle of the path. Returns nil if path has subpaths
-    // TODO: should this be facePolygons instead, to handle non-planar shapes?
+    /// TODO: should this be facePolygons instead, to handle non-planar shapes?
     var faceVertices: [Vertex]? {
         guard isClosed, let normal = plane?.normal, subpaths.count <= 1 else {
             return nil
@@ -283,14 +283,14 @@ internal extension Path {
         }
     }
 
-    // Convenience initializer
+    /// Convenience initializer
     init(unchecked points: [PathPoint]) {
         self.init(unchecked: points, plane: nil, subpathIndices: nil)
     }
 
-    // Test if path is self-intersecting
-    // TODO: extend this to work in 3D
-    // TODO: optimize by using http://www.webcitation.org/6ahkPQIsN
+    /// Test if path is self-intersecting
+    /// TODO: extend this to work in 3D
+    /// TODO: optimize by using http://www.webcitation.org/6ahkPQIsN
     var isSimple: Bool {
         let points = flattened().points.map { $0.position }
         for i in 0 ..< points.count - 2 {
@@ -313,8 +313,8 @@ internal extension Path {
         return true
     }
 
-    // flattens z-axis
-    // TODO: this is a hack and should be replaced by a better solution
+    /// flattens z-axis
+    /// TODO: this is a hack and should be replaced by a better solution
     func flattened() -> Path {
         if bounds.min.z == 0, bounds.max.z == 0 {
             return self
@@ -400,9 +400,9 @@ internal extension Path {
 
 // MARK: Private utility functions
 
-// Get the intersection point between two lines
-// TODO: extend this to work in 3D
-// TODO: improve this using https://en.wikipedia.org/wiki/Line–line_intersection
+/// Get the intersection point between two lines
+/// TODO: extend this to work in 3D
+/// TODO: improve this using https://en.wikipedia.org/wiki/Line–line_intersection
 private func lineIntersection(_ p0: Vector, _ p1: Vector,
                               _ p2: Vector, _ p3: Vector) -> Vector?
 {
@@ -433,7 +433,7 @@ private func lineIntersection(_ p0: Vector, _ p1: Vector,
     return Vector(ix, iy)
 }
 
-// TODO: extend this to work in 3D
+/// TODO: extend this to work in 3D
 private func lineSegmentsIntersect(_ p0: Vector, _ p1: Vector,
                                    _ p2: Vector, _ p3: Vector) -> Bool
 {

--- a/Snapshots/Euclid/Sources/Plane.swift
+++ b/Snapshots/Euclid/Sources/Plane.swift
@@ -115,14 +115,14 @@ internal extension Plane {
         self.init(unchecked: normal, pointOnPlane: points[0])
     }
 
-    // Approximate equality
+    /// Approximate equality
     func isEqual(to other: Plane, withPrecision p: Double = epsilon) -> Bool {
         return abs(w - other.w) < p && normal.isEqual(to: other.normal, withPrecision: p)
     }
 }
 
-// An enum of planes along the X, Y and Z axes
-// Used internally for flattening 3D paths and polygons
+/// An enum of planes along the X, Y and Z axes
+/// Used internally for flattening 3D paths and polygons
 enum FlatteningPlane: RawRepresentable {
     case xy
     case xz

--- a/Snapshots/Euclid/Sources/Polygon.swift
+++ b/Snapshots/Euclid/Sources/Polygon.swift
@@ -37,7 +37,7 @@ public struct Polygon: Hashable {
     public let isConvex: Bool
     public var material: Material
 
-    // Used to track split/join
+    /// Used to track split/join
     var id = 0
 }
 
@@ -58,7 +58,7 @@ public extension Polygon {
     }
 
     /// Test if point lies inside the polygon
-    // https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon#218081
+    /// https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon#218081
     func containsPoint(_ p: Vector) -> Bool {
         guard plane.containsPoint(p), bounds.containsPoint(p) else {
             return false
@@ -207,8 +207,8 @@ public extension Polygon {
 }
 
 internal extension Polygon {
-    // Create polygon from vertices and face normal without performing validation
-    // Vertices may be convex or concave, but are assumed to describe a non-degenerate polygon
+    /// Create polygon from vertices and face normal without performing validation
+    /// Vertices may be convex or concave, but are assumed to describe a non-degenerate polygon
     init(
         unchecked vertices: [Vertex],
         normal: Vector,
@@ -225,9 +225,9 @@ internal extension Polygon {
         )
     }
 
-    // Create polygon from vertices and plane without performing validation
-    // Vertices may be convex or concave, but are assumed to describe a non-degenerate polygon
-    // Vertices are assumed to be in anticlockwise order for the purpose of deriving the plane
+    /// Create polygon from vertices and plane without performing validation
+    /// Vertices may be convex or concave, but are assumed to describe a non-degenerate polygon
+    /// Vertices are assumed to be in anticlockwise order for the purpose of deriving the plane
     init(
         unchecked vertices: [Vertex],
         plane: Plane? = nil,
@@ -249,7 +249,7 @@ internal extension Polygon {
         self.id = id
     }
 
-    // Join touching polygons (without checking they are coplanar or share the same material)
+    /// Join touching polygons (without checking they are coplanar or share the same material)
     func join(unchecked other: Polygon) -> Polygon? {
         assert(material == other.material)
         assert(plane.isEqual(to: other.plane))

--- a/Snapshots/Euclid/Sources/SceneKit.swift
+++ b/Snapshots/Euclid/Sources/SceneKit.swift
@@ -347,7 +347,7 @@ public extension SCNGeometry {
         )
     }
 
-    // Creates a line-segment SCNGeometry from a Path
+    /// Creates a line-segment SCNGeometry from a Path
     convenience init(_ path: Path) {
         var indexData = Data()
         var vertexData = Data()
@@ -389,7 +389,7 @@ public extension SCNGeometry {
         )
     }
 
-    // Creates a line-segment bounding-box SCNGeometry from a Bounds
+    /// Creates a line-segment bounding-box SCNGeometry from a Bounds
     convenience init(bounds: Bounds) {
         var vertexData = Data()
         for point in bounds.corners {

--- a/Snapshots/Euclid/Sources/Shapes.swift
+++ b/Snapshots/Euclid/Sources/Shapes.swift
@@ -489,8 +489,8 @@ public extension Mesh {
         case .frontAndBack:
             return Mesh(polygons + polygons.map { $0.inverted() })
         case .default:
-            // seal loose ends
-            // TODO: improve this by not adding backfaces inside closed subsectors
+            /// seal loose ends
+            /// TODO: improve this by not adding backfaces inside closed subsectors
             if let first = vertices.first?.position,
                let last = vertices.last?.position,
                first != last, first.x != 0 || last.x != 0

--- a/Snapshots/Euclid/Sources/Transforms.swift
+++ b/Snapshots/Euclid/Sources/Transforms.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 
-// a rotation matrix
+/// a rotation matrix
 public struct Rotation: Hashable {
     var m11: Double
     var m12: Double
@@ -112,7 +112,7 @@ public extension Rotation {
     }
 
     /// Define a rotation from Euler angles
-    // http://planning.cs.uiuc.edu/node102.html
+    /// http://planning.cs.uiuc.edu/node102.html
     init(pitch: Double, yaw: Double = 0, roll: Double = 0) {
         self = .pitch(pitch)
         if yaw != 0 {
@@ -143,7 +143,7 @@ public extension Rotation {
         }
     }
 
-    // http://planning.cs.uiuc.edu/node103.html
+    /// http://planning.cs.uiuc.edu/node103.html
     var pitch: Double {
         return atan2(m32, m33)
     }
@@ -191,7 +191,7 @@ public extension Rotation {
 }
 
 internal extension Rotation {
-    // http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/
+    /// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/
     init(unchecked axis: Vector, radians: Double) {
         assert(axis.isNormalized)
         let c = cos(radians)
@@ -382,7 +382,7 @@ public extension Vertex {
 }
 
 public extension Vector {
-    /// NOTE: no need for a translated() function because of the + operator
+    // NOTE: no need for a translated() function because of the + operator
 
     func rotated(by m: Rotation) -> Vector {
         return Vector(

--- a/Snapshots/Euclid/Sources/Utilities.swift
+++ b/Snapshots/Euclid/Sources/Utilities.swift
@@ -29,10 +29,10 @@
 //  SOFTWARE.
 //
 
-// Tolerance used for calculating approximate equality
+/// Tolerance used for calculating approximate equality
 let epsilon = 1e-6
 
-// Round-off floating point values to simplify equality checks
+/// Round-off floating point values to simplify equality checks
 func quantize(_ value: Double) -> Double {
     let precision = 1e-8 * 1e-3
     return (value / precision).rounded() * precision
@@ -158,7 +158,7 @@ func faceNormalForConvexPoints(_ points: [Vector]) -> Vector {
     }
 }
 
-// https://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order#1165943
+/// https://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order#1165943
 func flattenedPointsAreClockwise(_ points: [Vector]) -> Bool {
     assert(!points.contains(where: { $0.z != 0 }))
     let points = (points.first == points.last) ? points.dropLast() : [Vector].SubSequence(points)

--- a/Snapshots/Euclid/Sources/Vector.swift
+++ b/Snapshots/Euclid/Sources/Vector.swift
@@ -113,7 +113,7 @@ public extension Vector {
 }
 
 internal extension Vector {
-    // Approximate equality
+    /// Approximate equality
     func isEqual(to other: Vector, withPrecision p: Double = epsilon) -> Bool {
         return abs(x - other.x) < p && abs(y - other.y) < p && abs(z - other.z) < p
     }

--- a/Snapshots/Euclid/Sources/Vertex.swift
+++ b/Snapshots/Euclid/Sources/Vertex.swift
@@ -71,7 +71,7 @@ internal extension Vertex {
         self.texcoord = texcoord
     }
 
-    // Approximate equality
+    /// Approximate equality
     func isEqual(to other: Vertex, withPrecision p: Double = epsilon) -> Bool {
         return position.isEqual(to: other.position, withPrecision: p) &&
             normal.isEqual(to: other.normal, withPrecision: p) &&

--- a/Snapshots/Expression/Examples/REPL/main.swift
+++ b/Snapshots/Expression/Examples/REPL/main.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-// Prevent control characters confusing expression
+/// Prevent control characters confusing expression
 private let start = UnicodeScalar(63232)!
 private let end = UnicodeScalar(63235)!
 private let cursorCharacters = CharacterSet(charactersIn: start ... end)
 
-// Previously defined variables
+/// Previously defined variables
 private var variables = [String: Any]()
 
 func evaluate(_ parsed: ParsedExpression) throws -> Any {

--- a/Snapshots/Expression/Sources/AnyExpression.swift
+++ b/Snapshots/Expression/Sources/AnyExpression.swift
@@ -136,7 +136,7 @@ public struct AnyExpression: CustomStringConvertible {
         self.init(expression, impureSymbols: { _ in nil }, pureSymbols: pureSymbols)
     }
 
-    // Private initializer implementation
+    /// Private initializer implementation
     private init(
         _ expression: ParsedExpression,
         options: Options,
@@ -559,12 +559,12 @@ public struct AnyExpression: CustomStringConvertible {
                 return (AnyExpression.cast(AnyExpression.stringify(anyValue)) as T?)!
             case is Bool.Type,
                  is Bool?.Type:
-                // TODO: should we boolify numeric types like this?
+                /// TODO: should we boolify numeric types like this?
                 if let value = AnyExpression.cast(anyValue) as Double? {
                     return (value != 0) as! T
                 }
             default:
-                // TODO: should we numberify Bool values like this?
+                /// TODO: should we numberify Bool values like this?
                 if let boolValue = anyValue as? Bool,
                    let value: T = AnyExpression.cast(boolValue ? 1 : 0)
                 {
@@ -659,7 +659,7 @@ extension AnyExpression.Error {
 }
 
 extension AnyExpression {
-    // Cast a value to the specified type
+    /// Cast a value to the specified type
     static func cast<T>(_ anyValue: Any) -> T? {
         if let value = anyValue as? T {
             return value
@@ -683,11 +683,11 @@ extension AnyExpression {
         }
     }
 
-    // Convert any value to a printable string
+    /// Convert any value to a printable string
     static func stringify(_ value: Any) -> String {
         switch value {
         case let number as NSNumber:
-            // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+            /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
             switch UnicodeScalar(UInt8(number.objCType.pointee)) {
             case "c",
                  "B":
@@ -725,7 +725,7 @@ extension AnyExpression {
         }
     }
 
-    // Unwraps a potentially optional value
+    /// Unwraps a potentially optional value
     static func unwrap(_ value: Any) -> Any? {
         switch value {
         case let optional as _Optional:
@@ -740,7 +740,7 @@ extension AnyExpression {
         }
     }
 
-    // Test if a value is nil
+    /// Test if a value is nil
     static func isNil(_ value: Any) -> Bool {
         if let optional = value as? _Optional {
             guard let value = optional.value else {
@@ -751,7 +751,7 @@ extension AnyExpression {
         return value is NSNull
     }
 
-    // Test if a value supports subscripting
+    /// Test if a value supports subscripting
     static func isSubscriptable(_ value: Any) -> Bool {
         return value is _Array || value is _Dictionary || value is _String
     }
@@ -760,7 +760,7 @@ extension AnyExpression {
 // MARK: Private API
 
 private extension AnyExpression {
-    // Value storage
+    /// Value storage
     final class NanBox {
         private static let mask = (-Double.nan).bitPattern
         private static let indexOffset = 4
@@ -773,15 +773,15 @@ private extension AnyExpression {
             return UInt64(index + indexOffset) | mask
         }
 
-        // Literal values
+        /// Literal values
         public static let nilValue = Double(bitPattern: nilBits)
         public static let trueValue = Double(bitPattern: trueBits)
         public static let falseValue = Double(bitPattern: falseBits)
 
-        // The values stored in the box
+        /// The values stored in the box
         public var values = [Any]()
 
-        // Store a value in the box
+        /// Store a value in the box
         public func store(_ value: Any) -> Double {
             switch value {
             case let doubleValue as Double:
@@ -818,7 +818,7 @@ private extension AnyExpression {
             return Double(bitPattern: NanBox.bitPattern(for: values.count - 1))
         }
 
-        // Retrieve a value from the box, if it exists
+        /// Retrieve a value from the box, if it exists
         func loadIfStored(_ arg: Double) -> Any? {
             switch arg.bitPattern {
             case NanBox.nilBits:
@@ -836,13 +836,13 @@ private extension AnyExpression {
             }
         }
 
-        // Retrieve a value if it exists, else return the argument
+        /// Retrieve a value if it exists, else return the argument
         func load(_ arg: Double) -> Any {
             return loadIfStored(arg) ?? arg
         }
     }
 
-    // Standard symbols
+    /// Standard symbols
     static let standardSymbols: [Symbol: Expression.SymbolEvaluator] = [
         // Math symbols
         .variable("pi"): { _ in .pi },
@@ -854,7 +854,7 @@ private extension AnyExpression {
         .infix("??"): { $0[0].bitPattern == NanBox.nilValue.bitPattern ? $0[1] : $0[0] },
     ]
 
-    // Cast an array
+    /// Cast an array
     static func arrayCast<T>(_ anyValue: Any) -> [T]? {
         guard let array = (anyValue as? _Array).map({ $0.values }) else {
             return nil
@@ -870,7 +870,7 @@ private extension AnyExpression {
     }
 }
 
-// Used for casting numeric values
+/// Used for casting numeric values
 private protocol _Numeric {
     init(truncating: NSNumber)
 }
@@ -895,7 +895,7 @@ extension Float: _Numeric {}
     extension CGFloat: _Numeric {}
 #endif
 
-// Used for subscripting
+/// Used for subscripting
 private protocol _Range {
     func slice(of array: _Array, for symbol: Expression.Symbol) throws -> ArraySlice<Any>
     func slice(of string: _String, for symbol: Expression.Symbol) throws -> Substring
@@ -1103,7 +1103,7 @@ extension PartialRangeFrom: _Range {
 
 #endif
 
-// Used for string values
+/// Used for string values
 private protocol _String {
     var substring: Substring { get }
 }
@@ -1126,7 +1126,7 @@ extension NSString: _String {
     }
 }
 
-// Used for array values
+/// Used for array values
 private protocol _Array {
     var values: [Any] { get }
 }
@@ -1161,7 +1161,7 @@ extension NSArray: _Array {
     }
 }
 
-// Used for dictionary values
+/// Used for dictionary values
 private protocol _Dictionary {
     func value(for key: Any) -> Any?
 }
@@ -1181,7 +1181,7 @@ extension NSDictionary: _Dictionary {
     }
 }
 
-// Used to test if a value is Optional
+/// Used to test if a value is Optional
 private protocol _Optional {
     var value: Any? { get }
     static var wrappedType: Any.Type { get }

--- a/Snapshots/Expression/Sources/Expression.swift
+++ b/Snapshots/Expression/Sources/Expression.swift
@@ -445,7 +445,7 @@ public final class Expression: CustomStringConvertible {
     private static var cache = [String: Subexpression]()
     private static let queue = DispatchQueue(label: "com.Expression")
 
-    // For testing
+    /// For testing
     static func isCached(_ expression: String) -> Bool {
         return queue.sync { cache[expression] != nil }
     }
@@ -598,7 +598,7 @@ public final class Expression: CustomStringConvertible {
 // MARK: Internal API
 
 extension Expression {
-    // Fallback evaluator for when symbol is not found
+    /// Fallback evaluator for when symbol is not found
     static func errorEvaluator(for symbol: Symbol) -> SymbolEvaluator {
         switch symbol {
         case .infix(","),
@@ -628,7 +628,7 @@ private extension Expression {
         return "\(number)"
     }
 
-    // https://github.com/apple/swift-evolution/blob/master/proposals/0077-operator-precedence.md
+    /// https://github.com/apple/swift-evolution/blob/master/proposals/0077-operator-precedence.md
     static let operatorPrecedence: [String: (precedence: Int, isRightAssociative: Bool)] = {
         var precedences = [
             "[]": 100,
@@ -803,7 +803,7 @@ public struct ParsedExpression: CustomStringConvertible {
     }
 }
 
-// The internal expression implementation
+/// The internal expression implementation
 private enum Subexpression: CustomStringConvertible {
     case literal(Double)
     case symbol(Expression.Symbol, [Subexpression], Expression.SymbolEvaluator?)
@@ -972,7 +972,7 @@ private enum Subexpression: CustomStringConvertible {
 
 // MARK: Expression parsing
 
-// Workaround for horribly slow Substring.UnicodeScalarView perf
+/// Workaround for horribly slow Substring.UnicodeScalarView perf
 private struct UnicodeScalarView {
     public typealias Index = String.UnicodeScalarView.Index
 
@@ -1258,8 +1258,8 @@ private extension UnicodeScalarView {
         return .symbol(.variable(identifier), [], nil)
     }
 
-    // Note: this is not actually part of the parser, but is colocated
-    // with `parseEscapedIdentifier()` because they should be updated together
+    /// Note: this is not actually part of the parser, but is colocated
+    /// with `parseEscapedIdentifier()` because they should be updated together
     func escapedIdentifier() -> String {
         guard let delimiter = first, "`'\"".unicodeScalars.contains(delimiter) else {
             return String(self)

--- a/Snapshots/Layout/Layout/Layout.swift
+++ b/Snapshots/Layout/Layout/Layout.swift
@@ -2,8 +2,8 @@
 
 import Foundation
 
-// Internal struct used to store
-// serialized layouts
+/// Internal struct used to store
+/// serialized layouts
 public struct Layout {
     var className: String
     var id: String?

--- a/Snapshots/Layout/Layout/LayoutBacked.swift
+++ b/Snapshots/Layout/Layout/LayoutBacked.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Protocol for views or controllers that are backed by a LayoutNode
 /// Exposes the node reference so that the view can update itself
 public protocol LayoutBacked: class {
-    /* weak */ var layoutNode: LayoutNode? { get }
+    /** weak */ var layoutNode: LayoutNode? { get }
 }
 
 public extension LayoutBacked where Self: NSObject {

--- a/Snapshots/Layout/Layout/LayoutConsole.swift
+++ b/Snapshots/Layout/Layout/LayoutConsole.swift
@@ -30,7 +30,7 @@ public enum LayoutConsole {
         }
     }
 
-    // Displays a warning
+    /// Displays a warning
     public static func showWarning(_ message: String) {
         guard isEnabled else {
             print("Layout warning: \(message)")

--- a/Snapshots/Layout/Layout/LayoutError.swift
+++ b/Snapshots/Layout/Layout/LayoutError.swift
@@ -148,8 +148,8 @@ public enum LayoutError: Error, Hashable, CustomStringConvertible {
         }
     }
 
-    // Returns true if the error can be cleared, or false if the
-    // error is fundamental, and requires a code change + reload to fix it
+    /// Returns true if the error can be cleared, or false if the
+    /// error is fundamental, and requires a code change + reload to fix it
     public var isTransient: Bool {
         switch self {
         case let .generic(error, _),

--- a/Snapshots/Layout/Layout/LayoutExpression.swift
+++ b/Snapshots/Layout/Layout/LayoutExpression.swift
@@ -983,7 +983,7 @@ struct LayoutExpression {
                         self.init(evaluate: { color }, symbols: [], isConstant: true)
                         return
                     }
-                    // Attempt to interpret as a color expression
+                    /// Attempt to interpret as a color expression
                     guard let _parsedExpression = try? parseExpression(name) else {
                         throw Expression.Error.message("Invalid color name '\(name)'")
                     }
@@ -1054,7 +1054,7 @@ struct LayoutExpression {
                         self.init(evaluate: { image }, symbols: [], isConstant: true)
                         return
                     }
-                    // Attempt to interpret as an image expression
+                    /// Attempt to interpret as an image expression
                     guard let _parsedExpression = try? parseExpression(name) else {
                         throw Expression.Error.message("Invalid image name '\(name)'")
                     }
@@ -1224,7 +1224,7 @@ struct LayoutExpression {
 
     init?(outletExpression: String, for node: LayoutNode) {
         #if arch(i386) || arch(x86_64)
-            // Pre-validate expression so we can produce more useful errors
+            /// Pre-validate expression so we can produce more useful errors
             if let parts = try? parseStringExpression(outletExpression) {
                 for part in parts {
                     switch part {

--- a/Snapshots/Layout/Layout/LayoutLoader.swift
+++ b/Snapshots/Layout/Layout/LayoutLoader.swift
@@ -8,7 +8,7 @@ func clearLayoutLoaderCache() {
     cache.removeAll()
 }
 
-// Cache for previously loaded layouts
+/// Cache for previously loaded layouts
 private var cache = [URL: Layout]()
 private let queue = DispatchQueue(label: "com.Layout.LayoutLoader")
 private var reloadLock = 0
@@ -54,7 +54,7 @@ private extension Layout {
         return insertChildren(layout.children, into: result)
     }
 
-    // Insert children into hierarchy
+    /// Insert children into hierarchy
     private func insertChildren(_ children: [Layout], into layout: Layout) -> Layout {
         func _insertChildren(_ children: [Layout], into layout: inout Layout) -> Bool {
             if let index = layout.childrenTagIndex {
@@ -120,7 +120,7 @@ private extension Layout {
     }
 }
 
-// API for loading a layout XML file
+/// API for loading a layout XML file
 class LayoutLoader {
     private var _originalURL: URL!
     private var _xmlURL: URL!

--- a/Snapshots/Layout/Layout/LayoutLoading.swift
+++ b/Snapshots/Layout/Layout/LayoutLoading.swift
@@ -82,7 +82,7 @@ public extension LayoutLoading {
         }
     }
 
-    // Used by LayoutLoading protocol
+    /// Used by LayoutLoading protocol
     internal var loader: LayoutLoader {
         guard let loader = objc_getAssociatedObject(self, &loaderKey) as? LayoutLoader else {
             let loader = LayoutLoader()

--- a/Snapshots/Layout/Layout/LayoutManaged.swift
+++ b/Snapshots/Layout/Layout/LayoutManaged.swift
@@ -25,10 +25,10 @@ import Foundation
     /// Empty value string indicates no replacement available
     @objc static var deprecatedSymbols: [String: String] { get }
 
-    // Set expression value
+    /// Set expression value
     @objc func setValue(_ value: Any, forExpression name: String) throws
 
-    // Set expression value with animation (if applicable)
+    /// Set expression value with animation (if applicable)
     @objc func setAnimatedValue(_ value: Any, forExpression name: String) throws
 
     /// Get symbol value
@@ -42,7 +42,7 @@ import Foundation
     @objc func didInsertChildNode(_ node: LayoutNode, at index: Int)
 
     /// Called immediately before a child node is removed
-    // TODO: remove index argument as it isn't used
+    /// TODO: remove index argument as it isn't used
     @objc func willRemoveChildNode(_ node: LayoutNode, at index: Int)
 
     /// Called immediately after layout has been updated

--- a/Snapshots/Layout/Layout/LayoutNode+Layout.swift
+++ b/Snapshots/Layout/Layout/LayoutNode+Layout.swift
@@ -83,8 +83,8 @@ extension LayoutNode {
 }
 
 extension Layout {
-    // Experimental - extracts a layout template from an existing node
-    // TODO: this isn't a lossless conversion - find a better approach
+    /// Experimental - extracts a layout template from an existing node
+    /// TODO: this isn't a lossless conversion - find a better approach
     init(_ node: LayoutNode) {
         self.init(
             className: nameOfClass(node._class),

--- a/Snapshots/Layout/Layout/LayoutNode.swift
+++ b/Snapshots/Layout/Layout/LayoutNode.swift
@@ -49,8 +49,8 @@ public class LayoutNode: NSObject {
     /// Constants that can be referenced by expressions in the node and its children
     public internal(set) var constants: [String: Any]
 
-    // The delegate used for handling errors
-    // Normally this is the same as the owner, but it can be overridden in special cases
+    /// The delegate used for handling errors
+    /// Normally this is the same as the owner, but it can be overridden in special cases
     private weak var _delegate: LayoutDelegate?
     weak var delegate: LayoutDelegate? {
         get {
@@ -74,7 +74,7 @@ public class LayoutNode: NSObject {
     /// Global legacy rendering mode toggle - affects all LayoutNodes created after setting
     public static var useLegacyLayoutMode: Bool?
 
-    // For internal use
+    /// For internal use
     private(set) var _class: LayoutManaged.Type
     @objc var _view: UIView?
     private(set) var _viewController: UIViewController?
@@ -85,7 +85,7 @@ public class LayoutNode: NSObject {
     var _macros: [String: String]
     var rootURL: URL?
 
-    // Same as viewControllers, but won't instantiate uninitialized controllers
+    /// Same as viewControllers, but won't instantiate uninitialized controllers
     private var _viewControllers: [UIViewController] {
         guard let viewController = _viewController else {
             return children.flatMap { $0._viewControllers }
@@ -113,7 +113,7 @@ public class LayoutNode: NSObject {
     // once these are set up, they won't be reset by a cleanUp(), so anything that
     // may effect them (such as adding children), must be done again
 
-    // Note: Thrown error is always a LayoutError
+    /// Note: Thrown error is always a LayoutError
     private var _setupComplete = false
     private func completeSetup() throws {
         guard !_setupComplete else { return }
@@ -211,7 +211,7 @@ public class LayoutNode: NSObject {
         _stopObservingFrame()
     }
 
-    // Depends on presence of parent - must be called again if parent is added or removed
+    /// Depends on presence of parent - must be called again if parent is added or removed
     private func updateObservers() {
         if parent != nil {
             _stopObservingContentSizeCategory()
@@ -258,7 +258,7 @@ public class LayoutNode: NSObject {
         }
     }
 
-    // called by UITableView/UICollectionView as cells are loaded
+    /// called by UITableView/UICollectionView as cells are loaded
     private var _anyExpressionDependsOnContentSize: Bool?
     internal func contentSizeChanged() {
         if _anyExpressionDependsOnContentSize == nil {
@@ -299,8 +299,8 @@ public class LayoutNode: NSObject {
         update()
     }
 
-    // Create the node using a UIView or UIViewController subclass
-    // TODO: is there any reason not to make this public?
+    /// Create the node using a UIView or UIViewController subclass
+    /// TODO: is there any reason not to make this public?
     init(
         class: AnyClass,
         id: String? = nil,
@@ -576,7 +576,7 @@ public class LayoutNode: NSObject {
         return errors
     }
 
-    // Find an the appropriate target object for a given selector
+    /// Find an the appropriate target object for a given selector
     private func target(for selector: Selector) -> LayoutDelegate? {
         var delegate = self.delegate
         var responder = delegate as? UIResponder
@@ -640,7 +640,7 @@ public class LayoutNode: NSObject {
         delegate.layoutError(error)
     }
 
-    // Attempt a throwing operation but catch the error and bubble it up the Layout hierarchy
+    /// Attempt a throwing operation but catch the error and bubble it up the Layout hierarchy
     func attempt<T>(_ closure: () throws -> T) -> T? {
         do {
             return try closure()
@@ -782,7 +782,7 @@ public class LayoutNode: NSObject {
         return next
     }
 
-    // Find a node by id, starting with the children and then progressing to siblings and parents
+    /// Find a node by id, starting with the children and then progressing to siblings and parents
     func node(withID id: String, excluding: LayoutNode? = nil) -> LayoutNode? {
         attempt(completeSetup)
         if self.id == id {
@@ -863,7 +863,7 @@ public class LayoutNode: NSObject {
         }
     }
 
-    // Experimental - used for nested XML reference loading
+    /// Experimental - used for nested XML reference loading
     internal func update(with layout: Layout) throws {
         let _newClass: AnyClass = try layout.getClass()
         let oldClass = _class
@@ -964,7 +964,7 @@ public class LayoutNode: NSObject {
 
     // MARK: expressions
 
-    // Depends on presence of parent - must be called again if parent is added or removed
+    /// Depends on presence of parent - must be called again if parent is added or removed
     private func overrideExpressions() {
         assert(_setupComplete && !_expressionsSetUp && _view != nil)
         expressions = _originalExpressions
@@ -1070,14 +1070,14 @@ public class LayoutNode: NSObject {
     private var _valueClearers = [() -> Void]()
     private var _valueHasChanged = [String: () -> Bool]()
 
-    // Note: thrown error is always a SymbolError
+    /// Note: thrown error is always a SymbolError
     private var _updateExpressionValues: (_ animated: Bool) throws -> Void = { _ in }
 
     private lazy var constructorArgumentTypes: [String: RuntimeType] =
         self.viewControllerClass?.parameterTypes ?? self.viewClass.parameterTypes
 
-    // Returns all expressions that can be set on the node
-    // Used for generating error suggestions
+    /// Returns all expressions that can be set on the node
+    /// Used for generating error suggestions
     lazy var availableExpressions: Set<String> = {
         var expressions = layoutSymbols
         expressions.formUnion(["outlet", "id", "xml", "template"])
@@ -1106,7 +1106,7 @@ public class LayoutNode: NSObject {
         return matches
     }
 
-    // Returns all symbols that can be referenced in an expression
+    /// Returns all symbols that can be referenced in an expression
     func availableSymbols(forExpression name: String) -> Set<String> {
         var symbols = Set(layoutSymbols)
         let type: RuntimeType
@@ -1164,7 +1164,7 @@ public class LayoutNode: NSObject {
         return symbols
     }
 
-    // Note: thrown error is always a SymbolError
+    /// Note: thrown error is always a SymbolError
     private func setUpExpression(for symbol: String) throws {
         guard _getters[symbol] == nil, let string = expressions[symbol], !_evaluating.contains(symbol) else {
             return
@@ -1264,7 +1264,7 @@ public class LayoutNode: NSObject {
                     case "contentSize.height":
                         expression = LayoutExpression(contentHeightExpression: string, for: self)
                     default:
-                        // Allow use of % in any vertical/horizontal property expression
+                        /// Allow use of % in any vertical/horizontal property expression
                         let parts = symbol.components(separatedBy: ".")
                         if ["left", "right", "x", "width"].contains(parts.last!) {
                             expression = LayoutExpression(xExpression: string, for: self)
@@ -1363,7 +1363,7 @@ public class LayoutNode: NSObject {
         return keys
     }
 
-    // Note: thrown error is always a LayoutError
+    /// Note: thrown error is always a LayoutError
     private var _settingUpExpressions = false
     private var _expressionsSetUp = false
     private func setUpExpressions() throws {
@@ -1450,7 +1450,7 @@ public class LayoutNode: NSObject {
         return string
     }
 
-    // Note: thrown error is always a SymbolError
+    /// Note: thrown error is always a SymbolError
     private func value(forParameter name: String) throws -> Any? {
         guard _parameters[name] != nil else {
             return nil
@@ -1500,7 +1500,7 @@ public class LayoutNode: NSObject {
         return nil
     }
 
-    // Used by LayoutExpression
+    /// Used by LayoutExpression
     func constantValue(forSymbol symbol: String) throws -> Any? {
         if symbolIsConstant(symbol) {
             guard !_evaluating.contains(symbol) else {
@@ -1535,7 +1535,7 @@ public class LayoutNode: NSObject {
         return true
     }
 
-    // Returns true if symbol is a constant, false if it's a variable, otherwise nil
+    /// Returns true if symbol is a constant, false if it's a variable, otherwise nil
     private func valueIsConstant(_ symbol: String) -> Bool? {
         attempt(completeSetup)
         do {
@@ -1593,7 +1593,7 @@ public class LayoutNode: NSObject {
         return false
     }
 
-    // Doesn't look up params defined directly on the callee, only its parents
+    /// Doesn't look up params defined directly on the callee, only its parents
     private func value(forVariableOrConstantOrParentParameter name: String) throws -> Any? {
         assert(_setupComplete)
         return try value(forKeyPath: name, in: _variables) ??
@@ -1686,8 +1686,8 @@ public class LayoutNode: NSObject {
         return false
     }
 
-    // Used by LayoutExpression and for unit tests
-    // Note: thrown error is always a SymbolError
+    /// Used by LayoutExpression and for unit tests
+    /// Note: thrown error is always a SymbolError
     func doubleValue(forSymbol symbol: String) throws -> Double {
         let anyValue = try value(forSymbol: symbol)
         if let doubleValue = anyValue as? Double {
@@ -1702,7 +1702,7 @@ public class LayoutNode: NSObject {
         throw SymbolError("\(symbol) is not a number", for: symbol)
     }
 
-    // Note: thrown error is always a SymbolError
+    /// Note: thrown error is always a SymbolError
     private func cgFloatValue(forSymbol symbol: String) throws -> CGFloat {
         let anyValue = try value(forSymbol: symbol)
         if let cgFloatValue = anyValue as? CGFloat {
@@ -1728,8 +1728,8 @@ public class LayoutNode: NSObject {
         return nil
     }
 
-    // Used by LayoutExpression and for unit tests
-    // Note: thrown error is always a SymbolError
+    /// Used by LayoutExpression and for unit tests
+    /// Note: thrown error is always a SymbolError
     func value(forSymbol symbol: String) throws -> Any {
         if let getter = _getters[symbol] {
             return try getter()
@@ -2292,7 +2292,7 @@ public class LayoutNode: NSObject {
     }
 
     /// The anticipated frame for the view, based on the current state
-    // TODO: should this be public?
+    /// TODO: should this be public?
     public var frame: CGRect {
         return attempt {
             CGRect(
@@ -2724,13 +2724,13 @@ public class LayoutNode: NSObject {
         )
     }
 
-    // AutoLayout support
+    /// AutoLayout support
     private var _topConstraint: NSLayoutConstraint?
     private var _leftConstraint: NSLayoutConstraint?
     private var _widthConstraint: NSLayoutConstraint?
     private var _heightConstraint: NSLayoutConstraint?
 
-    // Depends on parent view - must be called again if parent view changes
+    /// Depends on parent view - must be called again if parent view changes
     private func setUpPositionConstraints() {
         assert(_topConstraint == nil)
         if let parentView = parent?._view, !(parentView is UIStackView) {
@@ -2741,7 +2741,7 @@ public class LayoutNode: NSObject {
         }
     }
 
-    // Prevent `update()` from being called when making changes to view properties, etc
+    /// Prevent `update()` from being called when making changes to view properties, etc
     private var _updateLock = 0
     func performWithoutUpdate(_ block: () throws -> Void) rethrows {
         defer { _updateLock -= 1 }
@@ -2749,7 +2749,7 @@ public class LayoutNode: NSObject {
         try block()
     }
 
-    // Note: thrown error is always a LayoutError
+    /// Note: thrown error is always a LayoutError
     private func updateValues(animated: Bool) throws {
         guard _updateLock == 0 else { return }
         defer { _updateLock -= 1 }
@@ -2764,7 +2764,7 @@ public class LayoutNode: NSObject {
         }, for: self)
     }
 
-    // Note: thrown error is always a LayoutError
+    /// Note: thrown error is always a LayoutError
     private func updateFrame() throws {
         guard _updateLock == 0, let _view = _view, !(_view is UITabBar) else { return }
         let frame: CGRect
@@ -2956,7 +2956,7 @@ public class LayoutNode: NSObject {
 
             let viewsAndOutlets = viewsAndOutlets ?? NSMutableSet()
 
-            // Check if this view controller instance has already been used
+            /// Check if this view controller instance has already been used
             if let controller = viewController {
                 if viewsAndOutlets.contains(controller) {
                     throw LayoutError("Duplicate \(controller.classForCoder) instance in Layout hierarchy", for: self)
@@ -2972,7 +2972,7 @@ public class LayoutNode: NSObject {
                 viewsAndOutlets.add(view)
             }
 
-            // Check if an outlet with this name has already been bound
+            /// Check if an outlet with this name has already been bound
             if let outlet = outlet {
                 if viewsAndOutlets.contains(outlet) {
                     throw LayoutError("Duplicate outlet reference '\(outlet)'", for: self)
@@ -3130,7 +3130,7 @@ private extension UIView {
         viewSwizzled = true
     }
 
-    // Swizzled layoutSubviews implementation
+    /// Swizzled layoutSubviews implementation
     @objc private func layout_layoutSubviews() {
         layout_layoutSubviews()
         _layoutNode?.updateLayout()

--- a/Snapshots/Layout/Layout/Properties.swift
+++ b/Snapshots/Layout/Layout/Properties.swift
@@ -197,13 +197,13 @@ extension NSObject {
         return allProperties
     }
 
-    // Safe version of `setValue(forKeyPath:)`
-    // Checks that the property exists, and is settable, but doesn't validate the type
+    /// Safe version of `setValue(forKeyPath:)`
+    /// Checks that the property exists, and is settable, but doesn't validate the type
     func _setValue(_ value: Any, ofType type: RuntimeType?, forKey key: String) throws {
         _ = try _setValue(value, ofType: type, forKey: key, animated: false)
     }
 
-    // Animated version of `_setValue(_:ofType:forKey:)`
+    /// Animated version of `_setValue(_:ofType:forKey:)`
     func _setValue(_ value: Any, ofType type: RuntimeType?, forKey key: String, animated: Bool) throws -> Bool {
         if let setter = type?.setter {
             try setter(self, key, value)
@@ -306,8 +306,8 @@ extension NSObject {
         return true
     }
 
-    // Safe version of setValue(forKeyPath:)
-    // Checks that the property exists, and is settable, but doesn't validate the type
+    /// Safe version of setValue(forKeyPath:)
+    /// Checks that the property exists, and is settable, but doesn't validate the type
     func _setValue(_ value: Any, ofType type: RuntimeType?, forKeyPath name: String) throws {
         guard let range = name.range(of: ".", options: .backwards) else {
             try _setValue(value, ofType: type, forKey: name)

--- a/Snapshots/Layout/Layout/ReloadManager.swift
+++ b/Snapshots/Layout/Layout/ReloadManager.swift
@@ -10,7 +10,7 @@ class ReloadManager {
         weak var observer: LayoutLoading?
     }
 
-    // Useful for testing
+    /// Useful for testing
     static var observers: [LayoutLoading] {
         return boxes.compactMap { $0.observer }
     }

--- a/Snapshots/Layout/Layout/RuntimeType.swift
+++ b/Snapshots/Layout/Layout/RuntimeType.swift
@@ -558,7 +558,7 @@ public class RuntimeType: NSObject {
     }
 }
 
-// Return the human-readable name, without braces or underscores, etc
+/// Return the human-readable name, without braces or underscores, etc
 private func sanitizedStructName(_ objCType: String) -> String {
     guard let equalRange = objCType.range(of: "="),
           let braceRange = objCType.range(of: "{")
@@ -574,7 +574,7 @@ private func sanitizedStructName(_ objCType: String) -> String {
     }
 }
 
-// Converts type name to appropriate selector for lookup on RuntimeType
+/// Converts type name to appropriate selector for lookup on RuntimeType
 func sanitizedTypeName(_ typeName: String) -> String {
     var tail = Substring(typeName)
     var head = tail.popFirst().map { String($0.lowercased()) } ?? ""

--- a/Snapshots/Layout/Layout/Shared/ExpressionParser.swift
+++ b/Snapshots/Layout/Layout/Shared/ExpressionParser.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// Standard library symbols
+/// Standard library symbols
 let standardSymbols = Set(Expression.mathSymbols.keys).union(Expression.boolSymbols.keys).union([
     .infix("??"),
     .postfix("%"),
@@ -63,7 +63,7 @@ extension Array where Element == ParsedExpressionPart {
     }
 }
 
-// NOTE: it is not safe to access this concurrently from multiple threads due to cache
+/// NOTE: it is not safe to access this concurrently from multiple threads due to cache
 private var _expressionCache = [String: ParsedLayoutExpression]()
 func parseExpression(_ expression: String) throws -> ParsedLayoutExpression {
     if let parsedExpression = _expressionCache[expression] {
@@ -101,7 +101,7 @@ func parseExpression(_ expression: String) throws -> ParsedLayoutExpression {
     return parsedLayoutExpression
 }
 
-// NOTE: it is not safe to access this concurrently from multiple threads due to cache
+/// NOTE: it is not safe to access this concurrently from multiple threads due to cache
 private var _stringExpressionCache = [String: [ParsedExpressionPart]]()
 func parseStringExpression(_ expression: String) throws -> [ParsedExpressionPart] {
     if let parts = _stringExpressionCache[expression] {

--- a/Snapshots/Layout/Layout/Shared/Files.swift
+++ b/Snapshots/Layout/Layout/Shared/Files.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// An error relating to files or file parsing
+/// An error relating to files or file parsing
 struct FileError: Error, CustomStringConvertible {
     let message: String
     let file: URL
@@ -35,10 +35,10 @@ struct FileError: Error, CustomStringConvertible {
     }
 }
 
-// Name of the Layout ignore file
+/// Name of the Layout ignore file
 let layoutIgnoreFile = ".layout-ignore"
 
-// Parses a `.layout-ignore` file and returns the paths as URLs
+/// Parses a `.layout-ignore` file and returns the paths as URLs
 func parseIgnoreFile(_ file: URL) throws -> [URL] {
     let data = try FileError.wrap({ try Data(contentsOf: file) }, for: file)
     guard let string = String(data: data, encoding: .utf8) else {

--- a/Snapshots/Layout/Layout/Shared/Shared.swift
+++ b/Snapshots/Layout/Layout/Shared/Shared.swift
@@ -1,16 +1,16 @@
 //  Copyright © 2017 Schibsted. All rights reserved.
 
-// Expressions that affect layout
-// These are common to every Layout node
-// These are all of type CGFloat, apart from `center` which is a CGPoint
+/// Expressions that affect layout
+/// These are common to every Layout node
+/// These are all of type CGFloat, apart from `center` which is a CGPoint
 let layoutSymbols: Set<String> = [
     "left", "right", "leading", "trailing",
     "width", "top", "bottom", "height", "center",
     "center.x", "center.y", "firstBaseline", "lastBaseline",
 ]
 
-// HTML tags that should not contain children
-// http://w3c.github.io/html/syntax.html#void-elements
+/// HTML tags that should not contain children
+/// http://w3c.github.io/html/syntax.html#void-elements
 let emptyHTMLTags: Set<String> = [
     "area", "base", "br", "col", "embed", "hr",
     "img", "input", "link", "meta", "param",

--- a/Snapshots/Layout/Layout/TitleTextAttributes.swift
+++ b/Snapshots/Layout/Layout/TitleTextAttributes.swift
@@ -2,8 +2,8 @@
 
 import UIKit
 
-// Common attributes shared by any view with a titleTextAttributes property
-// The purpose of this protocol is to ensure consistent support between components
+/// Common attributes shared by any view with a titleTextAttributes property
+/// The purpose of this protocol is to ensure consistent support between components
 @objc protocol TitleTextAttributes {
     var titleColor: UIColor? { get set }
     var titleFont: UIFont? { get set }

--- a/Snapshots/Layout/Layout/UIFont+Layout.swift
+++ b/Snapshots/Layout/Layout/UIFont+Layout.swift
@@ -20,8 +20,8 @@ private let weightsBySuffix: [(String, UIFont.Weight)] = [
 ]
 
 extension UIFont {
-    // This is the actual default font size on iOS
-    // which is not the same as reported by `UIFont.systemFontSize`
+    /// This is the actual default font size on iOS
+    /// which is not the same as reported by `UIFont.systemFontSize`
     static let defaultSize: CGFloat = 17
 
     struct RelativeSize {

--- a/Snapshots/Layout/Layout/UITableView+Layout.swift
+++ b/Snapshots/Layout/Layout/UITableView+Layout.swift
@@ -469,7 +469,7 @@ public extension UITableView {
 }
 
 private class LayoutTableViewHeaderFooterView: UITableViewHeaderFooterView {
-    // TODO: it looks like UITableView doesn't use this for auto-sizing sections header/footer - remove it?
+    /// TODO: it looks like UITableView doesn't use this for auto-sizing sections header/footer - remove it?
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
         if let layoutNode = layoutNode {
             let height = (try? layoutNode.doubleValue(forSymbol: "height")) ?? 0

--- a/Snapshots/Layout/Layout/UIView+Layout.swift
+++ b/Snapshots/Layout/Layout/UIView+Layout.swift
@@ -190,7 +190,7 @@ extension UIView: LayoutManaged {
         return [:]
     }
 
-    // Return the best available VC for computing the layout guide
+    /// Return the best available VC for computing the layout guide
     var _layoutGuideController: UIViewController? {
         let viewController = self.viewController
         return viewController?.navigationController?.topViewController ??
@@ -223,7 +223,7 @@ extension UIView: LayoutManaged {
         }
     }
 
-    // Set expression value
+    /// Set expression value
     @objc open func setValue(_ value: Any, forExpression name: String) throws {
         if #available(iOS 11.0, *) {} else {
             let ltr = (_effectiveUserInterfaceLayoutDirection == .leftToRight)
@@ -271,7 +271,7 @@ extension UIView: LayoutManaged {
         }
     }
 
-    // Set expression value with animation (if applicable)
+    /// Set expression value with animation (if applicable)
     @objc open func setAnimatedValue(_ value: Any, forExpression name: String) throws {
         let type = Swift.type(of: self).cachedExpressionTypes[name]
         if try !_setValue(value, ofType: type, forKey: name, animated: true) {
@@ -354,7 +354,7 @@ extension UIView: LayoutManaged {
     }
 
     /// Called immediately before a child node is removed
-    // TODO: remove index argument as it isn't used
+    /// TODO: remove index argument as it isn't used
     @objc open func willRemoveChildNode(_ node: LayoutNode, at _: Int) {
         if node._view == nil { return }
         for controller in node.viewControllers {

--- a/Snapshots/Layout/Layout/UIViewController+Layout.swift
+++ b/Snapshots/Layout/Layout/UIViewController+Layout.swift
@@ -257,7 +257,7 @@ extension UIViewController: LayoutManaged {
         return [:]
     }
 
-    // Set expression value
+    /// Set expression value
     @objc open func setValue(_ value: Any, forExpression name: String) throws {
         switch name {
         case "tabBarItem.title":
@@ -301,7 +301,7 @@ extension UIViewController: LayoutManaged {
         }
     }
 
-    // Set expression value with animation (if applicable)
+    /// Set expression value with animation (if applicable)
     @objc open func setAnimatedValue(_ value: Any, forExpression name: String) throws {
         let type = Swift.type(of: self).cachedExpressionTypes[name]
         if try !_setValue(value, ofType: type, forKey: name, animated: true) {
@@ -657,7 +657,7 @@ extension UINavigationController {
     }
 }
 
-// TODO: better support for alert actions and text fields
+/// TODO: better support for alert actions and text fields
 extension UIAlertController {
     open override class var expressionTypes: [String: RuntimeType] {
         var types = super.expressionTypes

--- a/Snapshots/Layout/Layout/Utilities.swift
+++ b/Snapshots/Layout/Layout/Utilities.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 
-// Flatten an array of dictionaries
+/// Flatten an array of dictionaries
 func merge(_ dictionaries: [[String: Any]]) -> [String: Any] {
     var result = [String: Any]()
     for dict in dictionaries {
@@ -16,12 +16,12 @@ func merge(_ dictionaries: [[String: Any]]) -> [String: Any] {
 private let classPrefix = (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "")
     .replacingOccurrences(of: "[^a-zA-Z0-9_]", with: "_", options: .regularExpression)
 
-// Get a class by name, adding project prefix if needed
+/// Get a class by name, adding project prefix if needed
 func classFromString(_ name: String) -> AnyClass? {
     return NSClassFromString(name) ?? NSClassFromString("\(classPrefix).\(name)")
 }
 
-// Get the name of a class, without project prefix
+/// Get the name of a class, without project prefix
 func nameOfClass(_ name: AnyClass) -> String {
     let name = NSStringFromClass(name)
     let prefix = "\(classPrefix)."
@@ -31,12 +31,12 @@ func nameOfClass(_ name: AnyClass) -> String {
     return name
 }
 
-// Get a protocol by name
+/// Get a protocol by name
 func protocolFromString(_ name: String) -> Protocol? {
     return NSProtocolFromString(name) ?? NSProtocolFromString("\(classPrefix).\(name)")
 }
 
-// Internal API for converting a path to a full URL
+/// Internal API for converting a path to a full URL
 func urlFromString(_ path: String, relativeTo baseURL: URL? = nil) -> URL {
     if path.hasPrefix("~") {
         let path = path.removingPercentEncoding ?? path
@@ -61,7 +61,7 @@ func urlFromString(_ path: String, relativeTo baseURL: URL? = nil) -> URL {
     }
 }
 
-// Internal API for overriding built-in methods
+/// Internal API for overriding built-in methods
 func replace(_ sela: Selector, of cls: AnyClass, with selb: Selector) {
     let swizzledMethod = class_getInstanceMethod(cls, selb)!
     let originalMethod = class_getInstanceMethod(cls, sela)!

--- a/Snapshots/Layout/LayoutTests/Loading/LayoutViewControllerTests.swift
+++ b/Snapshots/Layout/LayoutTests/Loading/LayoutViewControllerTests.swift
@@ -13,7 +13,7 @@ private func url(forXml name: String) throws -> URL {
 }
 
 class LayoutViewControllerTests: XCTestCase {
-    // Test class which overrides layoutDidLoad(_:)
+    /// Test class which overrides layoutDidLoad(_:)
     private class TestLayoutViewController: UIViewController, LayoutLoading {
         var layoutDidLoadLayoutNode: LayoutNode?
         var layoutDidLoadLayoutNodeCallCount = 0

--- a/Snapshots/Layout/LayoutTool/Common.swift
+++ b/Snapshots/Layout/LayoutTool/Common.swift
@@ -214,7 +214,7 @@ func parseLayoutXML(_ fileURL: URL) throws -> [XMLNode]? {
     return try parseLayoutXML(data, for: fileURL)
 }
 
-// Currently only used for testing
+/// Currently only used for testing
 func parseXML(_ xml: String) throws -> [XMLNode] {
     guard let data = xml.data(using: .utf8, allowLossyConversion: true) else {
         throw FormatError.parsing("Invalid xml string")
@@ -242,7 +242,7 @@ func list(_ files: [String]) -> [FormatError] {
     return errors.map(FormatError.init)
 }
 
-// Determines if given type should be treated as a string expression
+/// Determines if given type should be treated as a string expression
 func isStringType(_ name: String) -> Bool {
     return [
         "String", "NSString",
@@ -255,7 +255,7 @@ func isStringType(_ name: String) -> Bool {
     ].contains(name)
 }
 
-// Returns the type name of an attribute in a node, or nil if uncertain
+/// Returns the type name of an attribute in a node, or nil if uncertain
 func typeOfAttribute(_ key: String, inNode node: XMLNode) -> String? {
     func typeForClass(_ className: String) -> String? {
         switch key {
@@ -270,7 +270,7 @@ func typeOfAttribute(_ key: String, inNode node: XMLNode) -> String? {
         case _ where layoutSymbols.contains(key):
             return "CGFloat"
         default:
-            // Look up the type
+            /// Look up the type
             if let props = UIKitSymbols[className] {
                 if let type = props[key] {
                     return type
@@ -322,8 +322,8 @@ func typeOfAttribute(_ key: String, inNode node: XMLNode) -> String? {
     return typeForClass(className)
 }
 
-// Determines if given attribute should be treated as a string expression
-// Returns true or false if reasonably certain, otherwise returns nil
+/// Determines if given attribute should be treated as a string expression
+/// Returns true or false if reasonably certain, otherwise returns nil
 func attributeIsString(_ key: String, inNode node: XMLNode) -> Bool? {
     guard let type = typeOfAttribute(key, inNode: node) else {
         return nil
@@ -342,7 +342,7 @@ func attributeIsString(_ key: String, inNode node: XMLNode) -> Bool? {
     }
 }
 
-// Check that the expression symbols are valid (or at least plausible)
+/// Check that the expression symbols are valid (or at least plausible)
 func validateLayoutExpression(_ parsedExpression: ParsedLayoutExpression) throws {
     if let error = parsedExpression.error, error != .unexpectedToken("") {
         throw error

--- a/Snapshots/Layout/LayoutTool/Formatter.swift
+++ b/Snapshots/Layout/LayoutTool/Formatter.swift
@@ -120,7 +120,7 @@ extension Collection where Iterator.Element == XMLNode {
     }
 }
 
-// Threshold for min number of attributes to begin linewrapping
+/// Threshold for min number of attributes to begin linewrapping
 private let attributeWrap = 2
 
 extension XMLNode {

--- a/Snapshots/Layout/LayoutTool/main.swift
+++ b/Snapshots/Layout/LayoutTool/main.swift
@@ -125,6 +125,6 @@ func processArguments(_ args: [String]) -> ExitResult {
     }
 }
 
-// Pass in arguments and exit
+/// Pass in arguments and exit
 let result = processArguments(CommandLine.arguments)
 exit(result.rawValue)

--- a/Snapshots/Sprinter/Sources/Sprinter.swift
+++ b/Snapshots/Sprinter/Sources/Sprinter.swift
@@ -106,7 +106,7 @@ public struct FormatString {
         case size = "z"
         case ptrdiff = "t"
         case longDouble = "L"
-        // Apple-specific
+        /// Apple-specific
         case quadword = "q" // equivalent to ll
 
         fileprivate init?(_ input: inout String.UnicodeScalarView.SubSequence) {
@@ -161,7 +161,7 @@ public struct FormatString {
         case wideChar = "C" // equivalent to lc
         case wideString = "S" // equivalent to ls
         case percentChar = "%"
-        // Apple-specific
+        /// Apple-specific
         case uppercaseDecimal = "D" // equivalent to d
         case uppercaseOctal = "O" // equivalent to o
         case uppercaseUnsigned = "U" // equivalent to u
@@ -582,11 +582,11 @@ public struct FormatString {
         }
     }
 
-    // Internal representation
+    /// Internal representation
     let locale: Locale?
     let tokens: [Token]
 
-    // Just the placeholder values - useful for testing
+    /// Just the placeholder values - useful for testing
     var placeholders: [Placeholder] {
         return tokens.flatMap { (token: Token) -> [Placeholder] in
             if case let .placeholder(placeholder) = token {

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1474,7 +1474,7 @@ private struct Examples {
     + extension Reducer<FooState, FooAction, FooEnvironment> {}
     ```
     """
-    
+
     let docComments = """
     ```diff
     - // A placeholder type used to demonstrate syntax rules

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1474,4 +1474,19 @@ private struct Examples {
     + extension Reducer<FooState, FooAction, FooEnvironment> {}
     ```
     """
+    
+    let docComments = """
+    ```diff
+    - // A placeholder type used to demonstrate syntax rules
+    + /// A placeholder type used to demonstrate syntax rules
+      class Foo {
+    -     // This function doesn't really do anything
+    +     /// This function doesn't really do anything
+          func bar() {
+    -         /// TODO: implement Foo.bar() algorithm
+    +         // TODO: implement Foo.bar() algorithm
+          }
+      }
+    ```
+    """
 }

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -69,6 +69,9 @@ public class Formatter: NSObject {
         return true
     }
 
+    /// Directives that can be used in comments, e.g. `// swiftformat:disable rule`
+    let directives = ["disable", "enable", "options", "sort"]
+
     // Process a comment token (which may contain directives)
     func processCommentBody(_ comment: String, at index: Int) {
         var prefix = "swiftformat:"
@@ -76,7 +79,7 @@ public class Formatter: NSObject {
             return
         }
         let comment = String(comment[range.upperBound...])
-        guard let directive = ["disable", "enable", "options", "sort"].first(where: {
+        guard let directive = directives.first(where: {
             comment.hasPrefix($0)
         }) else {
             let parts = comment.components(separatedBy: ":")

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1915,14 +1915,31 @@ extension Token {
     ///  - Notable exceptions are `class func` and symbol imports (like `import class Module.Type`)
     ///    which will include two of these keywords.
     var isDeclarationTypeKeyword: Bool {
+        isDeclarationTypeKeyword(excluding: [])
+    }
+
+    /// Whether or not this token "defines" the specific type of declaration
+    ///  - A valid declaration will usually include exactly one of these keywords in its outermost scope.
+    ///  - Notable exceptions are `class func` and symbol imports (like `import class Module.Type`)
+    ///    which will include two of these keywords.
+    func isDeclarationTypeKeyword(excluding keywordsToExclude: [String]) -> Bool {
         guard case let .keyword(keyword) = self else {
             return false
         }
+
         // All of the keywords that map to individual Declaration grammars
         // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_declaration
-        return ["import", "let", "var", "typealias", "func", "enum", "case",
-                "struct", "class", "actor", "protocol", "init", "deinit",
-                "extension", "subscript", "operator", "precedencegroup"].contains(keyword)
+        var declarationTypeKeywords = Set<String>([
+            "import", "let", "var", "typealias", "func", "enum", "case",
+            "struct", "class", "actor", "protocol", "init", "deinit",
+            "extension", "subscript", "operator", "precedencegroup",
+        ])
+
+        for keywordToExclude in keywordsToExclude {
+            declarationTypeKeywords.remove(keywordToExclude)
+        }
+
+        return declarationTypeKeywords.contains(keyword)
     }
 
     var isModifierKeyword: Bool {

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -121,8 +121,8 @@ class FormatterTests: XCTestCase {
     }
 
     func testDirectiveInMiddleOfComment() {
-        let input = "//fixme: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5;"
-        let output = "// FIXME: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5\n"
+        let input = "///fixme: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5;"
+        let output = "/// FIXME: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5\n"
         XCTAssertEqual(try format(input, rules: FormatRules.default), output)
     }
 

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -364,27 +364,27 @@ class GeneralTests: RulesTests {
     // MARK: - fileHeader
 
     func testStripHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n// func\nfunc foo() {}"
-        let output = "// func\nfunc foo() {}"
+        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
+        let output = "/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
     func testMultilineCommentHeader() {
-        let input = "/****************************/\n/* Created by Nick Lockwood */\n/****************************/\n\n\n// func\nfunc foo() {}"
-        let output = "// func\nfunc foo() {}"
+        let input = "/****************************/\n/* Created by Nick Lockwood */\n/****************************/\n\n\n/// func\nfunc foo() {}"
+        let output = "/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
     func testNoStripHeaderWhenDisabled() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n// func\nfunc foo() {}"
+        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: .ignore)
         testFormatting(for: input, rule: FormatRules.fileHeader, options: options)
     }
 
     func testNoStripComment() {
-        let input = "\n// func\nfunc foo() {}"
+        let input = "\n/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: FormatRules.fileHeader, options: options)
     }
@@ -415,22 +415,22 @@ class GeneralTests: RulesTests {
     }
 
     func testSetSingleLineHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n// func\nfunc foo() {}"
-        let output = "// Hello World\n\n// func\nfunc foo() {}"
+        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
+        let output = "// Hello World\n\n/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "// Hello World")
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
     func testSetMultilineHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n// func\nfunc foo() {}"
-        let output = "// Hello\n// World\n\n// func\nfunc foo() {}"
+        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
+        let output = "// Hello\n// World\n\n/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "// Hello\n// World")
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
     func testSetMultilineHeaderWithMarkup() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n// func\nfunc foo() {}"
-        let output = "/*--- Hello ---*/\n/*--- World ---*/\n\n// func\nfunc foo() {}"
+        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
+        let output = "/*--- Hello ---*/\n/*--- World ---*/\n\n/// func\nfunc foo() {}"
         let options = FormatOptions(fileHeader: "/*--- Hello ---*/\n/*--- World ---*/")
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
@@ -450,7 +450,7 @@ class GeneralTests: RulesTests {
     func testNoStripHeaderDocWithNewlineBeforeCode() {
         let input = "/// Header doc\n\nclass Foo {}"
         let options = FormatOptions(fileHeader: "")
-        testFormatting(for: input, rule: FormatRules.fileHeader, options: options)
+        testFormatting(for: input, rule: FormatRules.fileHeader, options: options, exclude: ["docComments"])
     }
 
     func testNoDuplicateHeaderIfMissingTrailingBlankLine() {

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -1126,7 +1126,7 @@ class IndentTests: RulesTests {
     }
 
     func testNoIndentAfterDefaultAsIdentifier() {
-        let input = "let foo = FileManager.default\n// Comment\nlet bar = 0"
+        let input = "let foo = FileManager.default\n/// Comment\nlet bar = 0"
         testFormatting(for: input, rule: FormatRules.indent)
     }
 
@@ -2189,7 +2189,7 @@ class IndentTests: RulesTests {
 
     func testNestedCommentIndenting2() {
         let input = """
-        /**
+        /*
         Some description;
         ```
         func foo() {
@@ -2199,7 +2199,7 @@ class IndentTests: RulesTests {
         */
         """
         let output = """
-        /**
+        /*
          Some description;
          ```
          func foo() {

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -484,8 +484,8 @@ class LinebreakTests: RulesTests {
     }
 
     func testBlankLineBetweenFunctionsIsBeforeComment() {
-        let input = "func foo() {\n}\n// headerdoc\nfunc bar() {\n}"
-        let output = "func foo() {\n}\n\n// headerdoc\nfunc bar() {\n}"
+        let input = "func foo() {\n}\n/// headerdoc\nfunc bar() {\n}"
+        let output = "func foo() {\n}\n\n/// headerdoc\nfunc bar() {\n}"
         testFormatting(for: input, output, rule: FormatRules.blankLinesBetweenScopes,
                        exclude: ["emptyBraces"])
     }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -22,8 +22,8 @@ class OrganizationTests: RulesTests {
             open var quack = 2
             var quux = 2
 
-            // `open` is the only visibility keyword that
-            // can also be used as an identifier.
+            /// `open` is the only visibility keyword that
+            /// can also be used as an identifier.
             var open = 10
 
             /*
@@ -63,8 +63,8 @@ class OrganizationTests: RulesTests {
 
             var quux = 2
 
-            // `open` is the only visibility keyword that
-            // can also be used as an identifier.
+            /// `open` is the only visibility keyword that
+            /// can also be used as an identifier.
             var open = 10
 
             // MARK: Private
@@ -661,7 +661,7 @@ class OrganizationTests: RulesTests {
             // MARK: Private
 
             @annotation // Private
-            // Private
+            /// Private
             private var foo: [String] = []
 
             private func bar() {
@@ -3062,7 +3062,7 @@ class OrganizationTests: RulesTests {
                 barConfiguration: Bar
             )
             case barFeature // Trailing comment -- bar feature
-            // Leading comment -- upsell A
+            /// Leading comment -- upsell A
             case upsellA(
                 fooConfiguration: Foo,
                 barConfiguration: Bar
@@ -3083,7 +3083,7 @@ class OrganizationTests: RulesTests {
                 fooConfiguration: Foo,
                 barConfiguration: Bar
             )
-            // Leading comment -- upsell A
+            /// Leading comment -- upsell A
             case upsellA(
                 fooConfiguration: Foo,
                 barConfiguration: Bar

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -818,8 +818,8 @@ class RedundancyTests: RulesTests {
     }
 
     func testRedundantObjcCommentNotRemoved() {
-        let input = "@objc // an outlet\n@IBOutlet var label: UILabel!"
-        let output = "// an outlet\n@IBOutlet var label: UILabel!"
+        let input = "@objc /// an outlet\n@IBOutlet var label: UILabel!"
+        let output = "/// an outlet\n@IBOutlet var label: UILabel!"
         testFormatting(for: input, output, rule: FormatRules.redundantObjc)
     }
 
@@ -5908,8 +5908,8 @@ class RedundancyTests: RulesTests {
         @discardableResult
         func discardableResult() -> String { "hello world" }
 
-        // We can't remove this closure, since the method called inline
-        // would return a String instead.
+        /// We can't remove this closure, since the method called inline
+        /// would return a String instead.
         let void: Void = { discardableResult() }()
         """
         testFormatting(for: input, rule: FormatRules.redundantClosure)
@@ -5920,8 +5920,8 @@ class RedundancyTests: RulesTests {
         @discardableResult
         func discardableResult() -> String { "hello world" }
 
-        // We can't remove this closure, since the method called inline
-        // would return a String instead.
+        /// We can't remove this closure, since the method called inline
+        /// would return a String instead.
         let void: () = { discardableResult() }()
         """
         testFormatting(for: input, rule: FormatRules.redundantClosure)

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1221,7 +1221,7 @@ class SpacingTests: RulesTests {
     func testSpaceInsideMultilineHeaderdocComment() {
         let input = "/**foo\n bar*/"
         let output = "/** foo\n bar */"
-        testFormatting(for: input, output, rule: FormatRules.spaceInsideComments)
+        testFormatting(for: input, output, rule: FormatRules.spaceInsideComments, exclude: ["docComments"])
     }
 
     func testSpaceInsideMultilineHeaderdocCommentType2() {
@@ -1238,7 +1238,7 @@ class SpacingTests: RulesTests {
 
     func testNoExtraSpaceInsideMultilineHeaderdocComment() {
         let input = "/** foo\n bar */"
-        testFormatting(for: input, rule: FormatRules.spaceInsideComments)
+        testFormatting(for: input, rule: FormatRules.spaceInsideComments, exclude: ["docComments"])
     }
 
     func testNoExtraSpaceInsideMultilineHeaderdocCommentType2() {
@@ -1281,7 +1281,7 @@ class SpacingTests: RulesTests {
 
     func testNoSpaceAddedToFirstLineOfDocComment() {
         let input = "/**\n Comment\n */"
-        testFormatting(for: input, rule: FormatRules.spaceInsideComments)
+        testFormatting(for: input, rule: FormatRules.spaceInsideComments, exclude: ["docComments"])
     }
 
     func testNoSpaceAddedToEmptyDocComment() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3076,4 +3076,108 @@ class SyntaxTests: RulesTests {
         )
         testFormatting(for: input, output, rule: FormatRules.genericExtensions, options: options)
     }
+
+    // MARK: docComments
+
+    func testConvertCommentsToDocComments() {
+        let input = """
+
+        // Multi-line comment before class with
+        // attribute between comment and declaration
+        @objc
+        class Foo {
+            // Single line comment before property
+            let foo = Foo()
+
+            // Single line comment before property with property wrapper
+            @State
+            let bar = Bar()
+
+            // Single line comment
+            func foo() {}
+
+            /* Single line block comment before method */
+            func baaz() {}
+
+            /*
+               Multi-line block comment before method with attribute.
+
+               This comment has a blank line in it.
+             */
+            @nonobjc
+            func baaz() {}
+        }
+        """
+
+        let output = """
+
+        /// Multi-line comment before class with
+        /// attribute between comment and declaration
+        @objc
+        class Foo {
+            /// Single line comment before property
+            let foo = Foo()
+
+            /// Single line comment before property with property wrapper
+            @State
+            let bar = Bar()
+
+            /// Single line comment
+            func foo() {}
+
+            /** Single line block comment before method */
+            func baaz() {}
+
+            /**
+               Multi-line block comment before method with attribute.
+
+               This comment has a blank line in it.
+             */
+            @nonobjc
+            func baaz() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.docComments, exclude: ["spaceInsideComments"])
+    }
+
+    func testConvertDocCommentsToComments() {
+        let input = """
+        /// Comment not associated with class
+
+        class Foo {
+            /** Comment not associated with function */
+
+            func bar() {
+                /// Comment inside function declaration.
+                /// This one is multi-line.
+
+                /// This comment is inside a function but proceeds a declaration,
+                /// so is still a doc comment.
+                let bar = Bar()
+                print(bar)
+            }
+        }
+        """
+
+        let output = """
+        // Comment not associated with class
+
+        class Foo {
+            /* Comment not associated with function */
+
+            func bar() {
+                // Comment inside function declaration.
+                // This one is multi-line.
+
+                /// This comment is inside a function but proceeds a declaration,
+                /// so is still a doc comment.
+                let bar = Bar()
+                print(bar)
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.docComments, exclude: ["spaceInsideComments"])
+    }
 }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4262,6 +4262,6 @@ class WrappingTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 13))
+        testFormatting(for: input, output, rule: FormatRules.wrapSingleLineComments, options: FormatOptions(maxWidth: 13), exclude: ["docComments"])
     }
 }


### PR DESCRIPTION
This PR adds a new `docComments` rule that enforces doc comments (`///` or `/**`) should always (and only) be used before declarations.

```diff
- // A placeholder type used to demonstrate syntax rules
+ /// A placeholder type used to demonstrate syntax rules
  class Foo {
-     // This function doesn't really do anything
+     /// This function doesn't really do anything
      func bar() {
-         /// TODO: implement Foo.bar() algorithm
+         // TODO: implement Foo.bar() algorithm
      }
  }
```