### PR TITLE
Fix bugs in `opaqueGenericParameters` rule

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1822,11 +1822,6 @@ extension Formatter {
         // The opaque parameter syntax that represents this generic type,
         // if the constraints can be expressed using this syntax
         func asOpaqueParameter(useSomeAny: Bool) -> [Token]? {
-            if conformances.isEmpty {
-                guard useSomeAny else { return nil }
-                return tokenize("some Any")
-            }
-
             // Protocols with primary associated types that can be used with
             // opaque parameter syntax. In the future we could make this extensible
             // so users can add their own types here.
@@ -1836,6 +1831,31 @@ extension Formatter {
             ]
 
             let constraints = conformances.filter { $0.type == .protocolConstraint }
+            let concreteTypes = conformances.filter { $0.type == .concreteType }
+
+            // If we have no type requirements at all, this is an
+            // unconstrained generic and is equivalent to `some Any`
+            if constraints.isEmpty, concreteTypes.isEmpty {
+                guard useSomeAny else { return nil }
+                return tokenize("some Any")
+            }
+
+            if constraints.isEmpty {
+                // If we have no constraints but exactly one concrete type (e.g. `== String`)
+                // then we can just substitute for that type. This sort of generic same-type
+                // requirement (`func foo<T>(_ t: T) where T == Foo`) is actually no longer
+                // allowed in Swift 6, since it's redundant.
+                if concreteTypes.count == 1 {
+                    return tokenize(concreteTypes[0].name)
+                }
+
+                // If there are multiple same-type type requirements,
+                // the code should fail to compile
+                else {
+                    return nil
+                }
+            }
+
             var primaryAssociatedTypes = [GenericConformance: GenericConformance]()
 
             // Validate that all of the conformances can be represented using this syntax
@@ -1948,8 +1968,9 @@ extension Formatter {
             }
 
             // or a concrete type of the form `T == Foo`
-            else if let equalsIndex = index(of: .operator("==", .infix), after: genericTypeNameIndex),
-                    equalsIndex < typeEndIndex
+            else if let equalsIndex = index(of: .operator("==", .infix), after: genericTypeNameIndex)
+                ?? index(of: .operator("==", .none), after: genericTypeNameIndex),
+                equalsIndex < typeEndIndex
             {
                 delineatorIndex = equalsIndex
                 conformanceType = .concreteType

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2897,6 +2897,47 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testVariadicParameterNotConvertedToOpaqueGeneric() {
+        let input = """
+        func variadic<T>(_ t: T...) {
+            print(t)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testNonGenericVariadicParametersDoesntPreventUsingOpaqueGenerics() {
+        let input = """
+        func variadic<U>(t: Any..., u: U, v: Any...) {
+            print(t, u, v)
+        }
+        """
+
+        let output = """
+        func variadic(t: Any..., u: some Any, v: Any...) {
+            print(t, u, v)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testIssue1275() {
+        let input = """
+        func loggedKeypath<T: CustomStringConvertible>(
+            by _: KeyPath<T, Element>...,
+            actionKeyword _: UserActionKeyword,
+            identifier _: String
+        ) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2838,6 +2838,65 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testGenericExtensionSameTypeConstraint() {
+        let input = """
+        func foo<U>(_ u: U) where U == String {
+            print(u)
+        }
+        """
+
+        let output = """
+        func foo(_ u: String) {
+            print(u)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericExtensionSameTypeGenericConstraint() {
+        let input = """
+        func foo<U, V>(_ u: U, _ v: V) where U == V {
+            print(u, v)
+        }
+
+        func foo<U, V>(_ u: U, _ v: V) where V == U {
+            print(u, v)
+        }
+        """
+
+        let output = """
+        func foo<V>(_ u: V, _ v: V) {
+            print(u, v)
+        }
+
+        func foo<U>(_ u: U, _ v: U) {
+            print(u, v)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testIssue1269() {
+        let input = """
+        func bar<V, R>(
+            _ value: V,
+            _ work: () -> R
+        ) -> R
+            where Value == @Sendable () -> V,
+            V: Sendable
+        {
+            work()
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {


### PR DESCRIPTION
This PR fixes #1269 and #1275, where the `opaqueGenericParameters` rule was causing build failures.