### PR TITLE
Fix crash in `opaqueGenericParameters` rule

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1916,9 +1916,10 @@ extension Formatter {
         var currentIndex = genericSignatureStartIndex
 
         while currentIndex < genericSignatureEndIndex - 1 {
-            guard let genericTypeNameIndex = index(of: .identifier, after: currentIndex) else {
-                break
-            }
+            guard
+                let genericTypeNameIndex = index(of: .identifier, after: currentIndex),
+                genericTypeNameIndex < genericSignatureEndIndex
+            else { break }
 
             let typeEndIndex: Int
             let nextCommaIndex = index(of: .delimiter(","), after: genericTypeNameIndex)
@@ -1968,9 +1969,8 @@ extension Formatter {
             }
 
             // or a concrete type of the form `T == Foo`
-            else if let equalsIndex = index(of: .operator("==", .infix), after: genericTypeNameIndex)
-                ?? index(of: .operator("==", .none), after: genericTypeNameIndex),
-                equalsIndex < typeEndIndex
+            else if let equalsIndex = index(after: genericTypeNameIndex, where: { $0.isOperator("==") }),
+                    equalsIndex < typeEndIndex
             {
                 delineatorIndex = equalsIndex
                 conformanceType = .concreteType

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2938,6 +2938,30 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testIssue1278() {
+        let input = """
+        public struct Foo<Value> {
+            public func withValue<V, R>(
+                _: V,
+                operation _: () throws -> R
+            ) rethrows -> R
+                where Value == @Sendable () -> V,
+                V: Sendable
+            {}
+
+            public func withValue<V, R>(
+                _: V,
+                operation _: () async throws -> R
+            ) async rethrows -> R
+                where Value == () -> V
+            {}
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {


### PR DESCRIPTION
This PR fixes #1278