### PR TITLE
Fix `parseGenericTypes` handling of constraints with their own generic types (e.g. `== Foo<Bar>`)

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1980,12 +1980,12 @@ extension Formatter {
                 let constrainedTypeName = tokens[genericTypeNameIndex ..< delineatorIndex]
                     .map { $0.string }
                     .joined()
-                    .trimmingCharacters(in: .init(charactersIn: " \n\r,<>{}"))
+                    .trimmingCharacters(in: .init(charactersIn: " \n\r,{}"))
 
                 let conformanceName = tokens[(delineatorIndex + 1) ... typeEndIndex]
                     .map { $0.string }
                     .joined()
-                    .trimmingCharacters(in: .init(charactersIn: " \n\r,<>{}"))
+                    .trimmingCharacters(in: .init(charactersIn: " \n\r,{}"))
 
                 genericType.conformances.append(.init(
                     name: conformanceName,

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2766,6 +2766,23 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testOpaqueGenericParameterWithAssociatedTypeConstraint() {
+        let input = """
+        func foo<T: Collection<Foo>>(_: T) {}
+        func bar<T>(_: T) where T: Collection<Foo> {}
+        func baaz<T>(_: T) where T == any Collection<Foo> {}
+        """
+
+        let output = """
+        func foo(_: some Collection<Foo>) {}
+        func bar(_: some Collection<Foo>) {}
+        func baaz(_: any Collection<Foo>) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     func testGenericTypeUsedInMultipleParameters() {
         let input = """
         func foo<T: Fooable>(_ first: T, second: T) {
@@ -2995,6 +3012,14 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.genericExtensions, options: options, exclude: ["typeSugar"])
     }
 
+    func testUpdatesArrayWithGenericElement() {
+        let input = "extension Array where Element == Foo<Bar> {}"
+        let output = "extension Array<Foo<Bar>> {}"
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.genericExtensions, options: options, exclude: ["typeSugar"])
+    }
+
     func testUpdatesDictionaryGenericExtensionToAngleBracketSyntax() {
         let input = "extension Dictionary where Key == Foo, Value == Bar {}"
         let output = "extension Dictionary<Foo, Bar> {}"
@@ -3070,6 +3095,161 @@ class SyntaxTests: RulesTests {
             swiftVersion: "5.7"
         )
         testFormatting(for: input, output, rule: FormatRules.genericExtensions, options: options)
+    }
+
+    func testOpaqueGenericParametersRuleSuccessfullyTerminatesInSampleCode() {
+        let input = """
+        class Service {
+            public func run() {}
+            private let foo: Foo<Void, Void>
+            private func a() -> Eventual<Void> {}
+            private func b() -> Eventual<Void> {}
+            private func c() -> Eventual<Void> {}
+            private func d() -> Eventual<Void> {}
+            private func e() -> Eventual<Void> {}
+            private func f() -> Eventual<Void> {}
+            private func g() -> Eventual<Void> {}
+            private func h() -> Eventual<Void> {}
+            private func i() {}
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterUsedInConstraintOfOtherTypeNotChanged() {
+        let input = """
+        func combineResults<ASuccess, AFailure, BSuccess, BFailure>(
+            _: Potential<ASuccess, AFailure>,
+            _: Potential<BSuccess, BFailure>
+        ) -> Potential<Success, Never> where
+            Success == (Result<ASuccess, AFailure>, Result<BSuccess, BFailure>),
+            Failure == Never
+        {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterInheritedFromContextNotRemoved() {
+        let input = """
+        func assign<Target>(
+            on _: DispatchQueue,
+            to _: AssignTarget<Target>,
+            at _: ReferenceWritableKeyPath<Target, Value>
+        ) where Value: Equatable {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterUsedInBodyNotRemoved() {
+        let input = """
+        func foo<T>(_ value: T) {
+            typealias TTT = T
+            let casted = value as TTT
+            print(casted)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericParameterUsedAsClosureParameterNotRemoved() {
+        let input = """
+        func foo<Foo>(_: (Foo) -> Void) {}
+        func bar<Foo>(_: (Foo) throws -> Void) {}
+        func baaz<Foo>(_: (Foo) async -> Void) {}
+        func quux<Foo>(_: (Foo) async throws -> Void) {}
+        func qaax<Foo>(_: ([Foo]) -> Void) {}
+        func qaax<Foo>(_: ((Foo, Bar)) -> Void) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testFinalGenericParamRemovedProperlyWithoutHangingComma() {
+        let input = """
+        func foo<Bar, Baaz>(
+            bar _: (Bar) -> Void,
+            baaz _: Baaz
+        ) {}
+        """
+
+        let output = """
+        func foo<Bar>(
+            bar _: (Bar) -> Void,
+            baaz _: some Any
+        ) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testAddsParensAroundTypeIfNecessary() {
+        let input = """
+        func foo<Foo>(_: Foo.Type) {}
+        func bar<Foo>(_: Foo?) {}
+        """
+
+        let output = """
+        func foo(_: (some Any).Type) {}
+        func bar(_: (some Any)?) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testHandlesSingleExactTypeGenericConstraint() {
+        let input = """
+        func foo<T>(with _: T) -> Foo where T == Dependencies {}
+        """
+
+        let output = """
+        func foo(with _: Dependencies) -> Foo {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testGenericConstraintThatIsGeneric() {
+        let input = """
+        class Foo<Bar, Baaz> {}
+        func foo<T: Foo<String, String>>(_: T) {}
+        class Bar<Baaz> {}
+        func bar<T: Bar<String>>(_: T) {}
+        """
+
+        let output = """
+        class Foo<Bar, Baaz> {}
+        func foo(_: some Foo<String, String>) {}
+        class Bar<Baaz> {}
+        func bar(_: some Bar<String>) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
+    func testDoesntChangeTypeWithConstraintThatReferencesItself() {
+        // This is a weird one but in the actual code this comes from `ViewModelContext` is both defined
+        // on the parent type of this declaration (where it has additional important constraints),
+        // and again in the method itself. Changing this to an opaque parameter breaks the build, because
+        // it loses the generic constraints applied by the parent type.
+        let input = """
+        func makeSections<ViewModelContext: RoutingBehaviors<ViewModelContext.Dependencies>>(_: ViewModelContext) {}
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
     // MARK: docComments


### PR DESCRIPTION
This PR fixes #1281, which affected both `opaqueGenericParameters` and `genericExtensions`.

This specific bug was originally fixed in https://github.com/nicklockwood/SwiftFormat/pull/1260, but it looks like the fix was lost at some point (probably due to merge conflicts?) 