### PR TITLE
Update `opaqueGenericParameters` rule to apply to initializers

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6898,15 +6898,17 @@ public struct _FormatRules {
         """,
         options: ["someAny"]
     ) { formatter in
-        formatter.forEach(.keyword("func")) { funcIndex, _ in
+        formatter.forEach(.keyword) { keywordIndex, keyword in
             guard
+                // Apply this rule to functions and initializers
+                ["func", "init"].contains(keyword.string),
                 // Opaque generic parameter syntax is only supported in Swift 5.7+
                 formatter.options.swiftVersion >= "5.7",
                 // Validate that this is a generic method using angle bracket syntax,
                 // and find the indices for all of the key tokens
-                let paramListStartIndex = formatter.index(of: .startOfScope("("), after: funcIndex),
+                let paramListStartIndex = formatter.index(of: .startOfScope("("), after: keywordIndex),
                 let paramListEndIndex = formatter.endOfScope(at: paramListStartIndex),
-                let genericSignatureStartIndex = formatter.index(of: .startOfScope("<"), after: funcIndex),
+                let genericSignatureStartIndex = formatter.index(of: .startOfScope("<"), after: keywordIndex),
                 let genericSignatureEndIndex = formatter.endOfScope(at: genericSignatureStartIndex),
                 genericSignatureStartIndex < paramListStartIndex,
                 genericSignatureEndIndex < paramListStartIndex,
@@ -7018,7 +7020,7 @@ public struct _FormatRules {
 
                 // If the generic type is used as a closure type parameter, it can't be removed or the compiler
                 // will emit a "'some' cannot appear in parameter position in parameter type <closure type>" error
-                for tokenIndex in funcIndex ... closeBraceIndex {
+                for tokenIndex in keywordIndex ... closeBraceIndex {
                     if
                         // Check if this is the start of a closure
                         formatter.tokens[tokenIndex] == .startOfScope("("),

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6900,8 +6900,8 @@ public struct _FormatRules {
     ) { formatter in
         formatter.forEach(.keyword) { keywordIndex, keyword in
             guard
-                // Apply this rule to functions and initializers
-                ["func", "init"].contains(keyword.string),
+                // Apply this rule to any function-like declaration
+                ["func", "init", "subscript"].contains(keyword.string),
                 // Opaque generic parameter syntax is only supported in Swift 5.7+
                 formatter.options.swiftVersion >= "5.7",
                 // Validate that this is a generic method using angle bracket syntax,

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2614,10 +2614,18 @@ class SyntaxTests: RulesTests {
         func foo<T>(_ value: T) {
             print(value)
         }
+
+        init<T>(_ value: T) {
+            print(value)
+        }
         """
 
         let output = """
         func foo(_ value: some Any) {
+            print(value)
+        }
+
+        init(_ value: some Any) {
             print(value)
         }
         """
@@ -2642,10 +2650,18 @@ class SyntaxTests: RulesTests {
         func foo<T: Fooable, U: Barable>(_ fooable: T, barable: U) -> Baaz {
             print(fooable, barable)
         }
+
+        init<T: Fooable, U: Barable>(_ fooable: T, barable: U) {
+            print(fooable, barable)
+        }
         """
 
         let output = """
         func foo(_ fooable: some Fooable, barable: some Barable) -> Baaz {
+            print(fooable, barable)
+        }
+
+        init(_ fooable: some Fooable, barable: some Barable) {
             print(fooable, barable)
         }
         """
@@ -2659,10 +2675,18 @@ class SyntaxTests: RulesTests {
         func foo<T, U>(_ t: T, _ u: U) -> Baaz where T: Fooable, T: Barable, U: Baazable {
             print(t, u)
         }
+
+        init<T, U>(_ t: T, _ u: U) where T: Fooable, T: Barable, U: Baazable {
+            print(t, u)
+        }
         """
 
         let output = """
         func foo(_ t: some Fooable & Barable, _ u: some Baazable) -> Baaz {
+            print(t, u)
+        }
+
+        init(_ t: some Fooable & Barable, _ u: some Baazable) {
             print(t, u)
         }
         """

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2618,6 +2618,19 @@ class SyntaxTests: RulesTests {
         init<T>(_ value: T) {
             print(value)
         }
+
+        subscript<T>(_ value: T) -> Foo {
+            Foo(value)
+        }
+
+        subscript<T>(_ value: T) -> Foo {
+            get {
+                Foo(value)
+            }
+            set {
+                print(newValue)
+            }
+        }
         """
 
         let output = """
@@ -2627,6 +2640,19 @@ class SyntaxTests: RulesTests {
 
         init(_ value: some Any) {
             print(value)
+        }
+
+        subscript(_ value: some Any) -> Foo {
+            Foo(value)
+        }
+
+        subscript(_ value: some Any) -> Foo {
+            get {
+                Foo(value)
+            }
+            set {
+                print(newValue)
+            }
         }
         """
 
@@ -2654,6 +2680,10 @@ class SyntaxTests: RulesTests {
         init<T: Fooable, U: Barable>(_ fooable: T, barable: U) {
             print(fooable, barable)
         }
+
+        subscript<T: Fooable, U: Barable>(_ fooable: T, barable: U) -> Any {
+            (fooable, barable)
+        }
         """
 
         let output = """
@@ -2663,6 +2693,10 @@ class SyntaxTests: RulesTests {
 
         init(_ fooable: some Fooable, barable: some Barable) {
             print(fooable, barable)
+        }
+
+        subscript(_ fooable: some Fooable, barable: some Barable) -> Any {
+            (fooable, barable)
         }
         """
 


### PR DESCRIPTION
This PR updates the `opaqueGenericParameters` rule to apply to `init` declarations, as well as `func` declarations. Fixes #1291.