### PR TITLE
Removed `preferDouble` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.51.0](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.51.0)
+
+- Removed `preferDouble` rule as it could introduce subtle bugs and compiler errors when used with system APIs
+
 ## [0.50.3](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.50.3) (2022-10-19)
 
 - Fixed bug where `redundantFileprivate` rule could break Array extensions using type sugar

--- a/Rules.md
+++ b/Rules.md
@@ -85,7 +85,6 @@
 * [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
 * [organizeDeclarations](#organizeDeclarations)
-* [preferDouble](#preferDouble)
 * [sortedSwitchCases](#sortedSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -1056,28 +1055,6 @@ Option | Description
 +     private let g: Int = 2
 +
  }
-```
-
-</details>
-<br/>
-
-## preferDouble
-
-Replaces occurrences of CGFloat with Double when targeting Swift 5.5 and above.
-
-## preferKeyPath
-
-Convert trivial `map { $0.foo }` closures to keyPath-based syntax.
-
-<details>
-<summary>Examples</summary>
-
-```diff
-- let barArray = fooArray.map { $0.bar }
-+ let barArray = fooArray.map(\.bar)
-
-- let barArray = fooArray.compactMap { $0.optionalBar }
-+ let barArray = fooArray.compactMap(\.optionalBar)
 ```
 
 </details>

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6521,19 +6521,6 @@ public struct _FormatRules {
         }
     }
 
-    public let preferDouble = FormatRule(
-        help: """
-        Replaces occurrences of CGFloat with Double when targeting Swift 5.5 and above.
-        """,
-        disabledByDefault: true
-    ) { formatter in
-        guard formatter.options.swiftVersion >= "5.5" else { return }
-
-        formatter.forEach(.identifier("CGFloat")) { index, _ in
-            formatter.replaceToken(at: index, with: .identifier("Double"))
-        }
-    }
-
     public let blockComments = FormatRule(
         help: "Changes block comments to single line comments.",
         disabledByDefault: true

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2270,44 +2270,6 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.acronyms)
     }
 
-    // MARK: - preferDouble
-
-    func testCGFloatsReplacedByDoubleOnSwift5_5() {
-        let input = """
-        let foo: CGFloat
-        let bar: CGFloat = 5
-        let baz: [CGFloat] = []
-
-        func foo(value: CGFloat) -> CGFloat { value }
-
-        extension CGFloat: Foopable {}
-        """
-        let output = """
-        let foo: Double
-        let bar: Double = 5
-        let baz: [Double] = []
-
-        func foo(value: Double) -> Double { value }
-
-        extension Double: Foopable {}
-        """
-        let options = FormatOptions(swiftVersion: "5.5")
-        testFormatting(for: input, output, rule: FormatRules.preferDouble, options: options)
-    }
-
-    func testCGFloatsNotReplacedByDoubleIfLessThanSwift5_5() {
-        let input = """
-        let foo: CGFloat
-        let bar: CGFloat = 5
-        let baz: [CGFloat] = []
-
-        func foo(value: CGFloat) -> CGFloat { value }
-
-        extension CGFloat: Foopable {}
-        """
-        testFormatting(for: input, rule: FormatRules.preferDouble)
-    }
-
     // MARK: - blockComments
 
     func testBlockCommentsOneLine() {


### PR DESCRIPTION
This was discussed in more depth in issue #1139, where this rule in particular was not only causing several compiler errors but has also been proven to introduce subtle bugs into applications which may not be obvious or easy to diagnose at first look.

I think the value of this rule, even with it being opt-in, does not outweigh the risk to projects with it being turned on. As such, I believe this should be removed.

Alternative options may include a more prominent warning or description for the rule, or significant work on the rule itself to make it more resilient (but as this would essentially require knowledge of the source of every function called and whether that resides within the source code of the client) is rather impractical.

Closes #1139. @nicklockwood: this may be perceived as a controversial change, I do believe that the issue contains enough valid feedback to warrant this response but of course this is your project and if you'd still rather keep it in then that's your call! It is opt-in.