### PR TITLE
Add Swift package command plugin

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---exclude Tests/XCTestManifests.swift,Tests/BadConfig,Snapshots,Build
+--exclude Tests/XCTestManifests.swift,Tests/BadConfig,Snapshots,Build,PluginTests
 
 # format options
 

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -14,7 +14,7 @@ let package = Package(
         .testTarget(name: "SwiftFormatTests", dependencies: ["SwiftFormat"], path: "Tests"),
         .plugin(name: "SwiftFormatPlugin",
                 capability: .command(
-                    intent: .sourceCodeFormatting(),
+                    intent: .custom(verb: "swiftformat", description: "Formats Swift source files using SwiftFormat"),
                     permissions: [
                         .writeToPackageDirectory(reason: "This command reformats source files"),
                     ]

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "SwiftFormat",
+    products: [
+        .executable(name: "swiftformat", targets: ["CommandLineTool"]),
+        .library(name: "SwiftFormat", targets: ["SwiftFormat"]),
+        .plugin(name: "SwiftFormatPlugin", targets: ["SwiftFormatPlugin"]),
+    ],
+    targets: [
+        .executableTarget(name: "CommandLineTool", dependencies: ["SwiftFormat"], path: "CommandLineTool"),
+        .target(name: "SwiftFormat", path: "Sources"),
+        .testTarget(name: "SwiftFormatTests", dependencies: ["SwiftFormat"], path: "Tests"),
+        .plugin(name: "SwiftFormatPlugin",
+                capability: .command(
+                    intent: .sourceCodeFormatting(),
+                    permissions: [
+                        .writeToPackageDirectory(reason: "This command reformats source files"),
+                    ]
+                ),
+                dependencies: [.target(name: "CommandLineTool")]),
+    ]
+)

--- a/PluginTests/.gitignore
+++ b/PluginTests/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/PluginTests/Package.swift
+++ b/PluginTests/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "PackageUsingPlugin",
+    products: [
+        .library(
+            name: "PackageUsingPlugin",
+            targets: ["PackageUsingPlugin"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../"),
+    ],
+    targets: [
+        .target(
+            name: "PackageUsingPlugin",
+            dependencies: []
+        ),
+    ]
+)

--- a/PluginTests/README.md
+++ b/PluginTests/README.md
@@ -1,0 +1,1 @@
+Run `test.sh` which fails if triggering Swift package plugin does not format `Sources/PackageUsingPlugin/NotFormattedFile.swift` as expected.

--- a/PluginTests/Sources/PackageUsingPlugin/NotFormattedFile.swift
+++ b/PluginTests/Sources/PackageUsingPlugin/NotFormattedFile.swift
@@ -1,0 +1,6 @@
+public struct PluginTests {
+    public private(set) var text="Hello, World!"
+
+    public init() {
+    }
+}

--- a/PluginTests/test.sh
+++ b/PluginTests/test.sh
@@ -1,4 +1,4 @@
-swift package plugin --allow-writing-to-package-directory format-source-code --unexclude .
+swift package plugin --allow-writing-to-package-directory swiftformat --unexclude .
 if [[ `git status --porcelain` ]]; then
     # Expected changes
     git restore Sources/PackageUsingPlugin/NotFormattedFile.swift

--- a/PluginTests/test.sh
+++ b/PluginTests/test.sh
@@ -1,0 +1,9 @@
+swift package plugin --allow-writing-to-package-directory format-source-code --unexclude .
+if [[ `git status --porcelain` ]]; then
+    # Expected changes
+    git restore Sources/PackageUsingPlugin/NotFormattedFile.swift
+    exit 0
+else
+    # No changes - unexpected
+    exit 1
+fi

--- a/Plugins/SwiftFormatPlugin/Shared/CommandPlugin+Extension.swift
+++ b/Plugins/SwiftFormatPlugin/Shared/CommandPlugin+Extension.swift
@@ -1,0 +1,59 @@
+//
+//  CommandPlugin+Extension.swift
+//  SwiftFormat
+//
+//  Created by Marco Eidinger
+//  Copyright 2022 Nick Lockwood
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import PackagePlugin
+
+#if swift(>=5.6)
+    extension CommandPlugin {
+        func formatCode(in directory: PackagePlugin.Path, context: PluginToolProviding, arguments: [String]) throws {
+            let tool = try context.tool(named: "CommandLineTool")
+            let toolURL = URL(fileURLWithPath: tool.path.string)
+
+            var processArguments = [directory.string]
+            processArguments.append(contentsOf: arguments)
+
+            let process = Process()
+            process.executableURL = toolURL
+            process.arguments = processArguments
+
+            try process.run()
+            process.waitUntilExit()
+
+            if process.terminationReason == .exit, process.terminationStatus == 0 {
+                print("Formatted the source code in \(directory.string).")
+            } else {
+                let problem = "\(process.terminationReason):\(process.terminationStatus)"
+                Diagnostics.error("swiftformat invocation failed: \(problem)")
+            }
+        }
+    }
+#endif

--- a/Plugins/SwiftFormatPlugin/Shared/PluginToolProviding.swift
+++ b/Plugins/SwiftFormatPlugin/Shared/PluginToolProviding.swift
@@ -1,0 +1,47 @@
+//
+//  PluginToolProviding.swift
+//  SwiftFormat
+//
+//  Created by Marco Eidinger
+//  Copyright 2022 Nick Lockwood
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import PackagePlugin
+
+#if swift(>=5.6)
+    protocol PluginToolProviding {
+        func tool(named name: String) throws -> PackagePlugin.PluginContext.Tool
+    }
+
+    extension PluginContext: PluginToolProviding {}
+
+    #if canImport(XcodeProjectPlugin)
+        import XcodeProjectPlugin
+
+        extension XcodePluginContext: PluginToolProviding {}
+    #endif
+#endif

--- a/Plugins/SwiftFormatPlugin/SwiftFormatPlugin.swift
+++ b/Plugins/SwiftFormatPlugin/SwiftFormatPlugin.swift
@@ -1,0 +1,61 @@
+//
+//  SwiftFormatPlugin.swift
+//  SwiftFormat
+//
+//  Created by Marco Eidinger
+//  Copyright 2022 Nick Lockwood
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import PackagePlugin
+
+#if swift(>=5.6)
+    @main
+    struct SwiftFormatPlugin: CommandPlugin {
+        /// This entry point is called when operating on a Swift package.
+        func performCommand(context: PluginContext, arguments: [String]) throws {
+            if arguments.contains("--verbose") {
+                print("Command plugin execution with arguments \(arguments.description) for Swift package \(context.package.displayName). All target information: \(context.package.targets.description)")
+            }
+
+            var targetsToProcess: [Target] = context.package.targets
+
+            var argExtractor = ArgumentExtractor(arguments)
+
+            let selectedTargets = argExtractor.extractOption(named: "target")
+
+            if selectedTargets.isEmpty == false {
+                targetsToProcess = context.package.targets.filter { selectedTargets.contains($0.name) }.map { $0 }
+            }
+
+            for target in targetsToProcess {
+                guard let target = target as? SourceModuleTarget else { continue }
+
+                try formatCode(in: target.directory, context: context, arguments: argExtractor.remainingArguments)
+            }
+        }
+    }
+#endif

--- a/Plugins/SwiftFormatPlugin/SwiftFormatPluginXcode.swift
+++ b/Plugins/SwiftFormatPlugin/SwiftFormatPluginXcode.swift
@@ -1,0 +1,54 @@
+//
+//  SwiftFormatPluginXcode.swift
+//  SwiftFormat
+//
+//  Created by Marco Eidinger
+//  Copyright 2022 Nick Lockwood
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import PackagePlugin
+
+#if swift(>=5.6)
+    #if canImport(XcodeProjectPlugin)
+        import XcodeProjectPlugin
+
+        extension SwiftFormatPlugin: XcodeCommandPlugin {
+            /// This entry point is called when operating on an Xcode project.
+            func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+                if arguments.contains("--verbose") {
+                    print("Command plugin execution with arguments \(arguments.description) for Swift package \(context.xcodeProject.displayName). All target information: \(context.xcodeProject.targets.description)")
+                    print("Plugin will run for directory: \(context.xcodeProject.directory.description)")
+                }
+
+                var argExtractor = ArgumentExtractor(arguments)
+                _ = argExtractor.extractOption(named: "target")
+
+                try formatCode(in: context.xcodeProject.directory, context: context, arguments: argExtractor.remainingArguments)
+            }
+        }
+    #endif
+#endif

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of Contents
     - [Command-line tool](#command-line-tool)
     - [Xcode source editor extension](#xcode-source-editor-extension)
     - [Xcode build phase](#xcode-build-phase)
+    - [Swift Package Manager plugin](#swift-package-manager-plugin)
     - [Via Applescript](#via-applescript)
     - [VSCode plugin](#vscode-plugin)
     - [Sublime Text plugin](#sublime-text-plugin)
@@ -311,6 +312,44 @@ fi
 
 This is not recommended for shared projects however, as different team members using different versions of SwiftFormat may result in noise in the commit history as code gets reformatted inconsistently.
 
+Swift Package Manager plugin
+-----------------------------
+
+You can use `SwiftFormat` as a SwiftPM command plugin.
+
+**NOTE:** Swift 5.6 or higher is required. Add the package to your dependencies in your `Package.swift` file.
+
+```swift
+dependencies: [
+    // ...
+    .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
+]
+```
+### Trigger Plugin From Command-Line
+
+```bash
+swift package plugin --allow-writing-to-package-directory format-source-code
+```
+
+You can limit the formatting to a particular target with `--target` option.
+
+You can also specify `SwiftFormat` arguments, e.g. `--swiftversion`.
+
+Example
+
+```bash
+swift package plugin --allow-writing-to-package-directory format-source-code --target MyLibrary --swiftversion 5.6 --verbose
+```
+
+### Trigger Plugin From Xcode
+
+In Xcode 14 you can trigger the command plugin execution for a Swift package or an Xcode project.
+
+For an Xcode project the project's main directory will be processed and the `--target` option will be ignored.
+
+You can also specify `SwiftFormat` arguments, e.g. `--swiftversion`.
+
+![Run plugin in Xcode 14](https://user-images.githubusercontent.com/4176826/179352584-db7f7f42-452c-4a42-a329-01b115a237a7.gif)
 
 Via AppleScript
 ----------------
@@ -885,6 +924,7 @@ Credits
 * [Daniele Formichelli](https://github.com/danyf90) - JSON reporter
 * [Mahdi Bchatnia](https://github.com/inket) - Linux build workflow
 * [Arthur Semenyutin](https://github.com/vox-humana) - Docker image
+* [Marco Eidinger](https://github.com/MarcoEidinger) - Swift Package Manager plugin
 * [Nick Lockwood](https://github.com/nicklockwood) - Everything else
 
 ([Full list of contributors](https://github.com/nicklockwood/SwiftFormat/graphs/contributors))

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ dependencies: [
 ### Trigger Plugin From Command-Line
 
 ```bash
-swift package plugin --allow-writing-to-package-directory format-source-code
+swift package plugin --allow-writing-to-package-directory swiftformat
 ```
 
 You can limit the formatting to a particular target with `--target` option.
@@ -338,7 +338,7 @@ You can also specify `SwiftFormat` arguments, e.g. `--swiftversion`.
 Example
 
 ```bash
-swift package plugin --allow-writing-to-package-directory format-source-code --target MyLibrary --swiftversion 5.6 --verbose
+swift package plugin --allow-writing-to-package-directory swiftformat --target MyLibrary --swiftversion 5.6 --verbose
 ```
 
 ### Trigger Plugin From Xcode

--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ dependencies: [
     .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
 ]
 ```
+
+The plugin will find an existing `.swiftformat` in your package root folder and honor it automatically.
+
 ### Trigger Plugin From Command-Line
 
 ```bash

--- a/Tests/SwiftFormatTests.swift
+++ b/Tests/SwiftFormatTests.swift
@@ -67,7 +67,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 62)
+        XCTAssertEqual(files.count, 67)
     }
 
     func testInputFilesMatchOutputFilesForSameOutput() {
@@ -78,7 +78,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 62)
+        XCTAssertEqual(files.count, 67)
     }
 
     func testInputFileNotEnumeratedWhenExcluded() {
@@ -93,7 +93,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 39)
+        XCTAssertEqual(files.count, 44)
     }
 
     // MARK: format function


### PR DESCRIPTION
Adding implementation for a Swift Package command plugin. Resolves #1198 

The implementation was previously shipped in https://github.com/MarcoEidinger/SwiftFormatPlugin and tested by other developers.

The plugin is available for developers
- who are using Swift 5.6 (or higher) and
- added `SwiftFormat` package as a dependency to their package.

In the folder `PluginTests` such usage is demonstrated. The shell script `PluginTests/test.sh` allows manual verification that `PluginTests/Sources/PackageUsingPlugin/NotFormattedFile.swift` file can be formatted. In a subsequent pull request, the shell script could be leveraged to introduce CI verification (e.g. GitHub action).

I did not increase the minimum swift-tools-version and rely on [version-specific manifest selection](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection) by introducing new `Package@swift-5.6.swift` file. Newly introduced code is safeguarded with compiler directives (`#if swift(>=5.6)`). This ensures that developers with a lower swift-tools-version are not negatively affected. The plugin is simply not available for them.

Example usage:

```
swift package plugin --allow-writing-to-package-directory swiftformat
```

~~Note: it would be possible to change the implementation using a custom intent/verb and replacing `format-source-code,` but I decided against that and therefore use the predefined `.sourceCodeFormatting` intent~~