### PR TITLE
Add option to wrap function effects (`throws`, `async`)

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2153,6 +2153,7 @@ Option | Description
 `--wrapconditions` | Wrap conditions: "before-first", "after-first", "preserve"
 `--wraptypealiases` | Wrap typealiases: "before-first", "after-first", "preserve"
 `--conditionswrap` | Wrap conditions as Xcode 12:"auto", "always", "disabled"
+`--effectsposition` | Effects position: "wrap", "with-closing-paren", "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -2153,7 +2153,7 @@ Option | Description
 `--wrapconditions` | Wrap conditions: "before-first", "after-first", "preserve"
 `--wraptypealiases` | Wrap typealiases: "before-first", "after-first", "preserve"
 `--conditionswrap` | Wrap conditions as Xcode 12:"auto", "always", "disabled"
-`--effectsposition` | Effects position: "wrap", "with-closing-paren", "preserve"
+`--wrapeffects` | Wrap effects: "if-multiline", "never", "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -290,29 +290,54 @@ extension Formatter {
             }
         }
 
-        func wrapReturnIfNecessary(
+        func wrapReturnAndEffectsIfNecessary(
             startOfScope: Int,
             endOfFunctionScope: Int
         ) {
-            switch options.wrapReturnType {
-            case .preserve:
-                break
-            case .ifMultiline:
-                guard token(at: startOfScope) == .startOfScope("("),
-                      let openBracket = index(of: .startOfScope, after: endOfFunctionScope),
-                      token(at: openBracket) == .startOfScope("{"),
-                      let returnArrowIndex = index(of: .operator("->", .infix), after: endOfFunctionScope),
-                      returnArrowIndex < openBracket
-                else { return }
+            guard token(at: startOfScope) == .startOfScope("("),
+                  let openBracket = index(of: .startOfScope, after: endOfFunctionScope),
+                  token(at: openBracket) == .startOfScope("{")
+            else { return }
 
-                // If the return arrow is on the same line as the closing paren, wrap it
-                if startOfLine(at: endOfFunctionScope) == startOfLine(at: returnArrowIndex) {
-                    insertSpace(indentForLine(at: returnArrowIndex), at: returnArrowIndex)
-                    insertLinebreak(at: returnArrowIndex)
+            func wrap(before index: Int) {
+                insertSpace(indentForLine(at: index), at: index)
+                insertLinebreak(at: index)
 
-                    // Remove any trailing whitespace that is now orphaned on the previous line
-                    if tokens[returnArrowIndex - 1].is(.space) {
-                        removeToken(at: returnArrowIndex - 1)
+                // Remove any trailing whitespace that is now orphaned on the previous line
+                if tokens[index - 1].is(.space) {
+                    removeToken(at: index - 1)
+                }
+            }
+
+            if let effectIndex = index(after: endOfFunctionScope, where: { $0.string == "throws" || $0.string == "async" }),
+               effectIndex < openBracket
+            {
+                switch options.effectsPosition {
+                case .preserve:
+                    break
+                case .wrap:
+                    // If the effect is on the same line as the closing paren, wrap it
+                    if startOfLine(at: endOfFunctionScope) == startOfLine(at: effectIndex) {
+                        wrap(before: effectIndex)
+                    }
+                case .withClosingParen:
+                    if startOfLine(at: endOfFunctionScope) != startOfLine(at: effectIndex) {
+                        replaceTokens(in: endOfLine(at: endOfFunctionScope) ..< effectIndex, with: [.space(" ")])
+                    }
+                }
+            }
+
+            if
+                let returnArrowIndex = index(of: .operator("->", .infix), after: endOfFunctionScope),
+                returnArrowIndex < openBracket
+            {
+                switch options.wrapReturnType {
+                case .preserve:
+                    break
+                case .ifMultiline:
+                    // If the return arrow is on the same line as the closing paren, wrap it
+                    if startOfLine(at: endOfFunctionScope) == startOfLine(at: returnArrowIndex) {
+                        wrap(before: returnArrowIndex)
                     }
                 }
             }
@@ -384,7 +409,7 @@ extension Formatter {
                 }
             }
 
-            wrapReturnIfNecessary(
+            wrapReturnAndEffectsIfNecessary(
                 startOfScope: i,
                 endOfFunctionScope: endOfScope
             )
@@ -454,7 +479,7 @@ extension Formatter {
                 insertLinebreak(at: breakIndex)
             }
 
-            wrapReturnIfNecessary(
+            wrapReturnAndEffectsIfNecessary(
                 startOfScope: i,
                 endOfFunctionScope: endOfScope
             )

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -312,10 +312,10 @@ extension Formatter {
             if let effectIndex = index(after: endOfFunctionScope, where: { $0.string == "throws" || $0.string == "async" }),
                effectIndex < openBracket
             {
-                switch options.effectsPosition {
+                switch options.wrapEffects {
                 case .preserve:
                     break
-                case .wrap:
+                case .ifMultiline:
                     // If the effect is on the same line as the closing paren, wrap it
                     if startOfLine(at: endOfFunctionScope) == startOfLine(at: effectIndex) {
                         wrap(before: effectIndex)
@@ -330,7 +330,7 @@ extension Formatter {
                             replaceTokens(in: endOfLine(at: tokenBeforeArrowIndex) ..< returnArrowIndex, with: [.space(" ")])
                         }
                     }
-                case .withClosingParen:
+                case .never:
                     if startOfLine(at: endOfFunctionScope) != startOfLine(at: effectIndex) {
                         replaceTokens(in: endOfLine(at: endOfFunctionScope) ..< effectIndex, with: [.space(" ")])
                     }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -319,6 +319,16 @@ extension Formatter {
                     // If the effect is on the same line as the closing paren, wrap it
                     if startOfLine(at: endOfFunctionScope) == startOfLine(at: effectIndex) {
                         wrap(before: effectIndex)
+
+                        // When wrapping the effect, we should also un-wrap any return type
+                        if
+                            let returnArrowIndex = index(of: .operator("->", .infix), after: endOfFunctionScope),
+                            returnArrowIndex < openBracket,
+                            let tokenBeforeArrowIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: returnArrowIndex),
+                            startOfLine(at: tokenBeforeArrowIndex) != startOfLine(at: returnArrowIndex)
+                        {
+                            replaceTokens(in: endOfLine(at: tokenBeforeArrowIndex) ..< returnArrowIndex, with: [.space(" ")])
+                        }
                     }
                 case .withClosingParen:
                     if startOfLine(at: endOfFunctionScope) != startOfLine(at: effectIndex) {

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -470,11 +470,11 @@ struct _Descriptors {
         help: "Wrap return type: \"if-multiline\", \"preserve\" (default)",
         keyPath: \.wrapReturnType
     )
-    let effectsPosition = OptionDescriptor(
-        argumentName: "effectsposition",
+    let wrapEffects = OptionDescriptor(
+        argumentName: "wrapeffects",
         displayName: "Wrap Function Effects (throws, async)",
-        help: "Effects position: \"wrap\", \"with-closing-paren\", \"preserve\"",
-        keyPath: \.effectsPosition
+        help: "Wrap effects: \"if-multiline\", \"never\", \"preserve\"",
+        keyPath: \.wrapEffects
     )
     let wrapConditions = OptionDescriptor(
         argumentName: "wrapconditions",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -470,6 +470,12 @@ struct _Descriptors {
         help: "Wrap return type: \"if-multiline\", \"preserve\" (default)",
         keyPath: \.wrapReturnType
     )
+    let effectsPosition = OptionDescriptor(
+        argumentName: "effectsposition",
+        displayName: "Wrap Function Effects (throws, async)",
+        help: "Effects position: \"wrap\", \"with-closing-paren\", \"preserve\"",
+        keyPath: \.wrapReturnType
+    )
     let wrapConditions = OptionDescriptor(
         argumentName: "wrapconditions",
         displayName: "Wrap Conditions",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -474,7 +474,7 @@ struct _Descriptors {
         argumentName: "effectsposition",
         displayName: "Wrap Function Effects (throws, async)",
         help: "Effects position: \"wrap\", \"with-closing-paren\", \"preserve\"",
-        keyPath: \.wrapReturnType
+        keyPath: \.effectsPosition
     )
     let wrapConditions = OptionDescriptor(
         argumentName: "wrapconditions",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -116,13 +116,14 @@ public enum WrapReturnType: String, CaseIterable {
     case preserve
 }
 
-/// Wrapping behavior for effects (`async`, `throws`) in multi-line methods
-public enum EffectsPosition: String, CaseIterable {
+/// Wrapping behavior for effects (`async`, `throws`)
+public enum WrapEffects: String, CaseIterable {
     case preserve
     /// `async` and `throws` are wrapped to the line after the closing paren
-    case wrap
-    /// `async` and `throws` are included on the same line as the closing paren
-    case withClosingParen = "with-closing-paren"
+    /// if the function spans multiple lines
+    case ifMultiline = "if-multiline"
+    /// `async` and `throws` are never wrapped, and are always included on the same line as the closing paren
+    case never
 }
 
 /// Annotation which should be kept when removing a redundant type
@@ -429,7 +430,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var removeStartOrEndBlankLinesFromTypes: Bool
     public var genericTypes: String
     public var useSomeAny: Bool
-    public var effectsPosition: EffectsPosition
+    public var wrapEffects: WrapEffects
 
     // Deprecated
     public var indentComments: Bool
@@ -526,7 +527,7 @@ public struct FormatOptions: CustomStringConvertible {
                 removeStartOrEndBlankLinesFromTypes: Bool = true,
                 genericTypes: String = "",
                 useSomeAny: Bool = true,
-                effectsPosition: EffectsPosition = .preserve,
+                wrapEffects: WrapEffects = .preserve,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -614,7 +615,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.removeStartOrEndBlankLinesFromTypes = removeStartOrEndBlankLinesFromTypes
         self.genericTypes = genericTypes
         self.useSomeAny = useSomeAny
-        self.effectsPosition = effectsPosition
+        self.wrapEffects = wrapEffects
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -116,6 +116,15 @@ public enum WrapReturnType: String, CaseIterable {
     case preserve
 }
 
+/// Wrapping behavior for effects (`async`, `throws`) in multi-line methods
+public enum EffectsPosition: String, CaseIterable {
+    case preserve
+    /// `async` and `throws` are wrapped to the line after the closing paren
+    case wrap
+    /// `async` and `throws` are included on the same line as the closing paren
+    case withClosingParen = "with-closing-paren"
+}
+
 /// Annotation which should be kept when removing a redundant type
 public enum RedundantType: String, CaseIterable {
     /// Preserves the type as a part of the property definition:
@@ -420,6 +429,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var removeStartOrEndBlankLinesFromTypes: Bool
     public var genericTypes: String
     public var useSomeAny: Bool
+    public var effectsPosition: EffectsPosition
 
     // Deprecated
     public var indentComments: Bool
@@ -516,6 +526,7 @@ public struct FormatOptions: CustomStringConvertible {
                 removeStartOrEndBlankLinesFromTypes: Bool = true,
                 genericTypes: String = "",
                 useSomeAny: Bool = true,
+                effectsPosition: EffectsPosition = .preserve,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -603,6 +614,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.removeStartOrEndBlankLinesFromTypes = removeStartOrEndBlankLinesFromTypes
         self.genericTypes = genericTypes
         self.useSomeAny = useSomeAny
+        self.effectsPosition = effectsPosition
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4163,7 +4163,7 @@ public struct _FormatRules {
         help: "Wrap lines that exceed the specified maximum width.",
         options: ["maxwidth", "nowrapoperators", "assetliterals", "wrapternary"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "indent",
-                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapternary", "conditionswrap", "effectsposition"]
+                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapternary", "conditionswrap", "wrapeffects"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }
@@ -4220,7 +4220,7 @@ public struct _FormatRules {
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: ["wrap"],
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen",
-                  "wrapreturntype", "wrapconditions", "wraptypealiases", "conditionswrap", "effectsposition"],
+                  "wrapreturntype", "wrapconditions", "wraptypealiases", "conditionswrap", "wrapeffects"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
                         "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
     ) { formatter in

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4163,7 +4163,7 @@ public struct _FormatRules {
         help: "Wrap lines that exceed the specified maximum width.",
         options: ["maxwidth", "nowrapoperators", "assetliterals", "wrapternary"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "indent",
-                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapternary", "conditionswrap"]
+                        "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapternary", "conditionswrap", "effectsposition"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }
@@ -4220,7 +4220,7 @@ public struct _FormatRules {
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: ["wrap"],
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen",
-                  "wrapreturntype", "wrapconditions", "wraptypealiases", "conditionswrap"],
+                  "wrapreturntype", "wrapconditions", "wraptypealiases", "conditionswrap", "effectsposition"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
                         "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
     ) { formatter in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -178,7 +178,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.wrapArguments, Descriptors.wrapParameters, Descriptors.wrapCollections,
                         Descriptors.closingParenOnSameLine, Descriptors.linebreak, Descriptors.truncateBlankLines,
                         Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs,
-                        Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType, Descriptors.effectsPosition,
+                        Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType, Descriptors.wrapEffects,
                         Descriptors.wrapConditions, Descriptors.wrapTypealiases, Descriptors.wrapTernaryOperators, Descriptors.conditionsWrap,
                     ]
                 case .identifier("indexWhereLineShouldWrapInLine"), .identifier("indexWhereLineShouldWrap"):

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -178,7 +178,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.wrapArguments, Descriptors.wrapParameters, Descriptors.wrapCollections,
                         Descriptors.closingParenOnSameLine, Descriptors.linebreak, Descriptors.truncateBlankLines,
                         Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs,
-                        Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType,
+                        Descriptors.maxWidth, Descriptors.assetLiteralWidth, Descriptors.wrapReturnType, Descriptors.effectsPosition,
                         Descriptors.wrapConditions, Descriptors.wrapTypealiases, Descriptors.wrapTernaryOperators, Descriptors.conditionsWrap,
                     ]
                 case .identifier("indexWhereLineShouldWrapInLine"), .identifier("indexWhereLineShouldWrap"):

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2730,6 +2730,31 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
     }
 
+    func testWrapEffectOnMultilineFunctionDeclaration() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String) async throws
+            -> String {}
+        """
+
+        let output = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String)
+            async throws -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            effectsPosition: .wrap
+        )
+
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
     func testUnwrapEffectOnMultilineFunctionDeclaration() {
         let input = """
         func multilineFunction(

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2724,10 +2724,25 @@ class WrappingTests: RulesTests {
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: true,
             wrapReturnType: .ifMultiline,
-            effectsPosition: .wrap
+            wrapEffects: .ifMultiline
         )
 
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testDoesntWrapReturnAndEffectOnSingleLineFunctionDeclaration() {
+        let input = """
+        func singleLineFunction() async throws -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
     }
 
     func testWrapEffectOnMultilineFunctionDeclaration() {
@@ -2749,7 +2764,7 @@ class WrappingTests: RulesTests {
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: true,
             wrapReturnType: .ifMultiline,
-            effectsPosition: .wrap
+            wrapEffects: .ifMultiline
         )
 
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
@@ -2774,7 +2789,7 @@ class WrappingTests: RulesTests {
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: true,
             wrapReturnType: .ifMultiline,
-            effectsPosition: .withClosingParen
+            wrapEffects: .never
         )
 
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
@@ -2844,7 +2859,7 @@ class WrappingTests: RulesTests {
             wrapArguments: .afterFirst,
             closingParenOnSameLine: true,
             wrapReturnType: .ifMultiline,
-            effectsPosition: .wrap
+            wrapEffects: .ifMultiline
         )
 
         testFormatting(
@@ -3385,7 +3400,7 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: false,
-            effectsPosition: .withClosingParen
+            wrapEffects: .never
         )
         testFormatting(for: input, [output], rules: [
             FormatRules.wrapMultilineStatementBraces,

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2706,6 +2706,55 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
     }
 
+    func testWrapReturnAndEffectOnMultilineFunctionDeclaration() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String) async throws -> String {}
+        """
+
+        let output = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String)
+            async throws -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            effectsPosition: .wrap
+        )
+
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testUnwrapEffectOnMultilineFunctionDeclaration() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String)
+            async throws -> String {}
+        """
+
+        let output = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String) async throws
+            -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            effectsPosition: .withClosingParen
+        )
+
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
     func testWrapReturnOnMultilineFunctionDeclarationWithAfterFirst() {
         let input = """
         func multilineFunction(foo _: String,
@@ -2746,6 +2795,31 @@ class WrappingTests: RulesTests {
             wrapArguments: .afterFirst,
             closingParenOnSameLine: true,
             wrapReturnType: .ifMultiline
+        )
+
+        testFormatting(
+            for: input, output, rule: FormatRules.wrapArguments, options: options,
+            exclude: ["indent"]
+        )
+    }
+
+    func testWrapReturnAndEffectOnMultilineThrowingFunctionDeclarationWithAfterFirst() {
+        let input = """
+        func multilineFunction(foo _: String,
+                               bar _: String) throws -> String {}
+        """
+
+        let output = """
+        func multilineFunction(foo _: String,
+                               bar _: String)
+                               throws -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .afterFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            effectsPosition: .wrap
         )
 
         testFormatting(
@@ -3258,6 +3332,35 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: false
+        )
+        testFormatting(for: input, [output], rules: [
+            FormatRules.wrapMultilineStatementBraces,
+            FormatRules.wrapArguments,
+        ], options: options)
+    }
+
+    func testWrapsMultilineStatementConsistently2_withEffects() {
+        let input = """
+        func aFunc(
+            one _: Int,
+            two _: Int) async throws -> String {
+            "one"
+        }
+        """
+
+        let output = """
+        func aFunc(
+            one _: Int,
+            two _: Int
+        ) async throws -> String {
+            "one"
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: false,
+            effectsPosition: .withClosingParen
         )
         testFormatting(for: input, [output], rules: [
             FormatRules.wrapMultilineStatementBraces,


### PR DESCRIPTION
This PR adds an option to wrap function effects (`throws`, `async`). This is helpful when using `closingParenOnSameLine: false`.

### `--wrapeffects if-mutliline`

```swift
func multilineFunction(
  foo _: String,
  bar _: String)
  async throws -> String {}
```

### `--wrapeffects never`

```swift
func multilineFunction(
  foo _: String,
  bar _: String) async throws 
  -> String {}
```

