### PR TITLE
Update `redundantSelf` rule to use implicit self in eligible closures (SE-0269, SE-0365)

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -417,7 +417,7 @@ extension Formatter {
     /// Gather declared variable names, starting at index after let/var keyword
     func processDeclaredVariables(at index: inout Int, names: inout Set<String>) {
         processDeclaredVariables(at: &index, names: &names, removeSelf: false,
-                                 onlyLocal: false)
+                                 onlyLocal: false, scopeAllowsImplicitSelfRebinding: false)
     }
 
     /// Returns true if token is inside the return type of a function or subscript

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3091,7 +3091,8 @@ public struct _FormatRules {
         func processBody(at index: inout Int,
                          localNames: Set<String>,
                          members: Set<String>,
-                         typeStack: inout [String],
+                         typeStack: inout [(name: String, keyword: String)],
+                         closureStack: inout [(allowsImplicitSelf: Bool, selfCapture: String?)],
                          membersByType: inout [String: Set<String>],
                          classMembersByType: inout [String: Set<String>],
                          usingDynamicLookup: Bool,
@@ -3129,10 +3130,17 @@ public struct _FormatRules {
                     }
                 }
             }
+            let inClosureDisallowingImplicitSelf = closureStack.last?.allowsImplicitSelf == false
+            /// Starting in Swift 5.8, self can be rebound using a `let self = self` unwrap condition
+            /// within a weak self closure. This is the only place where defining a property
+            /// named self affects the behavior of implicit self.
+            let scopeAllowsImplicitSelfRebinding = formatter.options.swiftVersion >= "5.8"
+                && closureStack.last?.selfCapture == "weak self"
+
             // Gather members & local variables
             let type = (isTypeRoot && typeStack.count == 1) ? typeStack.first : nil
-            var members = type.flatMap { membersByType[$0] } ?? members
-            var classMembers = type.flatMap { classMembersByType[$0] } ?? Set<String>()
+            var members = (type?.name).flatMap { membersByType[$0] } ?? members
+            var classMembers = (type?.name).flatMap { classMembersByType[$0] } ?? Set<String>()
             var localNames = localNames
             if !isTypeRoot || explicitSelf != .remove {
                 var i = index
@@ -3187,11 +3195,13 @@ public struct _FormatRules {
                                 formatter.processDeclaredVariables(at: &i, names: &members)
                             }
                         } else {
-                            let removeSelf = explicitSelf != .insert && !usingDynamicLookup
+                            let removeSelf = explicitSelf != .insert && !usingDynamicLookup && !inClosureDisallowingImplicitSelf
                             let onlyLocal = formatter.options.swiftVersion < "5"
+
                             formatter.processDeclaredVariables(at: &i, names: &localNames,
                                                                removeSelf: removeSelf,
-                                                               onlyLocal: onlyLocal)
+                                                               onlyLocal: onlyLocal,
+                                                               scopeAllowsImplicitSelfRebinding: scopeAllowsImplicitSelfRebinding)
                         }
                     case .keyword("func"):
                         guard let nameToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i) else {
@@ -3231,8 +3241,8 @@ public struct _FormatRules {
                 }
             }
             if let type = type {
-                membersByType[type] = members
-                classMembersByType[type] = classMembers
+                membersByType[type.name] = members
+                classMembersByType[type.name] = classMembers
             }
             // Remove or add `self`
             var lastKeyword = ""
@@ -3242,6 +3252,7 @@ public struct _FormatRules {
                 token: Token.space(""),
                 dynamicMemberTypes: Set<String>()
             )]
+
             while let token = formatter.token(at: index) {
                 switch token {
                 case .keyword("is"), .keyword("as"), .keyword("try"), .keyword("await"):
@@ -3251,13 +3262,13 @@ public struct _FormatRules {
                     lastKeyword = ""
                     if classOrStatic {
                         processFunction(at: &index, localNames: localNames, members: classMembers,
-                                        typeStack: &typeStack, membersByType: &membersByType,
+                                        typeStack: &typeStack, closureStack: &closureStack, membersByType: &membersByType,
                                         classMembersByType: &classMembersByType,
                                         usingDynamicLookup: usingDynamicLookup)
                         classOrStatic = false
                     } else {
                         processFunction(at: &index, localNames: localNames, members: members,
-                                        typeStack: &typeStack, membersByType: &membersByType,
+                                        typeStack: &typeStack, closureStack: &closureStack, membersByType: &membersByType,
                                         classMembersByType: &classMembersByType,
                                         usingDynamicLookup: usingDynamicLookup)
                     }
@@ -3284,6 +3295,7 @@ public struct _FormatRules {
                     }
                 case .keyword("extension"), .keyword("struct"), .keyword("enum"), .keyword("class"), .keyword("actor"),
                      .keyword("where") where ["extension", "struct", "enum", "class", "actor"].contains(lastKeyword):
+                    let keyword = formatter.tokens[index].string
                     guard formatter.last(.nonSpaceOrCommentOrLinebreak, before: index) != .keyword("import"),
                           let scopeStart = formatter.index(of: .startOfScope("{"), after: index)
                     else {
@@ -3306,9 +3318,9 @@ public struct _FormatRules {
                         usingDynamicLookup = true
                     }
                     index = scopeStart + 1
-                    typeStack.append(name)
+                    typeStack.append((name: name, keyword: keyword))
                     processBody(at: &index, localNames: ["init"], members: [], typeStack: &typeStack,
-                                membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                                 usingDynamicLookup: usingDynamicLookup, isTypeRoot: true, isInit: false)
                     typeStack.removeLast()
                 case .keyword("var"), .keyword("let"):
@@ -3335,8 +3347,9 @@ public struct _FormatRules {
                         var scopedNames = localNames
                         formatter.processDeclaredVariables(
                             at: &index, names: &scopedNames,
-                            removeSelf: explicitSelf != .insert,
-                            onlyLocal: false
+                            removeSelf: explicitSelf != .insert && !inClosureDisallowingImplicitSelf,
+                            onlyLocal: false,
+                            scopeAllowsImplicitSelfRebinding: scopeAllowsImplicitSelfRebinding
                         )
                         while let scope = formatter.currentScope(at: index) ?? formatter.token(at: index),
                               [.startOfScope("["), .startOfScope("(")].contains(scope),
@@ -3364,7 +3377,7 @@ public struct _FormatRules {
                         }
                         index = startIndex + 1
                         processBody(at: &index, localNames: scopedNames, members: members, typeStack: &typeStack,
-                                    membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                    closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                                     usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
                         lastKeyword = ""
                     case "case" where ["if", "while", "guard", "for"].contains(lastKeyword):
@@ -3389,7 +3402,7 @@ public struct _FormatRules {
                     }
                     index += 1
                     processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
-                                membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                                 usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
                     continue
                 case .keyword("while") where lastKeyword == "repeat":
@@ -3416,7 +3429,7 @@ public struct _FormatRules {
                     localNames.insert("error") // Implicit error argument
                     index += 1
                     processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
-                                membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                                 usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
                     continue
                 case .startOfScope("{") where isWhereClause && scopeStack.count == 1:
@@ -3429,7 +3442,7 @@ public struct _FormatRules {
                         switch token {
                         case .endOfScope("case"), .endOfScope("default"):
                             let localNames = localNames
-                            processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
+                            processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack, closureStack: &closureStack,
                                         membersByType: &membersByType, classMembersByType: &classMembersByType,
                                         usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
                             index -= 1
@@ -3449,7 +3462,7 @@ public struct _FormatRules {
                 case .startOfScope("{") where lastKeyword == "repeat":
                     index += 1
                     processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
-                                membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                                 usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
                     continue
                 case .startOfScope("{") where lastKeyword == "var":
@@ -3475,11 +3488,92 @@ public struct _FormatRules {
                     if let name = name {
                         processAccessors(["get", "set", "willSet", "didSet"], for: name,
                                          at: &index, localNames: localNames, members: members,
-                                         typeStack: &typeStack, membersByType: &membersByType,
+                                         typeStack: &typeStack, closureStack: &closureStack, membersByType: &membersByType,
                                          classMembersByType: &classMembersByType,
                                          usingDynamicLookup: usingDynamicLookup)
                     }
                     continue
+                case .startOfScope("{") where formatter.isStartOfClosure(at: index):
+                    /// The `self` capture in this closure's capture list, if present
+                    func selfCaptureType() -> String? {
+                        guard let captureListStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
+                              formatter.tokens[captureListStartIndex] == .startOfScope("["),
+                              let captureListEndIndex = formatter.endOfScope(at: captureListStartIndex),
+                              let inIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: captureListEndIndex),
+                              formatter.tokens[inIndex] == .keyword("in")
+                        else { return nil }
+
+                        let captureList = formatter.tokens[(captureListStartIndex + 1) ..< captureListEndIndex]
+                        let captureListEntires = captureList.split(separator: .delimiter(","))
+                            .map { $0.map { $0.string }.joined().trimmingCharacters(in: .whitespacesAndNewlines) }
+
+                        let supportedCaptures = Set([
+                            "self",
+                            "unowned self",
+                            "unowned(safe) self",
+                            "unowned(unsafe) self",
+                            "weak self",
+                        ])
+
+                        return captureListEntires.first(where: { supportedCaptures.contains($0) })
+                    }
+
+                    let selfCapture = selfCaptureType()
+
+                    /// Whether or not the closure at the current index permits implicit self.
+                    ///
+                    /// SE-0269 (in Swift 5.3) allows implicit self when:
+                    ///  - the closure captures self explicitly using [self] or [unowned self]
+                    ///  - self is not a reference type
+                    ///
+                    /// SE-0365 (in Swift 5.8) additionally allows implicit self using
+                    /// [weak self] captures after self has been unwrapped.
+                    func closureAllowsImplicitSelf() -> Bool {
+                        guard formatter.options.swiftVersion >= "5.3" else {
+                            return false
+                        }
+
+                        // If self is a reference type, capturing it won't create a retain cycle,
+                        // so the compiler lets us use implicit self
+                        if let enclosingTypeKeyword = typeStack.last?.keyword,
+                           enclosingTypeKeyword == "struct" || enclosingTypeKeyword == "enum"
+                        {
+                            return true
+                        }
+
+                        guard let selfCapture = selfCapture else {
+                            return false
+                        }
+
+                        // If self is captured strongly, or using `unowned`, then the compiler
+                        // lets us use implicit self since it's already clear that this closure
+                        // captures self strongly
+                        if selfCapture == "self"
+                            || selfCapture == "unowned self"
+                            || selfCapture == "unowned(safe) self"
+                            || selfCapture == "unowned(unsafe) self"
+                        {
+                            return true
+                        }
+
+                        // This is also supported for `weak self` captures, but only
+                        // in Swift 5.8 or later
+                        if selfCapture == "weak self",
+                           formatter.options.swiftVersion >= "5.8"
+                        {
+                            return true
+                        }
+
+                        return false
+                    }
+
+                    closureStack.append((allowsImplicitSelf: closureAllowsImplicitSelf(), selfCapture: selfCapture))
+                    index += 1
+                    processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack, closureStack: &closureStack,
+                                membersByType: &membersByType, classMembersByType: &classMembersByType,
+                                usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: isInit)
+                    index -= 1
+                    closureStack.removeLast()
                 case .startOfScope:
                     index = formatter.endOfScope(at: index) ?? (formatter.tokens.count - 1)
                 case .identifier("self"):
@@ -3501,6 +3595,9 @@ public struct _FormatRules {
                         {
                             break
                         }
+                    }
+                    if let closure = closureStack.last, !closure.allowsImplicitSelf {
+                        break
                     }
                     _ = formatter.removeSelf(at: index, exclude: localNames)
                 case .identifier("type"): // Special case for type(of:)
@@ -3600,7 +3697,8 @@ public struct _FormatRules {
         }
         func processAccessors(_ names: [String], for name: String, at index: inout Int,
                               localNames: Set<String>, members: Set<String>,
-                              typeStack: inout [String],
+                              typeStack: inout [(name: String, keyword: String)],
+                              closureStack: inout [(allowsImplicitSelf: Bool, selfCapture: String?)],
                               membersByType: inout [String: Set<String>],
                               classMembersByType: inout [String: Set<String>],
                               usingDynamicLookup: Bool)
@@ -3633,7 +3731,7 @@ public struct _FormatRules {
                     }
                 }
                 processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
-                            membersByType: &membersByType, classMembersByType: &classMembersByType,
+                            closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                             usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: false)
             }
             if foundAccessors {
@@ -3643,12 +3741,13 @@ public struct _FormatRules {
                 index += 1
                 localNames.insert(name)
                 processBody(at: &index, localNames: localNames, members: members, typeStack: &typeStack,
-                            membersByType: &membersByType, classMembersByType: &classMembersByType,
+                            closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                             usingDynamicLookup: usingDynamicLookup, isTypeRoot: false, isInit: false)
             }
         }
         func processFunction(at index: inout Int, localNames: Set<String>, members: Set<String>,
-                             typeStack: inout [String],
+                             typeStack: inout [(name: String, keyword: String)],
+                             closureStack: inout [(allowsImplicitSelf: Bool, selfCapture: String?)],
                              membersByType: inout [String: Set<String>],
                              classMembersByType: inout [String: Set<String>],
                              usingDynamicLookup: Bool)
@@ -3701,7 +3800,7 @@ public struct _FormatRules {
             if startToken == .keyword("subscript") {
                 index = bodyStartIndex
                 processAccessors(["get", "set"], for: "", at: &index, localNames: localNames,
-                                 members: members, typeStack: &typeStack, membersByType: &membersByType,
+                                 members: members, typeStack: &typeStack, closureStack: &closureStack, membersByType: &membersByType,
                                  classMembersByType: &classMembersByType,
                                  usingDynamicLookup: usingDynamicLookup)
             } else {
@@ -3710,6 +3809,7 @@ public struct _FormatRules {
                             localNames: localNames,
                             members: members,
                             typeStack: &typeStack,
+                            closureStack: &closureStack,
                             membersByType: &membersByType,
                             classMembersByType: &classMembersByType,
                             usingDynamicLookup: usingDynamicLookup,
@@ -3717,12 +3817,13 @@ public struct _FormatRules {
                             isInit: startToken == .keyword("init"))
             }
         }
-        var typeStack = [String]()
+        var typeStack = [(name: String, keyword: String)]()
+        var closureStack = [(allowsImplicitSelf: Bool, selfCapture: String?)]()
         var membersByType = [String: Set<String>]()
         var classMembersByType = [String: Set<String>]()
         var index = 0
         processBody(at: &index, localNames: [], members: [], typeStack: &typeStack,
-                    membersByType: &membersByType, classMembersByType: &classMembersByType,
+                    closureStack: &closureStack, membersByType: &membersByType, classMembersByType: &classMembersByType,
                     usingDynamicLookup: false, isTypeRoot: false, isInit: false)
     }
 

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -44,7 +44,7 @@ public let swiftVersionFile = ".swift-version"
 /// Supported Swift versions
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
-    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7",
+    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8",
 ]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat


### PR DESCRIPTION
As of SE-0269 and SE-0365, implicit self is allowed in closures under certain circumstances. This PR updates the `redundantSelf` rule to use implicit self in closures that meet these requirements.

### SE-0269 (Swift 5.3+)

```diff
  class Foo {
      let bar: Int
  
      func method() {
          closure { [self] in
              // self is already captured explicitly, so explicit self is not necessary:
-             print(self.bar)
+             print(bar)
          }
      }
  }
```

```diff
  struct Foo {
      let bar: Int
  
      func method() {
          closure {
              // self is a value type so capturing it is unlikely to produce a retain cycle:
-             print(self.bar)
+             print(bar)
          }
      }
  }
```

### SE-0365 (Swift 5.8+)

```diff
  class Foo {
      let bar: Int
  
      func method() {
          closure { [weak self] in
              guard let self else { return }
              // self is already captured explicitly, so explicit self is not necessary:
-             print(self.bar)
+             print(bar)
          }
      }
  }
```