### PR TITLE
Fix issue where `redundantSelf` ignored parameters in closures without capture list

### DIFF
--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -3321,6 +3321,23 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
     }
 
+    func testClosureParameterListShadowingPropertyOnSelfInStruct() {
+        let input = """
+        struct Foo {
+            var bar = "bar"
+
+            func method() {
+                closure { bar in
+                    self.bar = bar
+                }
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.3")
+        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
+    }
+
     func testClosureCaptureListShadowingPropertyOnSelf() {
         let input = """
         class Foo {


### PR DESCRIPTION
This PR fixes another issue with #1303 that could cause the build to break, because we weren't parsing and handling parameter lists in closures that didn't also have a capture list. For example:

```diff
  struct Foo {
      var bar = "bar"
      func method() {
          closure { [self] bar in
-           self.bar = bar
+           bar = bar
          }
      }
  }
```