### PR TITLE
Standardize working directory path

### DIFF
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -81,4 +81,6 @@ CLI.print = { message, type in
     }
 }
 
-exit(CLI.run(in: FileManager.default.currentDirectoryPath).rawValue)
+let currentDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).standardizedFileURL
+
+exit(CLI.run(in: currentDirectory.path).rawValue)

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -301,7 +301,7 @@ private func processDirectory(_ inputURL: URL, with options: inout Options, logg
         configCache[inputURL] = args
     }
     assert(options.formatOptions != nil)
-    try options.addArguments(args, in: inputURL.path)
+    try options.addArguments(args, in: inputURL.standardizedFileURL.path)
 }
 
 /// Line and column offset in source


### PR DESCRIPTION
Problem: when invoked from a directory such as `/var/tmp`, SwiftFormat will use the `/private/var/tmp` directory instead [as its working directory](https://github.com/nicklockwood/SwiftFormat/blob/ce821205ea1bb4de67817c2dbec99f881d0e50d4/CommandLineTool/main.swift#L84). It will then build all of the globs based on that directory and as a result of that, all exclusions/inclusions won't work because their `match(...)` will return `false`.

Solution: `/var` and `/private/var` on macOS [seems to be a big clusterfuck](https://stackoverflow.com/a/16026416/9316533), so assuming that Apple actually wants you to not use the real path (without symlinks), use the `standardizedFileURL` which kill `/private` part for us.