### PR TITLE
📝 Document `fileHeader` text tokens with example

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -676,6 +676,34 @@ Option | Description
 --- | ---
 `--header` | Header comments: "strip", "ignore", or the text you wish use
 
+<details>
+<summary>Examples</summary>
+
+You can use the following tokens in the text:
+
+Token | Description
+--- | ---
+`{file}` | File name
+`{year}` | Current year
+`{created}` | File creation date
+`{created.year}` | File creation year
+
+**Example**:
+
+`--header \n {file}\n\n Copyright © {created.year} CompanyName.\n`
+
+```diff
+- // SomeFile.swift
+
++ //
++ //  SomeFile.swift
++ //  Copyright © 2023 CompanyName.
++ //
+```
+
+</details>
+<br/>
+
 ## genericExtensions
 
 When extending generic types, use angle brackets (`extension Array<Foo>`)

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1478,4 +1478,28 @@ private struct Examples {
       }
     ```
     """
+
+    let fileHeader = """
+    You can use the following tokens in the text:
+
+    Token | Description
+    --- | ---
+    `{file}` | File name
+    `{year}` | Current year
+    `{created}` | File creation date
+    `{created.year}` | File creation year
+
+    **Example**:
+
+    `--header \\n {file}\\n\\n Copyright © {created.year} CompanyName.\\n`
+
+    ```diff
+    - // SomeFile.swift
+
+    + //
+    + //  SomeFile.swift
+    + //  Copyright © 2023 CompanyName.
+    + //
+    ```
+    """
 }


### PR DESCRIPTION
Hello,

I just wanted to standardise the headers of a project. I figured out the tokens by looking at the SwiftFormat source. Maybe it is documented elsewhere, but having an example in the `Rules.md` would have been helpful for me, so here is this PR :)