### PR TITLE
feat: Removing let when pattern is redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ Credits
 * [Romain Pouclet](https://github.com/palleas) - Homebrew formula
 * [Aerobounce](https://github.com/aerobounce) - Homebrew cask and Sublime Text plugin
 * [Cal Stephens](https://github.com/calda) - Several new formatting rules and options
-* [Facundo Menzella](https://github.com/acumenzella) - Several new formatting rules
+* [Facundo Menzella](https://github.com/facumenzella) - Several new formatting rules
 * [Ali Akhtarzada](https://github.com/aliak00) - Several path-related CLI enhancements
 * [Yonas Kolb](https://github.com/yonaskolb) - Swift Package Manager integration
 * [Wolfgang Lutz](https://github.com/Lutzifer) - AppleScript integration instructions

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2882,7 +2882,6 @@ public struct _FormatRules {
             if let prevIndex = prevIndex, formatter.tokens[prevIndex].isIdentifier,
                formatter.last(.nonSpaceOrComment, before: prevIndex)?.string == "."
             {
-                // Is an enum case
                 if let endOfScopeIndex = formatter.index(
                     before: prevIndex,
                     where: { tkn in tkn == .endOfScope("case") || tkn == .keyword("case") }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1648,7 +1648,7 @@ class RedundancyTests: RulesTests {
     // MARK: - redundantPattern
 
     func testRemoveRedundantPatternInIfCase() {
-        let input = "if case .foo(_, _) = bar {}"
+        let input = "if case let .foo(_, _) = bar {}"
         let output = "if case .foo = bar {}"
         testFormatting(for: input, output, rule: FormatRules.redundantPattern)
     }
@@ -1659,9 +1659,14 @@ class RedundancyTests: RulesTests {
     }
 
     func testRemoveRedundantPatternInSwitchCase() {
-        let input = "switch foo {\ncase .bar(_, _): break\ndefault: break\n}"
+        let input = "switch foo {\ncase let .bar(_, _): break\ndefault: break\n}"
         let output = "switch foo {\ncase .bar: break\ndefault: break\n}"
         testFormatting(for: input, output, rule: FormatRules.redundantPattern)
+    }
+
+    func testRemoveRedundantPatternNoRemoveLetInSwitchCase() {
+        let input = "switch foo {\ncase let .bar(_, a): break\ndefault: break\n}"
+        testFormatting(for: input, rule: FormatRules.redundantPattern)
     }
 
     func testNoRemoveRequiredPatternInSwitchCase() {


### PR DESCRIPTION
### Why?

Recently I've been seeing the warning detailed here https://github.com/nicklockwood/SwiftFormat/issues/1322

I've managed to easily fix it for this scenario:

```diff
var variable: Int {
  switch self {
-   case let .a(_): // 'let' pattern has no effect; sub-pattern didn't bind any variables
+   case .a: 
      return 0
    case .b:
      return 1
  }
}
```
I've implemented it inside `redundantPattern` since it was already identified.

On the other hand, when `(_)` is not present it's not straightforward, so I am taking a little bit more time to work on that one. (`redundantLet` iterates over `"_"` and `redundantPattern` over `(`)

```diff
var variable: Int {
  switch self {
-   case let .a: // 'let' pattern has no effect; sub-pattern didn't bind any variables
+   case .a:       
      return 0
    case .b:
      return 1
  } 
}
```

~I am already working on a bigger refactor over `redundantLet` to take care of all these cases~

I wonder if we should add a new rule. The missing case is not only for unused variable bindings. It can also happen when `let` is used on an enum case that has no associated value. 
Do you have thoughts around this @nicklockwood ? 