### PR TITLE
feat: Data type spacing around delimiter

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1762,6 +1762,7 @@ Option | Description
 `--operatorfunc` | Spacing for operator funcs: "spaced" (default) or "no-space"
 `--nospaceoperators` | Comma-delimited list of operators without surrounding space
 `--ranges` | Spacing for ranges: "spaced" (default) or "no-space"
+`--typedelimiter` | "trailing" (default) or "leading-trailing"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -678,6 +678,12 @@ struct _Descriptors {
             }
         }
     )
+    let spaceAroundDelimiter = OptionDescriptor(
+        argumentName: "typedelimiter",
+        displayName: "Spacing around delimiter",
+        help: "\"trailing\" (default) or \"leading-trailing\"",
+        keyPath: \.spaceAroundDelimiter
+    )
     let spaceAroundRangeOperators = OptionDescriptor(
         argumentName: "ranges",
         displayName: "Ranges",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -348,6 +348,12 @@ public enum EnumNamespacesMode: String, CaseIterable {
     case structsOnly = "structs-only"
 }
 
+/// Whether or not to add spacing around data type delimiter
+public enum SpaceAroundDelimiter: String, CaseIterable {
+    case trailing
+    case leadingTrailing = "leading-trailing"
+}
+
 /// Configuration options for formatting. These aren't actually used by the
 /// Formatter class itself, but it makes them available to the format rules.
 public struct FormatOptions: CustomStringConvertible {
@@ -431,6 +437,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var genericTypes: String
     public var useSomeAny: Bool
     public var wrapEffects: WrapEffects
+    public var spaceAroundDelimiter: SpaceAroundDelimiter
 
     // Deprecated
     public var indentComments: Bool
@@ -533,7 +540,8 @@ public struct FormatOptions: CustomStringConvertible {
                 ignoreConflictMarkers: Bool = false,
                 swiftVersion: Version = .undefined,
                 fileInfo: FileInfo = FileInfo(),
-                timeout: TimeInterval = 1)
+                timeout: TimeInterval = 1,
+                spaceAroundDelimiter: SpaceAroundDelimiter = .trailing)
     {
         self.lineAfterMarks = lineAfterMarks
         self.indent = indent
@@ -616,6 +624,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.genericTypes = genericTypes
         self.useSomeAny = useSomeAny
         self.wrapEffects = wrapEffects
+        self.spaceAroundDelimiter = spaceAroundDelimiter
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -449,7 +449,7 @@ public struct _FormatRules {
     ///   preceded by a space, unless it appears at the beginning of a line.
     public let spaceAroundOperators = FormatRule(
         help: "Add or remove space around operators or delimiters.",
-        options: ["operatorfunc", "nospaceoperators", "ranges"]
+        options: ["operatorfunc", "nospaceoperators", "ranges", "typedelimiter"]
     ) { formatter in
         formatter.forEachToken { i, token in
             switch token {
@@ -556,11 +556,15 @@ public struct _FormatRules {
                     // Ensure there is a space after the token
                     formatter.insert(.space(" "), at: i + 1)
                 }
-                if formatter.token(at: i - 1)?.isSpace == true,
-                   formatter.token(at: i - 2)?.isLinebreak == false
-                {
+
+                let spaceBeforeToken = formatter.token(at: i - 1)?.isSpace == true
+                    && formatter.token(at: i - 2)?.isLinebreak == false
+
+                if spaceBeforeToken, formatter.options.spaceAroundDelimiter == .trailing {
                     // Remove space before the token
                     formatter.removeToken(at: i - 1)
+                } else if !spaceBeforeToken, formatter.options.spaceAroundDelimiter == .leadingTrailing {
+                    formatter.insertSpace(" ", at: i)
                 }
             default:
                 break

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1167,6 +1167,63 @@ class SpacingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.spaceAroundOperators, options: options)
     }
 
+    func testSpaceAroundDataTypeDelimiterLeadingAdded() {
+        let input = "class Implementation: ImplementationProtocol {}"
+        let output = "class Implementation : ImplementationProtocol {}"
+        let options = FormatOptions(spaceAroundDelimiter: .leadingTrailing)
+        testFormatting(
+            for: input,
+            output,
+            rule: FormatRules.spaceAroundOperators,
+            options: options
+        )
+    }
+
+    func testSpaceAroundDataTypeDelimiterLeadingTrailingAdded() {
+        let input = "class Implementation:ImplementationProtocol {}"
+        let output = "class Implementation : ImplementationProtocol {}"
+        let options = FormatOptions(spaceAroundDelimiter: .leadingTrailing)
+        testFormatting(
+            for: input,
+            output,
+            rule: FormatRules.spaceAroundOperators,
+            options: options
+        )
+    }
+
+    func testSpaceAroundDataTypeDelimiterLeadingTrailingNotModified() {
+        let input = "class Implementation : ImplementationProtocol {}"
+        let options = FormatOptions(spaceAroundDelimiter: .leadingTrailing)
+        testFormatting(
+            for: input,
+            rule: FormatRules.spaceAroundOperators,
+            options: options
+        )
+    }
+
+    func testSpaceAroundDataTypeDelimiterTrailingAdded() {
+        let input = "class Implementation:ImplementationProtocol {}"
+        let output = "class Implementation: ImplementationProtocol {}"
+
+        let options = FormatOptions(spaceAroundDelimiter: .trailing)
+        testFormatting(
+            for: input,
+            output,
+            rule: FormatRules.spaceAroundOperators,
+            options: options
+        )
+    }
+
+    func testSpaceAroundDataTypeDelimiterLeadingNotAdded() {
+        let input = "class Implementation: ImplementationProtocol {}"
+        let options = FormatOptions(spaceAroundDelimiter: .trailing)
+        testFormatting(
+            for: input,
+            rule: FormatRules.spaceAroundOperators,
+            options: options
+        )
+    }
+
     // MARK: - spaceAroundComments
 
     func testSpaceAroundCommentInParens() {


### PR DESCRIPTION
## What?
Option to customise spacing around data type delimiter based on https://github.com/nicklockwood/SwiftFormat/issues/1168#issuecomment-1361464823
