### PR TITLE
FIX: Protocol Associated Type Declaration support doc style comments

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1937,6 +1937,7 @@ extension Token {
             "import", "let", "var", "typealias", "func", "enum", "case",
             "struct", "class", "actor", "protocol", "init", "deinit",
             "extension", "subscript", "operator", "precedencegroup",
+            "associatedtype",
         ])
 
         for keywordToExclude in keywordsToExclude {

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -1075,4 +1075,26 @@ class GeneralTests: RulesTests {
         """
         testFormatting(for: input, output, rule: FormatRules.leadingDelimiters)
     }
+
+    // MARK: - docComments
+
+    func testDocCommentsAssociatedTypeNotReplaced() {
+        let input = """
+        /// An interesting comment about Foo.
+        associatedtype Foo
+        """
+        testFormatting(for: input, rule: FormatRules.docComments)
+    }
+
+    func testNonDocCommentsAssociatedTypeReplaced() {
+        let input = """
+        // An interesting comment about Foo.
+        associatedtype Foo
+        """
+        let output = """
+        /// An interesting comment about Foo.
+        associatedtype Foo
+        """
+        testFormatting(for: input, output, rule: FormatRules.docComments)
+    }
 }


### PR DESCRIPTION
I think headerdoc style comments should be preserved in `associatedtype` declarations. Otherwise it breaks the header documentation being rendered within Xcode documentation/help system.

```
        /// An interesting comment about Foo.
        associatedtype Foo
```
should be preserved, not changed to
```
        // An interesting comment about Foo.
        associatedtype Foo
```

I have updated the `isDeclarationTypeKeyword` function to include this keyboard. Unit tests all pass locally.