### PR TITLE
enhancement: Add option to wrap only if associated values or raw values

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2328,6 +2328,10 @@ Wrap the bodies of inline conditional statements onto a new line.
 
 Writes one enum case per line.
 
+Option | Description
+--- | ---
+`--wrapEnumCases` | Wrap enumn cases: "always", "if-values"
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -446,6 +446,12 @@ struct _Descriptors {
         help: "Wrap all arguments: \"before-first\", \"after-first\", \"preserve\"",
         keyPath: \.wrapArguments
     )
+    let wrapEnumCases = OptionDescriptor(
+        argumentName: "wrapEnumCases",
+        displayName: "Wrap Enum Cases",
+        help: "Wrap enumn cases: \"always\", \"if-values\"",
+        keyPath: \.wrapEnumCases
+    )
     let wrapParameters = OptionDescriptor(
         argumentName: "wrapparameters",
         displayName: "Wrap Parameters",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -83,6 +83,12 @@ public enum WrapMode: String, CaseIterable {
     }
 }
 
+/// Wrap enum cases
+public enum WrapEnumCases: String, CaseIterable {
+    case always
+    case ifValues = "if-values"
+}
+
 /// Argument type for stripping
 public enum ArgumentStrippingMode: String, CaseIterable {
     case unnamedOnly = "unnamed-only"
@@ -376,6 +382,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapParameters: WrapMode
     public var wrapCollections: WrapMode
     public var wrapTypealiases: WrapMode
+    public var wrapEnumCases: WrapEnumCases
     public var closingParenOnSameLine: Bool
     public var wrapReturnType: WrapReturnType
     public var wrapConditions: WrapMode
@@ -474,6 +481,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapParameters: WrapMode = .default,
                 wrapCollections: WrapMode = .preserve,
                 wrapTypealiases: WrapMode = .preserve,
+                wrapEnumCases: WrapEnumCases = .always,
                 closingParenOnSameLine: Bool = false,
                 wrapReturnType: WrapReturnType = .preserve,
                 wrapConditions: WrapMode = .preserve,
@@ -563,6 +571,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapParameters = wrapParameters
         self.wrapCollections = wrapCollections
         self.wrapTypealiases = wrapTypealiases
+        self.wrapEnumCases = wrapEnumCases
         self.closingParenOnSameLine = closingParenOnSameLine
         self.wrapReturnType = wrapReturnType
         self.wrapConditions = wrapConditions

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1901,6 +1901,51 @@ extension Formatter {
         }
         return result
     }
+
+    struct EnumCaseRange: Comparable {
+        let value: Range<Int>
+        let endOfCaseRangeToken: Token
+
+        static func < (lhs: Formatter.EnumCaseRange, rhs: Formatter.EnumCaseRange) -> Bool {
+            lhs.value.lowerBound < rhs.value.lowerBound
+        }
+    }
+
+    func parseEnumCaseRanges() -> [[EnumCaseRange]] {
+        var indexedRanges: [Int: [EnumCaseRange]] = [:]
+
+        forEach(.keyword("case")) { i, _ in
+            guard isEnumCase(at: i) else { return }
+
+            var idx = i
+            while
+                let starOfCaseRangeIdx = index(of: .identifier, after: idx),
+                lastSignificantKeyword(at: starOfCaseRangeIdx) == "case",
+                let lastCaseIndex = lastIndex(of: .keyword("case"), in: i ..< starOfCaseRangeIdx),
+                lastCaseIndex == i,
+                let endOfCaseRangeIdx = index(
+                    after: starOfCaseRangeIdx,
+                    where: { $0 == .delimiter(",") || $0.isLinebreak }
+                ),
+                let endOfCaseRangeToken = token(at: endOfCaseRangeIdx)
+            {
+                let startOfScopeIdx = index(of: .startOfScope, before: starOfCaseRangeIdx) ?? 0
+
+                var indexedCase = indexedRanges[startOfScopeIdx, default: []]
+                indexedCase.append(
+                    EnumCaseRange(
+                        value: starOfCaseRangeIdx ..< endOfCaseRangeIdx,
+                        endOfCaseRangeToken: endOfCaseRangeToken
+                    )
+                )
+                indexedRanges[startOfScopeIdx] = indexedCase
+
+                idx = endOfCaseRangeIdx
+            }
+        }
+
+        return Array(indexedRanges.values)
+    }
 }
 
 extension _FormatRules {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4303,6 +4303,65 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrapEnumCases)
     }
 
+    func testEnumCasesIfValuesWithoutValuesDoesNothing() {
+        let input = """
+        enum Foo {
+            case bar, baz, quux
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.wrapEnumCases, options: FormatOptions(wrapEnumCases: .ifValues))
+    }
+
+    func testEnumCasesIfValuesWithRawValuesAndNestedEnum() {
+        let input = """
+        enum Foo {
+            case bar = 1, baz, quux
+
+            enum Foo2 {
+                case bar, baz, quux
+            }
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar = 1
+            case baz
+            case quux
+
+            enum Foo2 {
+                case bar, baz, quux
+            }
+        }
+        """
+        testFormatting(
+            for: input,
+            output,
+            rule: FormatRules.wrapEnumCases,
+            options: FormatOptions(wrapEnumCases: .ifValues)
+        )
+    }
+
+    func testEnumCasesIfValuesWithAssociatedValues() {
+        let input = """
+        enum Foo {
+            case bar(a: Int), baz, quux
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar(a: Int)
+            case baz
+            case quux
+        }
+        """
+        testFormatting(
+            for: input,
+            output,
+            rule: FormatRules.wrapEnumCases,
+            options: FormatOptions(wrapEnumCases: .ifValues)
+        )
+    }
+
     func testEnumCasesWithCommentsAlreadyWrappedOntoMultipleLines() {
         let input = """
         enum Foo {


### PR DESCRIPTION
## What?
Following on this [feature request](https://github.com/nicklockwood/SwiftFormat/issues/1136) to add an option only to wrap enum cases if there are associated values or raw values in at least one case.

This should do the trick.

