### PR TITLE
Update `redundantReturn` and `redundantClosure` rules to support single-statement if / switch expressions (SE-0380)

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1465,6 +1465,23 @@ Remove unneeded `return` keyword.
 ```diff
 - array.filter { return $0.foo == bar }
 + array.filter { $0.foo == bar }
+
+  // Swift 5.1+ (SE-0255)
+  var foo: String {
+-     return "foo"
++     "foo"
+  }
+
+  // Swift 5.8+ (SE-0380)
+  func foo(_ condition: Bool) -> String {
+      if condition {
+-         return "foo"
++         "foo"
+      } else {
+-         return "bar"
++         "bar"
+      }
+  }
 ```
 
 </details>

--- a/Snapshots/Consumer/Sources/Consumer.swift
+++ b/Snapshots/Consumer/Sources/Consumer.swift
@@ -70,7 +70,7 @@ public extension Consumer {
     struct Location: Equatable {
         fileprivate var source: String.UnicodeScalarView
         public let range: Range<String.Index>
-        public var offset: (line: Int, column: Int) { return _offset }
+        public var offset: (line: Int, column: Int) { _offset }
     }
 
     /// Abstract syntax tree returned by consumer

--- a/Snapshots/Layout/Layout/LayoutLoader.swift
+++ b/Snapshots/Layout/Layout/LayoutLoader.swift
@@ -420,9 +420,7 @@ class LayoutLoader {
         }
     }
 
-    private var _sourcePaths: [String: String] = {
-        layoutSettings["sourcePaths"] as? [String: String] ?? [:]
-    }()
+    private var _sourcePaths: [String: String] = layoutSettings["sourcePaths"] as? [String: String] ?? [:]
 
     private var sourcePaths: [String: String] {
         get { return _sourcePaths }

--- a/Snapshots/Layout/Layout/LayoutNode.swift
+++ b/Snapshots/Layout/Layout/LayoutNode.swift
@@ -1607,9 +1607,7 @@ public class LayoutNode: NSObject {
     }
 
     public lazy var viewExpressionTypes: [String: RuntimeType] = viewClass.cachedExpressionTypes
-    public lazy var viewControllerExpressionTypes: [String: RuntimeType] = {
-        self.viewControllerClass.map { $0.cachedExpressionTypes } ?? [:]
-    }()
+    public lazy var viewControllerExpressionTypes: [String: RuntimeType] = self.viewControllerClass.map { $0.cachedExpressionTypes } ?? [:]
 
     #if arch(i386) || arch(x86_64)
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -597,6 +597,23 @@ private struct Examples {
     ```diff
     - array.filter { return $0.foo == bar }
     + array.filter { $0.foo == bar }
+
+      // Swift 5.1+ (SE-0255)
+      var foo: String {
+    -     return "foo"
+    +     "foo"
+      }
+
+      // Swift 5.8+ (SE-0380)
+      func foo(_ condition: Bool) -> String {
+          if condition {
+    -         return "foo"
+    +         "foo"
+          } else {
+    -         return "bar"
+    +         "bar"
+          }
+      }
     ```
     """
 

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1211,7 +1211,7 @@ extension Formatter {
     }
 
     /// Whether the given index is directly within the body of the given scope, or part of a nested closure
-    private func indexIsWithinNestedClosure(_ index: Int, startOfScopeIndex: Int) -> Bool {
+    func indexIsWithinNestedClosure(_ index: Int, startOfScopeIndex: Int) -> Bool {
         let startOfScopeAtIndex: Int
         if token(at: index)?.isStartOfScope == true {
             startOfScopeAtIndex = index

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1037,7 +1037,7 @@ extension Formatter {
     func blockBodyHasSingleStatement(atStartOfScope startOfScopeIndex: Int) -> Bool {
         guard let endOfScopeIndex = endOfScope(at: startOfScopeIndex) else { return false }
 
-        let startOfBody = startOfBody(atStartOfScope: startOfScopeIndex)
+        let startOfBody = self.startOfBody(atStartOfScope: startOfScopeIndex)
 
         // Some heuristics to determine if this is a multi-statement block:
 

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1973,9 +1973,11 @@ class RedundancyTests: RulesTests {
                        exclude: ["redundantParens", "wrapConditionalBodies"])
     }
 
-    func testNoRemoveReturnInTupleVarGetter() {
+    func testRemoveReturnInTupleVarGetter() {
         let input = "var foo: (Int, Int) { return (1, 2) }"
-        testFormatting(for: input, rule: FormatRules.redundantReturn)
+        let output = "var foo: (Int, Int) { (1, 2) }"
+        let options = FormatOptions(swiftVersion: "5.1")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
     }
 
     func testNoRemoveReturnInIfLetWithNoSpaceAfterParen() {
@@ -5754,8 +5756,8 @@ class RedundancyTests: RulesTests {
     }
 
     func testOperatorArgumentsAreUnnamed() {
-        let input = "func == (lhs: Int, rhs: Int) { return false }"
-        let output = "func == (_: Int, _: Int) { return false }"
+        let input = "func == (lhs: Int, rhs: Int) { false }"
+        let output = "func == (_: Int, _: Int) { false }"
         testFormatting(for: input, output, rule: FormatRules.unusedArguments)
     }
 

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2147,6 +2147,65 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantReturn)
     }
 
+    func testRedundantIfStatementReturnSwift5_7() {
+        let input = """
+        func foo(condition: Bool) -> String {
+            if condition {
+                return "foo"
+            } else {
+                return "bar"
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.redundantReturn)
+    }
+
+    func testRedundantIfStatementReturnInFunction() {
+        let input = """
+        func foo(condition: Bool) -> String {
+            if condition {
+                return "foo"
+            } else {
+                return "bar"
+            }
+        }
+        """
+        let output = """
+        func foo(condition: Bool) -> String {
+            if condition {
+                "foo"
+            } else {
+                "bar"
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
+    func testRedundantIfStatementReturnInClosure() {
+        let input = """
+        let closure: (Bool) -> String { condition in
+            if condition {
+                return "foo"
+            } else {
+                return "bar"
+            }
+        }
+        """
+        let output = """
+        let closure: (Bool) -> String { condition in
+            if condition {
+                "foo"
+            } else {
+                "bar"
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
     // MARK: - redundantBackticks
 
     func testRemoveRedundantBackticksInLet() {


### PR DESCRIPTION
This PR updates the `redundantReturn` and `redundantClosure` rules to support the new single-statement if / switch expression syntax added in [SE-0380](https://github.com/apple/swift-evolution/blob/main/proposals/0380-if-switch-expressions.md), which looks like it will be included in Swift 5.8.

```diff
  func foo(_ condition: Bool) -> String {
      if condition {
-         return "foo"
+         "foo"
      } else {
-         return "bar"
+         "bar"
      }
  }
```

```diff

- let value = {
-     if condition {
-         return "foo"
-     } else {
-         return "bar"
-     }
- }()
+ let value = if condition {
+     "foo"
+ } else {
+     "bar"
+ }
```

I took these steps when working on this change, and you can review each of these changes individually by looking at the respective commit:

1. I factored out the `blockBodyHasSingleStatement` logic in the `redundantClosure` rule into a separate helper function

 2. I reimplemented the `redundantReturn` rule using the `blockBodyHasSingleStatement` helper. This made it a lot easier to apply this logic recursively (which is necessary to handle nested if/switch expressions), and lets us share the new logic across multiple rule implementations.

 3. I updated the `blockBodyHasSingleStatement` helper to support handling the new single-statenent if / switch expression syntax