### PR TITLE
[SE-0380] Add `conditionalAssignment` rule, update `redundantType` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -8,6 +8,7 @@
 * [blankLinesAtStartOfScope](#blankLinesAtStartOfScope)
 * [blankLinesBetweenScopes](#blankLinesBetweenScopes)
 * [braces](#braces)
+* [conditionalAssignment](#conditionalAssignment)
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
 * [duplicateImports](#duplicateImports)
@@ -439,6 +440,41 @@ Option | Description
   }
 + else {
     // bar
+  }
+```
+
+</details>
+<br/>
+
+## conditionalAssignment
+
+Assign properties using if / switch expressions.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let foo: String
+- if condition {
++ let foo = if condition {
+-     foo = "foo"
++     "foo"
+  } else {
+-     return "bar"
++     "bar"
+  }
+```
+
+```diff
+- let foo: String
+- switch condition {
++ let foo = switch condition {
+  case true:
+-     foo = "foo"
++     "foo"
+  case false:
+-     foo = "bar"
++     "bar"
   }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -460,7 +460,7 @@ Assign properties using if / switch expressions.
 -     foo = "foo"
 +     "foo"
   } else {
--     return "bar"
+-     bar = "bar"
 +     "bar"
   }
 ```
@@ -1612,6 +1612,23 @@ Option | Description
 -         let view: UIView = UIView()
 +         let view = UIView()
       }
+  }
+
+// Swift 5.8+, inferred (SE-0380)
+- let foo: Foo = if condition {
++ let foo = if condition {
+      Foo("foo")
+  } else {
+      Foo("bar")
+  }
+
+// Swift 5.8+, explicit (SE-0380)
+  let foo: Foo = if condition {
+-     Foo("foo")
++     .init("foo")
+  } else {
+-     Foo("bar")
++     .init("foo")
   }
 ```
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1530,4 +1530,31 @@ private struct Examples {
     + //
     ```
     """
+
+    let conditionalAssignment = """
+    ```diff
+    - let foo: String
+    - if condition {
+    + let foo = if condition {
+    -     foo = "foo"
+    +     "foo"
+      } else {
+    -     return "bar"
+    +     "bar"
+      }
+    ```
+
+    ```diff
+    - let foo: String
+    - switch condition {
+    + let foo = switch condition {
+      case true:
+    -     foo = "foo"
+    +     "foo"
+      case false:
+    -     foo = "bar"
+    +     "bar"
+      }
+    ```
+    """
 }

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -853,6 +853,23 @@ private struct Examples {
     +         let view = UIView()
           }
       }
+
+    // Swift 5.8+, inferred (SE-0380)
+    - let foo: Foo = if condition {
+    + let foo = if condition {
+          Foo("foo")
+      } else {
+          Foo("bar")
+      }
+
+    // Swift 5.8+, explicit (SE-0380)
+      let foo: Foo = if condition {
+    -     Foo("foo")
+    +     .init("foo")
+      } else {
+    -     Foo("bar")
+    +     .init("foo")
+      }
     ```
     """
 
@@ -1539,7 +1556,7 @@ private struct Examples {
     -     foo = "foo"
     +     "foo"
       } else {
-    -     return "bar"
+    -     bar = "bar"
     +     "bar"
       }
     ```

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1230,7 +1230,6 @@ extension Formatter {
                 for branch in conditionalBranches.reversed() {
                     handle(branch)
                 }
-                return
             } else {
                 handle(branch)
             }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1227,9 +1227,7 @@ extension Formatter {
             if let tokenAfterEquals = index(of: .nonSpaceOrCommentOrLinebreak, after: branch.startOfBranch),
                let conditionalBranches = conditionalBranches(at: tokenAfterEquals)
             {
-                for branch in conditionalBranches.reversed() {
-                    handle(branch)
-                }
+                forEachRecursiveConditionalBranch(in: conditionalBranches, handle)
             } else {
                 handle(branch)
             }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1142,6 +1142,53 @@ extension Formatter {
         }
     }
 
+    /// Parses a type name starting at the given index, of one of the following forms:
+    ///  - `Foo`
+    ///  - `[...]`
+    ///  - `(...)`
+    ///  - `Foo<...>`
+    ///  - `(...) -> ...`
+    func parseType(at startOfTypeIndex: Int) -> (name: String, range: ClosedRange<Int>) {
+        // Parse types of the form `[...]`
+        if tokens[startOfTypeIndex] == .startOfScope("["),
+           let endOfScope = endOfScope(at: startOfTypeIndex)
+        {
+            let typeRange = startOfTypeIndex ... endOfScope
+            return (name: tokens[typeRange].string, range: typeRange)
+        }
+
+        // Parse types of the form `(...)` or `(...) -> ...`
+        if tokens[startOfTypeIndex] == .startOfScope("("),
+           let endOfScope = endOfScope(at: startOfTypeIndex)
+        {
+            // Parse types of the form `(...) -> ...`
+            if let closureReturnIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfScope),
+               tokens[closureReturnIndex] == .operator("->", .infix),
+               let returnTypeIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: closureReturnIndex)
+            {
+                let returnTypeRange = parseType(at: returnTypeIndex).range
+                let typeRange = startOfTypeIndex ... returnTypeRange.upperBound
+                return (name: tokens[typeRange].string, range: typeRange)
+            }
+
+            // Otherwise this is just `(...)`
+            let typeRange = startOfTypeIndex ... endOfScope
+            return (name: tokens[typeRange].string, range: typeRange)
+        }
+
+        // Parse types of the form `Foo<...>`
+        if let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfTypeIndex),
+           tokens[nextTokenIndex] == .startOfScope("<"),
+           let endOfScope = endOfScope(at: nextTokenIndex)
+        {
+            let typeRange = startOfTypeIndex ... endOfScope
+            return (name: tokens[typeRange].string, range: typeRange)
+        }
+
+        // Otherwise this is just a single identifier
+        return (name: tokens[startOfTypeIndex].string, range: startOfTypeIndex ... startOfTypeIndex)
+    }
+
     struct ImportRange: Comparable {
         var module: String
         var range: Range<Int>

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1148,7 +1148,23 @@ extension Formatter {
     ///  - `(...)`
     ///  - `Foo<...>`
     ///  - `(...) -> ...`
+    ///  - `...?`
+    ///  - `...!`
     func parseType(at startOfTypeIndex: Int) -> (name: String, range: ClosedRange<Int>) {
+        let baseType = parseNonOptionalType(at: startOfTypeIndex)
+
+        // Any type can be optional, so check for a trailing `?` or `!`
+        if let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: baseType.range.upperBound),
+           ["?", "!"].contains(tokens[nextToken].string)
+        {
+            let typeRange = baseType.range.lowerBound ... nextToken
+            return (name: tokens[typeRange].string, range: typeRange)
+        }
+
+        return baseType
+    }
+
+    private func parseNonOptionalType(at startOfTypeIndex: Int) -> (name: String, range: ClosedRange<Int>) {
         // Parse types of the form `[...]`
         if tokens[startOfTypeIndex] == .startOfScope("["),
            let endOfScope = endOfScope(at: startOfTypeIndex)

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7683,13 +7683,13 @@ public struct _FormatRules {
                     // remaining code in the branch is a single statement. To do that we can
                     // create a temporary formatter with the branch body _excluding_ `identifier =`.
                     let assignmentStatementRange = valueStartIndex ..< branch.endOfBranch
-                    var fakeScopeTokens = [Token]()
-                    fakeScopeTokens.append(.startOfScope("{"))
-                    fakeScopeTokens.append(contentsOf: formatter.tokens[assignmentStatementRange])
-                    fakeScopeTokens.append(.endOfScope("}"))
+                    var tempScopeTokens = [Token]()
+                    tempScopeTokens.append(.startOfScope("{"))
+                    tempScopeTokens.append(contentsOf: formatter.tokens[assignmentStatementRange])
+                    tempScopeTokens.append(.endOfScope("}"))
 
-                    let formatter = Formatter(fakeScopeTokens, options: formatter.options)
-                    return formatter.blockBodyHasSingleStatement(atStartOfScope: 0)
+                    let tempFormatter = Formatter(tempScopeTokens, options: formatter.options)
+                    return tempFormatter.blockBodyHasSingleStatement(atStartOfScope: 0)
                 }
 
                 return false

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -524,6 +524,12 @@ extension Token {
     }
 }
 
+extension Collection<Token> {
+    var string: String {
+        map { $0.string }.joined()
+    }
+}
+
 extension UnicodeScalar {
     var isDigit: Bool { isdigit(Int32(value)) > 0 }
     var isHexDigit: Bool { isxdigit(Int32(value)) > 0 }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -524,7 +524,7 @@ extension Token {
     }
 }
 
-extension Collection<Token> {
+extension Collection where Element == Token {
     var string: String {
         map { $0.string }.joined()
     }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1628,6 +1628,20 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 5).name, "Foo")
     }
 
+    func testParseOptionalType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo? = .init()
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "Foo?")
+    }
+
+    func testParseIOUType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo! = .init()
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "Foo!")
+    }
+
     func testParseGenericType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo<Bar, Baaz> = .init()
@@ -1635,11 +1649,25 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 5).name, "Foo<Bar, Baaz>")
     }
 
+    func testParseOptionalGenericType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo<Bar, Baaz>? = .init()
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "Foo<Bar, Baaz>?")
+    }
+
     func testParseDictionaryType() {
         let formatter = Formatter(tokenize("""
         let foo: [Foo: Bar] = [:]
         """))
         XCTAssertEqual(formatter.parseType(at: 5).name, "[Foo: Bar]")
+    }
+
+    func testParseOptionalDictionaryType() {
+        let formatter = Formatter(tokenize("""
+        let foo: [Foo: Bar]? = [:]
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "[Foo: Bar]?")
     }
 
     func testParseTupleType() {
@@ -1654,5 +1682,19 @@ class ParsingHelpersTests: XCTestCase {
         let foo: (Foo, Bar) -> (Foo, Bar) = { foo, bar in (foo, bar) }
         """))
         XCTAssertEqual(formatter.parseType(at: 5).name, "(Foo, Bar) -> (Foo, Bar)")
+    }
+
+    func testParseOptionalReturningClosureType() {
+        let formatter = Formatter(tokenize("""
+        let foo: (Foo, Bar) -> (Foo, Bar)? = { foo, bar in (foo, bar) }
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "(Foo, Bar) -> (Foo, Bar)?")
+    }
+
+    func testParseOptionalClosureType() {
+        let formatter = Formatter(tokenize("""
+        let foo: ((Foo, Bar) -> (Foo, Bar)?)? = { foo, bar in (foo, bar) }
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "((Foo, Bar) -> (Foo, Bar)?)?")
     }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1618,4 +1618,41 @@ class ParsingHelpersTests: XCTestCase {
         """))
         XCTAssertFalse(formatter.isStartOfStatement(at: 16))
     }
+
+    // MARK: - parseTypes
+
+    func testParseSimpleType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo = .init()
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "Foo")
+    }
+
+    func testParseGenericType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo<Bar, Baaz> = .init()
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "Foo<Bar, Baaz>")
+    }
+
+    func testParseDictionaryType() {
+        let formatter = Formatter(tokenize("""
+        let foo: [Foo: Bar] = [:]
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "[Foo: Bar]")
+    }
+
+    func testParseTupleType() {
+        let formatter = Formatter(tokenize("""
+        let foo: (Foo, Bar) = (Foo(), Bar())
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "(Foo, Bar)")
+    }
+
+    func testParseClosureType() {
+        let formatter = Formatter(tokenize("""
+        let foo: (Foo, Bar) -> (Foo, Bar) = { foo, bar in (foo, bar) }
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5).name, "(Foo, Bar) -> (Foo, Bar)")
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1236,10 +1236,10 @@ class RedundancyTests: RulesTests {
 
     func testPreservesNonRedundantTypeWithIfExpression() {
         let input = """
-        let foo: FooOrBar = if condition {
+        let foo: Foo = if condition {
             Foo("foo")
         } else {
-            Bar("bar")
+            FooSubclass("bar")
         }
         """
         let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1284,29 +1284,74 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
+    func testRedundantTypeWithNestedIfExpression_inferred() {
+        let input = """
+        let foo: Foo = if condition {
+            switch condition {
+            case true:
+                if condition {
+                    Foo("foo")
+                } else {
+                    Foo("bar")
+                }
+            case false:
+                Foo("baaz")
+            }
+        } else {
+            Foo("quux")
+        }
+        """
+        let output = """
+        let foo = if condition {
+            switch condition {
+            case true:
+                if condition {
+                    Foo("foo")
+                } else {
+                    Foo("bar")
+                }
+            case false:
+                Foo("baaz")
+            }
+        } else {
+            Foo("quux")
+        }
+        """
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
     func testRedundantTypeWithNestedIfExpression_explicit() {
         let input = """
         let foo: Foo = if condition {
             switch condition {
             case true:
-                Foo("foo")
+                if condition {
+                    Foo("foo")
+                } else {
+                    Foo("bar")
+                }
             case false:
-                Foo("bar")
+                Foo("baaz")
             }
         } else {
-            Foo("baaz")
+            Foo("quux")
         }
         """
         let output = """
         let foo: Foo = if condition {
             switch condition {
             case true:
-                .init("foo")
+                if condition {
+                    .init("foo")
+                } else {
+                    .init("bar")
+                }
             case false:
-                .init("bar")
+                .init("baaz")
             }
         } else {
-            .init("baaz")
+            .init("quux")
         }
         """
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.8")

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1221,6 +1221,117 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantType, options: options)
     }
 
+    func testPreservesTypeWithIfExpressionInSwift5_7() {
+        let input = """
+        let foo: Foo
+        if condition {
+            foo = Foo("foo")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testPreservesNonRedundantTypeWithIfExpression() {
+        let input = """
+        let foo: FooOrBar = if condition {
+            Foo("foo")
+        } else {
+            Bar("bar")
+        }
+        """
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeWithIfExpression_inferred() {
+        let input = """
+        let foo: Foo = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+        let output = """
+        let foo = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeWithIfExpression_explicit() {
+        let input = """
+        let foo: Foo = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+        let output = """
+        let foo: Foo = if condition {
+            .init("foo")
+        } else {
+            .init("bar")
+        }
+        """
+        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeWithNestedIfExpression_explicit() {
+        let input = """
+        let foo: Foo = if condition {
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        } else {
+            Foo("baaz")
+        }
+        """
+        let output = """
+        let foo: Foo = if condition {
+            switch condition {
+            case true:
+                .init("foo")
+            case false:
+                .init("bar")
+            }
+        } else {
+            .init("baaz")
+        }
+        """
+        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
+    func testRedundantTypeWithLiteralsInIfExpression() {
+        let input = """
+        let foo: String = if condition {
+            "foo"
+        } else {
+            "bar"
+        }
+        """
+        let output = """
+        let foo = if condition {
+            "foo"
+        } else {
+            "bar"
+        }
+        """
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+    }
+
     // --redundanttype explicit
 
     func testVarRedundantTypeRemovalExplicitType() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3564,4 +3564,266 @@ class SyntaxTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.docComments)
     }
+
+    // MARK: - conditionalAssignment
+
+    func testDoesntConvertIfStatementAssignmentSwift5_7() {
+        let input = """
+        let foo: Foo
+        if condition {
+            foo = Foo("foo")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testConvertsIfStatementAssignment() {
+        let input = """
+        let foo: Foo
+        if condition {
+            foo = Foo("foo")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let output = """
+        let foo: Foo = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testConvertsSimpleSwitchStatementAssignment() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case true:
+            foo = Foo("foo")
+        case false:
+            foo = Foo("bar")
+        }
+        """
+        let output = """
+        let foo: Foo = switch condition {
+        case true:
+            Foo("foo")
+        case false:
+            Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testConvertsTrivialSwitchStatementAssignment() {
+        let input = """
+        let foo: Foo
+        switch enumWithOnceCase(let value) {
+        case singleCase:
+            foo = value
+        }
+        """
+        let output = """
+        let foo: Foo = switch enumWithOnceCase(let value) {
+        case singleCase:
+            value
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testConvertsNestedIfAndStatementAssignments() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case true:
+            if condition {
+                foo = Foo("foo")
+            } else {
+                foo = Foo("bar")
+            }
+        case false:
+            switch condition {
+            case true:
+                foo = Foo("baaz")
+            case false:
+                foo = Foo("quux")
+            }
+        }
+        """
+        let output = """
+        let foo: Foo = switch condition {
+        case true:
+            if condition {
+                Foo("foo")
+            } else {
+                Foo("bar")
+            }
+        case false:
+            switch condition {
+            case true:
+                Foo("baaz")
+            case false:
+                Foo("quux")
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testConvertsIfStatementAssignmentPreservingComment() {
+        let input = """
+        let foo: Foo
+        // This is a comment between the property and condition
+        if condition {
+            foo = Foo("foo")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let output = """
+        let foo: Foo
+        // This is a comment between the property and condition
+        = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["indent"])
+    }
+
+    func testDoesntConvertsIfStatementAssigningMultipleProperties() {
+        let input = """
+        let foo: Foo
+        let bar: Bar
+        if condition {
+            foo = Foo("foo")
+            bar = Bar("foo")
+        } else {
+            foo = Foo("bar")
+            bar = Bar("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertsIfStatementAssigningDifferentProperties() {
+        let input = """
+        var foo: Foo?
+        var bar: Bar?
+        if condition {
+            foo = Foo("foo")
+        } else {
+            bar = Bar("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertNonExhaustiveIfStatementAssignment1() {
+        let input = """
+        var foo: Foo?
+        if condition {
+            foo = Foo("foo")
+        } else if someOtherCondition {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertNonExhaustiveIfStatementAssignment2() {
+        let input = """
+        var foo: Foo?
+        if condition {
+            if condition {
+                foo = Foo("foo")
+            }
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementAssignment1() {
+        let input = """
+        let foo: Foo
+        if condition {
+            foo = Foo("foo")
+            print("Multi-statement")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementAssignment2() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case true:
+            foo = Foo("foo")
+            print("Multi-statement")
+        case false:
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementAssignment3() {
+        let input = """
+        let foo: Foo
+        if condition {
+            if condition {
+                foo = Foo("bar")
+            } else {
+                foo = Foo("baaz")
+            }
+            print("Multi-statement")
+        } else {
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementAssignment4() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case true:
+            if condition {
+                foo = Foo("bar")
+            } else {
+                foo = Foo("baaz")
+            }
+            print("Multi-statement")
+        case false:
+            foo = Foo("bar")
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.8")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3597,7 +3597,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.8")
-        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
     func testConvertsSimpleSwitchStatementAssignment() {
@@ -3619,7 +3619,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.8")
-        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
     func testConvertsTrivialSwitchStatementAssignment() {
@@ -3677,7 +3677,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.8")
-        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
     func testConvertsIfStatementAssignmentPreservingComment() {
@@ -3700,7 +3700,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.8")
-        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["indent"])
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["indent", "redundantType"])
     }
 
     func testDoesntConvertsIfStatementAssigningMultipleProperties() {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3655,7 +3655,11 @@ class SyntaxTests: RulesTests {
             case true:
                 foo = Foo("baaz")
             case false:
-                foo = Foo("quux")
+                if condition {
+                    foo = Foo("quux")
+                } else {
+                    foo = Foo("quack")
+                }
             }
         }
         """
@@ -3672,7 +3676,11 @@ class SyntaxTests: RulesTests {
             case true:
                 Foo("baaz")
             case false:
-                Foo("quux")
+                if condition {
+                    Foo("quux")
+                } else {
+                    Foo("quack")
+                }
             }
         }
         """


### PR DESCRIPTION
This PR adds a new `conditionalAssignment` rule and updates the `redundantType` rule to handle the if / switch expression assignment syntax added in Swift 5.8 (SE-0380).


This updates code using the following pattern:

```swift
let foo: Foo
if condition {
    foo = Foo("foo")
} else {
    foo = Foo("bar")
}
```

to either:

```swift
let foo = if condition {
    Foo("foo")
} else {
    Foo("bar")
}
```

or:

```swift
let foo: Foo = if condition {
    .init("foo")
} else {
    .init("bar")
}
```