### PR TITLE
Use Ubuntu 20.04 in Linux CI

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build SwiftFormat for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This makes sure `swiftformat` is linked against an old enough version of `glibc` to be able to be used with current stable distributions (like Debian 11, or Ubuntu >= 20.04).