### PR TITLE
Update if / switch expression features to be enabled in Swift 5.9+

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -781,8 +781,8 @@ public struct _FormatRules {
                 }
             }
 
-            // In Swift 5.8+ we need to handle if / switch expressions by checking each branch
-            if formatter.options.swiftVersion >= "5.8",
+            // In Swift 5.9+ (SE-0380) we need to handle if / switch expressions by checking each branch
+            if formatter.options.swiftVersion >= "5.9",
                let tokenAfterEquals = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
                let conditionalBranches = formatter.conditionalBranches(at: tokenAfterEquals),
                formatter.allRecursiveConditionalBranches(
@@ -7550,8 +7550,8 @@ public struct _FormatRules {
     public let conditionalAssignment = FormatRule(
         help: "Assign properties using if / switch expressions."
     ) { formatter in
-        // If / switch expressions were added in Swift 5.8 (SE-0380)
-        guard formatter.options.swiftVersion >= "5.8" else {
+        // If / switch expressions were added in Swift 5.9 (SE-0380)
+        guard formatter.options.swiftVersion >= "5.9" else {
             return
         }
 

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -44,7 +44,7 @@ public let swiftVersionFile = ".swift-version"
 /// Supported Swift versions
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
-    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8",
+    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9",
 ]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1221,7 +1221,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantType, options: options)
     }
 
-    func testPreservesTypeWithIfExpressionInSwift5_7() {
+    func testPreservesTypeWithIfExpressionInSwift5_8() {
         let input = """
         let foo: Foo
         if condition {
@@ -1230,7 +1230,7 @@ class RedundancyTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.7")
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
         testFormatting(for: input, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1242,7 +1242,7 @@ class RedundancyTests: RulesTests {
             FooSubclass("bar")
         }
         """
-        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1261,7 +1261,7 @@ class RedundancyTests: RulesTests {
             Foo("bar")
         }
         """
-        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1280,7 +1280,7 @@ class RedundancyTests: RulesTests {
             .init("bar")
         }
         """
-        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1317,7 +1317,7 @@ class RedundancyTests: RulesTests {
             Foo("quux")
         }
         """
-        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1354,7 +1354,7 @@ class RedundancyTests: RulesTests {
             .init("quux")
         }
         """
-        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 
@@ -1373,7 +1373,7 @@ class RedundancyTests: RulesTests {
             "bar"
         }
         """
-        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.8")
+        let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
     }
 

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3874,7 +3874,7 @@ class SyntaxTests: RulesTests {
 
     // MARK: - conditionalAssignment
 
-    func testDoesntConvertIfStatementAssignmentSwift5_7() {
+    func testDoesntConvertIfStatementAssignmentSwift5_8() {
         let input = """
         let foo: Foo
         if condition {
@@ -3883,7 +3883,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.7")
+        let options = FormatOptions(swiftVersion: "5.8")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -3903,7 +3903,7 @@ class SyntaxTests: RulesTests {
             Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
@@ -3925,7 +3925,7 @@ class SyntaxTests: RulesTests {
             Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
@@ -3943,7 +3943,7 @@ class SyntaxTests: RulesTests {
             value
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -3991,7 +3991,7 @@ class SyntaxTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["redundantType"])
     }
 
@@ -4014,7 +4014,7 @@ class SyntaxTests: RulesTests {
             Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["indent", "redundantType"])
     }
 
@@ -4030,7 +4030,7 @@ class SyntaxTests: RulesTests {
             bar = Bar("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4044,7 +4044,7 @@ class SyntaxTests: RulesTests {
             bar = Bar("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4057,7 +4057,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4072,7 +4072,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4086,7 +4086,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4101,7 +4101,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4119,7 +4119,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
@@ -4138,7 +4138,7 @@ class SyntaxTests: RulesTests {
             foo = Foo("bar")
         }
         """
-        let options = FormatOptions(swiftVersion: "5.8")
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 }


### PR DESCRIPTION
I noticed that [SE-0380](https://github.com/apple/swift-evolution/blob/main/proposals/0380-if-switch-expressions.md) (which added support for if / switch expressions) is now slated for Swift 5.9 instead of Swift 5.8. This PR updates the gating for functionality related to that feature.