### PR TITLE
fix README.md instructions for binaryTarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Another option is to include the binary artifactbundle in your `Package.swift`:
 
 ```swift
 .binaryTarget(
-    name: "SwiftFormat",
+    name: "swiftformat",
     url: "https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.12/swiftformat-macos.artifactbundle.zip",
     checksum: "CHECKSUM"
 ),


### PR DESCRIPTION
While reading the SwiftFormat `README.md`description, I founded an error typo in `Binary Target` part.

If you configure Swift Package binary target with the contents in the previous README, an error message such as `"downloaded archive of binary target 'SwiftFormat' does not contain expected binary artifact named 'SwiftFormat'` will occur. 
binary target name should be `swiftformat`.

Please review the changes in the README.md file to see the specific modifications.
Thanks :)

