### PR TITLE
Fix issue in #1392 where `opaqueGenericParamaters` would remove non-redundant generic type

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7134,12 +7134,19 @@ public struct _FormatRules {
                     continue
                 }
 
-                // If the generic type occurs multiple times in the parameter list,
-                // it isn't eligible to be removed. For example `(T, T) where T: Foo`
-                // requires the two params to be the same underlying type, but
-                // `(some Foo, some Foo)` does not.
+                // We can only remove the generic type if it appears exactly once in the parameter list.
+                //  - If the generic type occurs _multiple_ times in the parameter list,
+                //    it isn't eligible to be removed. For example `(T, T) where T: Foo`
+                //    requires the two params to be the same underlying type, but
+                //    `(some Foo, some Foo)` does not.
+                //  - If the generic type occurs _zero_ times in the parameter list
+                //    then removing the generic parameter would also remove any
+                //    potentially-important constraints (for example, if the type isn't
+                //    used in the function parameters / body and is only constrained relative
+                //    to generic types in the parent type scope). If this generic parameter
+                //    is truly unused and redundant then the compiler would emit an error.
                 let countInParameterList = parameterListTokens.filter { $0.string == genericType.name }.count
-                if countInParameterList > 1 {
+                if countInParameterList != 1 {
                     genericType.eligibleToRemove = false
                     continue
                 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2650,6 +2650,22 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testIssue1392() {
+        let input = """
+        public struct Ref<Value> {}
+
+        public extension Ref {
+            static func weak<Base: AnyObject, T>(
+                _: Base,
+                _: ReferenceWritableKeyPath<Base, Value>
+            ) -> Ref<Value> where T? == Value {}
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {


### PR DESCRIPTION
This PR fixes #1392. In the following example, `opaqueGenericParamaters` was removing the `T` generic parameter because it appeared redundant / unused within the type definition. This behavior would have been correct if the constraint was something like `where T == Int`, but the constraint is actually important here since it's being constrained relative to a  generic type from the parent scope.

```swift
public struct Ref<Value> {}

public extension Ref {
    static func weak<Base: AnyObject, T>(
        _: Base,
        _: ReferenceWritableKeyPath<Base, Value>
    ) -> Ref<Value> where T? == Value {}
}
```

As a fix we can just avoid removing parameters that seem unused. If the generic type was truly redundant / unused (e.g. with a `T == Int` constraint) the compiler would give us a `generic parameter 'T' is not used in function signature` error, so we don't have to worry about supporting that sort of case.