### PR TITLE
Fix stripping file header

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -65,7 +65,7 @@ public extension String {
     /// Is this string a comment directive (MARK:, TODO:, swiftlint:, etc)?
     var isCommentDirective: Bool {
         let parts = split(separator: ":")
-        guard parts.count > 1 else {
+        guard parts.count > 1 && !parts[1].hasPrefix("//") else {
             return false
         }
         return !parts[0].contains(" ")

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -370,6 +370,25 @@ class GeneralTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
+    func testStripHeaderWithWhenHeaderContainsUrl() {
+        let input = """
+        //
+        //  RulesTests+General.swift
+        //  SwiftFormatTests
+        //
+        //  Created by Nick Lockwood on 02/10/2021.
+        //  Copyright © 2021 Nick Lockwood. All rights reserved.
+        //  https://some.example.com
+        //
+
+        /// func
+        func foo() {}
+        """
+        let output = "/// func\nfunc foo() {}"
+        let options = FormatOptions(fileHeader: "")
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
     func testReplaceHeaderWhenFileContainsNoCode() {
         let input = "// foobar"
         let options = FormatOptions(fileHeader: "// foobar")


### PR DESCRIPTION
This PR fixes the issue #1425 

The `tokenizer` was detecting urls `https://  file:// .. etc.` as `CommentDirective`. This was preventing the header from being removed. After this PR, it will no longer be detected as `CommentDirective` and therefore, the process will continue parsing the header as expected.