### PR TITLE
Fix `@_spi` related bug for `blankLineAfterImports` rule

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1144,6 +1144,7 @@ public struct _FormatRules {
             switch formatter.tokens[nextIndex] {
             case .linebreak, .keyword("import"), .keyword("@testable"),
                  .keyword("@_exported"), .keyword("@_implementationOnly"),
+                 .keyword("@_spi"), .keyword("@_spiOnly"),
                  .keyword("#else"), .keyword("#elseif"), .endOfScope("#endif"):
                 break
             default:

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -402,6 +402,8 @@ class LinebreakTests: RulesTests {
         @testable import ModuleD
         @_exported import ModuleE
         @_implementationOnly import ModuleF
+        @_spi(SPI) import ModuleG
+        @_spiOnly import ModuleH
         class foo {}
         """
         let output = """
@@ -411,6 +413,8 @@ class LinebreakTests: RulesTests {
         @testable import ModuleD
         @_exported import ModuleE
         @_implementationOnly import ModuleF
+        @_spi(SPI) import ModuleG
+        @_spiOnly import ModuleH
 
         class foo {}
         """


### PR DESCRIPTION
- This PR fixes this PR https://github.com/nicklockwood/SwiftFormat/issues/1428
- I updated implementation and test of `blankLineAfterImports`