### PR TITLE
Redundant static Self

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -89,6 +89,7 @@
 * [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
 * [organizeDeclarations](#organizeDeclarations)
+* [redundantStaticSelf](#redundantStaticSelf)
 * [sortedSwitchCases](#sortedSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -1627,6 +1628,10 @@ by using `--self init-only`:
 
 </details>
 <br/>
+
+## redundantStaticSelf
+
+Remove explicit `Self` where applicable.
 
 ## redundantType
 

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -5988,6 +5988,119 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantSelf, options: FormatOptions(swiftVersion: "5.8"))
     }
 
+    // MARK: - redundantStaticSelf
+
+    func testRedundantStaticSelfInStaticVar() {
+        let input = "enum E { static var x: Int { Self.y } }"
+        let output = "enum E { static var x: Int { y } }"
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfInStaticMethod() {
+        let input = "enum E { static func foo() { Self.bar() } }"
+        let output = "enum E { static func foo() { bar() } }"
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfOnNextLine() {
+        let input = """
+        enum E {
+            static func foo() {
+                Self
+                    .bar()
+            }
+        }
+        """
+        let output = """
+        enum E {
+            static func foo() {
+                bar()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfWithReturn() {
+        let input = "enum E { static func foo() { return Self.bar() } }"
+        let output = "enum E { static func foo() { return bar() } }"
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfInConditional() {
+        let input = """
+        enum E {
+            static func foo() {
+                if Bool.random() {
+                    Self.bar()
+                }
+            }
+        }
+        """
+        let output = """
+        enum E {
+            static func foo() {
+                if Bool.random() {
+                    bar()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfInNestedFunction() {
+        let input = """
+        enum E {
+            static func foo() {
+                func bar() {
+                    Self.foo()
+                }
+            }
+        }
+        """
+        let output = """
+        enum E {
+            static func foo() {
+                func bar() {
+                    foo()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testRedundantStaticSelfInNestedType() {
+        let input = """
+        enum Outer {
+            enum Inner {
+                static func foo() {}
+                static func bar() { Self.foo() }
+            }
+        }
+        """
+        let output = """
+        enum Outer {
+            enum Inner {
+                static func foo() {}
+                static func bar() { foo() }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testStaticSelfNotRemovedWhenUsedAsImplicitInitializer() {
+        let input = "enum E { static func foo() { Self().bar() } }"
+        testFormatting(for: input, rule: FormatRules.redundantStaticSelf)
+    }
+
+    func testStaticSelfNotRemovedWhenUsedAsExplicitInitializer() {
+        let input = "enum E { static func foo() { Self.init().bar() } }"
+        testFormatting(for: input, rule: FormatRules.redundantStaticSelf, exclude: ["redundantInit"])
+    }
+
     // MARK: - semicolons
 
     func testSemicolonRemovedAtEndOfLine() {


### PR DESCRIPTION
Hi, first time contribution here.

This rule removes `Self.` from inside `static func` and `static var`s, since those are redundant, e.g.,

Before
```swift
static func foo() {
    Self
        .bar()
}
```

After
```swift
static func foo() {
    bar()
}
```

Please let me know if something needs to be updated.