### PR TITLE
Add `sortTypealiases` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -91,6 +91,7 @@
 * [markTypes](#markTypes)
 * [organizeDeclarations](#organizeDeclarations)
 * [redundantStaticSelf](#redundantStaticSelf)
+* [sortTypealiases](#sortTypealiases)
 * [sortedSwitchCases](#sortedSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -1791,6 +1792,29 @@ and declarations between // swiftformat:sort:begin and
           Foo()
       }
   }
+```
+
+</details>
+<br/>
+
+## sortTypealiases
+
+Sort protocol composition typealiases.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- typealias Placeholders = Foo & Bar & Baaz & Quux
++ typealias Placeholders = Baaz & Bar & Foo & Quux
+
+  typealias Dependencies
+-     = FooProviding
++     = BaazProviding
+      & BarProviding
+-     & BaazProviding
++     & FooProviding
+      & QuuxProviding
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1598,4 +1598,19 @@ private struct Examples {
       }
     ```
     """
+
+    let sortTypealiases = """
+    ```diff
+    - typealias Placeholders = Foo & Bar & Baaz & Quux
+    + typealias Placeholders = Baaz & Bar & Foo & Quux
+
+      typealias Dependencies
+    -     = FooProviding
+    +     = BaazProviding
+          & BarProviding
+    -     & BaazProviding
+    +     & FooProviding
+          & QuuxProviding
+    ```
+    """
 }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -867,35 +867,8 @@ extension Formatter {
         forEach(.keyword("typealias")) { typealiasIndex, _ in
             guard
                 options.wrapTypealiases == .beforeFirst || options.wrapTypealiases == .afterFirst,
-                let equalsIndex = index(of: .operator("=", .infix), after: typealiasIndex),
-                // Any type can follow the equals index of a typealias,
-                // but we're specifically looking to wrap lengthy composite protocols.
-                //  - Valid composite protocols are strictly _only_ identifiers
-                //    separated by `&` tokens. Protocols can't be generic,
-                //    so we know that this typealias can't be generic.
-                //  - `&` tokens in types are also _only valid_ for composite protocol types,
-                //    so if we see one then we know this if what we're looking for.
-                // https://docs.swift.org/swift-book/ReferenceManual/Types.html#grammar_protocol-composition-type
-                let firstIdentifierIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
-                tokens[firstIdentifierIndex].isIdentifier,
-                let firstAndIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: firstIdentifierIndex),
-                tokens[firstAndIndex] == .operator("&", .infix)
+                let (equalsIndex, andTokenIndices, lastIdentifierIndex) = parseProtocolCompositionTypealias(at: typealiasIndex)
             else { return }
-
-            // Parse through to the end of the composite protocol type
-            // so we know how long it is (and where the &s are)
-            var lastIdentifierIndex = firstIdentifierIndex
-            var andTokenIndices = [Int]()
-
-            while
-                let nextAndIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: lastIdentifierIndex),
-                tokens[nextAndIndex] == .operator("&", .infix),
-                let nextIdentifierIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: nextAndIndex),
-                tokens[nextIdentifierIndex].isIdentifier
-            {
-                andTokenIndices.append(nextAndIndex)
-                lastIdentifierIndex = nextIdentifierIndex
-            }
 
             // Decide which indices to wrap at
             //  - We always wrap at each `&`

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7769,7 +7769,7 @@ public struct _FormatRules {
     }
 
     public let sortTypealiases = FormatRule(
-        help: "Sort protocol composition typealiases",
+        help: "Sort protocol composition typealiases.",
         disabledByDefault: true
     ) { formatter in
         formatter.forEach(.keyword("typealias")) { typealiasIndex, _ in

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7767,4 +7767,118 @@ public struct _FormatRules {
             }
         }
     }
+
+    public let sortTypealiases = FormatRule(
+        help: "Sort protocol composition typealiases",
+        disabledByDefault: true
+    ) { formatter in
+        formatter.forEach(.keyword("typealias")) { typealiasIndex, _ in
+            guard
+                let (equalsIndex, andTokenIndices, endIndex) = formatter.parseProtocolCompositionTypealias(at: typealiasIndex),
+                let typealiasNameIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: equalsIndex)
+            else {
+                return
+            }
+
+            // Split the typealias into individual elements.
+            // Any comments on their own line are grouped with the following element.
+            let delimiters = [equalsIndex] + andTokenIndices
+            var parsedElements: [(startIndex: Int, delimiterIndex: Int, endIndex: Int, type: String, allTokens: [Token])] = []
+
+            for delimiter in delimiters.indices {
+                let endOfPreviousElement = parsedElements.last?.endIndex ?? typealiasNameIndex
+                let elementStartIndex = formatter.index(of: .nonSpaceOrLinebreak, after: endOfPreviousElement) ?? delimiters[delimiter]
+
+                // Start with the end index just being the end of the type name
+                var elementEndIndex: Int
+                let nextElementIsOnSameLine: Bool
+                if delimiter == delimiters.indices.last {
+                    elementEndIndex = endIndex
+                    nextElementIsOnSameLine = false
+                } else {
+                    let nextDelimiterIndex = delimiters[delimiter + 1]
+                    elementEndIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: nextDelimiterIndex) ?? (nextDelimiterIndex - 1)
+
+                    let endOfLine = formatter.endOfLine(at: elementEndIndex)
+                    nextElementIsOnSameLine = formatter.endOfLine(at: nextDelimiterIndex) == endOfLine
+                }
+
+                // Handle comments in multiline typealiases
+                if !nextElementIsOnSameLine {
+                    // Any comments on the same line as the type name should be considered part of this element.
+                    // Any comments after the linebreak are consisidered part of the next element.
+                    // To do that we just extend this element to the end of the current line.
+                    elementEndIndex = formatter.endOfLine(at: elementEndIndex) - 1
+                }
+
+                let tokens = Array(formatter.tokens[elementStartIndex ... elementEndIndex])
+                let typeName = tokens
+                    .filter { !$0.isSpaceOrCommentOrLinebreak && !$0.isOperator }
+                    .map { $0.string }.joined()
+
+                parsedElements.append((
+                    startIndex: elementStartIndex,
+                    delimiterIndex: delimiters[delimiter],
+                    endIndex: elementEndIndex,
+                    type: typeName,
+                    allTokens: tokens
+                ))
+            }
+
+            // Sort each element by type name
+            var sortedElements = parsedElements.sorted(by: { lhsElement, rhsElement in
+                lhsElement.type.lexicographicallyPrecedes(rhsElement.type)
+            })
+
+            // Don't modify the file if the typealias is already sorted
+            if parsedElements.map(\.startIndex) == sortedElements.map(\.startIndex) {
+                return
+            }
+
+            for elementIndex in sortedElements.indices {
+                // Revalidate all of the delimiters after sorting
+                // (the first delimiter should be `=` and all others should be `&`
+                let delimiterIndexInTokens = sortedElements[elementIndex].delimiterIndex - sortedElements[elementIndex].startIndex
+
+                if elementIndex == 0 {
+                    sortedElements[elementIndex].allTokens[delimiterIndexInTokens] = .operator("=", .infix)
+                } else {
+                    sortedElements[elementIndex].allTokens[delimiterIndexInTokens] = .operator("&", .infix)
+                }
+
+                // Make sure there's always a linebreak after any comments, to prevent
+                // them from accidentially commenting out following elements of the typealias
+                if
+                    elementIndex != sortedElements.indices.last,
+                    sortedElements[elementIndex].allTokens.last?.isComment == true,
+                    let nextToken = formatter.nextToken(after: parsedElements[elementIndex].endIndex),
+                    !nextToken.isLinebreak
+                {
+                    sortedElements[elementIndex].allTokens.append(.linebreak("\n", 0))
+                }
+
+                // If this element starts with a comment, that's because the comment
+                // was originally on a line all by itself. To preserve this, make sure
+                // there's a linebreak before the comment.
+                if
+                    elementIndex != sortedElements.indices.first,
+                    sortedElements[elementIndex].allTokens.first?.isComment == true,
+                    let previousToken = formatter.lastToken(before: parsedElements[elementIndex].startIndex, where: { !$0.isSpace }),
+                    !previousToken.isLinebreak
+                {
+                    sortedElements[elementIndex].allTokens.insert(.linebreak("\n", 0), at: 0)
+                }
+            }
+
+            // Replace each index in the parsed list with the corresponding index in the sorted list,
+            // working backwards to not invalidate any existing indices
+            for (originalElement, newElement) in zip(parsedElements, sortedElements).reversed() {
+                let newElementTokens =
+                    formatter.replaceTokens(
+                        in: originalElement.startIndex ... originalElement.endIndex,
+                        with: newElement.allTokens
+                    )
+            }
+        }
+    }
 }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -3491,4 +3491,114 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.organizeDeclarations)
     }
+
+    // MARK: - sortTypealiases
+
+    func testSortSingleLineTypealias() {
+        let input = """
+        typealias Placeholders = Foo & Bar & Quux & Baaz
+        """
+
+        let output = """
+        typealias Placeholders = Baaz & Bar & Foo & Quux
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
+
+    func testSortMultilineTypealias() {
+        let input = """
+        typealias Placeholders = Foo & Bar
+            & Quux & Baaz
+        """
+
+        let output = """
+        typealias Placeholders = Baaz & Bar
+            & Foo & Quux
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
+
+    func testSortMultilineTypealiasWithComments() {
+        let input = """
+        typealias Placeholders = Foo & Bar // Comment about Bar
+            // Comment about Quux
+            & Quux & Baaz // Comment about Baaz
+        """
+
+        let output = """
+        typealias Placeholders = Baaz // Comment about Baaz
+            & Bar // Comment about Bar
+            & Foo
+            // Comment about Quux
+            & Quux
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.sortTypealiases, FormatRules.indent, FormatRules.trailingSpace])
+    }
+
+    func testSortWrappedMultilineTypealias1() {
+        let input = """
+        typealias Dependencies = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies = BaazProviding
+            & BarProviding
+            & FooProviding
+            & QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
+
+    func testSortWrappedMultilineTypealias2() {
+        let input = """
+        typealias Dependencies
+            = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies
+            = BaazProviding
+            & BarProviding
+            & FooProviding
+            & QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
+
+    func testSortWrappedMultilineTypealiasWithComments() {
+        let input = """
+        typealias Dependencies
+            // Comment about FooProviding
+            = FooProviding
+            // Comment about BarProviding
+            & BarProviding
+            & QuuxProviding // Comment about QuuxProviding
+            // Comment about BaazProviding
+            & BaazProviding // Comment about BaazProviding
+        """
+
+        let output = """
+        typealias Dependencies
+            // Comment about BaazProviding
+            = BaazProviding // Comment about BaazProviding
+            // Comment about BarProviding
+            & BarProviding
+            // Comment about FooProviding
+            & FooProviding
+            & QuuxProviding // Comment about QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
 }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -3601,4 +3601,24 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
     }
+
+    func testSortTypealiasesWithAssociatedTypes() {
+        let input = """
+        typealias Collections
+            = Collection<Int>
+            & Collection<String>
+            & Collection<Double>
+            & Collection<Float>
+        """
+
+        let output = """
+        typealias Collections
+            = Collection<Double>
+            & Collection<Float>
+            & Collection<Int>
+            & Collection<String>
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
 }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2489,7 +2489,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 40)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_multipleTypealiases_beforeFirst() {
@@ -2512,7 +2512,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 45)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_afterFirst() {
@@ -2528,7 +2528,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 40)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_multipleTypealiases_afterFirst() {
@@ -2549,7 +2549,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 45)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth() {
@@ -2558,7 +2558,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 100)
-        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently() {
@@ -2575,7 +2575,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently2() {
@@ -2597,7 +2597,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently3() {
@@ -2615,7 +2615,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently4() {
@@ -2635,7 +2635,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistentlyWithComment() {
@@ -2655,7 +2655,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_singleTypePreserved() {
@@ -2679,7 +2679,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
-        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     func testWrapArguments_typealias_preservesCommentsAfterTypes() {
@@ -2691,7 +2691,24 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
-        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
+    }
+
+    func testWrapArguments_typealias_withAssociatedType() {
+        let input = """
+        typealias Collections = Collection<Int> & Collection<String> & Collection<Double> & Collection<Float>
+        """
+
+        let output = """
+        typealias Collections
+            = Collection<Int>
+            & Collection<String>
+            & Collection<Double>
+            & Collection<Float>
+        """
+
+        let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 50)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options, exclude: ["sortTypealiases"])
     }
 
     // MARK: - -return wrap-if-multiline


### PR DESCRIPTION
This PR adds a new `sortTypealiases` rule, which nicely compliments the existing `--wraptypealiases` option.

```diff
- typealias Placeholders = Foo & Bar & Baaz & Quux
+ typealias Placeholders = Baaz & Bar & Foo & Quux

  typealias Dependencies
-     = FooProviding
+     = BaazProviding
      & BarProviding
-     & BaazProviding
+     & FooProviding
      & QuuxProviding
```