### PR TITLE
SwiftFormat: adjust `expandPath` to be more portable

### DIFF
--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -605,13 +605,11 @@ public func lint(
 // MARK: Path utilities
 
 public func expandPath(_ path: String, in directory: String) -> URL {
-    if path.hasPrefix("/") {
-        return URL(fileURLWithPath: path).standardized
+    let nsPath: NSString = (path as NSString).expandingTildeInPath as NSString
+    if nsPath.isAbsolutePath {
+        return URL(fileURLWithPath: nsPath as String).standardized
     }
-    if path.hasPrefix("~") {
-        return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath).standardized
-    }
-    return URL(fileURLWithPath: directory).appendingPathComponent(path).standardized
+    return URL(fileURLWithPath: directory, isDirectory: true).appendingPathComponent(path).standardized
 }
 
 func getResourceValues(for url: URL, keys: [URLResourceKey]) throws -> URLResourceValues {


### PR DESCRIPTION
Reuse the implementation of `NSString`'s `isAbsolutePath` to determine if the path is absolute rather than re-implementing that logic inline. This allows use of `SwiftFormat` with the vknabel/SwiftFormat extension with Visual Studio Code on Windows.

We would previously attempt to check if the configuration path was absolute by checking for a leading `/` which does not represent an absolute path on Windows but rather a relative path (it is drive relative).  We perform a bit more bridging here but get the portable behaviour without resorting to manually invoking `IsPathRelativeW` on the path representation.  This also allows us to pick up the improvements to the path handling in Foundation for long paths without having to reconstruct special handling.