### PR TITLE
GHA: add a workflow for performing a Windows release

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -1,0 +1,61 @@
+name: Windows Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: 'Revision to build (branch, tag, or SHA)'
+        required: false
+        default: 'master'
+
+      version:
+        description: 'Version being released'
+        required: false
+        default: '0.0.0'
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - branch: swift-5.8.1-release
+            tag: 5.8.1-RELEASE
+
+          - branch: development
+            tag: DEVELOPMENT-SNAPSHOT-2023-06-05-a
+
+    name: Windows (${{ matrix.tag }})
+
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          tag: ${{ matrix.tag }}
+          branch: ${{ matrix.branch }}
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.revision }}
+
+      - run: swift build -c release -Xswiftc -gnone
+
+      - uses: microsoft/setup-msbuild@v1.3.1
+
+      - run: msbuild -nologo -restore Platforms\Windows\SwiftFormat.wixproj -p:Configuration=Release -p:ProductVersion=${{ github.event.inputs.version }} -p:SWIFTFORMAT_BUILD=${{ github.workspace }}\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+
+      - run: |
+          $MSI_PATH = cygpath -m ${{ github.workspace }}\artifacts\SwiftFormat.msi
+          Echo MSI_PATH=$MSI_PATH | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true
+          name: SwiftFormat v${{ github.event.inputs.version }} (Swift ${{ matrix.tag }})
+          tag_name: v${{ github.event.inputs.version }}
+          files: |
+            .build/x86_64-unknown-windows-msvc/release/swiftformat.exe
+            ${{ env.MSI_PATH }}

--- a/Platforms/Windows/SwiftFormat.wixproj
+++ b/Platforms/Windows/SwiftFormat.wixproj
@@ -1,0 +1,47 @@
+<Project Sdk="WixToolset.Sdk/4.0.0">
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
+    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
+
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>$(ProductVersion)</ProductVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>build\</OutputPath>
+    <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="WiXCodeSigning.targets" />
+
+  <PropertyGroup>
+    <DefineConstants>ProductArchitecture=$(ProductArchitecture);ProductVersion=$(ProductVersion);SWIFTFORMAT_BUILD=$(SWIFT_FORMAT_BUILD)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <InstallerPlatform>x64</InstallerPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <InstallerPlatform>arm64</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm' ">
+    <InstallerPlatform>arm</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <InstallerPlatform>x86</InstallerPlatform>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="SwiftFormat.wxs" />
+  </ItemGroup>
+</Project>

--- a/Platforms/Windows/SwiftFormat.wxs
+++ b/Platforms/Windows/SwiftFormat.wxs
@@ -1,0 +1,51 @@
+<Wix
+    xmlns="http://wixtoolset.org/schemas/v4/wxs"
+    xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="nicklockwood"
+      Name="SwiftFormat"
+      UpgradeCode="98e01ac8-a17d-43fd-99ed-1cd8b58715bf"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="SwiftFormat" />
+
+    <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
+
+    <StandardDirectory Id="%ProgramFiles64Folder%">
+      <Directory Id="Manufacturer" Name="nicklockwood">
+        <Directory Id="INSTALLDIR" Name="SwiftFormat">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin" />
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Component Directory="_usr_bin" Id="swiftformat.exe">
+      <File Id="swiftformat.exe" Source="$(var.SWIFTFORMAT_BUILD)\swiftformat.exe" Checksum="yes" KeyPath="yes" />
+    </Component>
+
+    <ComponentGroup Id="EnvironmentVariables">
+      <Component Id="SystemEnvironmentVariables" Condition="ALLUSERS=1" Directory="INSTALLDIR" Guid="b46687c3-f836-47e5-9b43-d9fd2552a731">
+        <Environment Id="SystemPath" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]usr\bin" />
+      </Component>
+      <Component Id="UserEnvironmentVariables" Condition="NOT ALLUSERS=1" Directory="INSTALLDIR" Guid="a1c1ada1-6eb3-4e42-a667-6b0720807ce4">
+        <Environment Id="UserPath" Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[INSTALLDIR]usr\bin" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="SwiftFormat" Level="1">
+      <ComponentRef Id="swiftformat.exe" />
+      <ComponentGroupRef Id="EnvironmentVariables" />
+    </Feature>
+
+    <UI>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
+    </UI>
+
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
+  </Package>
+</Wix>

--- a/Platforms/Windows/WixCodeSigning.targets
+++ b/Platforms/Windows/WixCodeSigning.targets
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SignOutput Condition=" '$(SignOutput)' == '' ">false</SignOutput>
+    <SignOutput>$(SignOutput)</SignOutput>
+  </PropertyGroup>
+
+  <Target Name="FindSignTool">
+    <PropertyGroup>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot10', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot81', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+      <WindowsKitsRoot Condition=" '$(WindowsKitsRoot)' == '' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+
+      <!-- Windows 11 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.22621.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22621.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.22000.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22000.0\x64\</SignToolPath>
+      <!-- Windows 10 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.20348.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.20348.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.19041.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.19041.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.18362.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.18362.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.17763.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17763.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.17134.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17134.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.16299.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.16299.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.15063.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.15063.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.14393.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.14393.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.10586.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10586.0\x64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\10.0.10240.0\x64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10240.0\x64\</SignToolPath>
+      <!-- Windows 8.1 SDKS -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' AND Exists('$(WindowsKitsRoot)bin\x64\signtool.exe')">$(WindowsKitsRoot)bin\x64\</SignToolPath>
+
+      <!-- Windows 11 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22621.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22621.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.22000.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.22000.0\arm64\</SignToolPath>
+      <!-- Windows 10 SDKs -->
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.20348.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.20348.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.19041.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.19041.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.18362.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.18362.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.17763.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17763.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.17134.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.17134.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.16299.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.16299.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.15063.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.15063.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.14393.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.14393.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.10586.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10586.0\arm64\</SignToolPath>
+      <SignToolPath Condition=" '$(SignToolPath)' == '' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64' AND Exists('$(WindowsKitsRoot)bin\10.0.10240.0\arm64\signtool.exe')">$(WindowsKitsRoot)bin\10.0.10240.0\arm64\</SignToolPath>
+
+      <SignTool>"$(SignToolPath)signtool.exe" sign /f "$(CERTIFICATE)" /p "$(PASSPHRASE)" /tr http://timestamp.digicert.com /fd sha256 /td sha256</SignTool>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="SignCabs" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignCabs.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignMsi" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignMsi.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignMsm" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;%(SignMsm.FullPath)&quot;" />
+  </Target>
+
+  <Target Name="SignBundleEngine" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;@(SignBundleEngine)&quot;" />
+  </Target>
+
+  <Target Name="SignBundle" DependsOnTargets="FindSignTool">
+    <Exec Command="$(SignTool) &quot;@(SignBundle)&quot;" />
+  </Target>
+</Project>


### PR DESCRIPTION
Add some build rules to package up a Windows installer for release builds.  Perform a separate build that is a release configuration and does not include debug information to minimise size and optimize load times.

Package this up into a MSI installer.  Ideally, we would perform code signing for the MSI and the binary, but that can be done as a follow up as it requires a Code Signing certificate to be available.

The default install location is:
  `%SystemDrive%\Program Files\nicklockwood\SwiftFormat`
following Windows conventions of
`[ProgramFiles][Manufacturer][ProductName]`.

Prefer to use `swoftprops/action-gh-release` over `actions/release` as the latter is marked as deprecated.