### PR TITLE
Windows: correct the XML tag for the installer manifest

### DIFF
--- a/Platforms/Windows/SwiftFormat.wixproj
+++ b/Platforms/Windows/SwiftFormat.wixproj
@@ -19,7 +19,7 @@
   <Import Project="WiXCodeSigning.targets" />
 
   <PropertyGroup>
-    <DefineConstants>ProductArchitecture=$(ProductArchitecture);ProductVersion=$(ProductVersion);SWIFTFORMAT_BUILD=$(SWIFT_FORMAT_BUILD)</DefineConstants>
+    <DefineConstants>ProductArchitecture=$(ProductArchitecture);ProductVersion=$(ProductVersion);SWIFTFORMAT_BUILD=$(SWIFTFORMAT_BUILD)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">

--- a/Platforms/Windows/SwiftFormat.wxs
+++ b/Platforms/Windows/SwiftFormat.wxs
@@ -12,15 +12,15 @@
 
     <Media Id="1" Cabinet="SwiftFormat.cab" EmbedCab="yes" />
 
-    <StandardDirectory Id="%ProgramFiles64Folder%">
-      <Directory Id="Manufacturer" Name="nicklockwood">
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="ManufacturerFolder" Name="nicklockwood">
         <Directory Id="INSTALLDIR" Name="SwiftFormat">
           <Directory Id="_usr" Name="usr">
             <Directory Id="_usr_bin" Name="bin" />
           </Directory>
         </Directory>
       </Directory>
-    </Directory>
+    </StandardDirectory>
 
     <Component Directory="_usr_bin" Id="swiftformat.exe">
       <File Id="swiftformat.exe" Source="$(var.SWIFTFORMAT_BUILD)\swiftformat.exe" Checksum="yes" KeyPath="yes" />


### PR DESCRIPTION
Correct the closing tag from `Directory` to match the opening tag of `StandardDirectory`.