### PR TITLE
GHA: adjust release tagging for Windows

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -53,9 +53,9 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          prerelease: true
+          prerelease: false
           name: SwiftFormat v${{ github.event.inputs.version }} (Swift ${{ matrix.tag }})
-          tag_name: v${{ github.event.inputs.version }}
+          tag_name: swift-${{matrix.tag}}-v${{ github.event.inputs.version }}
           files: |
             .build/x86_64-unknown-windows-msvc/release/swiftformat.exe
             ${{ env.MSI_PATH }}


### PR DESCRIPTION
Use a non-pre-release release tag and include the Swift version information into the tag to permit parallel releases of the same version until we can page the runtime into the distribution.