### PR TITLE
Add support for `package` keyword to `organizeDeclarations` rule

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1531,6 +1531,7 @@ extension Formatter {
         case lifecycle
         case open
         case `public`
+        case package
         case `internal`
         case `fileprivate`
         case `private`
@@ -1541,6 +1542,8 @@ extension Formatter {
                 self = .open
             case .public:
                 self = .public
+            case .package:
+                self = .package
             case .internal:
                 self = .internal
             case .fileprivate:
@@ -1565,6 +1568,7 @@ extension Formatter {
     enum Visibility: String, CaseIterable, Comparable {
         case open
         case `public`
+        case package
         case `internal`
         case `fileprivate`
         case `private`
@@ -1588,7 +1592,7 @@ extension Formatter {
     }
 
     static let categoryOrdering: [Category] = [
-        .beforeMarks, .lifecycle, .open, .public, .internal, .fileprivate, .private,
+        .beforeMarks, .lifecycle, .open, .public, .package, .internal, .fileprivate, .private,
     ]
 
     static let categorySubordering: [DeclarationType] = [

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -20,6 +20,7 @@ class OrganizationTests: RulesTests {
             private let bar = 1
             public let baz = 1
             open var quack = 2
+            package func packageMethod() {}
             var quux = 2
 
             /// `open` is the only visibility keyword that
@@ -58,6 +59,10 @@ class OrganizationTests: RulesTests {
 
             /// Doc comment
             public func publicMethod() {}
+
+            // MARK: Package
+
+            package func packageMethod() {}
 
             // MARK: Internal
 


### PR DESCRIPTION
This PR adds support` for the `package` keyword to the `organizeDeclarations` rule