### PR TITLE
New rule: "blankLinesBetweenChainedFuncs"

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1114,6 +1114,24 @@ public struct _FormatRules {
         }
     }
 
+    /// Remove blank lines between chained functions but keep the linebreaks
+    public let blankLinesBetweenChainedFuncs = FormatRule(
+        help: """
+        Remove blank lines between chained functions but keep the linebreaks.
+        """,
+        disabledByDefault: true,
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.forEach(.operator(".", .infix)) { currentDotIndex, _ in
+            guard let endOfLine = formatter.index(of: .linebreak, after: currentDotIndex),
+                  let nextDotIndex = formatter.index(of: .operator(".", .infix), after: endOfLine)
+            else {
+                return
+            }
+            formatter.removeTokens(in: endOfLine + 1 ..< nextDotIndex)
+        }
+    }
+
     /// Insert blank line after import statements
     public let blankLineAfterImports = FormatRule(
         help: """

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -392,6 +392,30 @@ class LinebreakTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.blankLinesBetweenImports)
     }
 
+    // MARK: - blankLinesBetweenChainedFuncs
+
+    func testBlankLinesBetweenChainedFuncs() {
+        let input = """
+        [0, 1, 2]
+        .map { $0 * 2 }
+
+
+
+        .map { $0 * 3 }
+        """
+        let output1 = """
+        [0, 1, 2]
+        .map { $0 * 2 }
+        .map { $0 * 3 }
+        """
+        let output2 = """
+        [0, 1, 2]
+            .map { $0 * 2 }
+            .map { $0 * 3 }
+        """
+        testFormatting(for: input, [output1, output2], rules: [FormatRules.blankLinesBetweenChainedFuncs])
+    }
+
     // MARK: - blankLineAfterImports
 
     func testBlankLineAfterImport() {


### PR DESCRIPTION
# Context
`blankLinesAtStartOfScope`, `blankLinesAtEndOfScope` are here to add blank lines (not delete them).
`blankLinesBetweenImports` & `consecutiveBlankLines` can delete blankLines but are designed to keep one blank line.
If a developer introduces blankLines between chained funcs during development I haven't found a rule to guarantee deletion of these lines.

# Proposition
I propose to introduce a new `blankLinesBetweenChainedFuncs` rule that for this kind of code
```swift
[0, 1, 2]
        .map { $0 * 2 }



        .map { $0 * 3 }
```
will produce
```swift
[0, 1, 2]
        .map { $0 * 2 }
        .map { $0 * 3 }
```

P.S: If this is achievable with the current existing rules and result from a misunderstanding on my end, then this PR can be closed. And will be curious about to achieve it :)