### PR TITLE
Update README.md to fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ if [[ "$(uname -m)" == arm64 ]]; then
 fi
 
 if which swiftformat > /dev/null; then
-  swiftformat
+  swiftformat .
 else
   echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
 fi


### PR DESCRIPTION
At first SwiftFormat didn't work and then I realized it was because of the typo.