### PR TITLE
Add `redundantInternal` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -39,6 +39,7 @@
 * [redundantFileprivate](#redundantFileprivate)
 * [redundantGet](#redundantGet)
 * [redundantInit](#redundantInit)
+* [redundantInternal](#redundantInternal)
 * [redundantLet](#redundantLet)
 * [redundantLetError](#redundantLetError)
 * [redundantNilInit](#redundantNilInit)
@@ -1379,6 +1380,32 @@ Remove explicit `init` if not required.
 ```diff
 - String.init("text")
 + String("text")
+```
+
+</details>
+<br/>
+
+## redundantInternal
+
+Remove redundant internal access control.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- internal class Foo {
++ class Foo {
+-     internal let bar: String
++     let bar: String
+
+-     internal func baaz() {}
++     func baaz() {}
+
+-     internal init() {
++     init() {
+          bar = "bar"
+      }
+  }
 ```
 
 </details>

--- a/Snapshots/Euclid/Sources/Paths.swift
+++ b/Snapshots/Euclid/Sources/Paths.swift
@@ -267,7 +267,7 @@ public extension Polygon {
     }
 }
 
-internal extension Path {
+extension Path {
     init(unchecked points: [PathPoint], plane: Plane?, subpathIndices: [Int]?) {
         assert(sanitizePoints(points) == points)
         self.points = points

--- a/Snapshots/Euclid/Sources/Plane.swift
+++ b/Snapshots/Euclid/Sources/Plane.swift
@@ -88,7 +88,7 @@ public extension Plane {
     }
 }
 
-internal extension Plane {
+extension Plane {
     init(unchecked normal: Vector, w: Double) {
         assert(normal.isNormalized)
         self.normal = normal

--- a/Snapshots/Euclid/Sources/Polygon.swift
+++ b/Snapshots/Euclid/Sources/Polygon.swift
@@ -206,7 +206,7 @@ public extension Polygon {
     }
 }
 
-internal extension Polygon {
+extension Polygon {
     /// Create polygon from vertices and face normal without performing validation
     /// Vertices may be convex or concave, but are assumed to describe a non-degenerate polygon
     init(

--- a/Snapshots/Euclid/Sources/Transforms.swift
+++ b/Snapshots/Euclid/Sources/Transforms.swift
@@ -190,7 +190,7 @@ public extension Rotation {
     }
 }
 
-internal extension Rotation {
+extension Rotation {
     /// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/
     init(unchecked axis: Vector, radians: Double) {
         assert(axis.isNormalized)

--- a/Snapshots/Euclid/Sources/Vector.swift
+++ b/Snapshots/Euclid/Sources/Vector.swift
@@ -112,7 +112,7 @@ public extension Vector {
     }
 }
 
-internal extension Vector {
+extension Vector {
     /// Approximate equality
     func isEqual(to other: Vector, withPrecision p: Double = epsilon) -> Bool {
         return abs(x - other.x) < p && abs(y - other.y) < p && abs(z - other.z) < p

--- a/Snapshots/Euclid/Sources/Vertex.swift
+++ b/Snapshots/Euclid/Sources/Vertex.swift
@@ -64,7 +64,7 @@ public extension Vertex {
     }
 }
 
-internal extension Vertex {
+extension Vertex {
     init(unchecked position: Vector, _ normal: Vector, _ texcoord: Vector = .zero) {
         self.position = position.quantized()
         self.normal = normal

--- a/Snapshots/Issues/794.swift
+++ b/Snapshots/Issues/794.swift
@@ -1,4 +1,4 @@
-internal protocol P1 {}
+protocol P1 {}
 
 extension P1 {
     public func f() {}

--- a/Snapshots/Layout/Layout/LayoutError.swift
+++ b/Snapshots/Layout/Layout/LayoutError.swift
@@ -16,7 +16,7 @@ private func stringify(_ error: Error) -> String {
 }
 
 /// An error relating to a specific symbol/expression
-internal struct SymbolError: Error, CustomStringConvertible {
+struct SymbolError: Error, CustomStringConvertible {
     let symbol: String
     let error: Error
     var fatal = false

--- a/Snapshots/Layout/Layout/LayoutNode.swift
+++ b/Snapshots/Layout/Layout/LayoutNode.swift
@@ -260,7 +260,7 @@ public class LayoutNode: NSObject {
 
     /// called by UITableView/UICollectionView as cells are loaded
     private var _anyExpressionDependsOnContentSize: Bool?
-    internal func contentSizeChanged() {
+    func contentSizeChanged() {
         if _anyExpressionDependsOnContentSize == nil {
             _anyExpressionDependsOnContentSize = anyExpressionDependsOn([
                 "inferredSize.width", "inferredSize.height",
@@ -864,7 +864,7 @@ public class LayoutNode: NSObject {
     }
 
     /// Experimental - used for nested XML reference loading
-    internal func update(with layout: Layout) throws {
+    func update(with layout: Layout) throws {
         let _newClass: AnyClass = try layout.getClass()
         let oldClass = _class
         guard let newClass = _newClass as? LayoutManaged.Type, _newClass.isSubclass(of: oldClass) else {

--- a/Snapshots/Layout/Layout/RuntimeType.swift
+++ b/Snapshots/Layout/Layout/RuntimeType.swift
@@ -100,13 +100,13 @@ public class RuntimeType: NSObject {
 
     public typealias Getter = (_ target: AnyObject, _ key: String) -> Any?
     public typealias Setter = (_ target: AnyObject, _ key: String, _ value: Any) throws -> Void
-    internal typealias Caster = (_ value: Any) -> Any?
+    typealias Caster = (_ value: Any) -> Any?
 
     let kind: Kind
     private(set) var availability = Availability.available
     private(set) var getter: Getter?
     private(set) var setter: Setter?
-    internal var caster: Caster?
+    var caster: Caster?
 
     fileprivate static var cache = [String: RuntimeType?]()
     private static let queue = DispatchQueue(label: "com.Layout.RuntimeType")

--- a/Snapshots/Layout/Layout/UIView+Layout.swift
+++ b/Snapshots/Layout/Layout/UIView+Layout.swift
@@ -215,7 +215,7 @@ extension UIView: LayoutManaged {
         )
     }
 
-    internal var _effectiveUserInterfaceLayoutDirection: UIUserInterfaceLayoutDirection {
+    var _effectiveUserInterfaceLayoutDirection: UIUserInterfaceLayoutDirection {
         if #available(iOS 10.0, *) {
             return effectiveUserInterfaceLayoutDirection
         } else {

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1613,4 +1613,22 @@ private struct Examples {
           & QuuxProviding
     ```
     """
+
+    let redundantInternal = """
+    ```diff
+    - internal class Foo {
+    + class Foo {
+    -     internal let bar: String
+    +     let bar: String
+
+    -     internal func baaz() {}
+    +     func baaz() {}
+
+    -     internal init() {
+    +     init() {
+              bar = "bar"
+          }
+      }
+    ```
+    """
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7897,4 +7897,34 @@ public struct _FormatRules {
             }
         }
     }
+
+    public let redundantInternal = FormatRule(
+        help: "Remove redundant internal access control."
+    ) { formatter in
+        formatter.forEach(.keyword("internal")) { internalKeywordIndex, _ in
+            let accessControlLevels = ["public", "package", "internal", "private", "fileprivate"]
+
+            // If we're inside an extension, than `internal` is only redundant
+            // if the extension itself is `internal`.
+            if
+                let startOfScope = formatter.startOfScope(at: internalKeywordIndex),
+                let typeKeywordIndex = formatter.indexOfLastSignificantKeyword(at: startOfScope),
+                formatter.tokens[typeKeywordIndex] == .keyword("extension"),
+                // In the language grammar, the ACL level always directly precedes the
+                // `extension` keyword if present.
+                let previousToken = formatter.last(.nonSpaceOrCommentOrLinebreak, before: typeKeywordIndex),
+                accessControlLevels.contains(previousToken.string),
+                previousToken.string != "internal"
+            {
+                // The extension has an explicit ACL other than `internal`, so is not internal.
+                // We can't remove the `internal` keyword since the declaration would change
+                // to the ACL of the extension.
+                return
+            }
+
+            guard formatter.token(at: internalKeywordIndex + 1)?.isSpace == true else { return }
+
+            formatter.removeTokens(in: internalKeywordIndex ... (internalKeywordIndex + 1))
+        }
+    }
 }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -205,7 +205,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: ["blankLinesAtStartOfScope", "redundantInternal"]
         )
     }
 
@@ -1361,7 +1361,8 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: FormatRules.extensionAccessControl,
-            options: FormatOptions(extensionACLPlacement: .onDeclarations)
+            options: FormatOptions(extensionACLPlacement: .onDeclarations),
+            exclude: ["redundantInternal"]
         )
     }
 
@@ -1724,7 +1725,7 @@ class OrganizationTests: RulesTests {
             func bar() {}
         }
         """
-        testFormatting(for: input, rule: FormatRules.extensionAccessControl)
+        testFormatting(for: input, rule: FormatRules.extensionAccessControl, exclude: ["redundantInternal"])
     }
 
     func testNoHoistAccessModifierForExtensionThatAddsProtocolConformance() {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -7793,4 +7793,82 @@ class RedundancyTests: RulesTests {
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, rule: FormatRules.redundantOptionalBinding, options: options)
     }
+
+    // MARK: - redundantInternal
+
+    func testRemoveRedundantInternalACL() {
+        let input = """
+        internal class Foo {
+            internal let bar: String
+
+            internal func baaz() {}
+
+            internal init() {
+                bar = "bar"
+            }
+        }
+        """
+
+        let output = """
+        class Foo {
+            let bar: String
+
+            func baaz() {}
+
+            init() {
+                bar = "bar"
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantInternal)
+    }
+
+    func testPreserveInternalInNonInternalExtensionExtension() {
+        let input = """
+        extension Foo {
+            /// internal is redundant here since the extension is internal
+            internal func bar() {}
+
+            public func baaz() {}
+
+            /// internal is redundant here since the extension is internal
+            internal func bar() {}
+        }
+
+        public extension Foo {
+            /// internal is not redundant here since the extension is public
+            internal func bar() {}
+
+            public func baaz() {}
+
+            /// internal is not redundant here since the extension is public
+            internal func bar() {}
+        }
+        """
+
+        let output = """
+        extension Foo {
+            /// internal is redundant here since the extension is internal
+            func bar() {}
+
+            public func baaz() {}
+
+            /// internal is redundant here since the extension is internal
+            func bar() {}
+        }
+
+        public extension Foo {
+            /// internal is not redundant here since the extension is public
+            internal func bar() {}
+
+            public func baaz() {}
+
+            /// internal is not redundant here since the extension is public
+            internal func bar() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantInternal, exclude: ["redundantExtensionACL"])
+    }
 }


### PR DESCRIPTION
This PR adds a new `redundantInternal` rule, which removes the `internal` keyword from declarations when it's redundant and doesn't affect the declaration's access control level:

```diff
- internal class Foo {
+ class Foo {
-     internal let bar: String
+     let bar: String
  
-     internal func baaz() {}
+     func baaz() {}
  
-     internal init() {
+     init() {
          bar = "bar"
      }
  }
```

This excludes declarations in non-internal extensions:

```swift
public extension Foo {
  /// `internal` is not redundant here since the extension is public, 
  /// and removing `internal` would make the declaration public
  internal func bar() {}
}
```