### PR TITLE
Fix edge cases in `forLoop` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -761,6 +761,11 @@ Token | Description
 
 Convert functional `forEach` calls to for loops.
 
+Option | Description
+--- | ---
+`--anonymousForEach` | Convert anonymous forEach: "convert" (default) or "preserve".
+`--oneLineForEach` | Convert one-line forEach: "preserve" (default) or "wrap".
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -943,6 +943,22 @@ struct _Descriptors {
         trueValues: ["true", "enabled"],
         falseValues: ["false", "disabled"]
     )
+    let preserveAnonymousForEach = OptionDescriptor(
+        argumentName: "anonymousForEach",
+        displayName: "Anonymous forEach closures",
+        help: "Convert anonymous forEach: \"convert\" (default) or \"preserve\".",
+        keyPath: \.preserveAnonymousForEach,
+        trueValues: ["preserve"],
+        falseValues: ["convert"]
+    )
+    let preserveSingleLineForEach = OptionDescriptor(
+        argumentName: "oneLineForEach",
+        displayName: "One-line forEach closures",
+        help: "Convert one-line forEach: \"preserve\" (default) or \"wrap\".",
+        keyPath: \.preserveSingleLineForEach,
+        trueValues: ["preserve"],
+        falseValues: ["wrap"]
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -448,6 +448,8 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapEffects: WrapEffects
     public var spaceAroundDelimiter: SpaceAroundDelimiter
     public var initCoderNil: Bool
+    public var preserveAnonymousForEach: Bool
+    public var preserveSingleLineForEach: Bool
 
     // Deprecated
     public var indentComments: Bool
@@ -548,6 +550,8 @@ public struct FormatOptions: CustomStringConvertible {
                 genericTypes: String = "",
                 useSomeAny: Bool = true,
                 wrapEffects: WrapEffects = .preserve,
+                preserveAnonymousForEach: Bool = false,
+                preserveSingleLineForEach: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -642,6 +646,8 @@ public struct FormatOptions: CustomStringConvertible {
         self.useSomeAny = useSomeAny
         self.wrapEffects = wrapEffects
         self.spaceAroundDelimiter = spaceAroundDelimiter
+        self.preserveAnonymousForEach = preserveAnonymousForEach
+        self.preserveSingleLineForEach = preserveSingleLineForEach
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1379,6 +1379,69 @@ extension Formatter {
         return importStack
     }
 
+    /// Parses the arguments of the closure whose open brace is at the given index.
+    /// Returns `nil` if this is an anonymous closure, or if there was an issue parsing the closure arguments.
+    ///  - `{ foo in ... }` returns `argumentNames: ["foo"]`
+    ///  - `{ foo, bar in ... }` returns `argumentNames: ["foo", "bar"]`
+    ///  - `{ (foo: Foo, bar: Bar) in ... }` returns `argumentNames: ["foo", "bar"]`
+    func parseClosureArgumentList(at closureOpenBraceIndex: Int) -> (argumentNames: [String], inKeywordIndex: Int)? {
+        var argumentNames = [String]()
+        let inKeywordIndex: Int
+
+        // Check if this is a closure `{ value in ... }` clause
+        if
+            let indexAfterOpenBrace = index(of: .nonSpaceOrCommentOrLinebreak, after: closureOpenBraceIndex),
+            tokens[indexAfterOpenBrace].isIdentifier
+        {
+            // Parse a list of argument names like `foo, bar, baaz` until the `in` keyword
+            var currentArgumentListIndex = indexAfterOpenBrace
+            while tokens[currentArgumentListIndex].isIdentifier {
+                argumentNames.append(tokens[currentArgumentListIndex].string)
+
+                guard let nextIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: currentArgumentListIndex) else {
+                    return nil
+                }
+
+                // Skip over any commas
+                if tokens[nextIndex] == .delimiter(",") {
+                    currentArgumentListIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: nextIndex) ?? nextIndex
+                } else {
+                    currentArgumentListIndex = nextIndex
+                }
+            }
+
+            // Finally we expect there to be an `in` keyword
+            guard tokens[currentArgumentListIndex] == .keyword("in") else {
+                return nil
+            }
+
+            inKeywordIndex = currentArgumentListIndex
+        }
+
+        // Check if this is a closure `{ (value: ValueType) in ... }` clause
+        else if
+            let indexAfterOpenBrace = index(of: .nonSpaceOrCommentOrLinebreak, after: closureOpenBraceIndex),
+            tokens[indexAfterOpenBrace] == .startOfScope("("),
+            let endOfArgumentsScopeIndex = endOfScope(at: indexAfterOpenBrace),
+            let firstTokenInArgumentsList = index(of: .nonSpaceOrCommentOrLinebreak, after: indexAfterOpenBrace),
+            let lastTokenInArgumentsList = index(of: .nonSpaceOrCommentOrLinebreak, before: endOfArgumentsScopeIndex),
+            let indexAfterArguments = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfArgumentsScopeIndex),
+            tokens[indexAfterArguments] == .keyword("in")
+        {
+            inKeywordIndex = indexAfterArguments
+
+            let argumentTokens = tokens[firstTokenInArgumentsList ... lastTokenInArgumentsList].split(separator: .delimiter(","))
+            argumentNames = argumentTokens.map { $0.first(where: \.isIdentifier)?.string ?? $0[0].string }
+        }
+
+        // Otherwise this is an anonymous closure
+        else {
+            return nil
+        }
+
+        return (argumentNames: argumentNames, inKeywordIndex: inKeywordIndex)
+    }
+
     enum Declaration: Equatable {
         /// A type-like declaration with body of additional declarations (`class`, `struct`, etc)
         indirect case type(kind: String, open: [Token], body: [Declaration], close: [Token])

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -8012,7 +8012,8 @@ public struct _FormatRules {
                 //  1. an identifier like `foo.`
                 //  2. a function call like `foo(...).`
                 //  3. a subscript like `foo[...].
-                //  4. Some other combination of parens / subscript like `(foo).`
+                //  4. a trailing closure like `map { ... }`
+                //  5. Some other combination of parens / subscript like `(foo).`
                 //     or even `foo["bar"]()()`.
                 // And any of these can be preceeded by one of the others
                 switch formatter.tokens[index] {
@@ -8045,6 +8046,15 @@ public struct _FormatRules {
                     //  - If the previous token is a newline then this isn't a function call
                     //    and we'd stop parsing. `foo   ()` is a function call but `foo\n()` isn't.
                     return startOfChainComponent(at: previousNonSpaceNonCommentIndex) ?? startOfScopeIndex
+                    
+                case .endOfScope("}"):
+                    // Stop parsing if we reach a trailing closure.
+                    // Converting this to a for loop would result in unusual looking syntax like
+                    // `for string in strings.map { $0.uppercased() } { print(string) }`
+                    // which causes a warning to be emitted: "trailing closure in this context is
+                    // confusable with the body of the statement; pass as a parenthesized argument
+                    // to silence this warning".
+                    return nil
 
                 default:
                     return nil

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7948,7 +7948,9 @@ public struct _FormatRules {
 
     public let forLoop = FormatRule(
         help: "Convert functional `forEach` calls to for loops.",
-        disabledByDefault: true
+        disabledByDefault: true,
+        options: ["anonymousForEach", "oneLineForEach"],
+        sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.identifier("forEach")) { forEachIndex, _ in
             // Make sure this is a function call preceeded by a `.`
@@ -8015,7 +8017,15 @@ public struct _FormatRules {
                 // And any of these can be preceeded by one of the others
                 switch formatter.tokens[index] {
                 case let .identifier(identifierName):
-                    if forLoopSubjectIdentifier == nil {
+                    // Allowlist certain dot chain elements that should be ignored.
+                    // For example, in `foos.reversed().forEach { ... }` we want
+                    // `forLoopSubjectIdentifier` to be `foos` rather than `reversed`.
+                    let chainElementsToIgnore = Set([
+                        "reversed", "sorted", "shuffled", "enumerated", "dropFirst", "dropLast",
+                        "map", "flatMap", "compactMap", "filter", "reduce", "lazy",
+                    ])
+
+                    if forLoopSubjectIdentifier == nil || chainElementsToIgnore.contains(forLoopSubjectIdentifier ?? "") {
                         // Since we have to pick a single identifier to represent the subject of the for loop,
                         // just use the last identifier in the chain
                         forLoopSubjectIdentifier = identifierName
@@ -8078,49 +8088,24 @@ public struct _FormatRules {
                 return
             }
 
-            // Next, parse the `in` clause of the closure. This can be either:
-            //  1. an anonymous closure with no `in` clause
-            //  2. a simple identifier like `{ value in ... }`
-            //  3. an identifier and a type, like `{ (value: ValueType) in ... }`
-
-            /// The name of the argument to the `forEach` closure. e.g. `foo` in `forEach { foo in ... }`.
-            let forEachValueName: String
+            /// The names of the argument to the `forEach` closure.
+            /// e.g. `["foo"]` in `forEach { foo in ... }`
+            /// or `["foo, bar"]` in `forEach { (foo: Foo, bar: Bar) in ... }`
+            let forEachValueNames: [String]
             let inKeywordIndex: Int?
             let isAnonymousClosure: Bool
 
-            // Check if this is a closure `{ value in ... }` clause
-            if
-                let indexAfterOpenBrace = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureOpenBraceIndex),
-                formatter.tokens[indexAfterOpenBrace].isIdentifier,
-                let indexAfterFirstIdentifier = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: indexAfterOpenBrace),
-                formatter.tokens[indexAfterFirstIdentifier] == .keyword("in")
-            {
-                forEachValueName = formatter.tokens[indexAfterOpenBrace].string
-                inKeywordIndex = indexAfterFirstIdentifier
+            if let argumentList = formatter.parseClosureArgumentList(at: closureOpenBraceIndex) {
                 isAnonymousClosure = false
-            }
-
-            // Check if this is a closure `{ (value: ValueType) in ... }` clause
-            else if
-                let indexAfterOpenBrace = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureOpenBraceIndex),
-                formatter.tokens[indexAfterOpenBrace] == .startOfScope("("),
-                let endOfArgumentsScopeIndex = formatter.endOfScope(at: indexAfterOpenBrace),
-                let firstTokenInArgumentsScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: indexAfterOpenBrace),
-                formatter.tokens[firstTokenInArgumentsScope].isIdentifier,
-                let indexAfterArguments = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfArgumentsScopeIndex),
-                formatter.tokens[indexAfterArguments] == .keyword("in")
-            {
-                forEachValueName = formatter.tokens[firstTokenInArgumentsScope].string
-                inKeywordIndex = indexAfterArguments
-                isAnonymousClosure = false
-            }
-
-            // Otherwise this is an anyonymous closure. Since the argument isn't
-            // named explicitly, we have to generate it ourselves. In simple cases
-            // we can just use the singluar form of the value being iterated over.
-            else {
-                inKeywordIndex = nil
+                forEachValueNames = argumentList.argumentNames
+                inKeywordIndex = argumentList.inKeywordIndex
+            } else {
                 isAnonymousClosure = true
+                inKeywordIndex = nil
+
+                if formatter.options.preserveAnonymousForEach {
+                    return
+                }
 
                 // We can't introduce an identifier that already exists in the for each body,
                 // so choose the first eligible option from a set of potential names
@@ -8144,17 +8129,52 @@ public struct _FormatRules {
                         && !formatter.tokens[closureOpenBraceIndex ... closureCloseBraceIndex].contains(where: { $0.string == potentialValueName })
                 }) else { return }
 
-                forEachValueName = chosenValueName
+                forEachValueNames = [chosenValueName]
+            }
+
+            // Validate that the closure body is eligible to be converted to a for loop
+            for closureBodyIndex in closureOpenBraceIndex ... closureCloseBraceIndex {
+                guard !formatter.indexIsWithinNestedClosure(closureBodyIndex, startOfScopeIndex: closureOpenBraceIndex) else { continue }
+
+                // We can only handle anonymous closures that just use $0, since we don't have good names to
+                // use for other arguments like $1, $2, etc. If the closure has an anonymous argument
+                // other than just $0 then we have to ignore it.
+                if formatter.tokens[closureBodyIndex].string.hasPrefix("$"),
+                   let intValue = Int(formatter.tokens[closureBodyIndex].string.dropFirst()),
+                   intValue != 0
+                {
+                    return
+                }
+
+                // We can convert `return`s to `continue`, but only when `return` is on its own line.
+                // It's legal to write something like `return print("foo")` in a `forEach` as long as
+                // you're still returning a `Void` value. Since `continue print("foo")` isn't legal,
+                // we should just ignore this closure.
+                if
+                    formatter.tokens[closureBodyIndex] == .keyword("return"),
+                    let tokenAfterReturnKeyword = formatter.next(.nonSpaceOrComment, after: closureBodyIndex),
+                    !tokenAfterReturnKeyword.isLinebreak
+                {
+                    return
+                }
             }
 
             // Start updating the `forEach` call to a `for .. in .. {` loop
+            let wasDefinedOnSingleLine = formatter.endOfLine(at: closureOpenBraceIndex) == formatter.endOfLine(at: closureCloseBraceIndex)
+
+            // If we're converting this single-line forEach to a multiline for loop, add a newline before the closing brace.
+            // Do this first since any other changes we make may invalidate this existing `closureCloseBraceIndex` value.
+            if wasDefinedOnSingleLine, !formatter.options.preserveSingleLineForEach {
+                formatter.insertLinebreak(at: closureCloseBraceIndex - 1)
+            }
+
             for closureBodyIndex in closureOpenBraceIndex ... closureCloseBraceIndex {
                 guard !formatter.indexIsWithinNestedClosure(closureBodyIndex, startOfScopeIndex: closureOpenBraceIndex) else { continue }
 
                 // The for loop won't have any `$0` identifiers anymore, so we have to
                 // update those to the value at the current loop index
                 if isAnonymousClosure, formatter.tokens[closureBodyIndex].string == "$0" {
-                    formatter.replaceToken(at: closureBodyIndex, with: .identifier(forEachValueName))
+                    formatter.replaceToken(at: closureBodyIndex, with: .identifier(forEachValueNames[0]))
                 }
 
                 // In a `forEach` closure, `return` continues to the next loop iteration.
@@ -8168,25 +8188,49 @@ public struct _FormatRules {
                 formatter.removeToken(at: forEachCallCloseParenIndex)
             }
 
-            let newTokens: [Token] =
-                [
-                    .keyword("for"),
-                    .space(" "),
-                    .identifier(forEachValueName),
-                    .space(" "),
-                    .keyword("in"),
-                    .space(" "),
-                ]
-                + formatter.tokens[forLoopSubjectRange]
-                + [
-                    .space(" "),
-                    .startOfScope("{"),
-                ]
+            // Construct the new for loop
+            var newTokens: [Token] = [
+                .keyword("for"),
+                .space(" "),
+            ]
+
+            let forEachValueNameTokens: [Token]
+            if forEachValueNames.count == 1 {
+                newTokens.append(.identifier(forEachValueNames[0]))
+            } else {
+                newTokens.append(contentsOf: tokenize("(\(forEachValueNames.joined(separator: ", ")))"))
+            }
+
+            newTokens.append(contentsOf: [
+                .space(" "),
+                .keyword("in"),
+                .space(" "),
+            ])
+
+            newTokens.append(contentsOf: formatter.tokens[forLoopSubjectRange])
+
+            newTokens.append(contentsOf: [
+                .space(" "),
+                .startOfScope("{"),
+            ])
+
+            if wasDefinedOnSingleLine, !formatter.options.preserveSingleLineForEach {
+                newTokens.append(formatter.linebreakToken(for: closureOpenBraceIndex))
+            }
 
             formatter.replaceTokens(
                 in: (forLoopSubjectRange.lowerBound) ... (inKeywordIndex ?? closureOpenBraceIndex),
                 with: newTokens
             )
+
+            // `forEach` is `rethrows`, so there may be a `try` before the call. Now that we're using `for` instead,
+            // `try` is invalid here and has to be removed.
+            if
+                let tokenIndexBeforeForLoop = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: forLoopSubjectRange.lowerBound),
+                formatter.tokens[tokenIndexBeforeForLoop] == .keyword("try")
+            {
+                formatter.removeTokens(in: tokenIndexBeforeForLoop ..< forLoopSubjectRange.lowerBound)
+            }
         }
     }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3705,11 +3705,23 @@ class SyntaxTests: RulesTests {
     func testPreservesChainWithClosure() {
         let input = """
         // Converting this to a for loop would result in unusual looking syntax like
-        // `for string in strings.map { $0.uppercased() } { print($0) }`
+        // `for string in strings.map { $0.uppercased() } { print(string) }`
         // which causes a warning to be emitted: "trailing closure in this context is
         // confusable with the body of the statement; pass as a parenthesized argument
         // to silence this warning".
         strings.map { $0.uppercased() }.forEach { print($0) }
+        """
+        testFormatting(for: input, rule: FormatRules.forLoop)
+    }
+
+    func testPreservesChainWithClosureInMiddleOfChain() {
+        let input = """
+        // Converting this to a for loop would result in unusual looking syntax like
+        // `for string in strings.map { $0.uppercased() }.values { print(string) }`
+        // which causes a warning to be emitted: "trailing closure in this context is
+        // confusable with the body of the statement; pass as a parenthesized argument
+        // to silence this warning".
+        strings.map { $0.uppercased() }.values.forEach { print($0) }
         """
         testFormatting(for: input, rule: FormatRules.forLoop)
     }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3713,4 +3713,191 @@ class SyntaxTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.forLoop)
     }
+
+    func testHandlesTryBeforeForEach() {
+        let input = """
+        try planets.forEach {
+            try $0.terraform()
+        }
+        """
+
+        let output = """
+        for planet in planets {
+            try planet.terraform()
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachReversed() {
+        let input = """
+        foos.reversed().forEach {
+            print($0)
+        }
+        """
+
+        let output = """
+        for foo in foos.reversed() {
+            print(foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachSorted() {
+        let input = """
+        foos.sorted().forEach {
+            print($0)
+        }
+        """
+
+        let output = """
+        for foo in foos.sorted() {
+            print(foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachMapFilterSort() {
+        let input = """
+        foos.map(\\.foo).filter(\\.isBar).sorted().forEach {
+            print($0)
+        }
+        """
+
+        let output = """
+        for foo in foos.map(\\.foo).filter(\\.isBar).sorted() {
+            print(foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachEnumeratedWithSingleVariable() {
+        let input = """
+        foos.enumerated().forEach {
+            print($0.offset, $0.element)
+        }
+        """
+
+        let output = """
+        for foo in foos.enumerated() {
+            print(foo.offset, foo.element)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachEnumeratedAnonymousNotConverted() {
+        let input = """
+        // We don't have an easy way to know what name to use for $1 here, so leave it as-is.
+        foos.enumerated().forEach {
+            print($0, $1)
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.forLoop)
+    }
+
+    func testForEachWithNamedArgumentAndType() {
+        let input = """
+        foos.forEach { (foo: Foo) in
+            print(foo)
+        }
+        """
+
+        let output = """
+        for foo in foos {
+            print(foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachWithNamedArguments() {
+        let input = """
+        foos.enumerated().forEach { index, foo in
+            print(index, foo)
+        }
+        """
+
+        let output = """
+        for (index, foo) in foos.enumerated() {
+            print(index, foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachWithNamedArgumentsAndTypes() {
+        let input = """
+        foos.enumerated().forEach { (index: Int, foo: Foo) in
+            print(index, foo)
+        }
+        """
+
+        let output = """
+        for (index, foo) in foos.enumerated() {
+            print(index, foo)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.forLoop)
+    }
+
+    func testForEachWithReturnVoidValue() {
+        let input = """
+        foos.forEach { foo in
+            // This is valid as long as `bar()` returns `Void`.
+            // It doesn't seem very safe to convert this to use `continue`,
+            // since `continue foo.bar()` would be invalid.
+            return foo.bar()
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.forLoop, exclude: ["redundantReturn"])
+    }
+
+    func testPreservesAnonymousClosure() {
+        let input = """
+        foos.forEach { print($0) }
+        foos.forEach { foo in print(foo) }
+        """
+
+        let output = """
+        foos.forEach { print($0) }
+        for foo in foos { print(foo) }
+        """
+
+        let options = FormatOptions(preserveAnonymousForEach: true)
+        testFormatting(for: input, output, rule: FormatRules.forLoop, options: options)
+    }
+
+    func testConvertSingleLineForEachToMultiLineForLoop() {
+        let input = """
+        foos.forEach { print($0) }
+        bars.forEach { print($0) }
+        """
+
+        let output = """
+        for foo in foos {
+            print(foo)
+        }
+
+        for bar in bars {
+            print(bar)
+        }
+        """
+
+        let options = FormatOptions(preserveSingleLineForEach: false)
+        testFormatting(for: input, [output], rules: [FormatRules.forLoop, FormatRules.indent, FormatRules.blankLinesBetweenScopes], options: options)
+    }
 }


### PR DESCRIPTION
This PR fixes several edge cases in the `forLoop` rule that I missed in #1490.

This PR also adds options to:
 1. not convert anonymous `forEach` closures to `for` loops
 2. convert single-line `forEach` closures to multi-line `for` loops