### PR TITLE
Add file header placeholders for user who created the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,8 @@ It is common practice to include the file name, creation date and/or the current
 * `{file}` - the name of the file
 * `{year}` - the current year
 * `{created}` - the date on which the file was created
+* `{created.name}` - the name of the user who first committed the file
+* `{created.email}` - the email of the user who first committed the file 
 * `{created.year}` - the year in which the file was created
 
 For example, a header template of:
@@ -813,7 +815,7 @@ Will be formatted as:
 // Created by John Smith on 01/02/2016.
 ```
 
-**NOTE:** the `{year}` value and `{created}` date format are determined from the current locale and timezone of the machine running the script.
+**NOTE:** the `{year}` value and `{created}` date format are determined from the current locale and timezone of the machine running the script. `{created.name}` and `{created.email}` requires the project to be version controlled by git.
 
 
 FAQ

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -484,7 +484,10 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
             var formatOptions = options.formatOptions ?? .default
             formatOptions.fileInfo = FileInfo(
                 filePath: resourceValues.path,
-                creationDate: resourceValues.creationDate
+                replacements: [
+                    .createdDate: resourceValues.creationDate?.shortString,
+                    .createdYear: resourceValues.creationDate?.yearString,
+                ].compactMapValues { $0 }
             )
             options.formatOptions = formatOptions
         }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2404,3 +2404,28 @@ extension Formatter {
         }
     }
 }
+
+extension Date {
+    static var shortDateFormatter: (Date) -> String = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return { date in formatter.string(from: date) }
+    }()
+
+    static var yearFormatter: (Date) -> String = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+        return { date in formatter.string(from: date) }
+    }()
+
+    static var currentYear = yearFormatter(Date())
+
+    var yearString: String {
+        Date.yearFormatter(self)
+    }
+
+    var shortString: String {
+        Date.shortDateFormatter(self)
+    }
+}

--- a/Sources/GitHelpers.swift
+++ b/Sources/GitHelpers.swift
@@ -1,0 +1,82 @@
+//
+//  GitHelpers.swift
+//  SwiftFormat
+//
+//  Created by Hampus Tågerud on 2023-08-08.
+//  Copyright 2023 Nick Lockwood and the SwiftFormat project authors
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+struct GitFileInfo {
+    var createdByName: String?
+    var createdByEmail: String?
+}
+
+enum GitHelpers {
+    private static var inGitRoot: Bool {
+        // Get current git repository top level directory
+        guard let root = "git rev-parse --show-toplevel".shellOutput() else { return false }
+        // Make sure a valid URL was returned
+        guard let _ = URL(string: root) else { return false }
+        // Make sure an existing path was returned
+        return FileManager.default.fileExists(atPath: root)
+    }
+
+    // If a file has never been committed, default to the local git user for that repository
+    private static var defaultGitInfo: GitFileInfo? {
+        guard inGitRoot else { return nil }
+
+        let name = "git config user.name".shellOutput()
+        let email = "git config user.email".shellOutput()
+
+        guard let safeName = name, let safeEmail = email else { return nil }
+
+        return GitFileInfo(createdByName: safeName, createdByEmail: safeEmail)
+    }
+
+    private enum FileInfoPart: String {
+        case email = "ae"
+        case name = "an"
+    }
+
+    private static func fileInfoPart(_ inputURL: URL, _ part: FileInfoPart) -> String? {
+        let value = "git log --diff-filter=A --pretty=%\(part.rawValue) \(inputURL.relativePath)"
+            .shellOutput()
+
+        guard let safeValue = value, !safeValue.isEmpty else { return nil }
+        return safeValue
+    }
+
+    static func fileInfo(_ inputURL: URL) -> GitFileInfo? {
+        guard inGitRoot else { return nil }
+
+        let name = fileInfoPart(inputURL, .name) ?? defaultGitInfo?.createdByName
+        let email = fileInfoPart(inputURL, .email) ?? defaultGitInfo?.createdByEmail
+
+        return GitFileInfo(createdByName: name, createdByEmail: email)
+    }
+}

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2297,24 +2297,6 @@ extension Formatter {
 }
 
 extension _FormatRules {
-    /// Short date formatter. Used by fileHeader rule
-    static var shortDateFormatter: (Date) -> String = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .none
-        return { formatter.string(from: $0) }
-    }()
-
-    /// Year formatter. Used by fileHeader rule
-    static var yearFormatter: (Date) -> String = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy"
-        return { formatter.string(from: $0) }
-    }()
-
-    /// Current year. Used by fileHeader rule
-    static var currentYear: String = yearFormatter(Date())
-
     /// Swiftlint semantic modifier groups
     static let semanticModifierGroups = ["acl", "setteracl", "mutators", "typemethods", "owned"]
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5086,7 +5086,7 @@ public struct _FormatRules {
             return
         case var .replace(string):
             for (key, replacement) in formatter.options.fileInfo.replacements {
-                if let range = string.range(of: "{\(key.rawValue)}") {
+                while let range = string.range(of: "{\(key.rawValue)}") {
                     string.replaceSubrange(range, with: replacement)
                 }
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5085,24 +5085,12 @@ public struct _FormatRules {
         case .ignore:
             return
         case var .replace(string):
-            if let range = string.range(of: "{file}"),
-               let file = formatter.options.fileInfo.fileName
-            {
-                string.replaceSubrange(range, with: file)
+            for (key, replacement) in formatter.options.fileInfo.replacements {
+                if let range = string.range(of: "{\(key.rawValue)}") {
+                    string.replaceSubrange(range, with: replacement)
+                }
             }
-            if let range = string.range(of: "{year}") {
-                string.replaceSubrange(range, with: currentYear)
-            }
-            if let range = string.range(of: "{created}"),
-               let date = formatter.options.fileInfo.creationDate
-            {
-                string.replaceSubrange(range, with: shortDateFormatter(date))
-            }
-            if let range = string.range(of: "{created.year}"),
-               let date = formatter.options.fileInfo.creationDate
-            {
-                string.replaceSubrange(range, with: yearFormatter(date))
-            }
+
             header = string
         }
 

--- a/Sources/ShellHelpers.swift
+++ b/Sources/ShellHelpers.swift
@@ -1,0 +1,59 @@
+//
+//  ShellHelpers.swift
+//  SwiftFormat
+//
+//  Created by Hampus Tågerud on 2023-08-08.
+//  Copyright 2023 Nick Lockwood and the SwiftFormat project authors
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+extension String {
+    func shellOutput() -> String? {
+        let process = Process()
+        let pipe = Pipe()
+
+        process.executableURL = URL(string: "/bin/bash")
+        process.arguments = ["-c", self]
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        let file = pipe.fileHandleForReading
+
+        do { try process.run() }
+        catch { return nil }
+
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let outputData = file.readDataToEndOfFile()
+        return String(data: outputData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -93,6 +93,14 @@
 		A3DF48252620E03600F45A5F /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
 		A3DF48262620E03600F45A5F /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
 		B9C4F55C2387FA3E0088DBEE /* SupportedContentUTIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4F55B2387FA3E0088DBEE /* SupportedContentUTIs.swift */; };
+		D52F6A642A82E04600FE1448 /* GitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A632A82E04600FE1448 /* GitHelpers.swift */; };
+		D52F6A652A82E04600FE1448 /* GitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A632A82E04600FE1448 /* GitHelpers.swift */; };
+		D52F6A662A82E04600FE1448 /* GitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A632A82E04600FE1448 /* GitHelpers.swift */; };
+		D52F6A672A82E04600FE1448 /* GitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A632A82E04600FE1448 /* GitHelpers.swift */; };
+		D52F6A692A82E0DD00FE1448 /* ShellHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */; };
+		D52F6A6A2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */; };
+		D52F6A6B2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */; };
+		D52F6A6C2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */; };
 		DD9AD39E2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */; };
 		DD9AD39F2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */; };
 		DD9AD3A32999FCC8001C2C0E /* Reporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39D2999FCC8001C2C0E /* Reporter.swift */; };
@@ -237,6 +245,8 @@
 		90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandErrors.swift; sourceTree = "<group>"; };
 		A3DF48242620E03600F45A5F /* JSONReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
 		B9C4F55B2387FA3E0088DBEE /* SupportedContentUTIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedContentUTIs.swift; sourceTree = "<group>"; };
+		D52F6A632A82E04600FE1448 /* GitHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHelpers.swift; sourceTree = "<group>"; };
+		D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHelpers.swift; sourceTree = "<group>"; };
 		DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubActionsLogReporter.swift; sourceTree = "<group>"; };
 		DD9AD39D2999FCC8001C2C0E /* Reporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reporter.swift; sourceTree = "<group>"; };
 		E41CB5BE2025761D00C1BEDE /* UserSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelection.swift; sourceTree = "<group>"; };
@@ -361,6 +371,8 @@
 				01A0EABF1D5DB4F700A0A8E3 /* Tokenizer.swift */,
 				01BBD85821DAA2A000457380 /* Globs.swift */,
 				2E7D30A32A7940C500C32174 /* GrammaticalNumber.swift */,
+				D52F6A632A82E04600FE1448 /* GitHelpers.swift */,
+				D52F6A682A82E0DD00FE1448 /* ShellHelpers.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -771,6 +783,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D52F6A642A82E04600FE1448 /* GitHelpers.swift in Sources */,
 				01045A992119979400D2BE3D /* Arguments.swift in Sources */,
 				01567D2F225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
 				DD9AD39E2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */,
@@ -778,6 +791,7 @@
 				DD9AD3A32999FCC8001C2C0E /* Reporter.swift in Sources */,
 				E4FABAD5202FEF060065716E /* OptionDescriptor.swift in Sources */,
 				01BBD85921DAA2A000457380 /* Globs.swift in Sources */,
+				D52F6A692A82E0DD00FE1448 /* ShellHelpers.swift in Sources */,
 				01ACAE05220CD90F003F3CCF /* Examples.swift in Sources */,
 				01D3B28624E9C9C700888DE0 /* FormattingHelpers.swift in Sources */,
 				E4E4D3C92033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
@@ -835,9 +849,11 @@
 				DD9AD39F2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */,
 				E4E4D3CA2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
 				01BBD85A21DAA2A600457380 /* Globs.swift in Sources */,
+				D52F6A6A2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */,
 				01045A92211988F100D2BE3D /* Inference.swift in Sources */,
 				01F3DF8D1DB9FD3F00454944 /* Options.swift in Sources */,
 				E4FABAD6202FEF060065716E /* OptionDescriptor.swift in Sources */,
+				D52F6A652A82E04600FE1448 /* GitHelpers.swift in Sources */,
 				A3DF48262620E03600F45A5F /* JSONReporter.swift in Sources */,
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
@@ -860,6 +876,7 @@
 				E487211D201D885A0014845E /* RulesViewController.swift in Sources */,
 				01045A9B2119979400D2BE3D /* Arguments.swift in Sources */,
 				E4872114201D3B8C0014845E /* Tokenizer.swift in Sources */,
+				D52F6A6B2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */,
 				E4872112201D3B860014845E /* Rules.swift in Sources */,
 				E4962DE0203F3CD500A02013 /* OptionsStore.swift in Sources */,
 				01ACAE07220CD915003F3CCF /* Examples.swift in Sources */,
@@ -873,6 +890,7 @@
 				E41CB5BF2025761D00C1BEDE /* UserSelection.swift in Sources */,
 				E4872111201D3B830014845E /* Options.swift in Sources */,
 				01A95BD3225BEDE400744931 /* ParsingHelpers.swift in Sources */,
+				D52F6A662A82E04600FE1448 /* GitHelpers.swift in Sources */,
 				90C4B6CD1DA4B04A009EB000 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -889,6 +907,7 @@
 				0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */,
 				E4E4D3CC2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
 				E4FABAD8202FEF060065716E /* OptionDescriptor.swift in Sources */,
+				D52F6A6C2A82E0DD00FE1448 /* ShellHelpers.swift in Sources */,
 				9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */,
 				90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */,
 				01A8320924EC7F7800A9D0EB /* FormattingHelpers.swift in Sources */,
@@ -902,6 +921,7 @@
 				90C4B6E71DA4B059009EB000 /* FormatSelectionCommand.swift in Sources */,
 				90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */,
 				01ACAE08220CD916003F3CCF /* Examples.swift in Sources */,
+				D52F6A672A82E04600FE1448 /* GitHelpers.swift in Sources */,
 				9028F7861DA4B435009FE5B4 /* Rules.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -661,7 +661,7 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testAddArgumentsDoesntBreakFileInfo() throws {
-        let fileInfo = FileInfo(filePath: "~/Foo.swift", creationDate: Date())
+        let fileInfo = createFileInfo(filePath: "~/Foo.swift", creationDate: Date())
         var options = Options(formatOptions: FormatOptions(fileInfo: fileInfo))
         try options.addArguments(["indent": "2"], in: "")
         guard let formatOptions = options.formatOptions else {

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -9,6 +9,16 @@
 import XCTest
 @testable import SwiftFormat
 
+func createFileInfo(filePath: String? = nil, creationDate: Date? = nil, replacements: [FileInfoKey: String] = [:]) -> FileInfo {
+    var allReplacements = replacements
+    allReplacements.merge([
+        .createdDate: creationDate?.shortString,
+        .createdYear: creationDate?.yearString,
+    ].compactMapValues { $0 }, uniquingKeysWith: { $1 })
+
+    return FileInfo(filePath: filePath, replacements: allReplacements)
+}
+
 class GeneralTests: RulesTests {
     // MARK: - initCoderUnavailable
 
@@ -538,8 +548,18 @@ class GeneralTests: RulesTests {
             formatter.dateFormat = "yyyy"
             return "// Copyright © \(formatter.string(from: date))\n\nlet foo = bar"
         }()
-        let fileInfo = FileInfo(creationDate: date)
+        let fileInfo = createFileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// Copyright © {created.year}", fileInfo: fileInfo)
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
+    func testFileHeaderCreatorReplacement() {
+        let name = "Test User"
+        let email = "test@email.com"
+        let input = "let foo = bar"
+        let output = "// Created by \(name) \(email)\n\nlet foo = bar"
+        let fileInfo = createFileInfo(replacements: [.createdName: name, .createdEmail: email])
+        let options = FormatOptions(fileHeader: "// Created by {created.name} {created.email}", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
@@ -552,7 +572,7 @@ class GeneralTests: RulesTests {
             formatter.timeStyle = .none
             return "// Created by Nick Lockwood on \(formatter.string(from: date)).\n\nlet foo = bar"
         }()
-        let fileInfo = FileInfo(creationDate: date)
+        let fileInfo = createFileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// Created by Nick Lockwood on {created}.", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -563,6 +563,15 @@ class GeneralTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
     }
 
+    func testFileHeaderMultipleReplacement() {
+        let name = "Test User"
+        let input = "let foo = bar"
+        let output = "// Copyright © \(name)\n// Created by \(name)\n\nlet foo = bar"
+        let fileInfo = createFileInfo(replacements: [.createdName: name])
+        let options = FormatOptions(fileHeader: "// Copyright © {created.name}\n// Created by {created.name}", fileInfo: fileInfo)
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
     func testFileHeaderCreationDateReplacement() {
         let input = "let foo = bar"
         let date = Date(timeIntervalSince1970: 0)

--- a/Tests/SwiftFormatTests.swift
+++ b/Tests/SwiftFormatTests.swift
@@ -67,7 +67,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 68)
+        XCTAssertEqual(files.count, 70)
     }
 
     func testInputFilesMatchOutputFilesForSameOutput() {
@@ -78,7 +78,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 68)
+        XCTAssertEqual(files.count, 70)
     }
 
     func testInputFileNotEnumeratedWhenExcluded() {
@@ -93,7 +93,7 @@ class SwiftFormatTests: XCTestCase {
             return { files.append(inputURL) }
         }
         XCTAssertEqual(errors.count, 0)
-        XCTAssertEqual(files.count, 43)
+        XCTAssertEqual(files.count, 45)
     }
 
     // MARK: format function


### PR DESCRIPTION
Hi! Thank you for this tool, it helps tremendously when working on Swift projects 🙏 

When setting up a configuration for a project where I want to generate the header I noticed that the "Created by" row is hard to keep as generated by Xcode, so I thought `{created.name}` and `{created.email}` could be a nice addition to the templating 🙂

The PR reworks the templating a bit to make it more loop-based, which could make it easier to add more placeholders later if needed.

It also fixes a bug where each placeholder could only be used once.

Related issue: #776 