### PR TITLE
Update sortTypealiases rule to also remove duplicates

### DIFF
--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -3651,4 +3651,42 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
     }
+
+    func testSortTypeAliasesAndRemoveDuplicates() {
+        let input = """
+        typealias Placeholders = Foo & Bar & Quux & Baaz & Bar
+
+        typealias Dependencies1
+            = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+            & FooProviding
+
+        typealias Dependencies2
+            = FooProviding
+            & BarProviding
+            & BaazProviding
+            & QuuxProviding
+            & BaazProviding
+        """
+
+        let output = """
+        typealias Placeholders = Baaz & Bar & Foo & Quux
+
+        typealias Dependencies1
+            = BaazProviding
+            & BarProviding
+            & FooProviding
+            & QuuxProviding
+
+        typealias Dependencies2
+            = BaazProviding
+            & BarProviding
+            & FooProviding
+            & QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
+    }
 }


### PR DESCRIPTION
With the `sortTypealiases` rule we've found its pretty common for folks to unintentionally add a type to the protocol composition multiple times. This can be hard to notice when the typealias isn't sorted, especially if the typealias is quite long:

```swift 
typealias Dependencies
    = FooProviding
    & BarProviding
    & BaazProviding
    & QuuxProviding
    & FooProviding
```

but is quite obvious after its sorted:

```swift
typealias Dependencies
    = BaazProviding
    & BarProviding
    & FooProviding
    & FooProviding
    & QuuxProviding
```

Since we're already parsing and reordering these in the `sortTypealiases` rule, we may as well also remove duplicates:

```swift
typealias Dependencies
    = BaazProviding
    & BarProviding
    & FooProviding
    & QuuxProviding
```