### PR TITLE
[#1525] Fix issue where removing return from failable init would break build

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3191,6 +3191,15 @@ public struct _FormatRules {
                 return
             }
 
+            // Make sure we aren't in a failable `init?`, where explicit return is required
+            if let lastSignificantKeywordIndex = formatter.indexOfLastSignificantKeyword(at: startOfScopeIndex),
+               formatter.tokens[lastSignificantKeywordIndex] == .keyword("init"),
+               let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: lastSignificantKeywordIndex),
+               nextToken == .operator("?", .postfix)
+            {
+                return
+            }
+
             // Removes return statements in the given single-statement scope
             func removeReturn(atStartOfScope startOfScopeIndex: Int) {
                 // If this scope is a single-statement if or switch statement then we have to recursively

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2220,6 +2220,39 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantReturn)
     }
 
+    func testNoRemoveReturnInFailableInitWithConditional() {
+        let input = """
+        init?(optionalHex: String?) {
+            if let optionalHex {
+                self.init(hex: optionalHex)
+            } else {
+                return nil
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantReturn, options: options)
+    }
+
+    func testNoRemoveReturnInFailableInitWithNestedConditional() {
+        let input = """
+        init?(optionalHex: String?) {
+            if let optionalHex {
+                self.init(hex: optionalHex)
+            } else {
+                switch foo {
+                case .foo:
+                    self.init()
+                case .bar:
+                    return nil
+                }
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantReturn, options: options)
+    }
+
     func testRemoveReturnInFailableInit() {
         let input = "init?() { return nil }"
         let output = "init?() { nil }"


### PR DESCRIPTION
This PR fixes #1525, where the redundant return rule would unexpectedly remove the `return` keyword from a conditional statement in a failable init, where explicit return is required.

### Before

```diff
init?(optionalHex: String?) {
    if let optionalHex {
        self.init(hex: optionalHex)
    } else {
-        return nil
+        nil
    }
}
```

### After

```diff
init?(optionalHex: String?) {
    if let optionalHex {
        self.init(hex: optionalHex)
    } else {
        return nil
    }
}
```