### PR TITLE
Improve `conditionalAssignment` and `redundantClosure` rules by parsing full expressions

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1216,7 +1216,7 @@ extension Formatter {
 
         // The body should contain exactly one expression.
         // We can confirm this by parsing the body with `parseExpressionRange`,
-        // and checking that the toke after that expression is just the end of the scope.
+        // and checking that the token after that expression is just the end of the scope.
         guard var firstTokenInBody = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfBody) else {
             return false
         }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3574,6 +3574,81 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
+    func testDoesntConvertMultiStatementIfStatementWithStringLiteral() {
+        let input = """
+        let text: String
+        if conditionOne {
+            text = "Hello World!"
+            doSomeStuffHere()
+        } else {
+            text = "Goodbye!"
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementWithCollectionLiteral() {
+        let input = """
+        let text: [String]
+        if conditionOne {
+            text = []
+            doSomeStuffHere()
+        } else {
+            text = ["Goodbye!"]
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementWithIntLiteral() {
+        let input = """
+        let number: Int?
+        if conditionOne {
+            number = 5
+            doSomeStuffHere()
+        } else {
+            number = 10
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementWithNilLiteral() {
+        let input = """
+        let number: Int?
+        if conditionOne {
+            number = nil
+            doSomeStuffHere()
+        } else {
+            number = 10
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testDoesntConvertMultiStatementIfStatementWithOtherProperty() {
+        let input = """
+        let number: Int?
+        if conditionOne {
+            number = someOtherProperty
+            doSomeStuffHere()
+        } else {
+            number = 10
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
     // MARK: - preferForLoop
 
     func testConvertSimpleForEachToForLoop() {


### PR DESCRIPTION
This PR improve `conditionalAssignment` and `redundantClosure` rules by updating them to parse full expressions, rather than using a set of loose heuristics.

This PR adds a `parseExpressionRange` helper, which parses [all of the expression types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/expressions/) in the Swift grammar. Then we can simplify `blockBodyHasSingleStatement` to just to parse the expression in the body to verify that the entire body is a single expression.

Fixes #1538.