### PR TITLE
Function definition vs calls, support `closingparen` in raywenderlich style guide

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -397,7 +397,25 @@ extension Formatter {
             keepParameterLabelsOnSameLine(startOfScope: i,
                                           endOfScope: &endOfScope)
 
-            if endOfScopeOnSameLine {
+            let isFunctionCall: Bool = {
+                if let openingParenIndex = self.index(of: .startOfScope("("), before: i + 1) {
+                    if let prevTokenIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: openingParenIndex),
+                       tokens[prevTokenIndex].isIdentifier
+                    {
+                        if let keywordIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: prevTokenIndex),
+                           tokens[keywordIndex] == .keyword("func") || tokens[keywordIndex] == .keyword("init")
+                        {
+                            return false
+                        }
+                        return true
+                    }
+                }
+                return false
+            }()
+
+            if isFunctionCall, options.forceClosingParenOnSameLineForFunctionCalls {
+                removeLinebreakBeforeEndOfScope(at: &endOfScope)
+            } else if endOfScopeOnSameLine {
                 removeLinebreakBeforeEndOfScope(at: &endOfScope)
             } else {
                 // Insert linebreak before closing paren

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -397,23 +397,7 @@ extension Formatter {
             keepParameterLabelsOnSameLine(startOfScope: i,
                                           endOfScope: &endOfScope)
 
-            let isFunctionCall: Bool = {
-                if let openingParenIndex = self.index(of: .startOfScope("("), before: i + 1) {
-                    if let prevTokenIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: openingParenIndex),
-                       tokens[prevTokenIndex].isIdentifier
-                    {
-                        if let keywordIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: prevTokenIndex),
-                           tokens[keywordIndex] == .keyword("func") || tokens[keywordIndex] == .keyword("init")
-                        {
-                            return false
-                        }
-                        return true
-                    }
-                }
-                return false
-            }()
-
-            if isFunctionCall, options.forceClosingParenOnSameLineForFunctionCalls {
+            if options.forceClosingParenOnSameLineForFunctionCalls, isFunctionCall(at: i) {
                 removeLinebreakBeforeEndOfScope(at: &endOfScope)
             } else if endOfScopeOnSameLine {
                 removeLinebreakBeforeEndOfScope(at: &endOfScope)
@@ -1277,6 +1261,23 @@ extension Formatter {
             }
         }
         return allSatisfy
+    }
+
+    /// Whether the given index is in a function call (not declaration)
+    func isFunctionCall(at index: Int) -> Bool {
+        if let openingParenIndex = self.index(of: .startOfScope("("), before: index + 1) {
+            if let prevTokenIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: openingParenIndex),
+               tokens[prevTokenIndex].isIdentifier
+            {
+                if let keywordIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: prevTokenIndex),
+                   tokens[keywordIndex] == .keyword("func") || tokens[keywordIndex] == .keyword("init")
+                {
+                    return false
+                }
+                return true
+            }
+        }
+        return false
     }
 
     /// Whether the given index is directly within the body of the given scope, or part of a nested closure

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -504,6 +504,14 @@ struct _Descriptors {
         trueValues: ["same-line"],
         falseValues: ["balanced"]
     )
+    let forceClosingParenOnSameLineForFunctionCalls = OptionDescriptor(
+        argumentName: "closingparenfcall",
+        displayName: "Force Closing Paren on same line for function calls",
+        help: "Force the closingParenOnSameLine option specifically for function calls: \"inherit\" (default) or \"force-same-line\"",
+        keyPath: \.forceClosingParenOnSameLineForFunctionCalls,
+        trueValues: ["force-same-line", "same-line"],
+        falseValues: ["inherit"]
+    )
     let uppercaseHex = OptionDescriptor(
         argumentName: "hexliteralcase",
         displayName: "Hex Literal Case",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -372,6 +372,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapTypealiases: WrapMode
     public var wrapEnumCases: WrapEnumCases
     public var closingParenOnSameLine: Bool
+    public var forceClosingParenOnSameLineForFunctionCalls: Bool
     public var wrapReturnType: WrapReturnType
     public var wrapConditions: WrapMode
     public var wrapTernaryOperators: TernaryOperatorWrapMode
@@ -472,6 +473,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapTypealiases: WrapMode = .preserve,
                 wrapEnumCases: WrapEnumCases = .always,
                 closingParenOnSameLine: Bool = false,
+                forceClosingParenOnSameLineForFunctionCalls: Bool = false,
                 wrapReturnType: WrapReturnType = .preserve,
                 wrapConditions: WrapMode = .preserve,
                 wrapTernaryOperators: TernaryOperatorWrapMode = .default,
@@ -562,6 +564,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapTypealiases = wrapTypealiases
         self.wrapEnumCases = wrapEnumCases
         self.closingParenOnSameLine = closingParenOnSameLine
+        self.forceClosingParenOnSameLineForFunctionCalls = forceClosingParenOnSameLineForFunctionCalls
         self.wrapReturnType = wrapReturnType
         self.wrapConditions = wrapConditions
         self.wrapTernaryOperators = wrapTernaryOperators

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -1404,6 +1404,86 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
     }
 
+    func testWrapParametersFunctionDeclarationClosingParenOnSameLine() {
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: true)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapParametersFunctionDeclarationClosingParenOnNextLine() {
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: false)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapParametersFunctionDeclarationClosingParenOnSameLineAndForce() {
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: true, forceClosingParenOnSameLineForFunctionCalls: true)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapParametersFunctionDeclarationClosingParenOnNextLineAndForce() {
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: false, forceClosingParenOnSameLineForFunctionCalls: true)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapParametersFunctionCallClosingParenOnNextLineAndForce() {
+        let input = """
+        foo(
+            bar: 42,
+            baz: "foo"
+        )
+        """
+        let output = """
+        foo(
+            bar: 42,
+            baz: "foo")
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenOnSameLine: false, forceClosingParenOnSameLineForFunctionCalls: true)
+        testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
     func testIndentMultilineStringWhenWrappingArguments() {
         let input = """
         foobar(foo: \"\""


### PR DESCRIPTION
Thank you for taking the time to review this PR. I believe this new feature will be a valuable addition to the project and benefit many users. I'm open to feedback and suggestions, and I'm more than happy to make any necessary changes to ensure that this fits perfectly within the project's guidelines and objectives.

**In Summary:**

- **Idea Behind the Changes:** This PR introduces a more refined approach to handling the positioning of closing parentheses, specifically distinguishing between _function-calls_ and _function-declarations_. The aim is to enable more granular control over formatting, while ensuring existing configurations remain unaffected.

- **Refinement to Existing `closingParenOnSameLine` Option:** While the `closingParenOnSameLine` option already existed, providing control over the positioning of the closing parentheses (either balanced or on the same line), this PR offers a more refined approach. It distinguishes between different scenarios, specifically targeting _function-calls_, to provide users with enhanced granularity in their formatting choices.

- **Introduction of `forceClosingParenOnSameLineForFunctionCalls`:** A new option descriptor, `forceClosingParenOnSameLineForFunctionCalls`, has been introduced. This new option specifically targets _function-calls_, allowing users to force the closing parenthesis onto the same line, in alignment with the recommendations of the [Ray Wenderlich Style Guide](https://github.com/raywenderlich/swift-style-guide).

- **Ray Wenderlich Style Guide:**  This enhancement aligns the tool more closely with the Ray Wenderlich Swift style guide.  With the introduction of this feature, users can adhere more faithfully to the guide's specifics on how closing parentheses should be formatted in different contexts, like [function-declarations](https://github.com/raywenderlich/swift-style-guide#function-declarations) and [function-calls](https://github.com/raywenderlich/swift-style-guide#function-calls)