### PR TITLE
Update `redundantClosure` rule to preserve closure where if/switch expression would not be allowed

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1314,9 +1314,7 @@ extension Formatter {
                 nextTokenAfterTry = nextTokenAfterTryOperator
             }
 
-            if let startOfFollowingExpressionIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: nextTokenAfterTry),
-               let followingExpression = parseExpressionRange(startingAt: startOfFollowingExpressionIndex)
-            {
+            if let followingExpression = parseExpressionRange(startingAt: nextTokenAfterTry) {
                 return startIndex ... followingExpression.upperBound
             }
         }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6200,7 +6200,17 @@ public struct _FormatRules {
                // because removing them could break the build.
                formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex) != closureEndIndex
             {
-                guard formatter.blockBodyHasSingleStatement(atStartOfScope: closureStartIndex) else {
+                /// Whether or not this closure has a single, simple expression in its body.
+                /// These closures can always be simplified / removed regardless of the context.
+                let hasSingleSimpleExpression = formatter.blockBodyHasSingleStatement(atStartOfScope: closureStartIndex, includingConditionalStatements: false)
+
+                /// Whether or not this closure has a single if/switch expression in its body.
+                /// Since if/switch expressions are only valid in the `return` position or as an `=` assignment,
+                /// these closures can only sometimes be simplified / removed.
+                let hasSingleConditionalExpression = !hasSingleSimpleExpression &&
+                    formatter.blockBodyHasSingleStatement(atStartOfScope: closureStartIndex, includingConditionalStatements: true)
+
+                guard hasSingleSimpleExpression || hasSingleConditionalExpression else {
                     return
                 }
 
@@ -6244,6 +6254,43 @@ public struct _FormatRules {
                     startIndex = prevIndex
                 }
 
+                // Since if/switch expressions are only valid in the `return` position or as an `=` assignment,
+                // these closures can only sometimes be simplified / removed.
+                if hasSingleConditionalExpression {
+                    // Find the `{` start of scope or `=` and verify that the entire following expression consists of just this closure.
+                    var startOfScopeContainingClosure = formatter.startOfScope(at: startIndex)
+                    var assignmentBeforeClosure = formatter.index(of: .operator("=", .infix), before: startIndex)
+
+                    let potentialStartOfExpressionContainingClosure: Int?
+                    switch (startOfScopeContainingClosure, assignmentBeforeClosure) {
+                    case (nil, nil):
+                        potentialStartOfExpressionContainingClosure = nil
+                    case (.some(let startOfScope), nil):
+                        potentialStartOfExpressionContainingClosure = startOfScope
+                    case (nil, let .some(assignmentBeforeClosure)):
+                        potentialStartOfExpressionContainingClosure = assignmentBeforeClosure
+                    case let (.some(startOfScope), .some(assignmentBeforeClosure)):
+                        potentialStartOfExpressionContainingClosure = max(startOfScope, assignmentBeforeClosure)
+                    }
+
+                    if let potentialStartOfExpressionContainingClosure = potentialStartOfExpressionContainingClosure {
+                        guard var startOfExpressionIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: potentialStartOfExpressionContainingClosure)
+                        else { return }
+
+                        // Skip over any return token that may be present
+                        if formatter.tokens[startOfExpressionIndex] == .keyword("return"),
+                           let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: startOfExpressionIndex)
+                        {
+                            startOfExpressionIndex = nextTokenIndex
+                        }
+
+                        // Parse the expression and require that entire expression is simply just this closure.
+                        guard let expressionRange = formatter.parseExpressionRange(startingAt: startOfExpressionIndex),
+                              expressionRange == startIndex ... closureCallCloseParenIndex
+                        else { return }
+                    }
+                }
+
                 // If the closure is a property with an explicit `Void` type,
                 // we can't remove the closure since the build would break
                 // if the method is `@discardableResult`
@@ -6276,14 +6323,13 @@ public struct _FormatRules {
                     closureEndIndex -= 1
                 }
 
-                // remove the { }() tokens
+                // remove the trailing }() tokens, working backwards to not invalidate any indices
                 formatter.removeToken(at: closureCallCloseParenIndex)
                 formatter.removeToken(at: closureCallOpenParenIndex)
                 formatter.removeToken(at: closureEndIndex)
-                formatter.removeTokens(in: startIndex ... closureStartIndex)
 
-                // Remove the initial return token, and any trailing space, if present
-                if let returnIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex - 1),
+                // Remove the initial return token, and any trailing space, if present.
+                if let returnIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex),
                    formatter.token(at: returnIndex)?.string == "return"
                 {
                     while formatter.token(at: returnIndex + 1)?.isSpaceOrLinebreak == true {
@@ -6292,6 +6338,9 @@ public struct _FormatRules {
 
                     formatter.removeToken(at: returnIndex)
                 }
+
+                // Finally, remove then open `{` token
+                formatter.removeTokens(in: startIndex ... closureStartIndex)
             }
         }
     }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1822,6 +1822,11 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssert(isSingleExpression(#"#selector(Foo.bar)"#))
         XCTAssert(isSingleExpression(#"#macro()"#))
         XCTAssert(isSingleExpression(#"#outerMacro(12, #innerMacro(34), "some text")"#))
+        XCTAssert(isSingleExpression(#"try { try printThrows(foo) }()"#))
+        XCTAssert(isSingleExpression(#"try! { try printThrows(foo) }()"#))
+        XCTAssert(isSingleExpression(#"try? { try printThrows(foo) }()"#))
+        XCTAssert(isSingleExpression(#"await { await printAsync(foo) }()"#))
+        XCTAssert(isSingleExpression(#"try await { try await printAsyncThrows(foo) }()"#))
 
         XCTAssert(isSingleExpression("""
         foo


### PR DESCRIPTION
This PR updates the `redundantClosure` rule to preserve closures with if/switch expressions if the closure is in a position where an if/switch expression would not be allowed. In Swift 5.9 if/switch expressions are only allowed as either return values, or as the result of an assignment.

This PR also fixes miscellaneous issues where `redundantClosure` didn't properly handle some combinations of explicit `return`, `try`/`await`, and if/switch expressions.

Fixes #1547 and #1548.