### PR TITLE
Fix more edge cases related to if/switch expressions

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6271,6 +6271,7 @@ public struct _FormatRules {
                     case (nil, nil):
                         potentialStartOfExpressionContainingClosure = nil
                     case (.some(let startOfScope), nil):
+                        guard formatter.tokens[startOfScope] == .startOfScope("{") else { return }
                         potentialStartOfExpressionContainingClosure = startOfScope
                     case (nil, let .some(assignmentBeforeClosure)):
                         potentialStartOfExpressionContainingClosure = assignmentBeforeClosure

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -44,7 +44,7 @@ public let swiftVersionFile = ".swift-version"
 /// Supported Swift versions
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
-    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9",
+    "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
 ]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -8485,6 +8485,70 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantClosure, options: options)
     }
 
+    func testClosureNotRemovedInMethodCall() {
+        let input = """
+        XCTAssert({
+            if foo {
+                bar
+            } else {
+                baaz
+            }
+        }())
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantClosure, options: options)
+    }
+
+    func testClosureNotRemovedInMethodCall2() {
+        let input = """
+        method("foo", {
+            if foo {
+                bar
+            } else {
+                baaz
+            }
+        }())
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantClosure, options: options)
+    }
+
+    func testClosureNotRemovedInMethodCall3() {
+        let input = """
+        XCTAssert({
+            if foo {
+                bar
+            } else {
+                baaz
+            }
+        }(), "message")
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantClosure, options: options)
+    }
+
+    func testClosureNotRemovedInMethodCall4() {
+        let input = """
+        method(
+            "foo",
+            {
+                if foo {
+                    bar
+                } else {
+                    baaz
+                }
+            }(),
+            "bar"
+        )
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.redundantClosure, options: options)
+    }
+
     // MARK: Redundant optional binding
 
     func testRemovesRedundantOptionalBindingsInSwift5_7() {


### PR DESCRIPTION
This PR fixes two issues where SwiftFormat would convert code to use if/switch expressions that did not compile:

1. If / switch expressions are not permitted in method calls, like:

```swift
XCTAssert(if condition {
  foo
} else {
  bar
}
```

2. Due to [this issue](https://github.com/apple/swift/issues/68764) in Swift 5.9 (fixed in 5.10), `as?` operators are not supported in if/switch expressions. This example does not compile in Swift 5.9:

```swift
let result: String? = if condition {
  foo as? String
} else {
  "bar"
}
```