### PR TITLE
Fix issue where `enumNamespaces` rule wouldn't be applied following import statement

### DIFF
--- a/Snapshots/Layout/Layout/ReloadManager.swift
+++ b/Snapshots/Layout/Layout/ReloadManager.swift
@@ -3,7 +3,7 @@
 import Foundation
 import UIKit
 
-class ReloadManager {
+enum ReloadManager {
     private static var boxes = [ObserverBox]()
 
     private struct ObserverBox {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -954,9 +954,8 @@ public struct _FormatRules {
             .keyword("class"),
             .keyword("struct"),
         ].contains($0) }) { i, token in
-            guard formatter.last(.keyword, before: i) != .keyword("import"),
-                  // exit if class is a type modifier
-                  let next = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i),
+            // exit if class is a type modifier
+            guard let next = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i),
                   !(next.isKeyword || next.isModifierKeyword),
                   // exit for class as protocol conformance
                   formatter.last(.nonSpaceOrCommentOrLinebreak, before: i) != .delimiter(":"),

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -928,6 +928,56 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.enumNamespaces, options: options)
     }
 
+    func testEnumNamespacesAfterImport1() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/1569
+        let input = """
+        import Foundation
+
+        final class MyViewModel2 {
+            static let = "A"
+        }
+        """
+
+        let output = """
+        import Foundation
+
+        enum MyViewModel2 {
+            static let = "A"
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.enumNamespaces)
+    }
+
+    func testEnumNamespacesAfterImport2() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/1569
+        let input = """
+        final class MyViewModel {
+            static let = "A"
+        }
+
+        import Foundation
+
+        final class MyViewModel2 {
+            static let = "A"
+        }
+        """
+
+        let output = """
+        enum MyViewModel {
+            static let = "A"
+        }
+
+        import Foundation
+
+        enum MyViewModel2 {
+            static let = "A"
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.enumNamespaces)
+    }
+
     // MARK: - numberFormatting
 
     // hex case


### PR DESCRIPTION
This PR fixes an issue where the `enumNamespaces` rule wouldn't be applied to a type following an import statement. Fixes #1569.