### PR TITLE
Fix issue where switch case with multiple where clauses could parse incorrectly

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1788,8 +1788,6 @@ public func tokenize(_ source: String) -> [Token] {
                     convertOpeningChevronToOperator(at: scopeIndex)
                     processToken()
                     return
-                case .keyword("where"):
-                    break
                 case .endOfScope, .keyword:
                     // If we encountered a keyword, or closing scope token that wasn't >
                     // then the opening < must have been an operator after all

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -8788,6 +8788,72 @@ class RedundancyTests: RulesTests {
                        options: options, exclude: ["indent", "blankLinesBetweenScopes"])
     }
 
+    func testRedundantSwitchStatementReturnInFunctionWithMultipleWhereClauses() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/1554
+        let input = """
+        func foo(cases: FooCases, count: Int) -> String? {
+            switch cases {
+            case .fooCase1 where count == 0:
+                return "foo"
+            case .fooCase2 where count < 100,
+                 .fooCase3 where count < 100,
+                 .fooCase4:
+                return "bar"
+            default:
+                return nil
+            }
+        }
+        """
+        let output = """
+        func foo(cases: FooCases, count: Int) -> String? {
+            switch cases {
+            case .fooCase1 where count == 0:
+                "foo"
+            case .fooCase2 where count < 100,
+                 .fooCase3 where count < 100,
+                 .fooCase4:
+                "bar"
+            default:
+                nil
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
+    func testRedundantSwitchStatementReturnInFunctionWithSingleWhereClause() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/1554
+        let input = """
+        func anotherFoo(cases: FooCases, count: Int) -> String? {
+            switch cases {
+            case .fooCase1 where count == 0:
+                return "foo"
+            case .fooCase2 where count < 100,
+                 .fooCase4:
+                return "bar"
+            default:
+                return nil
+            }
+        }
+        """
+        let output = """
+        func anotherFoo(cases: FooCases, count: Int) -> String? {
+            switch cases {
+            case .fooCase1 where count == 0:
+                "foo"
+            case .fooCase2 where count < 100,
+                 .fooCase4:
+                "bar"
+            default:
+                nil
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
     // MARK: - redundantOptionalBinding
 
     func testRemovesRedundantOptionalBindingsInSwift5_7() {

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -3266,26 +3266,6 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
-    func testGenericsWithWhereClause() {
-        let input = "<A where A.B == C>"
-        let output: [Token] = [
-            .startOfScope("<"),
-            .identifier("A"),
-            .space(" "),
-            .keyword("where"),
-            .space(" "),
-            .identifier("A"),
-            .operator(".", .infix),
-            .identifier("B"),
-            .space(" "),
-            .operator("==", .infix),
-            .space(" "),
-            .identifier("C"),
-            .endOfScope(">"),
-        ]
-        XCTAssertEqual(tokenize(input), output)
-    }
-
     func testIfLessThanGreaterThanExpression() {
         let input = "if x < (y + z), y > (z * w) {}"
         let output: [Token] = [


### PR DESCRIPTION
This PR fixes an issue where switch cases with multiple where clauses could parse incorrectly. Fixes https://github.com/nicklockwood/SwiftFormat/issues/1554.

Specifically, the `<` token in the example below was unexpectedly being tokenized as a `.startOfScope` token, leaving the `:` tokenized as a `delimiter` instead of a `startOfScope`. This broke the logic in `switchStatementBranches`, which was looking for a `.startOfScope(":")`.

```swift
func foo(cases: FooCases, count: Int) -> String? {
  switch cases {
  case .fooCase1 where count == 0:
    return "foo"
  case .fooCase2 where count < 100,
       .fooCase3 where count < 100,
       .fooCase4:
    return "bar"
  default:
    return nil
  }
}
```