### PR TITLE
Update if/switch expression workaround for Swift 5.9 bug to handle `as!` cast

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1377,7 +1377,8 @@ extension Formatter {
            let asIndex = index(of: .keyword("as"), after: startOfScopeIndex),
            let endOfScopeIndex = endOfScope(at: startOfScopeIndex),
            asIndex < endOfScopeIndex,
-           next(.nonSpaceOrCommentOrLinebreak, after: asIndex) == .operator("?", .postfix),
+           next(.nonSpaceOrCommentOrLinebreak, after: asIndex) == .operator("?", .postfix)
+           || next(.nonSpaceOrCommentOrLinebreak, after: asIndex) == .operator("!", .postfix),
            // Make sure the as? is at the top level, not nested in some
            // inner scope like a function call or closure
            startOfScope(at: asIndex) == startOfScopeIndex

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -8675,7 +8675,7 @@ class RedundancyTests: RulesTests {
         let result1: String? = {
             switch condition {
             case true:
-                return foo as? String
+                return foo as! String
             case false:
                 return "bar"
             }


### PR DESCRIPTION
This PR fixes an issue where `conditionalBranchHasUnsupportedCastOperator` handled `as?` casts but not `as!` casts (which are also unsupported in if/switch expressions in Swift 5.9).