### PR TITLE
Support configuring `wrapAttributes` rule to apply differently to computed properties vs stored properties

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2599,8 +2599,9 @@ Option | Description
 --- | ---
 `--funcattributes` | Function @attributes: "preserve", "prev-line", or "same-line"
 `--typeattributes` | Type @attributes: "preserve", "prev-line", or "same-line"
-`--varattributes` | Computed property @attributes: "preserve", "prev-line", or "same-line"
+`--varattributes` | [Deprecated] Property @attributes: "preserve", "prev-line", or "same-line"
 `--storedvarattrs` | Stored property @attributes: "preserve", "prev-line", or "same-line"
+`--computedvarattrs` | Stored property @attributes: "preserve", "prev-line", or "same-line"
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -2599,7 +2599,8 @@ Option | Description
 --- | ---
 `--funcattributes` | Function @attributes: "preserve", "prev-line", or "same-line"
 `--typeattributes` | Type @attributes: "preserve", "prev-line", or "same-line"
-`--varattributes` | Property @attributes: "preserve", "prev-line", or "same-line"
+`--varattributes` | Computed property @attributes: "preserve", "prev-line", or "same-line"
+`--storedvarattrs` | Stored property @attributes: "preserve", "prev-line", or "same-line"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -868,8 +868,14 @@ struct _Descriptors {
     let varAttributes = OptionDescriptor(
         argumentName: "varattributes",
         displayName: "Var Attributes",
-        help: "Property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
+        help: "Computed property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         keyPath: \.varAttributes
+    )
+    let storedVarAttributes = OptionDescriptor(
+        argumentName: "storedvarattrs",
+        displayName: "Stored Var Attributes",
+        help: "Stored property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
+        keyPath: \.storedVarAttributes
     )
     let yodaSwap = OptionDescriptor(
         argumentName: "yodaswap",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -868,14 +868,21 @@ struct _Descriptors {
     let varAttributes = OptionDescriptor(
         argumentName: "varattributes",
         displayName: "Var Attributes",
-        help: "Computed property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
+        help: "[Deprecated] Property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
+        deprecationMessage: "Replaced with --storedvarattrs and --computedvarattrs.",
         keyPath: \.varAttributes
     )
     let storedVarAttributes = OptionDescriptor(
         argumentName: "storedvarattrs",
-        displayName: "Stored Var Attributes",
+        displayName: "Stored Property Attributes",
         help: "Stored property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         keyPath: \.storedVarAttributes
+    )
+    let computedVarAttributes = OptionDescriptor(
+        argumentName: "computedvarattrs",
+        displayName: "Computed Property Attributes",
+        help: "Stored property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
+        keyPath: \.computedVarAttributes
     )
     let yodaSwap = OptionDescriptor(
         argumentName: "yodaswap",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -631,6 +631,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var funcAttributes: AttributeMode
     public var typeAttributes: AttributeMode
     public var varAttributes: AttributeMode
+    public var storedVarAttributes: AttributeMode
     public var markTypes: MarkMode
     public var typeMarkComment: String
     public var markExtensions: MarkMode
@@ -739,6 +740,7 @@ public struct FormatOptions: CustomStringConvertible {
                 funcAttributes: AttributeMode = .preserve,
                 typeAttributes: AttributeMode = .preserve,
                 varAttributes: AttributeMode = .preserve,
+                storedVarAttributes: AttributeMode = .preserve,
                 markTypes: MarkMode = .always,
                 typeMarkComment: String = "MARK: - %t",
                 markExtensions: MarkMode = .always,
@@ -837,6 +839,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.funcAttributes = funcAttributes
         self.typeAttributes = typeAttributes
         self.varAttributes = varAttributes
+        self.storedVarAttributes = storedVarAttributes
         self.markTypes = markTypes
         self.typeMarkComment = typeMarkComment
         self.markExtensions = markExtensions

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -632,6 +632,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var typeAttributes: AttributeMode
     public var varAttributes: AttributeMode
     public var storedVarAttributes: AttributeMode
+    public var computedVarAttributes: AttributeMode
     public var markTypes: MarkMode
     public var typeMarkComment: String
     public var markExtensions: MarkMode
@@ -741,6 +742,7 @@ public struct FormatOptions: CustomStringConvertible {
                 typeAttributes: AttributeMode = .preserve,
                 varAttributes: AttributeMode = .preserve,
                 storedVarAttributes: AttributeMode = .preserve,
+                computedVarAttributes: AttributeMode = .preserve,
                 markTypes: MarkMode = .always,
                 typeMarkComment: String = "MARK: - %t",
                 markExtensions: MarkMode = .always,
@@ -840,6 +842,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.typeAttributes = typeAttributes
         self.varAttributes = varAttributes
         self.storedVarAttributes = storedVarAttributes
+        self.computedVarAttributes = computedVarAttributes
         self.markTypes = markTypes
         self.typeMarkComment = typeMarkComment
         self.markExtensions = markExtensions

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -825,6 +825,59 @@ extension Formatter {
         }
     }
 
+    /// Whether or not this property at the given introducer index (either `var` or `let`)
+    /// is a stored property or a computed property.
+    func isStoredProperty(atIntroducerIndex introducerIndex: Int) -> Bool {
+        assert(["let", "var"].contains(tokens[introducerIndex].string))
+
+        var parseIndex = introducerIndex
+
+        // All properties have the property name after the introducer
+        if let propertyNameIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: parseIndex),
+           tokens[propertyNameIndex].isIdentifierOrKeyword
+        {
+            parseIndex = propertyNameIndex
+        }
+
+        // Properties have an optional `: TypeName` component
+        if let typeAnnotationStartIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: parseIndex),
+           tokens[typeAnnotationStartIndex] == .delimiter(":"),
+           let startOfTypeIndex = index(of: .nonSpaceOrComment, after: typeAnnotationStartIndex),
+           let typeRange = parseType(at: startOfTypeIndex)?.range
+        {
+            parseIndex = typeRange.upperBound
+        }
+
+        // Properties have an optional `= expression` component
+        if let assignmentIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: parseIndex),
+           tokens[assignmentIndex] == .operator("=", .infix)
+        {
+            // If the type has an assignment operator, it's guaranteed to be a stored property.
+            return true
+        }
+
+        // Finally, properties have an optional `{` body
+        if let startOfBody = index(of: .nonSpaceOrCommentOrLinebreak, after: parseIndex),
+           tokens[startOfBody] == .startOfScope("{")
+        {
+            // If this property has a body, then its a stored property if and only if the body
+            // has a `didSet` or `willSet` keyword, based on the grammar for a variable declaration.
+            if let nextToken = next(.nonSpaceOrCommentOrLinebreak, after: startOfBody),
+               [.identifier("willSet"), .identifier("didSet")].contains(nextToken)
+            {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        // If the property declaration isn't followed by a `{ ... }` block,
+        // then it's definitely a stored property and not a computed property.
+        else {
+            return true
+        }
+    }
+
     /// Determine if next line after this token should be indented
     func isEndOfStatement(at i: Int, in scope: Token? = nil) -> Bool {
         guard let token = token(at: i) else { return true }
@@ -1202,6 +1255,8 @@ extension Formatter {
     ///  - `(...) -> ...`
     ///  - `...?`
     ///  - `...!`
+    ///  - `any ...`
+    ///  - `some ...`
     ///  - `borrowing ...`
     ///  - `consuming ...`
     func parseType(at startOfTypeIndex: Int) -> (name: String, range: ClosedRange<Int>)? {
@@ -1255,8 +1310,8 @@ extension Formatter {
             return (name: tokens[typeRange].string, range: typeRange)
         }
 
-        // Parse types of the form `borrowing ...` and `consuming ...`
-        if ["borrowing", "consuming"].contains(tokens[startOfTypeIndex].string),
+        // Parse types of the form `any ...`, `some ...`, `borrowing ...`, `consuming ...`
+        if ["any", "some", "borrowing", "consuming"].contains(tokens[startOfTypeIndex].string),
            let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfTypeIndex),
            let followingType = parseType(at: nextToken)
         {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5391,7 +5391,7 @@ public struct _FormatRules {
 
     public let wrapAttributes = FormatRule(
         help: "Wrap @attributes onto a separate line, or keep them on the same line.",
-        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs"],
+        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs", "computedvarattrs"],
         sharedOptions: ["linebreaks", "maxwidth"]
     ) { formatter in
         formatter.forEach(.attribute) { i, _ in
@@ -5424,10 +5424,19 @@ public struct _FormatRules {
             case "class", "actor", "struct", "enum", "protocol", "extension":
                 attributeMode = formatter.options.typeAttributes
             case "var", "let":
+                let storedOrComputedAttributeMode: AttributeMode
                 if formatter.isStoredProperty(atIntroducerIndex: keywordIndex) {
-                    attributeMode = formatter.options.storedVarAttributes
+                    storedOrComputedAttributeMode = formatter.options.storedVarAttributes
                 } else {
+                    storedOrComputedAttributeMode = formatter.options.computedVarAttributes
+                }
+
+                // If the relevant `storedvarattrs` or `computedvarattrs` option hasn't been configured,
+                // fall back to the previous (now deprecated) `varattributes` option.
+                if storedOrComputedAttributeMode == .preserve {
                     attributeMode = formatter.options.varAttributes
+                } else {
+                    attributeMode = storedOrComputedAttributeMode
                 }
             default:
                 return

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5391,8 +5391,8 @@ public struct _FormatRules {
 
     public let wrapAttributes = FormatRule(
         help: "Wrap @attributes onto a separate line, or keep them on the same line.",
-        options: ["funcattributes", "typeattributes", "varattributes"],
-        sharedOptions: ["linebreaks"]
+        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs"],
+        sharedOptions: ["linebreaks", "maxwidth"]
     ) { formatter in
         formatter.forEach(.attribute) { i, _ in
             // Ignore sequential attributes
@@ -5424,7 +5424,11 @@ public struct _FormatRules {
             case "class", "actor", "struct", "enum", "protocol", "extension":
                 attributeMode = formatter.options.typeAttributes
             case "var", "let":
-                attributeMode = formatter.options.varAttributes
+                if formatter.isStoredProperty(atIntroducerIndex: keywordIndex) {
+                    attributeMode = formatter.options.storedVarAttributes
+                } else {
+                    attributeMode = formatter.options.varAttributes
+                }
             default:
                 return
             }
@@ -5450,6 +5454,20 @@ public struct _FormatRules {
                 if let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endIndex),
                    formatter.tokens[(endIndex + 1) ..< nextIndex].contains(where: { $0.isLinebreak })
                 {
+                    // If unwrapping the attribute causes the line to exceed the max width,
+                    // leave it as-is. The existing formatting is likely better than how
+                    // this would be re-unwrapped by the wrap rule.
+                    let startOfLine = formatter.startOfLine(at: i)
+                    let endOfLine = formatter.endOfLine(at: i)
+                    let startOfNextLine = formatter.startOfLine(at: nextIndex, excludingIndent: true)
+                    let endOfNextLine = formatter.endOfLine(at: nextIndex)
+                    let combinedLine = formatter.tokens[startOfLine ... endOfLine].map { $0.string }.joined()
+                        + formatter.tokens[startOfNextLine ..< endOfNextLine].map { $0.string }.joined()
+
+                    if formatter.options.maxWidth > 0, combinedLine.count > formatter.options.maxWidth {
+                        return
+                    }
+
                     // Replace the newline with a space so the attribute doesn't
                     // merge with the next token.
                     formatter.replaceTokens(in: (endIndex + 1) ..< nextIndex, with: .space(" "))

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -273,7 +273,10 @@ class MetadataTests: XCTestCase {
     func testArgumentNamesAreValidLength() {
         let arguments = Set(commandLineArguments).subtracting(deprecatedArguments)
         for argument in arguments {
-            XCTAssert(argument.count <= Options.maxArgumentNameLength)
+            XCTAssert(
+                argument.count <= Options.maxArgumentNameLength,
+                "\"\(argument)\" (length=\(argument.count)) longer than maximum allowed argument name length \(Options.maxArgumentNameLength)"
+            )
         }
     }
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4483,7 +4483,19 @@ class WrappingTests: RulesTests {
         @objc
         private(set) dynamic var foo = Foo()
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testDontWrapWrapPrivateSetVarAttributes() {
+        let input = """
+        @objc
+        private(set) dynamic var foo = Foo()
+        """
+        let output = """
+        @objc private(set) dynamic var foo = Foo()
+        """
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4507,7 +4519,19 @@ class WrappingTests: RulesTests {
         @OuterType.Wrapper
         var foo: Int
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testDontWrapPropertyWrapperAttribute() {
+        let input = """
+        @OuterType.Wrapper
+        var foo: Int
+        """
+        let output = """
+        @OuterType.Wrapper var foo: Int
+        """
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4519,7 +4543,7 @@ class WrappingTests: RulesTests {
         @OuterType.Generic<WrappedType>
         var foo: WrappedType
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4531,8 +4555,38 @@ class WrappingTests: RulesTests {
         @OuterType.Generic<WrappedType>.Foo
         var foo: WrappedType
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testWrapAvailableAttributeUnderMaxWidth() {
+        let input = """
+        @available(*, unavailable, message: "This property is deprecated.")
+        var foo: WrappedType
+        """
+        let output = """
+        @available(*, unavailable, message: "This property is deprecated.") var foo: WrappedType
+        """
+        let options = FormatOptions(maxWidth: 100, varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testDoesntWrapAvailableAttributeWithLongMessage() {
+        // Unwrapping this attribute would just cause it to wrap in a different way:
+        //
+        //   @available(
+        //       *,
+        //       unavailable,
+        //       message: "This property is deprecated. It has a really long message."
+        //   ) var foo: WrappedType
+        //
+        // so instead leave it un-wrapped to preserve the existing formatting.
+        let input = """
+        @available(*, unavailable, message: "This property is deprecated. It has a really long message.")
+        var foo: WrappedType
+        """
+        let options = FormatOptions(maxWidth: 100, varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
     func testWrapAttributesIndentsLineCorrectly() {
@@ -4547,8 +4601,77 @@ class WrappingTests: RulesTests {
             var foo = Foo()
         }
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testWrapOrDontWrapMultipleDeclarationsInClass() {
+        let input = """
+        class Foo {
+            @objc
+            var foo = Foo()
+
+            @available(*, unavailable)
+            var bar: Bar
+
+            @available(*, unavailable)
+            var myComputedFoo: String {
+                "myComputedFoo"
+            }
+
+            @Environment(\\.myEnvironmentVar)
+            var foo
+
+            @State
+            var myStoredFoo: String = "myStoredFoo" {
+                didSet {
+                    print(newValue)
+                }
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            @objc var foo = Foo()
+
+            @available(*, unavailable) var bar: Bar
+
+            @available(*, unavailable)
+            var myComputedFoo: String {
+                "myComputedFoo"
+            }
+
+            @Environment(\\.myEnvironmentVar) var foo
+
+            @State var myStoredFoo: String = "myStoredFoo" {
+                didSet {
+                    print(newValue)
+                }
+            }
+        }
+        """
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testWrapOrDontAttributesInSwiftUIView() {
+        let input = """
+        struct MyView: View {
+            @State var textContent: String
+
+            var body: some View {
+                childView
+            }
+
+            @ViewBuilder
+            var childView: some View {
+                Text(verbatim: textContent)
+            }
+        }
+        """
+
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
     func testInlineMainActorAttributeNotWrapped() {
@@ -4556,7 +4679,7 @@ class WrappingTests: RulesTests {
         var foo: @MainActor (Foo) -> Void
         var bar: @MainActor (Bar) -> Void
         """
-        let options = FormatOptions(varAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4475,6 +4475,18 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
+    func testWrapPrivateSetComputedVarAttributes() {
+        let input = """
+        @objc private(set) dynamic var foo = Foo()
+        """
+        let output = """
+        @objc
+        private(set) dynamic var foo = Foo()
+        """
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
     func testWrapPrivateSetVarAttributes() {
         let input = """
         @objc private(set) dynamic var foo = Foo()
@@ -4483,7 +4495,7 @@ class WrappingTests: RulesTests {
         @objc
         private(set) dynamic var foo = Foo()
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4511,6 +4523,18 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
+    func testWrapPropertyWrapperAttributeVarAttributes() {
+        let input = """
+        @OuterType.Wrapper var foo: Int
+        """
+        let output = """
+        @OuterType.Wrapper
+        var foo: Int
+        """
+        let options = FormatOptions(varAttributes: .prevLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
     func testWrapPropertyWrapperAttribute() {
         let input = """
         @OuterType.Wrapper var foo: Int
@@ -4519,7 +4543,7 @@ class WrappingTests: RulesTests {
         @OuterType.Wrapper
         var foo: Int
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4543,7 +4567,7 @@ class WrappingTests: RulesTests {
         @OuterType.Generic<WrappedType>
         var foo: WrappedType
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4555,7 +4579,7 @@ class WrappingTests: RulesTests {
         @OuterType.Generic<WrappedType>.Foo
         var foo: WrappedType
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4601,7 +4625,7 @@ class WrappingTests: RulesTests {
             var foo = Foo()
         }
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4650,7 +4674,7 @@ class WrappingTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4670,7 +4694,26 @@ class WrappingTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testWrapAttributesInSwiftUIView() {
+        let input = """
+        struct MyView: View {
+            @State var textContent: String
+
+            var body: some View {
+                childView
+            }
+
+            @ViewBuilder var childView: some View {
+                Text(verbatim: textContent)
+            }
+        }
+        """
+
+        let options = FormatOptions(varAttributes: .sameLine)
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4679,7 +4722,7 @@ class WrappingTests: RulesTests {
         var foo: @MainActor (Foo) -> Void
         var bar: @MainActor (Bar) -> Void
         """
-        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .prevLine)
+        let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 


### PR DESCRIPTION
This PR updates the `wrapAttributes` rules to support being applied differently to computed properties vs stored properties.

Take this example SwiftUI view:

```swift
struct MyView: View {
    @State var textContent: String

    var body: some View {
        childView
    }

    @ViewBuilder
    var childView: some View {
        Text(verbatim: textContent)
    }
}
```

We want the `@ViewBuilder` attribute to be on its own line, but the `@State` attribute to be on the same line as the property declaration. Previously this wasn't possible. Now this is supported using `--computedvarattrs prev-line --storedvarattrs same-line`.

---

Separately, when looking at adopting `--varattributes prev-line`, I noticed a type of case where I think we should preserve the existing formatting instead of wrapping. Take this example, with a max line width of 100 chars:

```swift
@available(*, unavailable, message: "This property is deprecated. It has a really long message.")
var foo: WrappedType
```

If we unwrap this so the attribute and the `var` are on the same line, since this exceeds the 100 char line width limit the `wrap` rule will then re-wrap the code into the following formatting:

```swift
@available(
   *,
   unavailable,
   message: "This property is deprecated. It has a really long message."
) var foo: WrappedType
```

I updated how `wrapAttributes` handles the `same-line` option, so it will preserve the existing formatting if unwrapping the attribute would cause the newly combined line to exceed the max line width. 

Let me know if you think this should be an option rather than the default behavior.