### PR TITLE
Add option to wrap complex attributes with arguments differently than simple attributes without arguments

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2601,6 +2601,8 @@ Option | Description
 `--typeattributes` | Type @attributes: "preserve", "prev-line", or "same-line"
 `--storedvarattrs` | Stored property @attributes: "preserve", "prev-line", or "same-line"
 `--computedvarattrs` | Stored property @attributes: "preserve", "prev-line", or "same-line"
+`--complexattrs` | Complex @attributes(...): "preserve", "prev-line", or "same-line"
+`--noncomplexattrs` | List of @attributes to exclude from complexattrs rule
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -877,6 +877,18 @@ struct _Descriptors {
         help: "Stored property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         keyPath: \.computedVarAttributes
     )
+    let complexAttributes = OptionDescriptor(
+        argumentName: "complexattrs",
+        displayName: "Complex Attributes",
+        help: "Complex @attributes(...): \"preserve\", \"prev-line\", or \"same-line\"",
+        keyPath: \.complexAttributes
+    )
+    let complexAttributesExceptions = OptionDescriptor(
+        argumentName: "noncomplexattrs",
+        displayName: "Complex Attribute exceptions",
+        help: "List of @attributes to exclude from complexattrs rule",
+        keyPath: \.complexAttributesExceptions
+    )
     let yodaSwap = OptionDescriptor(
         argumentName: "yodaswap",
         displayName: "Yoda Swap",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -633,6 +633,8 @@ public struct FormatOptions: CustomStringConvertible {
     public var varAttributes: AttributeMode
     public var storedVarAttributes: AttributeMode
     public var computedVarAttributes: AttributeMode
+    public var complexAttributes: AttributeMode
+    public var complexAttributesExceptions: Set<String>
     public var markTypes: MarkMode
     public var typeMarkComment: String
     public var markExtensions: MarkMode
@@ -743,6 +745,8 @@ public struct FormatOptions: CustomStringConvertible {
                 varAttributes: AttributeMode = .preserve,
                 storedVarAttributes: AttributeMode = .preserve,
                 computedVarAttributes: AttributeMode = .preserve,
+                complexAttributes: AttributeMode = .preserve,
+                complexAttributesExceptions: Set<String> = [],
                 markTypes: MarkMode = .always,
                 typeMarkComment: String = "MARK: - %t",
                 markExtensions: MarkMode = .always,
@@ -843,6 +847,8 @@ public struct FormatOptions: CustomStringConvertible {
         self.varAttributes = varAttributes
         self.storedVarAttributes = storedVarAttributes
         self.computedVarAttributes = computedVarAttributes
+        self.complexAttributes = complexAttributes
+        self.complexAttributesExceptions = complexAttributesExceptions
         self.markTypes = markTypes
         self.typeMarkComment = typeMarkComment
         self.markExtensions = markExtensions

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -746,7 +746,7 @@ public struct FormatOptions: CustomStringConvertible {
                 storedVarAttributes: AttributeMode = .preserve,
                 computedVarAttributes: AttributeMode = .preserve,
                 complexAttributes: AttributeMode = .preserve,
-                complexAttributesExceptions: Set<String> = [],
+                complexAttributesExceptions: Set<String> = ["@Environment"],
                 markTypes: MarkMode = .always,
                 typeMarkComment: String = "MARK: - %t",
                 markExtensions: MarkMode = .always,

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5391,7 +5391,7 @@ public struct _FormatRules {
 
     public let wrapAttributes = FormatRule(
         help: "Wrap @attributes onto a separate line, or keep them on the same line.",
-        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs", "computedvarattrs"],
+        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs", "computedvarattrs", "complexattrs", "noncomplexattrs"],
         sharedOptions: ["linebreaks", "maxwidth"]
     ) { formatter in
         formatter.forEach(.attribute) { i, _ in
@@ -5417,7 +5417,7 @@ public struct _FormatRules {
             }
 
             // Check which `AttributeMode` option to use
-            let attributeMode: AttributeMode
+            var attributeMode: AttributeMode
             switch keyword.string {
             case "func", "init", "subscript":
                 attributeMode = formatter.options.funcAttributes
@@ -5440,6 +5440,16 @@ public struct _FormatRules {
                 }
             default:
                 return
+            }
+
+            // If the complexAttriubtes option is configured, it takes precedence over other options
+            // if this is a complex attributes with arguments.
+            let attributeName = formatter.tokens[i].string
+            let isComplexAttribute = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i) == .startOfScope("(")
+                && !formatter.options.complexAttributesExceptions.contains(attributeName)
+
+            if isComplexAttribute, formatter.options.complexAttributes != .preserve {
+                attributeMode = formatter.options.complexAttributes
             }
 
             // Apply the `AttributeMode`

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -117,14 +117,20 @@ class OptionDescriptorTests: XCTestCase {
     func testAllDescriptorsHaveProperty() {
         let allProperties = Set(FormatOptions.default.allOptions.keys)
         for descriptor in Descriptors.all where !descriptor.isDeprecated {
-            XCTAssert(allProperties.contains(descriptor.propertyName))
+            XCTAssert(
+                allProperties.contains(descriptor.propertyName),
+                "FormatOptions doesn't have property named \(descriptor.propertyName)."
+            )
         }
     }
 
     func testAllPropertiesHaveDescriptor() {
         let allDescriptors = Set(Descriptors.all.map { $0.propertyName })
         for property in FormatOptions.default.allOptions.keys {
-            XCTAssert(allDescriptors.contains(property))
+            XCTAssert(
+                allDescriptors.contains(property),
+                "Missing OptionDescriptor for FormatOptions.\(property) option."
+            )
         }
     }
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4741,7 +4741,7 @@ class WrappingTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment"])
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4781,7 +4781,7 @@ class WrappingTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(varAttributes: .sameLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment"])
+        let options = FormatOptions(varAttributes: .sameLine, complexAttributes: .prevLine)
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4613,6 +4613,39 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
+    func testDoesntWrapComplexAttribute() {
+        let input = """
+        @Option(
+            name: ["myArgument"],
+            help: "Long help text for my example arg from Swift argument parser")
+        var foo: WrappedType
+        """
+        let options = FormatOptions(closingParenOnSameLine: true, varAttributes: .prevLine, storedVarAttributes: .sameLine, complexAttributes: .prevLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testDoesntWrapComplexMultilineAttribute() {
+        let input = """
+        @available(*, deprecated, message: "Deprecated!")
+        var foo: WrappedType
+        """
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine, complexAttributes: .prevLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testWrapsComplexAttribute() {
+        let input = """
+        @available(*, deprecated, message: "Deprecated!") var foo: WrappedType
+        """
+
+        let output = """
+        @available(*, deprecated, message: "Deprecated!")
+        var foo: WrappedType
+        """
+        let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine, complexAttributes: .prevLine)
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
     func testWrapAttributesIndentsLineCorrectly() {
         let input = """
         class Foo {
@@ -4627,6 +4660,39 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testComplexAttributesException() {
+        let input = """
+        @Environment(\\.myEnvironmentVar) var foo: Foo
+
+        @SomeCustomAttr(argument: true) var foo: Foo
+
+        @available(*, deprecated) var foo: Foo
+        """
+
+        let output = """
+        @Environment(\\.myEnvironmentVar) var foo: Foo
+
+        @SomeCustomAttr(argument: true) var foo: Foo
+
+        @available(*, deprecated)
+        var foo: Foo
+        """
+
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment", "@SomeCustomAttr"])
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testEscapingClosureNotMistakenForComplexAttribute() {
+        let input = """
+        func foo(_ fooClosure: @escaping () throws -> Void) {
+            try fooClosure()
+        }
+        """
+
+        let options = FormatOptions(complexAttributes: .prevLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
     func testWrapOrDontWrapMultipleDeclarationsInClass() {
@@ -4658,7 +4724,8 @@ class WrappingTests: RulesTests {
         class Foo {
             @objc var foo = Foo()
 
-            @available(*, unavailable) var bar: Bar
+            @available(*, unavailable)
+            var bar: Bar
 
             @available(*, unavailable)
             var myComputedFoo: String {
@@ -4674,7 +4741,7 @@ class WrappingTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine)
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment"])
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 
@@ -4702,6 +4769,7 @@ class WrappingTests: RulesTests {
         let input = """
         struct MyView: View {
             @State var textContent: String
+            @Environment(\\.myEnvironmentVar) var environmentVar
 
             var body: some View {
                 childView
@@ -4713,7 +4781,7 @@ class WrappingTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(varAttributes: .sameLine)
+        let options = FormatOptions(varAttributes: .sameLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment"])
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 


### PR DESCRIPTION
This PR adds a `--complexattrs` option to support wrapping complex attributes (attributes with arguments) differently from simple attributes (without arguments).

We want to use `--storedvarattrs same-line` for common attributes like `@State` and `@objc`:

```swift
@State private var foo: Foo
@objc private var bar: Bar
``` 

but the most idomatic usage of longer attributes (typically those with arguments, like `@available` or custom DSLs like Swift argument parser) is to leave them on the previous line:

```swift
// Uncommon:
@available(*, deprecated, message: "Deprecated!") var foo: WrappedType
@Option(help: "The absolute path to the SwiftFormat config file") var swiftFormatConfig: String

// More common:
@available(*, deprecated, message: "Deprecated!") 
var foo: WrappedType

@Option(help: "The absolute path to the SwiftFormat config file") 
var swiftFormatConfig: String
```

This is now supported with `--storedvarattrs same-line --complexattrs prev-line`. 

-----

This does pose a question about how to handle the SwiftUI `@Environment` attribute. I find that idiomatic usage of this attribute specifically is to leave it on the same line as the property to match other SwiftUI property wrappers, like:

```swift
@State private var foo: Foo
@Environment(\.barFromEnvironment) var bar
```

By default `--complexattrs prev-line` would apply to this. To support avoiding that this PR also adds a `--noncomplexattrs` option that lets you exclude individual attributes from the `--complexattrs` option. So in our case, we would use `--noncomplexattrs @Environment`.

Since I've only ever seen `@Environment` written in this way (and not wrapped). I think it makes sense to include `--noncomplexattrs @Environment` as the default behavior.