### PR TITLE
Update wrapAttributes "complex attributes" logic to exclude attributes with a single unnamed argument

### DIFF
--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -746,7 +746,7 @@ public struct FormatOptions: CustomStringConvertible {
                 storedVarAttributes: AttributeMode = .preserve,
                 computedVarAttributes: AttributeMode = .preserve,
                 complexAttributes: AttributeMode = .preserve,
-                complexAttributesExceptions: Set<String> = ["@Environment"],
+                complexAttributesExceptions: Set<String> = [],
                 markTypes: MarkMode = .always,
                 typeMarkComment: String = "MARK: - %t",
                 markExtensions: MarkMode = .always,

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5442,10 +5442,10 @@ public struct _FormatRules {
                 return
             }
 
-            // If the complexAttriubtes option is configured, it takes precedence over other options
+            // If the complexAttributes option is configured, it takes precedence over other options
             // if this is a complex attributes with arguments.
             let attributeName = formatter.tokens[i].string
-            let isComplexAttribute = formatter.next(.nonSpaceOrCommentOrLinebreak, after: i) == .startOfScope("(")
+            let isComplexAttribute = formatter.isComplexAttribute(at: i)
                 && !formatter.options.complexAttributesExceptions.contains(attributeName)
 
             if isComplexAttribute, formatter.options.complexAttributes != .preserve {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4680,7 +4680,56 @@ class WrappingTests: RulesTests {
         var foo: Foo
         """
 
-        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@Environment", "@SomeCustomAttr"])
+        let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine, complexAttributesExceptions: ["@SomeCustomAttr"])
+        testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
+    }
+
+    func testMixedComplexAndSimpleAttributes() {
+        let input = """
+        /// Simple attributes stay on a single line:
+        @State private var warpDriveEnabled: Bool
+
+        @ObservedObject private var lifeSupportService: LifeSupportService
+
+        @Environment(\\.controlPanelStyle) private var controlPanelStyle
+
+        @AppStorage("ControlsConfig") private var controlsConfig: ControlConfiguration
+
+        /// Complex attributes are wrapped:
+        @AppStorage("ControlPanelState", store: myCustomUserDefaults) private var controlPanelState: ControlPanelState
+
+        @Tweak(name: "Aspect ratio") private var aspectRatio = AspectRatio.stretch
+
+        @available(*, unavailable) var saturn5Builder: Saturn5Builder
+
+        @available(*, unavailable, message: "No longer in production") var saturn5Builder: Saturn5Builder
+        """
+
+        let output = """
+        /// Simple attributes stay on a single line:
+        @State private var warpDriveEnabled: Bool
+
+        @ObservedObject private var lifeSupportService: LifeSupportService
+
+        @Environment(\\.controlPanelStyle) private var controlPanelStyle
+
+        @AppStorage("ControlsConfig") private var controlsConfig: ControlConfiguration
+
+        /// Complex attributes are wrapped:
+        @AppStorage("ControlPanelState", store: myCustomUserDefaults)
+        private var controlPanelState: ControlPanelState
+
+        @Tweak(name: "Aspect ratio")
+        private var aspectRatio = AspectRatio.stretch
+
+        @available(*, unavailable)
+        var saturn5Builder: Saturn5Builder
+
+        @available(*, unavailable, message: "No longer in production")
+        var saturn5Builder: Saturn5Builder
+        """
+
+        let options = FormatOptions(storedVarAttributes: .sameLine, complexAttributes: .prevLine)
         testFormatting(for: input, output, rule: FormatRules.wrapAttributes, options: options)
     }
 


### PR DESCRIPTION
This PR updates the `wrapAttributes` "complex attributes" logic to exclude attributes with a single unnamed argument.

This removes the need to special-case the `@Environment` attribute, which we specifically don't want to consider "complex". Since this doesn't require special casing any particular attribute, it generalizes to other similar attributes like `@AppStorage` from SwiftUI and `@Dependency` from TCA.

These are no longer considered complex, so can be configured to not wrap using `--storedvarattrs same-line`:

```swift
@Environment(\.controlPanelStyle) private var controlPanelStyle
@Dependency(\.controlsService) private var controlsService
@AppStorage("ControlsConfig") private var controlsConfig: ControlConfiguration
```

These examples are all still considered complex, so can be configured to always wrap using `--complexattrs prev-line`:

```swift
@AppStorage("ControlsConfig", store: myCustomUserDefaults)
private var controlsConfig: ControlConfiguration

@Tweak(name: "Aspect ratio")
private var aspectRatio = AspectRatio.stretch

@available(*, unavailable)
var saturn5Builder: Saturn5Builder

@available(*, unavailable, message: "No longer in production")
var saturn5Builder: Saturn5Builder
```