### PR TITLE
Fix issue where parseType helper didn't handle qualified types like Foo.Bar

### DIFF
--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1746,6 +1746,27 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 5)?.name, "any Foo")
     }
 
+    func testParseCompoundType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo.Bar.Baaz
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo.Bar.Baaz")
+    }
+
+    func testParseCompoundGenericType() {
+        let formatter = Formatter(tokenize("""
+        let foo: Foo<Bar>.Bar.Baaz<Quux.V2>
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo<Bar>.Bar.Baaz<Quux.V2>")
+    }
+
+    func testParseExistentialTypeWithSubtype() {
+        let formatter = Formatter(tokenize("""
+        let foo: (any Foo).Bar.Baaz
+        """))
+        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(any Foo).Bar.Baaz")
+    }
+
     func testParseOpaqueReturnType() {
         let formatter = Formatter(tokenize("""
         var body: some View { EmptyView() }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -4843,6 +4843,20 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
     }
 
+    func testAttributeOnComputedProperty() {
+        let input = """
+        extension SectionContainer: ContentProviding where Section: ContentProviding {
+            @_disfavoredOverload
+            public var content: Section.Content {
+                section.content
+            }
+        }
+        """
+
+        let options = FormatOptions(storedVarAttributes: .sameLine, computedVarAttributes: .prevLine)
+        testFormatting(for: input, rule: FormatRules.wrapAttributes, options: options)
+    }
+
     // MARK: wrapEnumCases
 
     func testMultilineEnumCases() {


### PR DESCRIPTION
This PR fixes an issue where the `parseType` helper didn't handle qualified types like `Foo.Bar` or `Foo.Bar.Baaz`. 

This could cause the `isStoredProperty(atIntroducerIndex:)` helper to return the incorrect result for properties with a qualified type name, like in the example added as a test case.