### PR TITLE
Remove runtime stdlib dependency from pre-built binary targeting Linux

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: Build it
         run: |
-          swift build --configuration release
+          swift build --configuration release --static-swift-stdlib --enable-dead-strip
           SWIFTFORMAT_BIN_PATH=`swift build --configuration release --show-bin-path`
           mv $SWIFTFORMAT_BIN_PATH/swiftformat "${HOME}/swiftformat_linux"
       - name: 'Upload Artifact'


### PR DESCRIPTION
Currently, the pre-built binary targeting Linux links Swift stdlib and core libraries dynamically. Unlike darwin platforms, Swift does not guarantee ABI stability on Linux, so the pre-built binary must be run with exactly the same version of Swift stdlib and core libraries that it was built with on GitHub Actions. And also the shared libraries can be installed in various locations, so users usually need to set `LD_LIBRARY_PATH`.

However, asking users to do the above works only for power users. Reducing the runtime dependencies makes it usable for more users.

The only downside of static-linkage is the significant binary-size (9.4M -> 57M). But IMHO a larger binary is better than the one hard to run. The most of huge binary size came from unused ICU data and Foundation, so we can expect it will be much smaller after adopting https://github.com/apple/swift-foundation and LTO integration in SwiftPM (upcoming in 5.10)