### PR TITLE
Add new rules related to blank lines in switch statements

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -580,8 +580,6 @@ Replace consecutive spaces with a single space.
 ## consistentSwitchStatementSpacing
 
 Ensures consistent spacing among all of the cases in a switch statement.
-If the majority of cases have a trailing blank line, all cases should have a trailing blank line.
-If the majority of cases do not have a trailing blank line, no cases should have a trailing blank line.
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -5,7 +5,6 @@
 * [applicationMain](#applicationMain)
 * [assertionFailures](#assertionFailures)
 * [blankLineAfterImports](#blankLineAfterImports)
-* [blankLineAfterMultilineSwitchCase](#blankLineAfterMultilineSwitchCase)
 * [blankLinesAroundMark](#blankLinesAroundMark)
 * [blankLinesAtEndOfScope](#blankLinesAtEndOfScope)
 * [blankLinesAtStartOfScope](#blankLinesAtStartOfScope)
@@ -15,7 +14,6 @@
 * [conditionalAssignment](#conditionalAssignment)
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
-* [consistentSwitchStatementSpacing](#consistentSwitchStatementSpacing)
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
@@ -93,8 +91,10 @@
 # Opt-in Rules (disabled by default)
 
 * [acronyms](#acronyms)
+* [blankLineAfterMultilineSwitchCase](#blankLineAfterMultilineSwitchCase)
 * [blankLinesBetweenImports](#blankLinesBetweenImports)
 * [blockComments](#blockComments)
+* [consistentSwitchStatementSpacing](#consistentSwitchStatementSpacing)
 * [docComments](#docComments)
 * [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
@@ -244,6 +244,33 @@ Insert blank line after import statements.
 
 Insert a blank line after multiline switch cases (excluding the last case,
 which is followed by a closing brace).
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  func handle(_ action: SpaceshipAction) {
+      switch action {
+      case .engageWarpDrive:
+          navigationComputer.destination = targetedDestination
+          await warpDrive.spinUp()
+          warpDrive.activate()
++
+      case let .scanPlanet(planet):
+          scanner.target = planet
+          scanner.scanAtmosphere()
+          scanner.scanBiosphere()
+          scanner.scanForArticialLife()
++
+      case .handleIncomingEnergyBlast:
+          await energyShields.prepare()
+          energyShields.engage()
+      }
+  }
+```
+
+</details>
+<br/>
 
 ## blankLinesAroundMark
 
@@ -555,6 +582,59 @@ Replace consecutive spaces with a single space.
 Ensures consistent spacing among all of the cases in a switch statement.
 If the majority of cases have a trailing blank line, all cases should have a trailing blank line.
 If the majority of cases do not have a trailing blank line, no cases should have a trailing blank line.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  func handle(_ action: SpaceshipAction) {
+      switch action {
+      case .engageWarpDrive:
+          navigationComputer.destination = targetedDestination
+          await warpDrive.spinUp()
+          warpDrive.activate()
+
+      case .enableArtificialGravity:
+          artificialGravityEngine.enable(strength: .oneG)
++
+      case let .scanPlanet(planet):
+          scanner.target = planet
+          scanner.scanAtmosphere()
+          scanner.scanBiosphere()
+          scanner.scanForArtificialLife()
+
+      case .handleIncomingEnergyBlast:
+          energyShields.engage()
+      }
+  }
+```
+
+```diff
+  var name: PlanetType {
+  switch self {
+  case .mercury:
+      "Mercury"
+-
+  case .venus:
+      "Venus"
+  case .earth:
+      "Earth"
+  case .mars:
+      "Mars"
+-
+  case .jupiter:
+      "Jupiter"
+  case .saturn:
+      "Saturn"
+  case .uranus:
+      "Uranus"
+  case .neptune:
+      "Neptune"
+  }
+```
+
+</details>
+<br/>
 
 ## docComments
 
@@ -2752,7 +2832,6 @@ Wrap multiline conditional assignment expressions after the assignment operator.
 +     } else {
 +         "Rogue planet"
 +     }
-```
 
 </details>
 <br/>

--- a/Rules.md
+++ b/Rules.md
@@ -5,6 +5,7 @@
 * [applicationMain](#applicationMain)
 * [assertionFailures](#assertionFailures)
 * [blankLineAfterImports](#blankLineAfterImports)
+* [blankLineAfterMultilineSwitchCase](#blankLineAfterMultilineSwitchCase)
 * [blankLinesAroundMark](#blankLinesAroundMark)
 * [blankLinesAtEndOfScope](#blankLinesAtEndOfScope)
 * [blankLinesAtStartOfScope](#blankLinesAtStartOfScope)
@@ -14,6 +15,7 @@
 * [conditionalAssignment](#conditionalAssignment)
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
+* [consistentSwitchStatementSpacing](#consistentSwitchStatementSpacing)
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
@@ -237,6 +239,11 @@ Insert blank line after import statements.
 
 </details>
 <br/>
+
+## blankLineAfterMultilineSwitchCase
+
+Insert a blank line after multiline switch cases (excluding the last case,
+which is followed by a closing brace).
 
 ## blankLinesAroundMark
 
@@ -542,6 +549,12 @@ Replace consecutive spaces with a single space.
 
 </details>
 <br/>
+
+## consistentSwitchStatementSpacing
+
+Ensures consistent spacing among all of the cases in a switch statement.
+If the majority of cases have a trailing blank line, all cases should have a trailing blank line.
+If the majority of cases do not have a trailing blank line, no cases should have a trailing blank line.
 
 ## docComments
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1754,6 +1754,29 @@ private struct Examples {
     ```
     """
 
+    let blankLineAfterMultilineSwitchCase = #"""
+    ```diff
+      func handle(_ action: SpaceshipAction) {
+          switch action {
+          case .engageWarpDrive:
+              navigationComputer.destination = targetedDestination
+              await warpDrive.spinUp()
+              warpDrive.activate()
+    +
+          case let .scanPlanet(planet):
+              scanner.target = planet
+              scanner.scanAtmosphere()
+              scanner.scanBiosphere()
+              scanner.scanForArticialLife()
+    +
+          case .handleIncomingEnergyBlast:
+              await energyShields.prepare()
+              energyShields.engage()
+          }
+      }
+    ```
+    """#
+
     let wrapMultilineConditionalAssignment = #"""
     ```diff
     - let planetLocation = if let star = planet.star {
@@ -1767,6 +1790,54 @@ private struct Examples {
     +     } else {
     +         "Rogue planet"
     +     }
+    """#
+
+    let consistentSwitchStatementSpacing = #"""
+    ```diff
+      func handle(_ action: SpaceshipAction) {
+          switch action {
+          case .engageWarpDrive:
+              navigationComputer.destination = targetedDestination
+              await warpDrive.spinUp()
+              warpDrive.activate()
+
+          case .enableArtificialGravity:
+              artificialGravityEngine.enable(strength: .oneG)
+    +
+          case let .scanPlanet(planet):
+              scanner.target = planet
+              scanner.scanAtmosphere()
+              scanner.scanBiosphere()
+              scanner.scanForArtificialLife()
+
+          case .handleIncomingEnergyBlast:
+              energyShields.engage()
+          }
+      }
+    ```
+
+    ```diff
+      var name: PlanetType {
+      switch self {
+      case .mercury:
+          "Mercury"
+    -
+      case .venus:
+          "Venus"
+      case .earth:
+          "Earth"
+      case .mars:
+          "Mars"
+    -
+      case .jupiter:
+          "Jupiter"
+      case .saturn:
+          "Saturn"
+      case .uranus:
+          "Uranus"
+      case .neptune:
+          "Neptune"
+      }
     ```
     """#
 }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1423,6 +1423,90 @@ extension Formatter {
         return allSatisfy
     }
 
+    /// Context describing the structure of a case in a switch statement
+    struct SwitchStatementBranchWithSpacingInfo {
+        let startOfBranch: Int
+        let endOfBranchExcludingTrailingComments: Int
+        let spansMultipleLines: Bool
+        let isLastCase: Bool
+        let isFollowedByBlankLine: Bool
+        let linebreakBeforeEndOfScope: Int?
+        let linebreakBeforeBlankLine: Int?
+
+        /// Inserts a blank line at the end of the switch case
+        func insertTrailingBlankLine(using formatter: Formatter) {
+            guard let linebreakBeforeEndOfScope = linebreakBeforeEndOfScope else {
+                return
+            }
+
+            formatter.insertLinebreak(at: linebreakBeforeEndOfScope)
+        }
+
+        /// Removes the trailing blank line from the switch case if present
+        func removeTrailingBlankLine(using formatter: Formatter) {
+            guard let linebreakBeforeEndOfScope = linebreakBeforeEndOfScope,
+                  let linebreakBeforeBlankLine = linebreakBeforeBlankLine
+            else { return }
+
+            formatter.removeTokens(in: (linebreakBeforeBlankLine + 1) ... linebreakBeforeEndOfScope)
+        }
+    }
+
+    /// Finds all of the branch bodies in a switch statement, and derives additional information
+    /// about the structure of each branch / case.
+    func switchStatementBranchesWithSpacingInfo(at switchIndex: Int) -> [SwitchStatementBranchWithSpacingInfo]? {
+        guard let switchStatementBranches = switchStatementBranches(at: switchIndex) else { return nil }
+
+        return switchStatementBranches.enumerated().compactMap { caseIndex, switchCase -> SwitchStatementBranchWithSpacingInfo? in
+            // Consider any trailing comments to actually be leading comments of the following case
+            var endOfBranchExcludingTrailingComments = switchCase.endOfBranch
+            while let tokenBeforeEndOfScope = index(of: .nonSpace, before: endOfBranchExcludingTrailingComments),
+                  tokens[tokenBeforeEndOfScope].isLinebreak,
+                  let commentBeforeEndOfScope = index(of: .nonSpace, before: tokenBeforeEndOfScope),
+                  tokens[commentBeforeEndOfScope].isComment,
+                  let startOfComment = startOfScope(at: commentBeforeEndOfScope),
+                  tokens[startOfComment].isComment
+            {
+                endOfBranchExcludingTrailingComments = startOfComment
+            }
+
+            guard let firstTokenInBody = index(of: .nonSpaceOrLinebreak, after: switchCase.startOfBranch),
+                  let lastTokenInBody = index(of: .nonSpaceOrLinebreak, before: endOfBranchExcludingTrailingComments)
+            else { return nil }
+
+            let isLastCase = caseIndex == switchStatementBranches.indices.last
+            let spansMultipleLines = !onSameLine(firstTokenInBody, lastTokenInBody)
+
+            var isFollowedByBlankLine = false
+            var linebreakBeforeEndOfScope: Int?
+            var linebreakBeforeBlankLine: Int?
+
+            if let tokenBeforeEndOfScope = index(of: .nonSpace, before: endOfBranchExcludingTrailingComments),
+               tokens[tokenBeforeEndOfScope].isLinebreak
+            {
+                linebreakBeforeEndOfScope = tokenBeforeEndOfScope
+            }
+
+            if let linebreakBeforeEndOfScope = linebreakBeforeEndOfScope,
+               let tokenBeforeBlankLine = index(of: .nonSpace, before: linebreakBeforeEndOfScope),
+               tokens[tokenBeforeBlankLine].isLinebreak
+            {
+                linebreakBeforeBlankLine = tokenBeforeBlankLine
+                isFollowedByBlankLine = true
+            }
+
+            return SwitchStatementBranchWithSpacingInfo(
+                startOfBranch: switchCase.startOfBranch,
+                endOfBranchExcludingTrailingComments: endOfBranchExcludingTrailingComments,
+                spansMultipleLines: spansMultipleLines,
+                isLastCase: isLastCase,
+                isFollowedByBlankLine: isFollowedByBlankLine,
+                linebreakBeforeEndOfScope: linebreakBeforeEndOfScope,
+                linebreakBeforeBlankLine: linebreakBeforeBlankLine
+            )
+        }
+    }
+
     /// Whether the given index is in a function call (not declaration)
     func isFunctionCall(at index: Int) -> Bool {
         if let openingParenIndex = self.index(of: .startOfScope("("), before: index + 1) {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7753,7 +7753,7 @@ public struct _FormatRules {
         Insert a blank line after multiline switch cases (excluding the last case,
         which is followed by a closing brace).
         """,
-        sharedOptions: ["linebreaks"]
+        orderAfter: ["redundantBreak"]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in
             guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }
@@ -7785,15 +7785,14 @@ public struct _FormatRules {
         If the majority of cases have a trailing blank line, all cases should have a trailing blank line.
         If the majority of cases do not have a trailing blank line, no cases should have a trailing blank line.
         """,
-        orderAfter: ["blankLineAfterMultilineSwitchCase"],
-        sharedOptions: ["linebreaks"]
+        orderAfter: ["blankLineAfterMultilineSwitchCase"]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in
             guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }
 
             // When counting the switch cases, exclude the last case (which should never have a trailing blank line).
-            let countWithTrailingBlankLine = switchCases.dropLast(1).filter { $0.isFollowedByBlankLine }.count
-            let countWithoutTrailingBlankLine = switchCases.dropLast(1).filter { !$0.isFollowedByBlankLine }.count
+            var countWithTrailingBlankLine = switchCases.filter { $0.isFollowedByBlankLine && !$0.isLastCase }.count
+            var countWithoutTrailingBlankLine = switchCases.filter { !$0.isFollowedByBlankLine && !$0.isLastCase }.count
 
             // We want the spacing to be consistent for all switch cases,
             // so use whichever formatting is used for the majority of cases.

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7753,6 +7753,7 @@ public struct _FormatRules {
         Insert a blank line after multiline switch cases (excluding the last case,
         which is followed by a closing brace).
         """,
+        disabledByDefault: true,
         orderAfter: ["redundantBreak"]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in
@@ -7785,6 +7786,7 @@ public struct _FormatRules {
         If the majority of cases have a trailing blank line, all cases should have a trailing blank line.
         If the majority of cases do not have a trailing blank line, no cases should have a trailing blank line.
         """,
+        disabledByDefault: true,
         orderAfter: ["blankLineAfterMultilineSwitchCase"]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -553,18 +553,18 @@ class IndentTests: RulesTests {
 
     func testIndentSwitchAfterRangeCase() {
         let input = "switch x {\ncase 0 ..< 2:\n    switch y {\n    default:\n        break\n    }\ndefault:\n    break\n}"
-        testFormatting(for: input, rule: FormatRules.indent)
+        testFormatting(for: input, rule: FormatRules.indent, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIndentEnumDeclarationInsideSwitchCase() {
         let input = "switch x {\ncase y:\nenum Foo {\ncase z\n}\nbar()\ndefault: break\n}"
         let output = "switch x {\ncase y:\n    enum Foo {\n        case z\n    }\n    bar()\ndefault: break\n}"
-        testFormatting(for: input, output, rule: FormatRules.indent)
+        testFormatting(for: input, output, rule: FormatRules.indent, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIndentEnumCaseBodyAfterWhereClause() {
         let input = "switch foo {\ncase _ where baz < quux:\n    print(1)\n    print(2)\ndefault:\n    break\n}"
-        testFormatting(for: input, rule: FormatRules.indent)
+        testFormatting(for: input, rule: FormatRules.indent, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIndentSwitchCaseCommentsCorrectly() {
@@ -590,7 +590,7 @@ class IndentTests: RulesTests {
             break
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.indent)
+        testFormatting(for: input, output, rule: FormatRules.indent, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIndentMultilineSwitchCaseCommentsCorrectly() {
@@ -2949,14 +2949,14 @@ class IndentTests: RulesTests {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\ncase .bar:\n    #if x\n        bar()\n    #endif\n    baz()\ncase .baz: break\n}"
         let options = FormatOptions(indentCase: false)
-        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testSwitchIfEndifInsideCaseIndenting2() {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\n    case .bar:\n        #if x\n            bar()\n        #endif\n        baz()\n    case .baz: break\n}"
         let options = FormatOptions(indentCase: true)
-        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIfUnknownCaseEndifIndenting() {
@@ -3191,14 +3191,14 @@ class IndentTests: RulesTests {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\ncase .bar:\n    #if x\n    bar()\n    #endif\n    baz()\ncase .baz: break\n}"
         let options = FormatOptions(indentCase: false, ifdefIndent: .noIndent)
-        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testIfEndifInsideCaseNoIndenting2() {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\n    case .bar:\n        #if x\n        bar()\n        #endif\n        baz()\n    case .baz: break\n}"
         let options = FormatOptions(indentCase: true, ifdefIndent: .noIndent)
-        testFormatting(for: input, output, rule: FormatRules.indent, options: options)
+        testFormatting(for: input, output, rule: FormatRules.indent, options: options, exclude: ["blankLineAfterMultilineSwitchCase"])
     }
 
     func testSwitchCaseInIfEndif() {

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -2790,6 +2790,7 @@ class OrganizationTests: RulesTests {
             case .value:
                 print("value")
             }
+
         case .failure:
             guard self.bar else {
                 print(self.bar)

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1324,6 +1324,7 @@ class RedundancyTests: RulesTests {
                 } else {
                     Foo("bar")
                 }
+
             case false:
                 Foo("baaz")
             }
@@ -1340,6 +1341,7 @@ class RedundancyTests: RulesTests {
                 } else {
                     Foo("bar")
                 }
+
             case false:
                 Foo("baaz")
             }
@@ -1361,6 +1363,7 @@ class RedundancyTests: RulesTests {
                 } else {
                     Foo("bar")
                 }
+
             case false:
                 Foo("baaz")
             }
@@ -1377,6 +1380,7 @@ class RedundancyTests: RulesTests {
                 } else {
                     .init("bar")
                 }
+
             case false:
                 .init("baaz")
             }
@@ -1838,6 +1842,7 @@ class RedundancyTests: RulesTests {
                 case .bar:
                     var foo: String?
                     Text(foo ?? "")
+
                 default:
                     EmptyView()
                 }
@@ -1938,6 +1943,7 @@ class RedundancyTests: RulesTests {
                     let _ = {
                         foo = "\\(max)"
                     }()
+
                 default:
                     EmptyView()
                 }
@@ -2785,6 +2791,7 @@ class RedundancyTests: RulesTests {
             case true:
                 // foo
                 return "foo"
+
             default:
                 /* bar */
                 return "bar"
@@ -2797,6 +2804,7 @@ class RedundancyTests: RulesTests {
             case true:
                 // foo
                 "foo"
+
             default:
                 /* bar */
                 "bar"
@@ -2867,6 +2875,7 @@ class RedundancyTests: RulesTests {
                         return "baaz"
                     }
                 }
+
             case false:
                 return "quux"
             }
@@ -2886,6 +2895,7 @@ class RedundancyTests: RulesTests {
                         "baaz"
                     }
                 }
+
             case false:
                 "quux"
             }
@@ -6158,6 +6168,7 @@ class RedundancyTests: RulesTests {
                             print(self.bar)
                         }
                     }
+
                 case .failure:
                     if self.bar {
                         print(self.bar)
@@ -6185,6 +6196,7 @@ class RedundancyTests: RulesTests {
                     }
                 }
                 self.method()
+
             case .failure:
                 break
             }
@@ -6215,6 +6227,7 @@ class RedundancyTests: RulesTests {
                     case .value:
                         print("value")
                     }
+
                 case .failure:
                     guard self.bar else {
                         print(self.bar)

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1968,4 +1968,52 @@ class SpacingTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.consistentSwitchStatementSpacing)
     }
+
+    func testSingleLineAndMultiLineSwitchCase1() {
+        let input = """
+        switch planetType {
+        case .terrestrial:
+            if options.treatPlutoAsPlanet {
+                [.mercury, .venus, .earth, .mars, .pluto]
+            } else {
+                [.mercury, .venus, .earth, .mars]
+            }
+        case .gasGiant:
+            [.jupiter, .saturn, .uranus, .neptune]
+        }
+        """
+
+        let output = """
+        switch planetType {
+        case .terrestrial:
+            if options.treatPlutoAsPlanet {
+                [.mercury, .venus, .earth, .mars, .pluto]
+            } else {
+                [.mercury, .venus, .earth, .mars]
+            }
+
+        case .gasGiant:
+            [.jupiter, .saturn, .uranus, .neptune]
+        }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.blankLineAfterMultilineSwitchCase, FormatRules.consistentSwitchStatementSpacing])
+    }
+
+    func testSingleLineAndMultiLineSwitchCase2() {
+        let input = """
+        switch planetType {
+        case .gasGiant:
+            [.jupiter, .saturn, .uranus, .neptune]
+        case .terrestrial:
+            if options.treatPlutoAsPlanet {
+                [.mercury, .venus, .earth, .mars, .pluto]
+            } else {
+                [.mercury, .venus, .earth, .mars]
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.consistentSwitchStatementSpacing)
+    }
 }

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1655,6 +1655,17 @@ class SpacingTests: RulesTests {
         let input = """
         var planetType: PlanetType {
             switch self {
+            case .mercury, .venus, .earth, .mars:
+                // The terrestrial planets are smaller and have a solid, rocky surface
+                .terrestrial
+            case .jupiter, .saturn, .uranus, .neptune:
+                // The gas giants are huge and lack a solid surface
+                .gasGiant
+            }
+        }
+
+        var planetType: PlanetType {
+            switch self {
             // The terrestrial planets are smaller and have a solid, rocky surface
             case .mercury, .venus, .earth, .mars:
                 .terrestrial
@@ -1680,10 +1691,14 @@ class SpacingTests: RulesTests {
                 "Mars"
             case .jupiter:
                 "Jupiter"
-            // Other planets have rings, but satun's are the best.
             case .saturn:
+                // Other planets have rings, but satun's are the best.
+                // It's rings are the only once that are usually visible in photos.
                 "Saturn"
             case .uranus:
+                /*
+                 * The pronunciation of this planet's name is subject of scholarly debate
+                 */
                 "Uranus"
             case .neptune:
                 "Neptune"
@@ -1691,7 +1706,7 @@ class SpacingTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: FormatRules.blankLineAfterMultilineSwitchCase, exclude: ["sortSwitchCases", "wrapSwitchCases"])
+        testFormatting(for: input, rule: FormatRules.blankLineAfterMultilineSwitchCase, exclude: ["sortSwitchCases", "wrapSwitchCases", "blockComments"])
     }
 
     func testMixedSingleLineAndMultiLineCases() {

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -2015,4 +2015,60 @@ class SpacingTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.consistentSwitchStatementSpacing)
     }
+
+    func testSwitchStatementWithSingleMultilineCase_blankLineAfterMultilineSwitchCaseEnabled() {
+        let input = """
+        switch action {
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+        case let .scanPlanet(planet):
+            scanner.scan(planet)
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        let output = """
+        switch action {
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case let .scanPlanet(planet):
+            scanner.scan(planet)
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.consistentSwitchStatementSpacing, FormatRules.blankLineAfterMultilineSwitchCase])
+    }
+
+    func testSwitchStatementWithSingleMultilineCase_blankLineAfterMultilineSwitchCaseDisabled() {
+        let input = """
+        switch action {
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+        case let .scanPlanet(planet):
+            scanner.scan(planet)
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.consistentSwitchStatementSpacing, exclude: ["blankLineAfterMultilineSwitchCase"])
+    }
 }

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1566,4 +1566,192 @@ class SpacingTests: RulesTests {
         let options = FormatOptions(emptyBracesSpacing: .linebreak)
         testFormatting(for: input, rule: FormatRules.emptyBraces, options: options)
     }
+
+    // MARK: - blankLineAfterMultilineSwitchCase
+
+    func testAddsBlankLineAfterMultilineSwitchCases() {
+        let input = """
+        func handle(_ action: SpaceshipAction) {
+            switch action {
+            // The warp drive can be engaged by pressing a button on the control panel
+            case .engageWarpDrive:
+                navigationComputer.destination = targetedDestination
+                await warpDrive.spinUp()
+                warpDrive.activate()
+            // Triggered automatically whenever we detect an energy blast was fired in our direction
+            case .handleIncomingEnergyBlast:
+                await energyShields.prepare()
+                energyShields.engage()
+            }
+        }
+        """
+
+        let output = """
+        func handle(_ action: SpaceshipAction) {
+            switch action {
+            // The warp drive can be engaged by pressing a button on the control panel
+            case .engageWarpDrive:
+                navigationComputer.destination = targetedDestination
+                await warpDrive.spinUp()
+                warpDrive.activate()
+
+            // Triggered automatically whenever we detect an energy blast was fired in our direction
+            case .handleIncomingEnergyBlast:
+                await energyShields.prepare()
+                energyShields.engage()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+    }
+
+    func testRemovesBlankLineAfterLastSwitchCase() {
+        let input = """
+        func handle(_ action: SpaceshipAction) {
+            switch action {
+            case .engageWarpDrive:
+                navigationComputer.destination = targetedDestination
+                await warpDrive.spinUp()
+                warpDrive.activate()
+
+            case let .scanPlanet(planet):
+                scanner.target = planet
+                scanner.scanAtmosphere()
+                scanner.scanBiosphere()
+                scanner.scanForArticialLife()
+
+            case .handleIncomingEnergyBlast:
+                await energyShields.prepare()
+                energyShields.engage()
+
+            }
+        }
+        """
+
+        let output = """
+        func handle(_ action: SpaceshipAction) {
+            switch action {
+            case .engageWarpDrive:
+                navigationComputer.destination = targetedDestination
+                await warpDrive.spinUp()
+                warpDrive.activate()
+
+            case let .scanPlanet(planet):
+                scanner.target = planet
+                scanner.scanAtmosphere()
+                scanner.scanBiosphere()
+                scanner.scanForArticialLife()
+
+            case .handleIncomingEnergyBlast:
+                await energyShields.prepare()
+                energyShields.engage()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+    }
+
+    func testDoesntAddBlankLineAfterSingleLineSwitchCase() {
+        let input = """
+        var planetType: PlanetType {
+            switch self {
+            // The terrestrial planets are smaller and have a solid, rocky surface
+            case .mercury, .venus, .earth, .mars:
+                .terrestrial
+            // The gas giants are huge and lack a solid surface
+            case .jupiter, .saturn, .uranus, .neptune:
+                .gasGiant
+            }
+        }
+
+        var name: PlanetType {
+            switch self {
+            // The planet closest to the sun
+            case .mercury:
+                "Mercury"
+            case .venus:
+                "Venus"
+            // The best planet, where everything cool happens
+            case .earth:
+                "Earth"
+            // This planet is entirely inhabited by robots.
+            // There are cool landers, rovers, and even a helicopter.
+            case .mars:
+                "Mars"
+            case .jupiter:
+                "Jupiter"
+            // Other planets have rings, but satun's are the best.
+            case .saturn:
+                "Saturn"
+            case .uranus:
+                "Uranus"
+            case .neptune:
+                "Neptune"
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.blankLineAfterMultilineSwitchCase, exclude: ["sortSwitchCases", "wrapSwitchCases"])
+    }
+
+    func testMixedSingleLineAndMultiLineCases() {
+        let input = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case let .scanPlanet(planet):
+            scanner.target = planet
+            scanner.scanAtmosphere()
+            scanner.scanBiosphere()
+            scanner.scanForArtificialLife()
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        let output = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case let .scanPlanet(planet):
+            scanner.target = planet
+            scanner.scanAtmosphere()
+            scanner.scanBiosphere()
+            scanner.scanForArtificialLife()
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+    }
+
+    func testAllowsBlankLinesAfterSingleLineCases() {
+        let input = """
+        switch action {
+        case .engageWarpDrive:
+            warpDrive.engage()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+
+        case .scanPlanet(let planet):
+            scanner.scan(planet)
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+    }
 }

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1732,7 +1732,7 @@ class SpacingTests: RulesTests {
             energyShields.engage()
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+        testFormatting(for: input, output, rule: FormatRules.blankLineAfterMultilineSwitchCase, exclude: ["consistentSwitchStatementSpacing"])
     }
 
     func testAllowsBlankLinesAfterSingleLineCases() {
@@ -1744,7 +1744,7 @@ class SpacingTests: RulesTests {
         case .enableArtificialGravity:
             artificialGravityEngine.enable(strength: .oneG)
 
-        case .scanPlanet(let planet):
+        case let .scanPlanet(planet):
             scanner.scan(planet)
 
         case .handleIncomingEnergyBlast:
@@ -1753,5 +1753,219 @@ class SpacingTests: RulesTests {
         """
 
         testFormatting(for: input, rule: FormatRules.blankLineAfterMultilineSwitchCase)
+    }
+
+    // MARK: - consistentSwitchStatementSpacing
+
+    func testInsertsBlankLinesToMakeSwitchStatementSpacingConsistent1() {
+        let input = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case let .scanPlanet(planet):
+            scanner.target = planet
+            scanner.scanAtmosphere()
+            scanner.scanBiosphere()
+            scanner.scanForArtificialLife()
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        let output = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+
+        case let .scanPlanet(planet):
+            scanner.target = planet
+            scanner.scanAtmosphere()
+            scanner.scanBiosphere()
+            scanner.scanForArtificialLife()
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.consistentSwitchStatementSpacing)
+    }
+
+    func testInsertsBlankLinesToMakeSwitchStatementSpacingConsistent2() {
+        let input = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+
+        let output = """
+        switch action {
+        case .engageWarpDrive:
+            navigationComputer.destination = targetedDestination
+            await warpDrive.spinUp()
+            warpDrive.activate()
+
+        case .enableArtificialGravity:
+            artificialGravityEngine.enable(strength: .oneG)
+
+        case .handleIncomingEnergyBlast:
+            energyShields.engage()
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.consistentSwitchStatementSpacing)
+    }
+
+    func testInsertsBlankLinesToMakeSwitchStatementSpacingConsistent3() {
+        let input = """
+        var name: PlanetType {
+            switch self {
+            // The planet closest to the sun
+            case .mercury:
+                "Mercury"
+            // Similar to Earth but way more deadly
+            case .venus:
+                "Venus"
+
+            // The best planet, where everything cool happens
+            case .earth:
+                "Earth"
+
+            // This planet is entirely inhabited by robots.
+            // There are cool landers, rovers, and even a helicopter.
+            case .mars:
+                "Mars"
+
+            // The biggest planet with the most moons
+            case .jupiter:
+                "Jupiter"
+
+            // Other planets have rings, but satun's are the best.
+            case .saturn:
+                "Saturn"
+            case .uranus:
+                "Uranus"
+            case .neptune:
+                "Neptune"
+            }
+        }
+        """
+
+        let output = """
+        var name: PlanetType {
+            switch self {
+            // The planet closest to the sun
+            case .mercury:
+                "Mercury"
+
+            // Similar to Earth but way more deadly
+            case .venus:
+                "Venus"
+
+            // The best planet, where everything cool happens
+            case .earth:
+                "Earth"
+
+            // This planet is entirely inhabited by robots.
+            // There are cool landers, rovers, and even a helicopter.
+            case .mars:
+                "Mars"
+
+            // The biggest planet with the most moons
+            case .jupiter:
+                "Jupiter"
+
+            // Other planets have rings, but satun's are the best.
+            case .saturn:
+                "Saturn"
+
+            case .uranus:
+                "Uranus"
+
+            case .neptune:
+                "Neptune"
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.consistentSwitchStatementSpacing)
+    }
+
+    func testRemovesBlankLinesToMakeSwitchStatementConsistent() {
+        let input = """
+        var name: PlanetType {
+            switch self {
+            // The planet closest to the sun
+            case .mercury:
+                "Mercury"
+
+            case .venus:
+                "Venus"
+            // The best planet, where everything cool happens
+            case .earth:
+                "Earth"
+            // This planet is entirely inhabited by robots.
+            // There are cool landers, rovers, and even a helicopter.
+            case .mars:
+                "Mars"
+            case .jupiter:
+                "Jupiter"
+            // Other planets have rings, but satun's are the best.
+            case .saturn:
+                "Saturn"
+
+            case .uranus:
+                "Uranus"
+            case .neptune:
+                "Neptune"
+            }
+        }
+        """
+
+        let output = """
+        var name: PlanetType {
+            switch self {
+            // The planet closest to the sun
+            case .mercury:
+                "Mercury"
+            case .venus:
+                "Venus"
+            // The best planet, where everything cool happens
+            case .earth:
+                "Earth"
+            // This planet is entirely inhabited by robots.
+            // There are cool landers, rovers, and even a helicopter.
+            case .mars:
+                "Mars"
+            case .jupiter:
+                "Jupiter"
+            // Other planets have rings, but satun's are the best.
+            case .saturn:
+                "Saturn"
+            case .uranus:
+                "Uranus"
+            case .neptune:
+                "Neptune"
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.consistentSwitchStatementSpacing)
     }
 }

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -1929,7 +1929,6 @@ class SpacingTests: RulesTests {
             // Other planets have rings, but satun's are the best.
             case .saturn:
                 "Saturn"
-
             case .uranus:
                 "Uranus"
             case .neptune:

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3356,6 +3356,7 @@ class SyntaxTests: RulesTests {
         case .bar:
             // bar
             let bar = baz()
+
         default:
             // baz
             let baz = quux()
@@ -3490,10 +3491,12 @@ class SyntaxTests: RulesTests {
             } else {
                 foo = Foo("bar")
             }
+
         case false:
             switch condition {
             case true:
                 foo = Foo("baaz")
+
             case false:
                 if condition {
                     foo = Foo("quux")
@@ -3511,10 +3514,12 @@ class SyntaxTests: RulesTests {
             } else {
                 Foo("bar")
             }
+
         case false:
             switch condition {
             case true:
                 Foo("baaz")
+
             case false:
                 if condition {
                     Foo("quux")
@@ -3630,6 +3635,7 @@ class SyntaxTests: RulesTests {
         case true:
             foo = Foo("foo")
             print("Multi-statement")
+
         case false:
             foo = Foo("bar")
         }
@@ -3667,6 +3673,7 @@ class SyntaxTests: RulesTests {
                 foo = Foo("baaz")
             }
             print("Multi-statement")
+
         case false:
             foo = Foo("bar")
         }


### PR DESCRIPTION
This PR adds two new rules related to blank lines in switch statements. 


### `blankLineAfterMultilineSwitchCase`

This rule inserts a blank line following any switch statement case that spans multiple lines:

```diff
  func handle(_ action: SpaceshipAction) {
      switch action {
      case .engageWarpDrive:
          navigationComputer.destination = targetedDestination
          await warpDrive.spinUp()
          warpDrive.activate()
+
      case let .scanPlanet(planet):
          scanner.target = planet
          scanner.scanAtmosphere()
          scanner.scanBiosphere()
          scanner.scanForArticialLife()
+
      case .handleIncomingEnergyBlast:
          await energyShields.prepare()
          energyShields.engage()
      }
  }
```

### `consistentSwitchStatementSpacing`

This rule ensures that the cases in a switch statement have consistent spacing. If the majority of cases have a blank line, then all cases should have a blank line. This is complimentary with the above rule, and improves cases like this:

```diff
  func handle(_ action: SpaceshipAction) {
      switch action {
      case .engageWarpDrive:
          navigationComputer.destination = targetedDestination
          await warpDrive.spinUp()
          warpDrive.activate()

      case .enableArtificialGravity:
          artificialGravityEngine.enable(strength: .oneG)
+
      case let .scanPlanet(planet):
          scanner.target = planet
          scanner.scanAtmosphere()
          scanner.scanBiosphere()
          scanner.scanForArtificialLife()

      case .handleIncomingEnergyBlast:
          energyShields.engage()
      }
  }
```

This rule also works in the other direction, and will remove unnecessary blank lines if the majority of cases don't have one:

```diff
  var name: PlanetType {
  switch self {
  case .mercury:
      "Mercury"
-
  case .venus:
      "Venus"
  case .earth:
      "Earth"
  case .mars:
      "Mars"
-
  case .jupiter:
      "Jupiter"
  case .saturn:
      "Saturn"
  case .uranus:
      "Uranus"
  case .neptune:
      "Neptune"
  }
```

### Combined example

These two rules compliment each other and combine nicely. When both rules are enabled, they will take a complex switch statement like the one below and add a blank line after all of the cases:

```diff
  func handle(_ action: SpaceshipAction) {
      switch action {
      case .engageWarpDrive:
          navigationComputer.destination = targetedDestination
          await warpDrive.spinUp()
          warpDrive.activate()
+
      case .enableArtificialGravity:
          artificialGravityEngine.enable(strength: .oneG)
+
      case let .scanPlanet(planet):
          scanner.target = planet
          scanner.scanAtmosphere()
          scanner.scanBiosphere()
          scanner.scanForArtificialLife()
+
      case .handleIncomingEnergyBlast:
          energyShields.engage()
      }
  }
```

while preserving the common pattern where simple switch statements don't use any blank lines:

```diff
  // Unchanged!
  var name: PlanetType {
  switch self {
  case .mercury:
      "Mercury"
  case .venus:
      "Venus"
  case .earth:
      "Earth"
  case .mars:
      "Mars"
  case .jupiter:
      "Jupiter"
  case .saturn:
      "Saturn"
  case .uranus:
      "Uranus"
  case .neptune:
      "Neptune"
  }
```