### PR TITLE
Fix conditionalAssignment bugs with @unknown default cases

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -397,7 +397,7 @@ public extension Token {
         if case let .endOfScope(string) = self {
             return ["case", "default"].contains(string)
         }
-        return false
+        return self == .keyword("@unknown") // support `@unknown default` as well
     }
 
     func isOperator(_ string: String) -> Bool {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3891,6 +3891,96 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment"])
     }
 
+    func testConvertsSwitchWithDefaultCase() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case .foo:
+            foo = Foo("foo")
+        case .bar:
+            foo = Foo("bar")
+        default:
+            foo = Foo("default")
+        }
+        """
+
+        let output = """
+        let foo: Foo = switch condition {
+        case .foo:
+            Foo("foo")
+        case .bar:
+            Foo("bar")
+        default:
+            Foo("default")
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment", "redundantType"])
+    }
+
+    func testConvertsSwitchWithUnknownDefaultCase() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case .foo:
+            foo = Foo("foo")
+        case .bar:
+            foo = Foo("bar")
+        @unknown default:
+            foo = Foo("default")
+        }
+        """
+
+        let output = """
+        let foo: Foo = switch condition {
+        case .foo:
+            Foo("foo")
+        case .bar:
+            Foo("bar")
+        @unknown default:
+            Foo("default")
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, output, rule: FormatRules.conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment", "redundantType"])
+    }
+
+    func testPreservesSwitchWithReturnInDefaultCase() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case .foo:
+            foo = Foo("foo")
+        case .bar:
+            foo = Foo("bar")
+        default:
+            return
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
+    func testPreservesSwitchWithReturnInUnknownDefaultCase() {
+        let input = """
+        let foo: Foo
+        switch condition {
+        case .foo:
+            foo = Foo("foo")
+        case .bar:
+            foo = Foo("bar")
+        @unknown default:
+            return
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
+    }
+
     // MARK: - forLoop
 
     func testConvertSimpleForEachToForLoop() {


### PR DESCRIPTION
This PR fixes some bugs in how the `conditionalAssignment` rule handled `@unknown default` cases, which could result in build failures. For example:

```swift
let foo: Foo
switch condition {
case .foo:
  foo = Foo("foo")
case .bar:
  foo = Foo("bar")
@unknown default:
  foo = Foo("default")
}
```

was being converted to:

```swift
let foo = switch condition {
case .foo:
  Foo("foo")
case .bar:
  Foo("bar")
@unknown default:
  foo = Foo("default")
}
```