### PR TITLE
Fix issue where declaration body wouldn't be sorted if organizeDeclarations was enabled but excluded declaration type

### DIFF
--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -3287,34 +3287,24 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.sortDeclarations)
     }
 
-    func testTypeBodyWithBlankLines() {
+    func testSortsTypeBody() {
         let input = """
         // swiftformat:sort
         enum FeatureFlags {
-
             case upsellB
-
             case fooFeature
-
             case barFeature
-
             case upsellA
-
         }
         """
 
         let output = """
         // swiftformat:sort
         enum FeatureFlags {
-
             case barFeature
-
             case fooFeature
-
             case upsellA
-
             case upsellB
-
         }
         """
 
@@ -3521,6 +3511,69 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, rule: FormatRules.organizeDeclarations)
+    }
+
+    func testSortDeclarationsSortsExtensionBody() {
+        let input = """
+        enum Namespace {}
+
+        // swiftformat:sort
+        extension Namespace {
+            static let foo = "foo"
+            public static let bar = "bar"
+            static let baaz = "baaz"
+        }
+        """
+
+        let output = """
+        enum Namespace {}
+
+        // swiftformat:sort
+        extension Namespace {
+            static let baaz = "baaz"
+            public static let bar = "bar"
+            static let foo = "foo"
+        }
+        """
+
+        // organizeTypes doesn't include "extension". So even though the
+        // organizeDeclarations rule is enabled, the extension should be
+        // sorted by the sortDeclarations rule.
+        let options = FormatOptions(organizeTypes: ["class"])
+        testFormatting(for: input, [output], rules: [FormatRules.sortDeclarations, FormatRules.organizeDeclarations], options: options)
+    }
+
+    func testOrganizeDeclarationsSortsExtensionBody() {
+        let input = """
+        enum Namespace {}
+
+        // swiftformat:sort
+        extension Namespace {
+            static let foo = "foo"
+            public static let bar = "bar"
+            static let baaz = "baaz"
+        }
+        """
+
+        let output = """
+        enum Namespace {}
+
+        // swiftformat:sort
+        extension Namespace {
+
+            // MARK: Public
+
+            public static let bar = "bar"
+
+            // MARK: Internal
+
+            static let baaz = "baaz"
+            static let foo = "foo"
+        }
+        """
+
+        let options = FormatOptions(organizeTypes: ["extension"])
+        testFormatting(for: input, output, rule: FormatRules.organizeDeclarations, options: options, exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
     }
 
     // MARK: - sortTypealiases


### PR DESCRIPTION
This PR fixes an issue where declaration bodies wouldn't be sorted if the `organizeDeclarations` rule was enabled, but configured with a `organizeTypes` value that excluded that declaration type.

For example, `organizeTypes` excludes extensions by default. So when `organizeDeclarations` was enabled, the neither the `sortDeclarations` rule nor the `organizeDeclarations` rule would apply the `// swiftformat:sort` directive.

This PR should fix https://github.com/nicklockwood/SwiftFormat/issues/1622.