### PR TITLE
Add option to preserve all doc comments, preserve regular comments before grouped declarations

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -638,6 +638,10 @@ Ensures consistent spacing among all of the cases in a switch statement.
 
 Use doc comments for API declarations, otherwise use regular comments.
 
+Option | Description
+--- | ---
+`--doccomments` | Preserve doc comments: "default" or "preserve".
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -979,6 +979,16 @@ struct _Descriptors {
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
     )
+
+    let preserveDocComments = OptionDescriptor(
+        argumentName: "doccomments",
+        displayName: "Doc comments",
+        help: "Preserve doc comments: \"default\" or \"preserve\".",
+        keyPath: \.preserveSingleLineForEach,
+        trueValues: ["preserve"],
+        falseValues: ["default"]
+    )
+
     let initCoderNil = OptionDescriptor(
         argumentName: "initcodernil",
         displayName: "nil for initWithCoder",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -663,6 +663,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapEffects: WrapEffects
     public var preserveAnonymousForEach: Bool
     public var preserveSingleLineForEach: Bool
+    public var preserveDocComments: Bool
     public var spaceAroundDelimiter: SpaceAroundDelimiter
     public var initCoderNil: Bool
     public var dateFormat: DateFormat
@@ -775,6 +776,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapEffects: WrapEffects = .preserve,
                 preserveAnonymousForEach: Bool = false,
                 preserveSingleLineForEach: Bool = true,
+                preserveDocComments: Bool = false,
                 dateFormat: DateFormat = .system,
                 timeZone: FormatTimeZone = .system,
                 // Doesn't really belong here, but hard to put elsewhere
@@ -877,6 +879,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapEffects = wrapEffects
         self.preserveAnonymousForEach = preserveAnonymousForEach
         self.preserveSingleLineForEach = preserveSingleLineForEach
+        self.preserveDocComments = preserveDocComments
         self.spaceAroundDelimiter = spaceAroundDelimiter
         self.dateFormat = dateFormat
         self.timeZone = timeZone

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3273,6 +3273,231 @@ class SyntaxTests: RulesTests {
                        exclude: ["spaceInsideComments"])
     }
 
+    func testPreservesDocComments() {
+        let input = """
+        /// Comment not associated with class
+
+        class Foo {
+            /** Comment not associated with function */
+
+            // Documentation for function
+            func bar() {
+                /// Comment inside function declaration.
+                /// This one is multi-line.
+
+                /// This comment is inside a function and precedes a declaration.
+                /// Since the option to preserve doc comments is enabled,
+                /// it should be left as-is.
+                let bar: Bar? = Bar()
+                print(bar)
+            }
+
+            // Documentation for property
+            var baaz: Baaz {
+                /// Comment inside property getter
+                let baazImpl = Baaz()
+                return baazImpl
+            }
+
+            // Documentation for function
+            var quux: Quux {
+                didSet {
+                    /// Comment inside didSet
+                    let newQuux = Quux()
+                    print(newQuux)
+                }
+            }
+        }
+        """
+
+        let output = """
+        /// Comment not associated with class
+
+        class Foo {
+            /** Comment not associated with function */
+
+            /// Documentation for function
+            func bar() {
+                /// Comment inside function declaration.
+                /// This one is multi-line.
+
+                /// This comment is inside a function and precedes a declaration.
+                /// Since the option to preserve doc comments is enabled,
+                /// it should be left as-is.
+                let bar: Bar? = Bar()
+                print(bar)
+            }
+
+            /// Documentation for property
+            var baaz: Baaz {
+                /// Comment inside property getter
+                let baazImpl = Baaz()
+                return baazImpl
+            }
+
+            /// Documentation for function
+            var quux: Quux {
+                didSet {
+                    /// Comment inside didSet
+                    let newQuux = Quux()
+                    print(newQuux)
+                }
+            }
+        }
+        """
+
+        let options = FormatOptions(preserveDocComments: true)
+        testFormatting(for: input, output, rule: FormatRules.docComments, options: options, exclude: ["spaceInsideComments"])
+    }
+
+    func testDoesntConvertCommentBeforeConsecutivePropertiesToDocComment() {
+        let input = """
+        // Names of the planets
+        struct PlanetNames {
+            // Inner planets
+            let mercury = "Mercury"
+            let venus = "Venus"
+            let earth = "Earth"
+            let mars = "Mars"
+
+            // Inner planets
+            let jupiter = "Jupiter"
+            let saturn = "Saturn"
+            let uranus = "Uranus"
+            let neptune = "Neptune"
+
+            /// Dwarf planets
+            let pluto = "Pluto"
+            let ceres = "Ceres"
+        }
+        """
+
+        let output = """
+        /// Names of the planets
+        struct PlanetNames {
+            // Inner planets
+            let mercury = "Mercury"
+            let venus = "Venus"
+            let earth = "Earth"
+            let mars = "Mars"
+
+            // Inner planets
+            let jupiter = "Jupiter"
+            let saturn = "Saturn"
+            let uranus = "Uranus"
+            let neptune = "Neptune"
+
+            /// Dwarf planets
+            let pluto = "Pluto"
+            let ceres = "Ceres"
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.docComments)
+    }
+
+    func testConvertsCommentsToDocCommentsInConsecutiveDeclarations() {
+        let input = """
+        // Names of the planets
+        enum PlanetNames {
+            // Mercuy
+            case mercury
+            // Venus
+            case venus
+            // Earth
+            case earth
+            // Mars
+            case mars
+
+            // Jupiter
+            case jupiter
+
+            // Saturn
+            case saturn
+
+            // Uranus
+            case uranus
+
+            // Neptune
+            case neptune
+        }
+        """
+
+        let output = """
+        /// Names of the planets
+        enum PlanetNames {
+            /// Mercuy
+            case mercury
+            /// Venus
+            case venus
+            /// Earth
+            case earth
+            /// Mars
+            case mars
+
+            /// Jupiter
+            case jupiter
+
+            /// Saturn
+            case saturn
+
+            /// Uranus
+            case uranus
+
+            /// Neptune
+            case neptune
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.docComments)
+    }
+
+    func testDoesntConvertCommentBeforeConsecutiveEnumCasesToDocComment() {
+        let input = """
+        // Names of the planets
+        enum PlanetNames {
+            // Inner planets
+            case mercury
+            case venus
+            case earth
+            case mars
+
+            // Inner planets
+            case jupiter
+            case saturn
+            case uranus
+            case neptune
+
+            // Dwarf planets
+            case pluto
+            case ceres
+        }
+        """
+
+        let output = """
+        /// Names of the planets
+        enum PlanetNames {
+            // Inner planets
+            case mercury
+            case venus
+            case earth
+            case mars
+
+            // Inner planets
+            case jupiter
+            case saturn
+            case uranus
+            case neptune
+
+            // Dwarf planets
+            case pluto
+            case ceres
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.docComments)
+    }
+
     func testDoesntConvertAnnotationCommentsToDocComments() {
         let input = """
         // swiftformat:disable some_swift_format_rule


### PR DESCRIPTION
This PR makes two improvements to the `docComments` rule.

First, this PR adds a `--doccomments preserve` options. When this option is enabled, it disables the part of the rule that converts doc comments into regular comments, so the rule will only ever convert regular comments into doc comments.

Second, this PR updates the rule to preserve any regular comments preceding a block of grouped declarations. For example:

```swift
/// The planets of the solar system
enum Planets {
    // Inner planets
    case mercury
    case venus
    case earth
    case mars

    // Inner planets
    case jupiter
    case saturn
    case uranus
    case neptune

    // Dwarf planets
    case pluto
    case ceres
}
```

Since the comments refer to the code block as a whole, and not a specific property, it makes sense to use regular comments rather than doc comments (doc comments are fine too and also preserved in this case).

This is (finally!) a follow-up to https://github.com/nicklockwood/SwiftFormat/pull/1283#issuecomment-1271989083.