### PR TITLE
Add Swift 6.0 to list of supported Swift versions

### DIFF
--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -45,6 +45,7 @@ public let swiftVersionFile = ".swift-version"
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
+    "6.0",
 ]
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat


### PR DESCRIPTION
Now that we know that the next version of Swift will be Swift 6.0 ([link](https://forums.swift.org/t/swift-6-0-release-process/70220)), it seems like it makes sense to go ahead and add support for `--swift-version 6.0` by adding it as a supported version.