### PR TITLE
Add preferInferredTypes rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -100,6 +100,7 @@
 * [markTypes](#markTypes)
 * [noExplicitOwnership](#noExplicitOwnership)
 * [organizeDeclarations](#organizeDeclarations)
+* [preferInferredTypes](#preferInferredTypes)
 * [sortSwitchCases](#sortSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -1438,6 +1439,31 @@ Option | Description
       .filter { $0.style == .fooBar }
       .map { $0.uppercased() }
       .forEach { print($0) }
+```
+
+</details>
+<br/>
+
+## preferInferredTypes
+
+Prefer using inferred types on property definitions (`let foo = Foo()`) rather than explicit types (`let foo: Foo = .init()`).
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let foo: Foo = .init()
++ let foo: Foo = .init()
+
+- let bar: Bar = .defaultValue
++ let bar = .defaultValue
+
+- let baaz: Baaz = .buildBaaz(foo: foo, bar: bar)
++ let baaz = Baaz.buildBaaz(foo: foo, bar: bar)
+
+  let float: CGFloat = 10.0
+  let array: [String] = []
+  let anyFoo: AnyFoo = foo
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1841,4 +1841,21 @@ private struct Examples {
       }
     ```
     """#
+
+    let preferInferredTypes = """
+    ```diff
+    - let foo: Foo = .init()
+    + let foo: Foo = .init()
+
+    - let bar: Bar = .defaultValue
+    + let bar = .defaultValue
+
+    - let baaz: Baaz = .buildBaaz(foo: foo, bar: bar)
+    + let baaz = Baaz.buildBaaz(foo: foo, bar: bar)
+
+      let float: CGFloat = 10.0
+      let array: [String] = []
+      let anyFoo: AnyFoo = foo
+    ```
+    """
 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1366,6 +1366,21 @@ extension Formatter {
         return nil
     }
 
+    // Whether or not the token at this index could potentially be the last token in a type.
+    // For a full list of all supported type patterns, check the documentation of `parseType(at:)`.
+    func isValidEndOfType(at index: Int) -> Bool {
+        if tokens[index].isIdentifier {
+            return true
+        }
+
+        let validEndOfTypeTokens = ["]", ")", ">", "?", "!"]
+        if validEndOfTypeTokens.contains(tokens[index].string) {
+            return true
+        }
+
+        return false
+    }
+
     /// Parses the expression starting at the given index.
     ///
     /// A full list of expression types are available here:

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -759,8 +759,16 @@ public struct _FormatRules {
             switch formatter.options.redundantType {
             case .inferred:
                 isInferred = true
+
             case .explicit:
-                isInferred = false
+                // If the `preferInferredTypes` rule is also enabled, it takes precedence
+                // over the `--redundanttype explicit` option.
+                if formatter.options.enabledRules.contains("preferInferredTypes") {
+                    isInferred = true
+                } else {
+                    isInferred = false
+                }
+
             case .inferLocalsOnly:
                 switch formatter.declarationScope(at: equalsIndex) {
                 case .global, .type:
@@ -7832,7 +7840,8 @@ public struct _FormatRules {
     public let preferInferredTypes = FormatRule(
         help: "Prefer using inferred types on property definitions (`let foo = Foo()`) rather than explicit types (`let foo: Foo = .init()`).",
         disabledByDefault: true,
-        orderAfter: ["redundantType"]
+        orderAfter: ["redundantType"],
+        sharedOptions: ["redundanttype"]
     ) { formatter in
         formatter.forEach(.operator("=", .infix)) { equalsIndex, _ in
             guard // Parse and validate the LHS of the property declaration.
@@ -7847,6 +7856,11 @@ public struct _FormatRules {
                 let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
                 formatter.tokens[dotIndex] == .operator(".", .prefix)
             else { return }
+
+            // Respect the `.inferLocalsOnly` option if enabled
+            if formatter.options.redundantType == .inferLocalsOnly,
+               formatter.declarationScope(at: equalsIndex) != .local
+            { return }
 
             let typeTokens = formatter.tokens[type.range]
 

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4381,7 +4381,8 @@ public struct _FormatRules {
 
     /// Strip redundant `.init` from type instantiations
     public let redundantInit = FormatRule(
-        help: "Remove explicit `init` if not required."
+        help: "Remove explicit `init` if not required.",
+        orderAfter: ["preferInferredTypes"]
     ) { formatter in
         formatter.forEach(.identifier("init")) { i, _ in
             guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i, if: {
@@ -4391,8 +4392,12 @@ public struct _FormatRules {
             }), let closeParenIndex = formatter.index(of: .endOfScope(")"), after: openParenIndex),
             formatter.last(.nonSpaceOrCommentOrLinebreak, before: closeParenIndex) != .delimiter(":"),
             let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: dotIndex),
-            let prevToken = formatter.token(at: prevIndex), case let .identifier(name) = prevToken,
-            let firstChar = name.first, firstChar != "$",
+            let prevToken = formatter.token(at: prevIndex),
+            formatter.isValidEndOfType(at: prevIndex),
+            // A valid type is guaranteed to have an identifier in it, just maybe not as the last token
+            let prevIdentifierIndex = prevToken.isIdentifier ? prevIndex : formatter.index(of: .identifierOrKeyword, before: prevIndex),
+            case let .identifier(string) = formatter.tokens[prevIdentifierIndex],
+            let firstChar = string.first, firstChar != "$",
             String(firstChar).uppercased() == String(firstChar) else {
                 return
             }
@@ -7821,6 +7826,35 @@ public struct _FormatRules {
                     switchCase.removeTrailingBlankLine(using: formatter)
                 }
             }
+        }
+    }
+
+    public let preferInferredTypes = FormatRule(
+        help: "Prefer using inferred types on property definitions (`let foo = Foo()`) rather than explicit types (`let foo: Foo = .init()`).",
+        disabledByDefault: true,
+        orderAfter: ["redundantType"]
+    ) { formatter in
+        formatter.forEach(.operator("=", .infix)) { equalsIndex, _ in
+            guard // Parse and validate the LHS of the property declaration.
+                // It should take the form `(let|var) propertyName: (Type) = .staticMember`
+                let introducerIndex = formatter.indexOfLastSignificantKeyword(at: equalsIndex),
+                ["var", "let"].contains(formatter.tokens[introducerIndex].string),
+                let colonIndex = formatter.index(of: .delimiter(":"), before: equalsIndex),
+                introducerIndex < colonIndex,
+                let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
+                let type = formatter.parseType(at: typeStartIndex),
+                // If the RHS starts with a leading dot, then we know its accessing some static member on this type.
+                let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                formatter.tokens[dotIndex] == .operator(".", .prefix)
+            else { return }
+
+            let typeTokens = formatter.tokens[type.range]
+
+            // Insert a copy of the type on the RHS before the dot
+            formatter.insert(typeTokens, at: dotIndex)
+
+            // Remove the colon and explicit type before the equals token
+            formatter.removeTokens(in: colonIndex ... type.range.upperBound)
         }
     }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1378,7 +1378,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment", "preferInferredTypes"])
     }
 
     func testRedundantTypeWithNestedIfExpression_inferred() {
@@ -1456,7 +1456,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment", "preferInferredTypes"])
     }
 
     func testRedundantTypeWithLiteralsInIfExpression() {
@@ -1617,7 +1617,7 @@ class RedundancyTests: RulesTests {
     func testRedundantTypeDoesNothingWithChainedMember() {
         let input = "let session: URLSession = URLSession.default.makeCopy()"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantRedundantChainedMemberTypeRemovedOnSwift5_4() {
@@ -1631,13 +1631,13 @@ class RedundancyTests: RulesTests {
     func testRedundantTypeDoesNothingWithChainedMember2() {
         let input = "let color: UIColor = UIColor.red.withAlphaComponent(0.5)"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember3() {
         let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovedWithChainedMemberOnSwift5_4() {
@@ -1650,19 +1650,19 @@ class RedundancyTests: RulesTests {
     func testRedundantTypeDoesNothingIfLet() {
         let input = "if let foo: Foo = Foo() {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingGuardLet() {
         let input = "guard let foo: Foo = Foo() else {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingIfLetAfterComma() {
         let input = "if check == true, let foo: Foo = Foo() {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeWorksAfterIf() {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -531,7 +531,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: FormatRules.redundantFileprivate, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantFileprivate, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testFileprivateInitNotChangedToPrivateWhenUsingTrailingClosureInit() {
@@ -863,6 +863,54 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: FormatRules.redundantInit, exclude: ["indent"])
+    }
+
+    func testRemoveInitAfterCollectionLiterals() {
+        let input = """
+        let array = [String].init()
+        let dictionary = [String: Int].init()
+        """
+        let output = """
+        let array = [String]()
+        let dictionary = [String: Int]()
+        """
+        testFormatting(for: input, output, rule: FormatRules.redundantInit)
+    }
+
+    func testRemoveInitAfterOptionalType() {
+        let input = """
+        let someOptional = String?.init("Foo")
+        // (String!.init("Foo") isn't valid Swift code, so we don't test for it)
+        """
+        let output = """
+        let someOptional = String?("Foo")
+        // (String!.init("Foo") isn't valid Swift code, so we don't test for it)
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantInit)
+    }
+
+    func testPreservesTryBeforeInit() {
+        let input = """
+        let throwing: Foo = try .init()
+        let throwingOptional1: Foo = try? .init()
+        let throwingOptional2: Foo = try! .init()
+        """
+
+        testFormatting(for: input, rule: FormatRules.redundantInit)
+    }
+
+    func testRemoveInitAfterGenericType() {
+        let input = """
+        let array = Array<String>.init()
+        let dictionary = Dictionary<String, Int>.init()
+        """
+        let output = """
+        let array = Array<String>()
+        let dictionary = Dictionary<String, Int>()
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantInit, exclude: ["typeSugar"])
     }
 
     // MARK: - redundantLetError
@@ -1437,7 +1485,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testVarRedundantTypeRemovalExplicitType2() {
@@ -1445,7 +1493,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = .init /* foo */()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options, exclude: ["spaceAroundComments"])
+                       options: options, exclude: ["spaceAroundComments", "preferInferredTypes"])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitType() {
@@ -1453,7 +1501,7 @@ class RedundancyTests: RulesTests {
         let output = "let relay: BehaviourRelay<Int?> = .init(value: nil)"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitTypeIfValueOnNextLine() {
@@ -1461,7 +1509,7 @@ class RedundancyTests: RulesTests {
         let output = "let relay: Foo<Int?> = \n    .default"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options, exclude: ["trailingSpace"])
+                       options: options, exclude: ["trailingSpace", "preferInferredTypes"])
     }
 
     func testVarNonRedundantTypeDoesNothingExplicitType() {
@@ -1475,7 +1523,7 @@ class RedundancyTests: RulesTests {
         let output = "let view: UIView = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovedIfValueOnNextLineExplicitType() {
@@ -1489,7 +1537,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovedIfValueOnNextLine2ExplicitType() {
@@ -1503,7 +1551,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovalWithCommentExplicitType() {
@@ -1511,7 +1559,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView /* view */ = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovalWithComment2ExplicitType() {
@@ -1519,7 +1567,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = /* view */ .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovalWithStaticMember() {
@@ -1541,7 +1589,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeRemovalWithStaticFunc() {
@@ -1563,7 +1611,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember() {
@@ -1577,7 +1625,7 @@ class RedundancyTests: RulesTests {
         let output = "let session: URLSession = .default.makeCopy()"
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.4")
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember2() {
@@ -1596,7 +1644,7 @@ class RedundancyTests: RulesTests {
         let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
         let output = "let url: URL = .init(fileURLWithPath: #file).deletingLastPathComponent()"
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.4")
-        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options)
+        testFormatting(for: input, output, rule: FormatRules.redundantType, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeDoesNothingIfLet() {
@@ -1628,7 +1676,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeIfVoid() {
@@ -1636,7 +1684,7 @@ class RedundancyTests: RulesTests {
         let output = "let foo: [Void] = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     func testRedundantTypeWithIntegerLiteralNotMangled() {
@@ -1706,7 +1754,7 @@ class RedundancyTests: RulesTests {
 
         let options = FormatOptions(redundantType: .inferLocalsOnly)
         testFormatting(for: input, output, rule: FormatRules.redundantType,
-                       options: options)
+                       options: options, exclude: ["preferInferredTypes"])
     }
 
     // MARK: - redundantNilInit
@@ -3315,7 +3363,7 @@ class RedundancyTests: RulesTests {
     func testNoRemoveBackticksAroundInitPropertyInSwift5() {
         let input = "let foo: Foo = .`init`"
         let options = FormatOptions(swiftVersion: "5")
-        testFormatting(for: input, rule: FormatRules.redundantBackticks, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantBackticks, options: options, exclude: ["preferInferredTypes"])
     }
 
     func testNoRemoveBackticksAroundAnyProperty() {
@@ -6783,7 +6831,7 @@ class RedundancyTests: RulesTests {
             case networkOnly
             case cacheFirst
 
-            static let defaultCacheAge: TimeInterval = .minutes(5)
+            static let defaultCacheAge = TimeInterval.minutes(5)
 
             func requestStrategy<Outcome>() -> SingleRequestStrategy<Outcome> {
                 switch self {

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4430,7 +4430,8 @@ class SyntaxTests: RulesTests {
         let optional = String?.init("Foo")
         """
 
-        testFormatting(for: input, output, rule: FormatRules.preferInferredTypes, exclude: ["redundantInit"])
+        let options = FormatOptions(redundantType: .inferred)
+        testFormatting(for: input, output, rule: FormatRules.preferInferredTypes, options: options, exclude: ["redundantInit"])
     }
 
     func testPreservesExplicitTypeIfNoRHS() {
@@ -4439,7 +4440,8 @@ class SyntaxTests: RulesTests {
         let bar: Bar
         """
 
-        testFormatting(for: input, rule: FormatRules.preferInferredTypes)
+        let options = FormatOptions(redundantType: .inferred)
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes, options: options)
     }
 
     func testPreservesExplicitTypeIfUsingLocalValueOrLiteral() {
@@ -4453,6 +4455,58 @@ class SyntaxTests: RulesTests {
         let tuple: (String, Int) = ("foo", 123)
         """
 
-        testFormatting(for: input, rule: FormatRules.preferInferredTypes)
+        let options = FormatOptions(redundantType: .inferred)
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes, options: options, exclude: ["redundantType"])
+    }
+
+    func testCompatibleWithRedundantTypeInferred() {
+        let input = """
+        let foo: Foo = Foo()
+        """
+
+        let output = """
+        let foo = Foo()
+        """
+
+        let options = FormatOptions(redundantType: .inferred)
+        testFormatting(for: input, [output], rules: [FormatRules.redundantType, FormatRules.preferInferredTypes], options: options)
+    }
+
+    func testCompatibleWithRedundantTypeExplicit() {
+        let input = """
+        let foo: Foo = Foo()
+        """
+
+        let output = """
+        let foo = Foo()
+        """
+
+        let options = FormatOptions(redundantType: .explicit)
+        testFormatting(for: input, [output], rules: [FormatRules.redundantType, FormatRules.preferInferredTypes], options: options)
+    }
+
+    func testCompatibleWithRedundantTypeInferLocalsOnly() {
+        let input = """
+        let foo: Foo = Foo.init()
+        let foo: Foo = .init()
+
+        func bar() {
+            let baaz: Baaz = Baaz.init()
+            let baaz: Baaz = .init()
+        }
+        """
+
+        let output = """
+        let foo: Foo = .init()
+        let foo: Foo = .init()
+
+        func bar() {
+            let baaz = Baaz.init()
+            let baaz = Baaz.init()
+        }
+        """
+
+        let options = FormatOptions(redundantType: .inferLocalsOnly)
+        testFormatting(for: input, [output], rules: [FormatRules.redundantType, FormatRules.preferInferredTypes], options: options, exclude: ["redundantInit"])
     }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4402,4 +4402,57 @@ class SyntaxTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.preferForLoop)
     }
+
+    // MARK: preferInferredTypes
+
+    func testConvertsExplicitTypeToImplicitType() {
+        let input = """
+        let foo: Foo = .init()
+        let bar: Bar = .staticBar
+        let baaz: Baaz = .Example.default
+        let quux: Quux = .quuxBulder(foo: .foo, bar: .bar)
+
+        let dictionary: [Foo: Bar] = .init()
+        let array: [Foo] = .init()
+        let genericType: MyGenericType<Foo, Bar> = .init()
+        let optional: String? = .init("Foo")
+        """
+
+        let output = """
+        let foo = Foo.init()
+        let bar = Bar.staticBar
+        let baaz = Baaz.Example.default
+        let quux = Quux.quuxBulder(foo: .foo, bar: .bar)
+
+        let dictionary = [Foo: Bar].init()
+        let array = [Foo].init()
+        let genericType = MyGenericType<Foo, Bar>.init()
+        let optional = String?.init("Foo")
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.preferInferredTypes, exclude: ["redundantInit"])
+    }
+
+    func testPreservesExplicitTypeIfNoRHS() {
+        let input = """
+        let foo: Foo
+        let bar: Bar
+        """
+
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes)
+    }
+
+    func testPreservesExplicitTypeIfUsingLocalValueOrLiteral() {
+        let input = """
+        let foo: Foo = localFoo
+        let bar: Bar = localBar
+        let int: Int64 = 1234
+        let number: CGFloat = 12.345
+        let array: [String] = []
+        let dictionary: [String: Int] = [:]
+        let tuple: (String, Int) = ("foo", 123)
+        """
+
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes)
+    }
 }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -3611,7 +3611,7 @@ class WrappingTests: RulesTests {
 
     func testMultilineBraceAppliedToGetterBody_wrapBeforeFirst() {
         let input = """
-        var items: Adaptive<CGFloat> = .adaptive(
+        var items = Adaptive<CGFloat>.adaptive(
             compact: Sizes.horizontalPaddingTiny_8,
             regular: Sizes.horizontalPaddingLarge_64) {
                 didSet { updateAccessoryViewSpacing() }
@@ -3619,7 +3619,7 @@ class WrappingTests: RulesTests {
         """
 
         let output = """
-        var items: Adaptive<CGFloat> = .adaptive(
+        var items = Adaptive<CGFloat>.adaptive(
             compact: Sizes.horizontalPaddingTiny_8,
             regular: Sizes.horizontalPaddingLarge_64)
         {
@@ -3663,8 +3663,8 @@ class WrappingTests: RulesTests {
 
     func testMultilineBraceAppliedToGetterBody_wrapAfterFirst() {
         let input = """
-        var items: Adaptive<CGFloat> = .adaptive(compact: Sizes.horizontalPaddingTiny_8,
-                                                 regular: Sizes.horizontalPaddingLarge_64)
+        var items = Adaptive<CGFloat>.adaptive(compact: Sizes.horizontalPaddingTiny_8,
+                                               regular: Sizes.horizontalPaddingLarge_64)
         {
             didSet { updateAccessoryViewSpacing() }
         }


### PR DESCRIPTION
This PR adds a new `preferInferredTypes` rule that converts property declarations with an explicit type (e.g. `let foo: Foo = .init()`) to instead use an inferred type (`let foo = Foo()`).

```diff
- let foo: Foo = .init()
+ let foo = Foo()

- let bar: Bar = .defaultValue
+ let bar = Bar.defaultValue

- let baaz: Baaz = .buildBaaz(foo: foo, bar: bar)
+ let baaz = Baaz.buildBaaz(foo: foo, bar: bar)

  let float: CGFloat = 10.0
  let array: [String] = []
  let anyFoo: AnyFoo = foo
```

Another approach I considered, but didn't implement, was to have a more general `propertyDeclarationTypes` rule that can also do the inverse transformation (convert `let foo = Foo()` to `let foo: Foo = .init()`). 

That conversion is more error-prone, since we don't exactly know what the name of the type is. For example, `Foo()` could be actually be referring to a `func Foo() -> Bar`. A real-world example that comes to mind is `let rect = CGRectMake(0, 0, 0, 0)`.

