### PR TITLE
Update conditionalAssignment rule to also simplify if/switch expressions that don't immediately follow property declaration

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1384,7 +1384,7 @@ extension Formatter {
     ///  - Any value can be preceded by `try`, `try?`, `try!`, or `await`
     ///  - Any value can be followed by a postfix operator
     ///  - Any value can be followed by an infix operator plus a right-hand-side expression.
-    ///  - Any value can be followed by an arbitrary number of method calls `(...)` or subscripts `[...]`.
+    ///  - Any value can be followed by an arbitrary number of method calls `(...)`, subscripts `[...]`, or generic arguments `<...>`.
     ///  - Any value can be followed by a `.identifier`
     func parseExpressionRange(startingAt startIndex: Int) -> ClosedRange<Int>? {
         // Any expression can start with a prefix operator, or `await`
@@ -1440,8 +1440,8 @@ extension Formatter {
               let nextToken = token(at: nextTokenIndex)
         {
             switch nextToken {
-            // Any expression can be followed by an arbitrary number of method calls `(...)` or subscripts `[...]`.
-            case .startOfScope("("), .startOfScope("["):
+            // Any expression can be followed by an arbitrary number of method calls `(...)`, subscripts `[...]`, or generic arguments `<...>`.
+            case .startOfScope("("), .startOfScope("["), .startOfScope("<"):
                 // If there's a linebreak between an expression and a paren or subscript,
                 // then it's not parsed as a method call and is actually a separate expression
                 if tokens[endOfExpression ..< nextTokenIndex].contains(where: \.isLinebreak) {

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1879,6 +1879,8 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssert(isSingleExpression(#"try? { try printThrows(foo) }()"#))
         XCTAssert(isSingleExpression(#"await { await printAsync(foo) }()"#))
         XCTAssert(isSingleExpression(#"try await { try await printAsyncThrows(foo) }()"#))
+        XCTAssert(isSingleExpression(#"Foo<Bar>()"#))
+        XCTAssert(isSingleExpression(#"Foo<Bar, Baaz>(quux: quux)"#))
 
         XCTAssert(isSingleExpression("""
         foo

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -9008,6 +9008,22 @@ class RedundancyTests: RulesTests {
                        options: options, exclude: ["indent", "blankLinesBetweenScopes", "wrapMultilineConditionalAssignment"])
     }
 
+    func testRemovesRedundantClosureWithGenericExistentialTypes() {
+        let input = """
+        let foo: Foo<Bar> = { DefaultFoo<Bar>() }()
+        let foo: any Foo = { DefaultFoo() }()
+        let foo: any Foo<Bar> = { DefaultFoo<Bar>() }()
+        """
+
+        let output = """
+        let foo: Foo<Bar> = DefaultFoo<Bar>()
+        let foo: any Foo = DefaultFoo()
+        let foo: any Foo<Bar> = DefaultFoo<Bar>()
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantClosure)
+    }
+
     func testRedundantSwitchStatementReturnInFunctionWithMultipleWhereClauses() {
         // https://github.com/nicklockwood/SwiftFormat/issues/1554
         let input = """

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4269,6 +4269,209 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.conditionalAssignment, options: options)
     }
 
+    func testConvertsIfStatementNotFollowingPropertyDefinition() {
+        let input = """
+        if condition {
+            property = Foo("foo")
+        } else {
+            property = Foo("bar")
+        }
+        """
+
+        let output = """
+        property =
+            if condition {
+                Foo("foo")
+            } else {
+                Foo("bar")
+            }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testPreservesIfStatementNotFollowingPropertyDefinitionWithInvalidBranch() {
+        let input = """
+        if condition {
+            property = Foo("foo")
+        } else {
+            property = Foo("bar")
+            print("A second expression on this branch")
+        }
+
+        if condition {
+            property = Foo("foo")
+        } else {
+            if otherCondition {
+                property = Foo("foo")
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testPreservesNonExhaustiveIfStatementNotFollowingPropertyDefinition() {
+        let input = """
+        if condition {
+            property = Foo("foo")
+        }
+
+        if condition {
+            property = Foo("foo")
+        } else if otherCondition {
+            property = Foo("foo")
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testConvertsSwitchStatementNotFollowingPropertyDefinition() {
+        let input = """
+        switch condition {
+        case true:
+            property = Foo("foo")
+        case false:
+            property = Foo("bar")
+        }
+        """
+
+        let output = """
+        property =
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testDoesntMergePropertyWithUnrelatedCondition() {
+        let input = """
+        let differentProperty: Foo
+        switch condition {
+        case true:
+            property = Foo("foo")
+        case false:
+            property = Foo("bar")
+        }
+        """
+
+        let output = """
+        let differentProperty: Foo
+        property =
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testConvertsNestedIfSwitchStatementNotFollowingPropertyDefinition() {
+        let input = """
+        switch firstCondition {
+        case true:
+            if secondCondition {
+                property = Foo("foo")
+            } else {
+                property = Foo("bar")
+            }
+
+        case false:
+            if thirdCondition {
+                property = Foo("baaz")
+            } else {
+                property = Foo("quux")
+            }
+        }
+        """
+
+        let output = """
+        property =
+            switch firstCondition {
+            case true:
+                if secondCondition {
+                    Foo("foo")
+                } else {
+                    Foo("bar")
+                }
+
+            case false:
+                if thirdCondition {
+                    Foo("baaz")
+                } else {
+                    Foo("quux")
+                }
+            }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testPreservesSwitchConditionWithIneligibleBranch() {
+        let input = """
+        switch firstCondition {
+        case true:
+            // Even though this condition is eligible to be converted,
+            // we leave it as-is because it's nested in an ineligible condition.
+            if secondCondition {
+                property = Foo("foo")
+            } else {
+                property = Foo("bar")
+            }
+
+        case false:
+            if thirdCondition {
+                property = Foo("baaz")
+            } else {
+                property = Foo("quux")
+                print("A second expression on this branch")
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
+    func testPreservesIfConditionWithIneligibleBranch() {
+        let input = """
+        if firstCondition {
+            // Even though this condition is eligible to be converted,
+            // we leave it as-is because it's nested in an ineligible condition.
+            if secondCondition {
+                property = Foo("foo")
+            } else {
+                property = Foo("bar")
+            }
+        } else {
+            if thirdCondition {
+                property = Foo("baaz")
+            } else {
+                property = Foo("quux")
+                print("A second expression on this branch")
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
     // MARK: - preferForLoop
 
     func testConvertSimpleForEachToForLoop() {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -5450,4 +5450,48 @@ class WrappingTests: RulesTests {
 
         testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent])
     }
+
+    func testWrapIfAssignmentWithoutIntroducer() {
+        let input = """
+        property = if condition {
+            Foo("foo")
+        } else {
+            Foo("bar")
+        }
+        """
+
+        let output = """
+        property =
+            if condition {
+                Foo("foo")
+            } else {
+                Foo("bar")
+            }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent])
+    }
+
+    func testWrapSwitchAssignmentWithoutIntroducer() {
+        let input = """
+        property = switch condition {
+        case true:
+            Foo("foo")
+        case false:
+            Foo("bar")
+        }
+        """
+
+        let output = """
+        property =
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent])
+    }
 }


### PR DESCRIPTION
This PR updates the `conditionalAssignment` rule to also simplify if/switch expressions that don't immediately follow property declarations.

Previously the `conditionalAssignment` rule only handled if/switch expressions that followed a property declaration:

```swift
// Before
let property: Foo
if condition {
  property = Foo("foo")
} else {
  property = Foo("bar")
}

// After
let property =
  if condition {
    Foo("foo")
  } else {
    Foo("bar")
  }
```

but did nothing in other cases like this:

```swift
if condition {
  property = Foo("foo")
} else {
  property = Foo("bar")
}
```

Now we apply the simplification to this case as well:

```swift
// Before
if condition {
  property = Foo("foo")
} else {
  property = Foo("bar")
}

// After
property =
  if condition {
    Foo("foo")
  } else {
    Foo("bar")
  }
```