### PR TITLE
Update conditionalAssignment rule to support more complex lvalues

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -520,7 +520,6 @@ Assign properties using if / switch expressions.
 -     bar = "bar"
 +     "bar"
   }
-```
 
 ```diff
 - let foo: String
@@ -532,6 +531,17 @@ Assign properties using if / switch expressions.
   case false:
 -     foo = "bar"
 +     "bar"
+  }
+```
+
+- switch condition {
++ foo.bar = switch condition {
+  case true:
+-     foo.bar = "baaz"
++     "baaz"
+  case false:
+-     foo.bar = "quux"
++     "quux"
   }
 ```
 

--- a/Rules.md
+++ b/Rules.md
@@ -507,6 +507,10 @@ Option | Description
 
 Assign properties using if / switch expressions.
 
+Option | Description
+--- | ---
+`--condassignment` | Use cond. assignment: "after-property" (default) or "always".
+
 <details>
 <summary>Examples</summary>
 
@@ -534,6 +538,7 @@ Assign properties using if / switch expressions.
   }
 ```
 
+// With --condassignment always (disabled by default)
 - switch condition {
 + foo.bar = switch condition {
   case true:

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1683,6 +1683,7 @@ private struct Examples {
       }
     ```
 
+    // With --condassignment always (disabled by default)
     - switch condition {
     + foo.bar = switch condition {
       case true:

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1669,7 +1669,6 @@ private struct Examples {
     -     bar = "bar"
     +     "bar"
       }
-    ```
 
     ```diff
     - let foo: String
@@ -1681,6 +1680,17 @@ private struct Examples {
       case false:
     -     foo = "bar"
     +     "bar"
+      }
+    ```
+
+    - switch condition {
+    + foo.bar = switch condition {
+      case true:
+    -     foo.bar = "baaz"
+    +     "baaz"
+      case false:
+    -     foo.bar = "quux"
+    +     "quux"
       }
     ```
     """

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -979,7 +979,6 @@ struct _Descriptors {
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
     )
-
     let preserveDocComments = OptionDescriptor(
         argumentName: "doccomments",
         displayName: "Doc comments",
@@ -988,7 +987,14 @@ struct _Descriptors {
         trueValues: ["preserve"],
         falseValues: ["default"]
     )
-
+    let conditionalAssignmentOnlyAfterNewProperties = OptionDescriptor(
+        argumentName: "condassignment",
+        displayName: "Apply conditionalAssignment rule",
+        help: "Use cond. assignment: \"after-property\" (default) or \"always\".",
+        keyPath: \.preserveSingleLineForEach,
+        trueValues: ["after-property"],
+        falseValues: ["always"]
+    )
     let initCoderNil = OptionDescriptor(
         argumentName: "initcodernil",
         displayName: "nil for initWithCoder",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -664,6 +664,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var preserveAnonymousForEach: Bool
     public var preserveSingleLineForEach: Bool
     public var preserveDocComments: Bool
+    public var conditionalAssignmentOnlyAfterNewProperties: Bool
     public var spaceAroundDelimiter: SpaceAroundDelimiter
     public var initCoderNil: Bool
     public var dateFormat: DateFormat
@@ -777,6 +778,7 @@ public struct FormatOptions: CustomStringConvertible {
                 preserveAnonymousForEach: Bool = false,
                 preserveSingleLineForEach: Bool = true,
                 preserveDocComments: Bool = false,
+                conditionalAssignmentOnlyAfterNewProperties: Bool = true,
                 dateFormat: DateFormat = .system,
                 timeZone: FormatTimeZone = .system,
                 // Doesn't really belong here, but hard to put elsewhere
@@ -880,6 +882,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.preserveAnonymousForEach = preserveAnonymousForEach
         self.preserveSingleLineForEach = preserveSingleLineForEach
         self.preserveDocComments = preserveDocComments
+        self.conditionalAssignmentOnlyAfterNewProperties = conditionalAssignmentOnlyAfterNewProperties
         self.spaceAroundDelimiter = spaceAroundDelimiter
         self.dateFormat = dateFormat
         self.timeZone = timeZone

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7107,11 +7107,10 @@ public struct _FormatRules {
                 startOfFirstBranch = startOfNestedBranch
             }
 
-            // Check if the first branch starts with the pattern `identifier =`.
-            guard let firstIdentifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: startOfFirstBranch),
-                  let identifier = formatter.token(at: firstIdentifierIndex),
-                  identifier.isIdentifier,
-                  let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstIdentifierIndex),
+            // Check if the first branch starts with the pattern `lvalue =`.
+            guard let firstTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: startOfFirstBranch),
+                  let lvalueRange = formatter.parseExpressionRange(startingAt: firstTokenIndex),
+                  let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: lvalueRange.upperBound),
                   formatter.tokens[equalsIndex] == .operator("=", .infix)
             else { return }
 
@@ -7142,7 +7141,7 @@ public struct _FormatRules {
 
             // Whether or not the given conditional branch body qualifies as a single statement
             // that assigns a value to `identifier`. This is either:
-            //  1. a single assignment to `identifier =`
+            //  1. a single assignment to `lvalue =`
             //  2. a single `if` or `switch` statement where each of the branches also qualify,
             //     and the statement is exhaustive.
             func isExhaustiveSingleStatementAssignment(_ branch: Formatter.ConditionalBranch) -> Bool {
@@ -7169,9 +7168,10 @@ public struct _FormatRules {
                         && isExhaustive
                 }
 
-                // Otherwise we expect this to be of the pattern `identifier = (statement)`
-                else if formatter.tokens[firstTokenIndex] == identifier,
-                        let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstTokenIndex),
+                // Otherwise we expect this to be of the pattern `lvalue = (statement)`
+                else if let firstExpressionRange = formatter.parseExpressionRange(startingAt: firstTokenIndex),
+                        formatter.tokens[firstExpressionRange] == formatter.tokens[lvalueRange],
+                        let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstExpressionRange.upperBound),
                         formatter.tokens[equalsIndex] == .operator("=", .infix),
                         let valueStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex)
                 {
@@ -7223,7 +7223,8 @@ public struct _FormatRules {
             func removeAssignmentFromAllBranches() {
                 formatter.forEachRecursiveConditionalBranch(in: conditionalBranches) { branch in
                     guard let firstTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: branch.startOfBranch),
-                          let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstTokenIndex),
+                          let firstExpressionRange = formatter.parseExpressionRange(startingAt: firstTokenIndex),
+                          let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstExpressionRange.upperBound),
                           formatter.tokens[equalsIndex] == .operator("=", .infix),
                           let valueStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex)
                     else { return }
@@ -7241,7 +7242,8 @@ public struct _FormatRules {
                let propertyIdentifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: introducerIndex),
                let propertyIdentifier = formatter.token(at: propertyIdentifierIndex),
                propertyIdentifier.isIdentifier,
-               propertyIdentifier == identifier,
+               formatter.tokens[lvalueRange.lowerBound] == propertyIdentifier,
+               lvalueRange.count == 1,
                let colonIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: propertyIdentifierIndex),
                formatter.tokens[colonIndex] == .delimiter(":"),
                let startOfTypeIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
@@ -7305,12 +7307,13 @@ public struct _FormatRules {
                    (startOfFirstParentBranch ... endOfLastParentBranch).contains(startOfConditional)
                 { return }
 
+                let lvalueTokens = formatter.tokens[lvalueRange]
+
                 // Now we can remove the `identifier =` from each branch,
                 // and instead add it before the if / switch expression.
                 removeAssignmentFromAllBranches()
 
-                let identifierEqualsTokens: [Token] = [
-                    identifier,
+                let identifierEqualsTokens = lvalueTokens + [
                     .space(" "),
                     .operator("=", .infix),
                     .space(" "),

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7084,7 +7084,8 @@ public struct _FormatRules {
 
     public let conditionalAssignment = FormatRule(
         help: "Assign properties using if / switch expressions.",
-        orderAfter: ["redundantReturn"]
+        orderAfter: ["redundantReturn"],
+        options: ["condassignment"]
     ) { formatter in
         // If / switch expressions were added in Swift 5.9 (SE-0380)
         guard formatter.options.swiftVersion >= "5.9" else {
@@ -7281,7 +7282,7 @@ public struct _FormatRules {
             }
 
             // Otherwise we insert an `identifier =` before the if/switch expression
-            else {
+            else if !formatter.options.conditionalAssignmentOnlyAfterNewProperties {
                 // In this case we should only apply the conversion if this is a top-level condition,
                 // and not nested in some parent condition. In large complex if/switch conditions
                 // with multiple layers of nesting, for example, this prevents us from making any

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4354,6 +4354,30 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
+    func testConvertsSwitchStatementWithComplexLValueNotFollowingPropertyDefinition() {
+        let input = """
+        switch condition {
+        case true:
+            property?.foo!.bar["baaz"] = Foo("foo")
+        case false:
+            property?.foo!.bar["baaz"] = Foo("bar")
+        }
+        """
+
+        let output = """
+        property?.foo!.bar["baaz"] =
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
+    }
+
     func testDoesntMergePropertyWithUnrelatedCondition() {
         let input = """
         let differentProperty: Foo

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4287,7 +4287,7 @@ class SyntaxTests: RulesTests {
             }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4309,7 +4309,7 @@ class SyntaxTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4326,7 +4326,7 @@ class SyntaxTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4350,7 +4350,7 @@ class SyntaxTests: RulesTests {
             }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4374,7 +4374,7 @@ class SyntaxTests: RulesTests {
             }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4400,7 +4400,7 @@ class SyntaxTests: RulesTests {
             }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4442,7 +4442,7 @@ class SyntaxTests: RulesTests {
             }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 
@@ -4468,7 +4468,7 @@ class SyntaxTests: RulesTests {
         }
         """
 
-        let options = FormatOptions(swiftVersion: "5.9")
+        let options = FormatOptions(conditionalAssignmentOnlyAfterNewProperties: false, swiftVersion: "5.9")
         testFormatting(for: input, rules: [FormatRules.conditionalAssignment, FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent], options: options)
     }
 

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -5494,4 +5494,27 @@ class WrappingTests: RulesTests {
 
         testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent])
     }
+
+    func testWrapSwitchAssignmentWithComplexLValue() {
+        let input = """
+        property?.foo!.bar["baaz"] = switch condition {
+        case true:
+            Foo("foo")
+        case false:
+            Foo("bar")
+        }
+        """
+
+        let output = """
+        property?.foo!.bar["baaz"] =
+            switch condition {
+            case true:
+                Foo("foo")
+            case false:
+                Foo("bar")
+            }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.wrapMultilineConditionalAssignment, FormatRules.indent])
+    }
 }


### PR DESCRIPTION
This PR updates the `conditionalAssignment` rule to support more complex lvalues. Previously it required that the value being assigned was just a simple identifier like `foo =`. Now it supports more complex lvalues like `foo?.bar =`, `foo["bar"] =`, etc.

For example, this sample code was left as-is before:

```swift
switch condition {
case true:
    property?.foo!.bar["baaz"] = Foo("foo")
case false:
    property?.foo!.bar["baaz"] = Foo("bar")
}
```

Now it is updated as expected:

```swift
property?.foo!.bar["baaz"] =
    switch condition {
    case true:
        Foo("foo")
    case false:
        Foo("bar")
    }
```

I also added a new `--condassignment after-property` to let consumers disable the new functionality added in https://github.com/nicklockwood/SwiftFormat/pull/1643. After running the updated rule on our codebase, I found too many of the changes weird and unusual. On the other hand I found the previous behavior (only applying the new syntax after a new property declaration) reasonable almost all of the time.