### PR TITLE
Add redundantProperty rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -101,6 +101,7 @@
 * [noExplicitOwnership](#noExplicitOwnership)
 * [organizeDeclarations](#organizeDeclarations)
 * [preferInferredTypes](#preferInferredTypes)
+* [redundantProperty](#redundantProperty)
 * [sortSwitchCases](#sortSwitchCases)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -1848,6 +1849,24 @@ Remove redundant pattern matching parameter syntax.
 ```diff
 - let (_, _) = bar
 + let _ = bar
+```
+
+</details>
+<br/>
+
+## redundantProperty
+
+Simplifies redundant property definitions that are immediately returned.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  func foo() -> Foo {
+-   let foo = Foo()
+-   return foo
++   return Foo()
+  }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1880,4 +1880,14 @@ private struct Examples {
         }
     ```
     """
+
+    let redundantProperty = """
+    ```diff
+      func foo() -> Foo {
+    -   let foo = Foo()
+    -   return foo
+    +   return Foo()
+      }
+    ```
+    """
 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1407,17 +1407,24 @@ extension Formatter {
     ///  - `[...]` (array or dictionary)
     ///  - `{ ... }` (closure)
     ///  - `#selector(...)` / macro invocations
+    ///  - An `if/switch` expression (only allowed if this is the only expression in
+    ///    a code block or if following an assignment `=` operator).
     ///  - Any value can be preceded by a prefix operator
     ///  - Any value can be preceded by `try`, `try?`, `try!`, or `await`
     ///  - Any value can be followed by a postfix operator
     ///  - Any value can be followed by an infix operator plus a right-hand-side expression.
     ///  - Any value can be followed by an arbitrary number of method calls `(...)`, subscripts `[...]`, or generic arguments `<...>`.
     ///  - Any value can be followed by a `.identifier`
-    func parseExpressionRange(startingAt startIndex: Int) -> ClosedRange<Int>? {
+    func parseExpressionRange(
+        startingAt startIndex: Int,
+        allowConditionalExpressions: Bool = false
+    )
+        -> ClosedRange<Int>?
+    {
         // Any expression can start with a prefix operator, or `await`
         if tokens[startIndex].isOperator(ofType: .prefix) || tokens[startIndex].string == "await",
            let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: startIndex),
-           let followingExpression = parseExpressionRange(startingAt: nextTokenIndex)
+           let followingExpression = parseExpressionRange(startingAt: nextTokenIndex, allowConditionalExpressions: allowConditionalExpressions)
         {
             return startIndex ... followingExpression.upperBound
         }
@@ -1433,7 +1440,7 @@ extension Formatter {
                 nextTokenAfterTry = nextTokenAfterTryOperator
             }
 
-            if let followingExpression = parseExpressionRange(startingAt: nextTokenAfterTry) {
+            if let followingExpression = parseExpressionRange(startingAt: nextTokenAfterTry, allowConditionalExpressions: allowConditionalExpressions) {
                 return startIndex ... followingExpression.upperBound
             }
         }
@@ -1459,10 +1466,16 @@ extension Formatter {
             // #selector() and macro expansions like #macro() are parsed into keyword tokens.
             endOfExpression = startIndex
 
+        case .keyword("if"), .keyword("switch"):
+            guard allowConditionalExpressions,
+                  let conditionalBranches = conditionalBranches(at: startIndex),
+                  let lastBranch = conditionalBranches.last
+            else { return nil }
+            endOfExpression = lastBranch.endOfBranch
+
         default:
             return nil
         }
-
         while let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfExpression),
               let nextToken = token(at: nextTokenIndex)
         {
@@ -1479,7 +1492,7 @@ extension Formatter {
                 endOfExpression = endOfScope
 
             /// Any value can be followed by a `.identifier`
-            case .delimiter("."):
+            case .delimiter("."), .operator(".", _):
                 guard let nextIdentifierIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: nextTokenIndex),
                       tokens[nextIdentifierIndex].isIdentifier
                 else { return startIndex ... endOfExpression }
@@ -1555,6 +1568,73 @@ extension Formatter {
             let lb = rhs.module.lowercased()
             return la == lb ? lhs.module < rhs.module : la < lb
         }
+    }
+
+    /// A property of the format `(let|var) identifier: Type = expression`.
+    ///  - `: Type` and `= expression` elements are optional
+    struct PropertyDeclaration {
+        let introducerIndex: Int
+        let identifier: String
+        let identifierIndex: Int
+        let type: (colonIndex: Int, name: String, range: ClosedRange<Int>)?
+        let value: (assignmentIndex: Int, expressionRange: ClosedRange<Int>)?
+
+        var range: ClosedRange<Int> {
+            if let value = value {
+                return introducerIndex ... value.expressionRange.upperBound
+            } else if let type = type {
+                return introducerIndex ... type.range.upperBound
+            } else {
+                return introducerIndex ... identifierIndex
+            }
+        }
+    }
+
+    /// Parses a property of the format `(let|var) identifier: Type = expression`
+    /// starting at the given introducer index (the `let` / `var` keyword).
+    func parsePropertyDeclaration(atIntroducerIndex introducerIndex: Int) -> PropertyDeclaration? {
+        assert(["let", "var"].contains(tokens[introducerIndex].string))
+
+        guard let propertyIdentifierIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: introducerIndex),
+              let propertyIdentifier = token(at: propertyIdentifierIndex),
+              propertyIdentifier.isIdentifier
+        else { return nil }
+
+        var typeInformation: (colonIndex: Int, name: String, range: ClosedRange<Int>)?
+
+        if let colonIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: propertyIdentifierIndex),
+           tokens[colonIndex] == .delimiter(":"),
+           let startOfTypeIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
+           let type = parseType(at: startOfTypeIndex)
+        {
+            typeInformation = (
+                colonIndex: colonIndex,
+                name: type.name,
+                range: type.range
+            )
+        }
+
+        let endOfTypeOrIdentifier = typeInformation?.range.upperBound ?? propertyIdentifierIndex
+        var valueInformation: (assignmentIndex: Int, expressionRange: ClosedRange<Int>)?
+
+        if let assignmentIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfTypeOrIdentifier),
+           tokens[assignmentIndex] == .operator("=", .infix),
+           let startOfExpression = index(of: .nonSpaceOrCommentOrLinebreak, after: assignmentIndex),
+           let expressionRange = parseExpressionRange(startingAt: startOfExpression, allowConditionalExpressions: true)
+        {
+            valueInformation = (
+                assignmentIndex: assignmentIndex,
+                expressionRange: expressionRange
+            )
+        }
+
+        return PropertyDeclaration(
+            introducerIndex: introducerIndex,
+            identifier: propertyIdentifier.string,
+            identifierIndex: propertyIdentifierIndex,
+            type: typeInformation,
+            value: valueInformation
+        )
     }
 
     /// Shared import rules implementation

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7235,15 +7235,10 @@ public struct _FormatRules {
             //    matches the identifier assigned on each conditional branch.
             if let introducerIndex = formatter.indexOfLastSignificantKeyword(at: startOfConditional, excluding: ["if", "switch"]),
                ["let", "var"].contains(formatter.tokens[introducerIndex].string),
-               let propertyIdentifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: introducerIndex),
-               let propertyIdentifier = formatter.token(at: propertyIdentifierIndex),
-               propertyIdentifier.isIdentifier,
-               formatter.tokens[lvalueRange.lowerBound] == propertyIdentifier,
-               lvalueRange.count == 1,
-               let colonIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: propertyIdentifierIndex),
-               formatter.tokens[colonIndex] == .delimiter(":"),
-               let startOfTypeIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
-               let typeRange = formatter.parseType(at: startOfTypeIndex)?.range,
+               let property = formatter.parsePropertyDeclaration(atIntroducerIndex: introducerIndex),
+               formatter.tokens[lvalueRange.lowerBound].string == property.identifier,
+               property.value == nil,
+               let typeRange = property.type?.range,
                let nextTokenAfterProperty = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: typeRange.upperBound),
                nextTokenAfterProperty == startOfConditional
             {
@@ -7923,11 +7918,9 @@ public struct _FormatRules {
                 // It should take the form `(let|var) propertyName: (Type) = .staticMember`
                 let introducerIndex = formatter.indexOfLastSignificantKeyword(at: equalsIndex),
                 ["var", "let"].contains(formatter.tokens[introducerIndex].string),
-                let colonIndex = formatter.index(of: .delimiter(":"), before: equalsIndex),
-                introducerIndex < colonIndex,
-                let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
-                let type = formatter.parseType(at: typeStartIndex),
-                let rhsStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex)
+                let property = formatter.parsePropertyDeclaration(atIntroducerIndex: introducerIndex),
+                let type = property.type,
+                let rhsStartIndex = property.value?.expressionRange.lowerBound
             else { return }
 
             let typeTokens = formatter.tokens[type.range]
@@ -7970,7 +7963,48 @@ public struct _FormatRules {
             }
 
             // Remove the colon and explicit type before the equals token
-            formatter.removeTokens(in: colonIndex ... type.range.upperBound)
+            formatter.removeTokens(in: type.colonIndex ... type.range.upperBound)
+        }
+    }
+
+    public let redundantProperty = FormatRule(
+        help: "Simplifies redundant property definitions that are immediately returned.",
+        disabledByDefault: true,
+        orderAfter: ["preferInferredTypes"]
+    ) { formatter in
+        formatter.forEach(.keyword) { introducerIndex, introducerToken in
+            // Find properties like `let identifier = value` followed by `return identifier`
+            guard ["let", "var"].contains(introducerToken.string),
+                  let property = formatter.parsePropertyDeclaration(atIntroducerIndex: introducerIndex),
+                  let (assignmentIndex, expressionRange) = property.value,
+                  let returnIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: expressionRange.upperBound),
+                  formatter.tokens[returnIndex] == .keyword("return"),
+                  let returnedValueIndex = formatter.index(of: .nonSpaceOrComment, after: returnIndex),
+                  let returnedExpression = formatter.parseExpressionRange(startingAt: returnedValueIndex, allowConditionalExpressions: true),
+                  formatter.tokens[returnedExpression] == [.identifier(property.identifier)]
+            else { return }
+
+            let returnRange = formatter.startOfLine(at: returnIndex) ... formatter.endOfLine(at: returnedExpression.upperBound)
+            let propertyRange = introducerIndex ... expressionRange.upperBound
+
+            guard !propertyRange.overlaps(returnRange) else { return }
+
+            // Remove the line with the `return identifier` statement.
+            formatter.removeTokens(in: returnRange)
+
+            // If there's nothing but whitespace between the end of the expression
+            // and the return statement, we can remove all of it. But if there's a comment,
+            // we should preserve it.
+            let rangeBetweenExpressionAndReturn = (expressionRange.upperBound + 1) ..< (returnRange.lowerBound - 1)
+            if formatter.tokens[rangeBetweenExpressionAndReturn].allSatisfy(\.isSpaceOrLinebreak) {
+                formatter.removeTokens(in: rangeBetweenExpressionAndReturn)
+            }
+
+            // Replace the `let identifier = value` with `return value`
+            formatter.replaceTokens(
+                in: introducerIndex ..< expressionRange.lowerBound,
+                with: [.keyword("return"), .space(" ")]
+            )
         }
     }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1827,7 +1827,10 @@ class ParsingHelpersTests: XCTestCase {
     // MARK: - parseExpressionRange
 
     func testParseIndividualExpressions() {
+        XCTAssert(isSingleExpression(#"Foo()"#))
         XCTAssert(isSingleExpression(#"Foo("bar")"#))
+        XCTAssert(isSingleExpression(#"Foo.init()"#))
+        XCTAssert(isSingleExpression(#"Foo.init("bar")"#))
         XCTAssert(isSingleExpression(#"foo.bar"#))
         XCTAssert(isSingleExpression(#"foo .bar"#))
         XCTAssert(isSingleExpression(#"foo["bar"]("baaz")"#))
@@ -1881,6 +1884,29 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssert(isSingleExpression(#"try await { try await printAsyncThrows(foo) }()"#))
         XCTAssert(isSingleExpression(#"Foo<Bar>()"#))
         XCTAssert(isSingleExpression(#"Foo<Bar, Baaz>(quux: quux)"#))
+        XCTAssert(!isSingleExpression(#"if foo { "foo" } else { "bar" }"#))
+
+        XCTAssert(isSingleExpression(
+            #"if foo { "foo" } else { "bar" }"#,
+            allowConditionalExpressions: true
+        ))
+
+        XCTAssert(isSingleExpression("""
+        if foo {
+          "foo"
+        } else {
+          "bar"
+        }
+        """, allowConditionalExpressions: true))
+
+        XCTAssert(isSingleExpression("""
+        switch foo {
+        case true:
+            "foo"
+        case false:
+            "bar"
+        }
+        """, allowConditionalExpressions: true))
 
         XCTAssert(isSingleExpression("""
         foo
@@ -1991,9 +2017,9 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(parseExpressions(input), expectedExpressions)
     }
 
-    func isSingleExpression(_ string: String) -> Bool {
+    func isSingleExpression(_ string: String, allowConditionalExpressions: Bool = false) -> Bool {
         let formatter = Formatter(tokenize(string))
-        guard let expressionRange = formatter.parseExpressionRange(startingAt: 0) else { return false }
+        guard let expressionRange = formatter.parseExpressionRange(startingAt: 0, allowConditionalExpressions: allowConditionalExpressions) else { return false }
         return expressionRange.upperBound == formatter.tokens.indices.last!
     }
 

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -448,7 +448,7 @@ class IndentTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: FormatRules.indent,
-                       exclude: ["braces", "wrapMultilineStatementBraces"])
+                       exclude: ["braces", "wrapMultilineStatementBraces", "redundantProperty"])
     }
 
     func testIndentLineAfterIndentedInlineClosure() {
@@ -460,7 +460,7 @@ class IndentTests: RulesTests {
             return viewController
         }
         """
-        testFormatting(for: input, rule: FormatRules.indent)
+        testFormatting(for: input, rule: FormatRules.indent, exclude: ["redundantProperty"])
     }
 
     func testIndentLineAfterNonIndentedClosure() {
@@ -473,7 +473,7 @@ class IndentTests: RulesTests {
             return viewController
         }
         """
-        testFormatting(for: input, rule: FormatRules.indent)
+        testFormatting(for: input, rule: FormatRules.indent, exclude: ["redundantProperty"])
     }
 
     func testIndentMultilineStatementDoesntFailToTerminate() {
@@ -3888,7 +3888,7 @@ class IndentTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: FormatRules.indent)
+        testFormatting(for: input, output, rule: FormatRules.indent, exclude: ["redundantProperty"])
     }
 
     func testIndentNestedSwitchExpressionAssignment() {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2535,7 +2535,7 @@ class RedundancyTests: RulesTests {
             return bar
         }()
         """
-        testFormatting(for: input, rule: FormatRules.redundantReturn)
+        testFormatting(for: input, rule: FormatRules.redundantReturn, exclude: ["redundantProperty"])
     }
 
     func testNoRemoveReturnInForWhereLoop() {
@@ -2658,7 +2658,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: FormatRules.redundantReturn,
-                       options: FormatOptions(swiftVersion: "5.1"))
+                       options: FormatOptions(swiftVersion: "5.1"), exclude: ["redundantProperty"])
     }
 
     func testDisableNextRedundantReturn() {
@@ -3220,6 +3220,58 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.10")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
+    func testRemovesRedundantReturnBeforeIfExpression() {
+        let input = """
+        func foo() -> Foo {
+            return if condition {
+                Foo.foo()
+            } else {
+                Foo.bar()
+            }
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            if condition {
+                Foo.foo()
+            } else {
+                Foo.bar()
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
+    }
+
+    func testRemovesRedundantReturnBeforeSwitchExpression() {
+        let input = """
+        func foo() -> Foo {
+            return switch condition {
+            case true:
+                Foo.foo()
+            case false:
+                Foo.bar()
+            }
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            switch condition {
+            case true:
+                Foo.foo()
+            case false:
+                Foo.bar()
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: FormatRules.redundantReturn, options: options)
     }
 
@@ -5137,7 +5189,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options, exclude: ["redundantProperty"])
     }
 
     func testDisableRedundantSelfDirective() {
@@ -5151,7 +5203,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options, exclude: ["redundantProperty"])
     }
 
     func testDisableRedundantSelfDirective2() {
@@ -5166,7 +5218,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options, exclude: ["redundantProperty"])
     }
 
     func testSelfInsertDirective() {
@@ -5180,7 +5232,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantSelf, options: options, exclude: ["redundantProperty"])
     }
 
     func testNoRemoveVariableShadowedLaterInScopeInOlderSwiftVersions() {
@@ -7220,7 +7272,7 @@ class RedundancyTests: RulesTests {
             return parser
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedArguments)
+        testFormatting(for: input, rule: FormatRules.unusedArguments, exclude: ["redundantProperty"])
     }
 
     func testShadowedClosureArgument2() {
@@ -7230,7 +7282,7 @@ class RedundancyTests: RulesTests {
             return input
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedArguments)
+        testFormatting(for: input, rule: FormatRules.unusedArguments, exclude: ["redundantProperty"])
     }
 
     func testUnusedPropertyWrapperArgument() {
@@ -7631,7 +7683,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedArguments)
+        testFormatting(for: input, rule: FormatRules.unusedArguments, exclude: ["redundantProperty"])
     }
 
     func testTryAwaitArgumentNotMarkedUnused() {
@@ -7642,7 +7694,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedArguments)
+        testFormatting(for: input, rule: FormatRules.unusedArguments, exclude: ["redundantProperty"])
     }
 
     func testTypedTryAwaitArgumentNotMarkedUnused() {
@@ -7653,7 +7705,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedArguments)
+        testFormatting(for: input, rule: FormatRules.unusedArguments, exclude: ["redundantProperty"])
     }
 
     func testConditionalIfLetMarkedAsUnused() {
@@ -9446,5 +9498,161 @@ class RedundancyTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: FormatRules.noExplicitOwnership)
+    }
+
+    // MARK: - redundantProperty
+
+    func testRemovesRedundantProperty() {
+        let input = """
+        func foo() -> Foo {
+            let foo = Foo(bar: bar, baaz: baaz)
+            return foo
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            return Foo(bar: bar, baaz: baaz)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantProperty, exclude: ["redundantReturn"])
+    }
+
+    func testRemovesRedundantPropertyWithIfExpression() {
+        let input = """
+        func foo() -> Foo {
+            let foo =
+                if condition {
+                    Foo.foo()
+                } else {
+                    Foo.bar()
+                }
+
+            return foo
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            if condition {
+                Foo.foo()
+            } else {
+                Foo.bar()
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.redundantProperty, FormatRules.redundantReturn, FormatRules.indent], options: options)
+    }
+
+    func testRemovesRedundantPropertyWithSwitchExpression() {
+        let input = """
+        func foo() -> Foo {
+            let foo: Foo
+            switch condition {
+            case true:
+                foo = Foo(bar)
+            case false:
+                foo = Foo(baaz)
+            }
+
+            return foo
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            switch condition {
+            case true:
+                Foo(bar)
+            case false:
+                Foo(baaz)
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.9")
+        testFormatting(for: input, [output], rules: [FormatRules.conditionalAssignment, FormatRules.redundantProperty, FormatRules.redundantReturn, FormatRules.indent], options: options)
+    }
+
+    func testRemovesRedundantPropertyWithPreferInferredType() {
+        let input = """
+        func bar() -> Bar {
+            let bar: Bar = .init(baaz: baaz, quux: quux)
+            return bar
+        }
+        """
+
+        let output = """
+        func bar() -> Bar {
+            return Bar(baaz: baaz, quux: quux)
+        }
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.preferInferredTypes, FormatRules.redundantProperty, FormatRules.redundantInit], exclude: ["redundantReturn"])
+    }
+
+    func testRemovesRedundantPropertyWithComments() {
+        let input = """
+        func foo() -> Foo {
+            // There's a comment before this property
+            let foo = Foo(bar: bar, baaz: baaz)
+            // And there's a comment after the property
+            return foo
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            // There's a comment before this property
+            return Foo(bar: bar, baaz: baaz)
+            // And there's a comment after the property
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantProperty, exclude: ["redundantReturn"])
+    }
+
+    func testRemovesRedundantPropertyFollowingOtherProperty() {
+        let input = """
+        func foo() -> Foo {
+            let bar = Bar(baaz: baaz)
+            let foo = Foo(bar: bar)
+            return foo
+        }
+        """
+
+        let output = """
+        func foo() -> Foo {
+            let bar = Bar(baaz: baaz)
+            return Foo(bar: bar)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.redundantProperty)
+    }
+
+    func testPreservesPropertyWhereReturnIsNotRedundant() {
+        let input = """
+        func foo() -> Foo {
+            let foo = Foo(bar: bar, baaz: baaz)
+            return foo.with(quux: quux)
+        }
+
+        func bar() -> Foo {
+            let bar = Bar(baaz: baaz)
+            return bar.baaz
+        }
+
+        func baaz() -> Foo {
+            let bar = Bar(baaz: baaz)
+            print(bar)
+            return bar
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.redundantProperty)
     }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -3270,7 +3270,7 @@ class SyntaxTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: FormatRules.docComments,
-                       exclude: ["spaceInsideComments"])
+                       exclude: ["spaceInsideComments", "redundantProperty"])
     }
 
     func testPreservesDocComments() {
@@ -3347,7 +3347,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(preserveDocComments: true)
-        testFormatting(for: input, output, rule: FormatRules.docComments, options: options, exclude: ["spaceInsideComments"])
+        testFormatting(for: input, output, rule: FormatRules.docComments, options: options, exclude: ["spaceInsideComments", "redundantProperty"])
     }
 
     func testDoesntConvertCommentBeforeConsecutivePropertiesToDocComment() {


### PR DESCRIPTION
This PR adds a new `redundantProperty` rule, which removes a property declaration if that property is just returned immediately. For example:

```diff
  func foo() -> Foo {
-   let foo = Foo()
-   return foo
+   return Foo()
  }
```

Here's an example of a pattern I saw somewhat frequently in Airbnb's codebase:

```swift
func foo() -> Foo {
    let foo: Foo
    switch condition {
    case true:
        foo = Foo(bar)
    case false:
        foo = Foo(baaz)
    }

    return foo
}
```

The `conditionalAssignment` rule converts this to `let foo = switch { ... }; return foo`. Now with both `conditionalAssignment` and `redundantProperty` enabled, it's instead converted to an even simpler form:

```swift
func foo() -> Foo {
    switch condition {
    case true:
        Foo(bar)
    case false:
        Foo(baaz)
    }
}
```