### PR TITLE
Extend preferInferredTypes rule to support if/switch expressions

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1452,6 +1452,10 @@ Option | Description
 
 Prefer using inferred types on property definitions (`let foo = Foo()`) rather than explicit types (`let foo: Foo = .init()`).
 
+Option | Description
+--- | ---
+`--inferredtypes` | "exclude-cond-exprs" (default) or "always"
+
 <details>
 <summary>Examples</summary>
 
@@ -1468,6 +1472,17 @@ Prefer using inferred types on property definitions (`let foo = Foo()`) rather t
   let float: CGFloat = 10.0
   let array: [String] = []
   let anyFoo: AnyFoo = foo
+
+  // with --inferredtypes always:
+- let foo: Foo =
++ let foo =
+    if condition {
+-     .init(bar)
++     Foo(bar)
+    } else {
+-     .init(baaz)
++     Foo(baaz)
+    }
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1856,6 +1856,17 @@ private struct Examples {
       let float: CGFloat = 10.0
       let array: [String] = []
       let anyFoo: AnyFoo = foo
+
+      // with --inferredtypes always:
+    - let foo: Foo =
+    + let foo =
+        if condition {
+    -     .init(bar)
+    +     Foo(bar)
+        } else {
+    -     .init(baaz)
+    +     Foo(baaz)
+        }
     ```
     """
 }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -907,6 +907,14 @@ struct _Descriptors {
         help: "\"inferred\", \"explicit\", or \"infer-locals-only\" (default)",
         keyPath: \.redundantType
     )
+    let inferredTypesInConditionalExpressions = OptionDescriptor(
+        argumentName: "inferredtypes",
+        displayName: "Prefer Inferred Types",
+        help: "\"exclude-cond-exprs\" (default) or \"always\"",
+        keyPath: \.inferredTypesInConditionalExpressions,
+        trueValues: ["exclude-cond-exprs"],
+        falseValues: ["always"]
+    )
     let emptyBracesSpacing = OptionDescriptor(
         argumentName: "emptybraces",
         displayName: "Empty Braces",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -652,6 +652,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var redundantType: RedundantType
+    public var inferredTypesInConditionalExpressions: Bool
     public var emptyBracesSpacing: EmptyBracesSpacing
     public var acronyms: Set<String>
     public var indentStrings: Bool
@@ -765,6 +766,7 @@ public struct FormatOptions: CustomStringConvertible {
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 redundantType: RedundantType = .inferLocalsOnly,
+                inferredTypesInConditionalExpressions: Bool = false,
                 emptyBracesSpacing: EmptyBracesSpacing = .noSpace,
                 acronyms: Set<String> = ["ID", "URL", "UUID"],
                 indentStrings: Bool = false,
@@ -868,6 +870,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
         self.redundantType = redundantType
+        self.inferredTypesInConditionalExpressions = inferredTypesInConditionalExpressions
         self.emptyBracesSpacing = emptyBracesSpacing
         self.acronyms = acronyms
         self.indentStrings = indentStrings

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -4394,7 +4394,7 @@ public struct _FormatRules {
     ) { formatter in
         formatter.forEach(.identifier("init")) { i, _ in
             guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i, if: {
-                $0 == .operator(".", .infix)
+                $0.isOperator(".")
             }), let openParenIndex = formatter.index(of: .nonSpaceOrLinebreak, after: i, if: {
                 $0 == .startOfScope("(")
             }), let closeParenIndex = formatter.index(of: .endOfScope(")"), after: openParenIndex),
@@ -7911,9 +7911,15 @@ public struct _FormatRules {
         help: "Prefer using inferred types on property definitions (`let foo = Foo()`) rather than explicit types (`let foo: Foo = .init()`).",
         disabledByDefault: true,
         orderAfter: ["redundantType"],
+        options: ["inferredtypes"],
         sharedOptions: ["redundanttype"]
     ) { formatter in
         formatter.forEach(.operator("=", .infix)) { equalsIndex, _ in
+            // Respect the `.inferLocalsOnly` option if enabled
+            if formatter.options.redundantType == .inferLocalsOnly,
+               formatter.declarationScope(at: equalsIndex) != .local
+            { return }
+
             guard // Parse and validate the LHS of the property declaration.
                 // It should take the form `(let|var) propertyName: (Type) = .staticMember`
                 let introducerIndex = formatter.indexOfLastSignificantKeyword(at: equalsIndex),
@@ -7922,20 +7928,47 @@ public struct _FormatRules {
                 introducerIndex < colonIndex,
                 let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
                 let type = formatter.parseType(at: typeStartIndex),
-                // If the RHS starts with a leading dot, then we know its accessing some static member on this type.
-                let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
-                formatter.tokens[dotIndex] == .operator(".", .prefix)
+                let rhsStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex)
             else { return }
-
-            // Respect the `.inferLocalsOnly` option if enabled
-            if formatter.options.redundantType == .inferLocalsOnly,
-               formatter.declarationScope(at: equalsIndex) != .local
-            { return }
 
             let typeTokens = formatter.tokens[type.range]
 
-            // Insert a copy of the type on the RHS before the dot
-            formatter.insert(typeTokens, at: dotIndex)
+            // If the RHS starts with a leading dot, then we know its accessing some static member on this type.
+            if formatter.tokens[rhsStartIndex].isOperator(".") {
+                // Insert a copy of the type on the RHS before the dot
+                formatter.insert(typeTokens, at: rhsStartIndex)
+            }
+
+            // If the RHS is an if/switch expression, check that each branch starts with a leading dot
+            else if formatter.options.inferredTypesInConditionalExpressions,
+                    ["if", "switch"].contains(formatter.tokens[rhsStartIndex].string),
+                    let conditonalBranches = formatter.conditionalBranches(at: rhsStartIndex)
+            {
+                var hasInvalidConditionalBranch = false
+                formatter.forEachRecursiveConditionalBranch(in: conditonalBranches) { branch in
+                    guard let firstTokenInBranch = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: branch.startOfBranch) else {
+                        hasInvalidConditionalBranch = true
+                        return
+                    }
+
+                    if !formatter.tokens[firstTokenInBranch].isOperator(".") {
+                        hasInvalidConditionalBranch = true
+                    }
+                }
+
+                guard !hasInvalidConditionalBranch else { return }
+
+                // Insert a copy of the type on the RHS before the dot in each branch
+                formatter.forEachRecursiveConditionalBranch(in: conditonalBranches) { branch in
+                    guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: branch.startOfBranch) else { return }
+
+                    formatter.insert(typeTokens, at: dotIndex)
+                }
+            }
+
+            else {
+                return
+            }
 
             // Remove the colon and explicit type before the equals token
             formatter.removeTokens(in: colonIndex ... type.range.upperBound)

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4847,19 +4847,19 @@ class SyntaxTests: RulesTests {
         """
 
         let output = """
-        let foo = Foo.init()
+        let foo = Foo()
         let bar = Bar.staticBar
         let baaz = Baaz.Example.default
         let quux = Quux.quuxBulder(foo: .foo, bar: .bar)
 
-        let dictionary = [Foo: Bar].init()
-        let array = [Foo].init()
-        let genericType = MyGenericType<Foo, Bar>.init()
-        let optional = String?.init("Foo")
+        let dictionary = [Foo: Bar]()
+        let array = [Foo]()
+        let genericType = MyGenericType<Foo, Bar>()
+        let optional = String?("Foo")
         """
 
         let options = FormatOptions(redundantType: .inferred)
-        testFormatting(for: input, output, rule: FormatRules.preferInferredTypes, options: options, exclude: ["redundantInit"])
+        testFormatting(for: input, [output], rules: [FormatRules.preferInferredTypes, FormatRules.redundantInit], options: options)
     }
 
     func testPreservesExplicitTypeIfNoRHS() {
@@ -4929,12 +4929,88 @@ class SyntaxTests: RulesTests {
         let foo: Foo = .init()
 
         func bar() {
-            let baaz = Baaz.init()
-            let baaz = Baaz.init()
+            let baaz = Baaz()
+            let baaz = Baaz()
         }
         """
 
         let options = FormatOptions(redundantType: .inferLocalsOnly)
-        testFormatting(for: input, [output], rules: [FormatRules.redundantType, FormatRules.preferInferredTypes], options: options, exclude: ["redundantInit"])
+        testFormatting(for: input, [output], rules: [FormatRules.redundantType, FormatRules.preferInferredTypes, FormatRules.redundantInit], options: options)
+    }
+
+    func testPreferInferredTypesWithIfExpressionDisabledByDefault() {
+        let input = """
+        let foo: SomeTypeWithALongGenrericName<AndGenericArgument> =
+            if condition {
+                .init(bar)
+            } else {
+                .init(baaz)
+            }
+        """
+
+        let options = FormatOptions(redundantType: .inferred)
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes, options: options)
+    }
+
+    func testPreferInferredTypesWithIfExpression() {
+        let input = """
+        let foo: Foo =
+            if condition {
+                .init(bar)
+            } else {
+                .init(baaz)
+            }
+        """
+
+        let output = """
+        let foo =
+            if condition {
+                Foo(bar)
+            } else {
+                Foo(baaz)
+            }
+        """
+
+        let options = FormatOptions(redundantType: .inferred, inferredTypesInConditionalExpressions: true)
+        testFormatting(for: input, [output], rules: [FormatRules.preferInferredTypes, FormatRules.redundantInit], options: options)
+    }
+
+    func testPreferInferredTypesWithSwitchExpression() {
+        let input = """
+        let foo: Foo =
+            switch condition {
+            case true:
+                .init(bar)
+            case false:
+                .init(baaz)
+            }
+        """
+
+        let output = """
+        let foo =
+            switch condition {
+            case true:
+                Foo(bar)
+            case false:
+                Foo(baaz)
+            }
+        """
+
+        let options = FormatOptions(redundantType: .inferred, inferredTypesInConditionalExpressions: true)
+        testFormatting(for: input, [output], rules: [FormatRules.preferInferredTypes, FormatRules.redundantInit], options: options)
+    }
+
+    func testPreservesNonMatchingIfExpression() {
+        let input = """
+        let foo: Foo =
+            if condition {
+                .init(bar)
+            } else {
+                [] // e.g. using ExpressibleByArrayLiteral
+            }
+        """
+
+        let options = FormatOptions(redundantType: .inferred, inferredTypesInConditionalExpressions: true)
+        testFormatting(for: input, rule: FormatRules.preferInferredTypes, options: options)
     }
 }


### PR DESCRIPTION
The PR extends the `preferInferredTypes` rule to support if/switch expressions.

Previously this example was left as-is:

```swift
let foo: Foo =
    if condition {
        .init(bar)
    } else {
        .init(baaz)
    }
```

Now it's converted to:

```swift
let foo =
    if condition {
        Foo(bar)
    } else {
        Foo(baaz)
    }
```