### PR TITLE
Fix issue where --wrapreturntype if-multiline didn't work with arrays, dictionaries, tuples, or generic types

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -329,8 +329,7 @@ extension Formatter {
             endOfFunctionScope: Int
         ) {
             guard token(at: startOfScope) == .startOfScope("("),
-                  let openBracket = index(of: .startOfScope, after: endOfFunctionScope),
-                  token(at: openBracket) == .startOfScope("{")
+                  let openBracket = index(of: .startOfScope("{"), after: endOfFunctionScope)
             else { return }
 
             func wrap(before index: Int) {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -3720,7 +3720,132 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(
             wrapArguments: .beforeFirst,
             closingParenOnSameLine: true,
-            wrapReturnType: .ifMultiline
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+        testFormatting(for: input, [output], rules: [
+            FormatRules.wrapMultilineStatementBraces,
+            FormatRules.wrapArguments,
+        ], options: options)
+    }
+
+    func testWrapsMultilineStatementConsistentlyWithEffects() {
+        let input = """
+        func aFunc(
+            one _: Int,
+            two _: Int) async throws -> String {
+            "one"
+        }
+        """
+
+        let output = """
+        func aFunc(
+            one _: Int,
+            two _: Int)
+            async throws -> String
+        {
+            "one"
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+        testFormatting(for: input, [output], rules: [
+            FormatRules.wrapMultilineStatementBraces,
+            FormatRules.wrapArguments,
+        ], options: options)
+    }
+
+    func testWrapsMultilineStatementConsistentlyWithArrayReturnType() {
+        let input = """
+        public func aFunc(
+            one _: Int,
+            two _: Int) -> [String] {
+            ["one"]
+        }
+        """
+
+        let output = """
+        public func aFunc(
+            one _: Int,
+            two _: Int)
+            -> [String]
+        {
+            ["one"]
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+        testFormatting(for: input, [output], rules: [
+            FormatRules.wrapMultilineStatementBraces,
+            FormatRules.wrapArguments,
+        ], options: options)
+    }
+
+    func testWrapsMultilineStatementConsistentlyWithComplexGenericReturnType() {
+        let input = """
+        public func aFunc(
+            one _: Int,
+            two _: Int) throws -> some Collection<String> {
+            ["one"]
+        }
+        """
+
+        let output = """
+        public func aFunc(
+            one _: Int,
+            two _: Int)
+            throws -> some Collection<String>
+        {
+            ["one"]
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+        testFormatting(for: input, [output], rules: [
+            FormatRules.wrapMultilineStatementBraces,
+            FormatRules.wrapArguments,
+        ], options: options)
+    }
+
+    func testWrapsMultilineStatementConsistentlyWithTuple() {
+        let input = """
+        public func aFunc(
+            one: Int,
+            two: Int) -> (one: String, two: String) {
+            (one: String(one), two: String(two))
+        }
+        """
+
+        let output = """
+        public func aFunc(
+            one: Int,
+            two: Int)
+            -> (one: String, two: String)
+        {
+            (one: String(one), two: String(two))
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenOnSameLine: true,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
         )
         testFormatting(for: input, [output], rules: [
             FormatRules.wrapMultilineStatementBraces,


### PR DESCRIPTION
This PR fixes an issue where the `--wrapreturntype if-multiline` option didn't work if the return type was an array, dictionary, tuple, or generic type.