### PR TITLE
Add --strict option to emit non-zero exit code after applying changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Error codes
 The swiftformat command-line tool will always exit with one of the following codes:
 
 * 0 - Success. This code will be returned in the event of a successful formatting run or if `--lint` detects no violations.
-* 1 - Lint failure. This code will be returned only when running in `--lint` mode if the input requires formatting.
+* 1 - Lint failure. This code will be returned when running in `--lint` mode, or when autocorrecting in `--strict` mode, if the input requires formatting.
 * 70 - Program error. This code will be returned if there is a problem with the input or configuration arguments.
 
 

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -663,6 +663,7 @@ let commandLineArguments = [
     "dryrun",
     "lint",
     "lenient",
+    "strict",
     "verbose",
     "quiet",
     "reporter",


### PR DESCRIPTION
This PR adds a new `--strict` option that causes SwiftFormat to emit a non-zero exit code if it applies any formatting changes.

Within Airbnb we want our tooling to be able to detect when running SwiftFormat applies formatting changes. Historically we've done this by running SwiftFormat twice: once with `--lint` to determine whether or not there are changes needing formatting, and then again without `--lint`. This isn't very efficient since it requires running SwiftFormat twice, so instead we'd like to just run SwiftFormat a single time. A `--strict` option is really helpful for this.

As an example of prior art, [SwiftLint](https://github.com/realm/SwiftLint) also provides a `--strict` flag with this exact same functionality (it causes autocorrect to return a non-zero exit code after applying changes).

------

I experimented with adding a test for this in `CommandLineTests`, but after some tinkering didn't find an easy way to set up the test case. I see there's no test case for the `--lenient` flag for example. Happy to revist this if you'd like.

I have confirmed that this functionality works in an executable build, and validated that it unlocks the workflow that we're interested in using within Airbnb.