### PR TITLE
`organizeDeclarations` by type

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1372,9 +1372,12 @@ Option | Description
 `--classthreshold` | Minimum line count to organize class body. Defaults to 0
 `--enumthreshold` | Minimum line count to organize enum body. Defaults to 0
 `--extensionlength` | Minimum line count to organize extension body. Defaults to 0
+`--organizationmode` | Organization mode for declarations. Defaults to "visibility"
 
 <details>
 <summary>Examples</summary>
+
+`--organizationmode visibility` (default)
 
 ```diff
   public class Foo {
@@ -1415,6 +1418,47 @@ Option | Description
 +     // MARK: Private
 +
 +     private let g: Int = 2
++
+ }
+```
+
+`--organizationmode type`
+
+```diff
+  public class Foo {
+-     public func c() -> String {}
+-
+-     public let a: Int = 1
+-     private let g: Int = 2
+-     let e: Int = 2
+-     public let b: Int = 3
+-
+-     public func d() {}
+-     func f() {}
+-     init() {}
+-     deinit() {}
+ }
+
+  public class Foo {
++
++     // MARK: Properties
++
++     public let a: Int = 1
++     public let b: Int = 3
++
++     let e: Int = 2
++
++     private let g: Int = 2
++
++     // MARK: Lifecycle
++
++     init() {}
++     deinit() {}
++
++     // MARK: Functions
++
++     public func c() -> String {}
++     public func d() {}
 +
  }
 ```

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1288,6 +1288,8 @@ private struct Examples {
     """
 
     let organizeDeclarations = """
+    `--organizationmode visibility` (default)
+
     ```diff
       public class Foo {
     -     public func c() -> String {}
@@ -1327,6 +1329,47 @@ private struct Examples {
     +     // MARK: Private
     +
     +     private let g: Int = 2
+    +
+     }
+    ```
+
+    `--organizationmode type`
+
+    ```diff
+      public class Foo {
+    -     public func c() -> String {}
+    -
+    -     public let a: Int = 1
+    -     private let g: Int = 2
+    -     let e: Int = 2
+    -     public let b: Int = 3
+    -
+    -     public func d() {}
+    -     func f() {}
+    -     init() {}
+    -     deinit() {}
+     }
+
+      public class Foo {
+    +
+    +     // MARK: Properties
+    +
+    +     public let a: Int = 1
+    +     public let b: Int = 3
+    +
+    +     let e: Int = 2
+    +
+    +     private let g: Int = 2
+    +
+    +     // MARK: Lifecycle
+    +
+    +     init() {}
+    +     deinit() {}
+    +
+    +     // MARK: Functions
+    +
+    +     public func c() -> String {}
+    +     public func d() {}
     +
      }
     ```

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1779,42 +1779,31 @@ extension Formatter {
 /// Utility functions used by organizeDeclarations rule
 // TODO: find a better place to put this
 extension Formatter {
-    /// Categories of declarations within an individual type
-    enum Category: String, CaseIterable {
-        case beforeMarks
-        case lifecycle
-        case open
-        case `public`
-        case package
-        case `internal`
-        case `fileprivate`
-        case `private`
+    struct Category: Equatable, Hashable {
+        var visibility: VisibilityType
+        var type: DeclarationType
+        var order: Int
 
-        init(from visibility: Visibility) {
-            switch visibility {
-            case .open:
-                self = .open
-            case .public:
-                self = .public
-            case .package:
-                self = .package
-            case .internal:
-                self = .internal
-            case .fileprivate:
-                self = .fileprivate
-            case .private:
-                self = .private
+        func shouldBeMarked(in categories: Set<Category>, for mode: DeclarationOrganizationMode) -> Bool {
+            guard type != .beforeMarks else {
+                return false
+            }
+
+            switch mode {
+            case .type:
+                return !categories.contains(where: { $0.type == type })
+            case .visibility:
+                return !categories.contains(where: { $0.visibility == visibility })
             }
         }
 
         /// The comment tokens that should precede all declarations in this category
-        func markComment(from template: String) -> String? {
-            switch self {
-            case .beforeMarks:
-                return nil
-            default:
-                return "// \(template.replacingOccurrences(of: "%c", with: rawValue.capitalized))"
-            }
+        func markComment(from template: String, with mode: DeclarationOrganizationMode) -> String? {
+            "// " + template
+                .replacingOccurrences(
+                    of: "%c",
+                    with: mode == .type ? type.rawValue : visibility.rawValue
+                )
         }
     }
 
@@ -1832,80 +1821,122 @@ extension Formatter {
         }
     }
 
-    /// Types of declarations that can be present within an individual category
-    enum DeclarationType {
+    /// The visibility category of a declaration
+    enum VisibilityType: CaseIterable, Hashable {
+        case visibility(Visibility)
+        case explicit(DeclarationType)
+
+        var rawValue: String {
+            switch self {
+            case let .visibility(type):
+                type.rawValue.capitalized
+            case let .explicit(type):
+                type.rawValue
+            }
+        }
+
+        static var allCases: [VisibilityType] {
+            [.explicit(.beforeMarks), .explicit(.instanceLifecycle)] + Visibility.allCases
+                .map { .visibility($0) }
+        }
+    }
+
+    /// The type of a declaration
+    enum DeclarationType: String, CaseIterable {
+        case beforeMarks
         case nestedType
         case staticProperty
         case staticPropertyWithBody
         case classPropertyWithBody
+        case overriddenProperty
         case instanceProperty
         case instancePropertyWithBody
+        case instanceLifecycle
+        case swiftUIProperty
+        case swiftUIMethod
+        case overriddenMethod
         case staticMethod
         case classMethod
         case instanceMethod
-    }
+        case conditionalCompilation
 
-    static let categoryOrdering: [Category] = [
-        .beforeMarks, .lifecycle, .open, .public, .package, .internal, .fileprivate, .private,
-    ]
-
-    static let categorySubordering: [DeclarationType] = [
-        .nestedType, .staticProperty, .staticPropertyWithBody, .classPropertyWithBody,
-        .instanceProperty, .instancePropertyWithBody, .staticMethod, .classMethod, .instanceMethod,
-    ]
-
-    /// The `Category` of the given `Declaration`
-    func category(of declaration: Declaration) -> Category {
-        switch declaration {
-        case let .declaration(keyword, tokens), let .type(keyword, open: tokens, _, _):
-            guard let keywordIndex = tokens.firstIndex(of: .keyword(keyword)) else {
-                // This should never happen (the declaration's `keyword` will always be present in the tokens)
-                return .internal
+        var rawValue: String {
+            switch self {
+            case .beforeMarks:
+                "Before Marks"
+            case .nestedType:
+                "Nested Types"
+            case .staticProperty:
+                "Static Properties"
+            case .staticPropertyWithBody:
+                "Static Computed Properties"
+            case .classPropertyWithBody:
+                "Class Properties"
+            case .overriddenProperty:
+                "Overridden Properties"
+            case .instanceLifecycle:
+                "Lifecycle"
+            case .overriddenMethod:
+                "Overridden Functions"
+            case .swiftUIProperty, .swiftUIMethod:
+                "Content"
+            case .instanceProperty:
+                "Properties"
+            case .instancePropertyWithBody:
+                "Computed Properties"
+            case .staticMethod:
+                "Static Functions"
+            case .classMethod:
+                "Class Functions"
+            case .instanceMethod:
+                "Functions"
+            case .conditionalCompilation:
+                "Conditional Compilation"
             }
+        }
 
-            // Enum cases don't fit into any of the other categories,
-            // so they should go in the initial top section.
-            //  - The user can also provide other declaration types to place in this category
-            if keyword == "case" || options.beforeMarks.contains(keyword) {
-                return .beforeMarks
-            }
-
-            let parser = Formatter(tokens)
-            if Formatter.categoryOrdering.contains(.lifecycle) {
-                // `init` and `deinit` always go in Lifecycle if it's present
-                if ["init", "deinit"].contains(keyword) {
-                    return .lifecycle
-                }
-
-                // The user can also provide specific instance method names to place in Lifecycle
-                //  - In the function declaration grammar, the function name always
-                //    immediately follows the `func` keyword:
-                //    https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_function-name
-                if keyword == "func",
-                   let methodName = parser.next(.nonSpaceOrCommentOrLinebreak, after: keywordIndex),
-                   options.lifecycleMethods.contains(methodName.string)
-                {
-                    return .lifecycle
-                }
-            }
-
-            // Other than `beforeMarks` and `lifecycle`, the category is just the visibility level
-            return Category(from: visibility(of: declaration) ?? .internal)
-
-        case let .conditionalCompilation(_, body, _):
-            // Conditional compilation blocks themselves don't have a category or visbility-level,
-            // but we still have to assign them a category for the sorting algorithm to function.
-            // A reasonable heuristic here is to simply use the category of the first declaration
-            // inside the conditional compilation block.
-            if let firstDeclarationInBlock = body.first {
-                return category(of: firstDeclarationInBlock)
-            } else {
-                return .beforeMarks
+        func shouldBeMarked(in declarationTypes: [DeclarationType]) -> Bool {
+            switch self {
+            case .beforeMarks, .classPropertyWithBody:
+                false
+            case .swiftUIMethod:
+                !declarationTypes.contains(.swiftUIProperty)
+            default:
+                true
             }
         }
     }
 
-    /// The access control `Visibility` of the given `Declaration`
+    func category(of declaration: Declaration, for mode: DeclarationOrganizationMode) -> Category {
+        let visibility = visibility(of: declaration) ?? .internal
+        let visibilityType: VisibilityType
+        let type = type(of: declaration, for: mode)
+
+        switch mode {
+        case .visibility:
+            guard VisibilityType.allCases.contains(.explicit(type)) else {
+                fallthrough
+            }
+
+            visibilityType = .explicit(type)
+        default:
+            visibilityType = .visibility(visibility)
+        }
+
+        let order: Int = switch mode {
+        case .visibility:
+            VisibilityType.allCases.firstIndex(of: visibilityType)! * DeclarationType.allCases.count + DeclarationType.allCases.firstIndex(of: type)!
+        case .type:
+            DeclarationType.allCases.firstIndex(of: type)! * VisibilityType.allCases.count + VisibilityType.allCases.firstIndex(of: visibilityType)!
+        }
+
+        return Category(
+            visibility: visibilityType,
+            type: type,
+            order: order
+        )
+    }
+
     func visibility(of declaration: Declaration) -> Visibility? {
         switch declaration {
         case let .declaration(keyword, tokens), let .type(keyword, open: tokens, _, _):
@@ -1928,24 +1959,39 @@ extension Formatter {
             }
 
             return nil
-        case .conditionalCompilation:
-            return nil
+        case let .conditionalCompilation(_, body, _):
+            // Conditional compilation blocks themselves don't have a category or visbility-level,
+            // but we still have to assign them a category for the sorting algorithm to function.
+            // A reasonable heuristic here is to simply use the category of the first declaration
+            // inside the conditional compilation block.
+            if let firstDeclarationInBlock = body.first {
+                return visibility(of: firstDeclarationInBlock)
+            } else {
+                return nil
+            }
         }
     }
 
-    /// The `DeclarationType` of the given `Declaration`
-    func type(of declaration: Declaration) -> DeclarationType? {
+    func type(of declaration: Declaration, for mode: DeclarationOrganizationMode) -> DeclarationType {
         switch declaration {
-        case .type:
-            return .nestedType
+        case let .type(keyword, _, _, _):
+            return options.beforeMarks.contains(keyword) ? .beforeMarks : .nestedType
 
         case let .declaration(keyword, tokens):
             guard let declarationTypeTokenIndex = tokens.firstIndex(of: .keyword(keyword)) else {
-                return nil
+                return .beforeMarks
             }
 
             let declarationParser = Formatter(tokens)
             let declarationTypeToken = declarationParser.tokens[declarationTypeTokenIndex]
+
+            if keyword == "case" || options.beforeMarks.contains(keyword) {
+                return .beforeMarks
+            }
+
+            for token in declarationParser.tokens {
+                if options.beforeMarks.contains(token.string) { return .beforeMarks }
+            }
 
             let isStaticDeclaration = declarationParser.index(
                 of: .keyword("static"),
@@ -1957,10 +2003,27 @@ extension Formatter {
                 before: declarationTypeTokenIndex
             ) != nil
 
+            let isOverriddenDeclaration = mode == .type && declarationParser.index(
+                of: .identifier("override"),
+                before: declarationTypeTokenIndex
+            ) != nil
+
+            let isViewDeclaration = mode == .type && {
+                guard let someKeywordIndex = declarationParser.index(
+                    of: .identifier("some"), after: declarationTypeTokenIndex
+                ) else { return false }
+
+                return declarationParser.index(of: .identifier("View"), after: someKeywordIndex) != nil
+            }()
+
             switch declarationTypeToken {
             // Properties and property-like declarations
             case .keyword("let"), .keyword("var"),
-                 .keyword("case"), .keyword("operator"), .keyword("precedencegroup"):
+                 .keyword("operator"), .keyword("precedencegroup"):
+
+                if isOverriddenDeclaration {
+                    return .overriddenProperty
+                }
 
                 var hasBody: Bool
                 // If there is a code block at the end of the declaration that is _not_ a closure,
@@ -1987,6 +2050,8 @@ extension Formatter {
                     // so there's no such thing as a class property without a body.
                     // https://forums.swift.org/t/class-properties/16539/11
                     return .classPropertyWithBody
+                } else if isViewDeclaration {
+                    return .swiftUIProperty
                 } else {
                     if hasBody {
                         return .instancePropertyWithBody
@@ -1996,25 +2061,43 @@ extension Formatter {
                 }
 
             // Functions and function-like declarations
-            case .keyword("func"), .keyword("init"), .keyword("deinit"), .keyword("subscript"):
-                if isStaticDeclaration {
+            case .keyword("func"), .keyword("subscript"):
+                // The user can also provide specific instance method names to place in Lifecycle
+                //  - In the function declaration grammar, the function name always
+                //    immediately follows the `func` keyword:
+                //    https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_function-name
+                if let methodName = declarationParser.next(.nonSpaceOrCommentOrLinebreak, after: declarationTypeTokenIndex),
+                   options.lifecycleMethods.contains(methodName.string)
+                {
+                    return .instanceLifecycle
+                } else if isOverriddenDeclaration {
+                    return .overriddenMethod
+                } else if isStaticDeclaration {
                     return .staticMethod
                 } else if isClassDeclaration {
                     return .classMethod
+                } else if isViewDeclaration {
+                    return .swiftUIMethod
                 } else {
                     return .instanceMethod
                 }
+
+            case .keyword("init"), .keyword("deinit"):
+                return .instanceLifecycle
 
             // Type-like declarations
             case .keyword("typealias"):
                 return .nestedType
 
+            case .keyword("case"):
+                return .beforeMarks
+
             default:
-                return nil
+                return .beforeMarks
             }
 
         case .conditionalCompilation:
-            return nil
+            return .conditionalCompilation
         }
     }
 
@@ -2049,7 +2132,7 @@ extension Formatter {
     }
 
     /// Removes any existing category separators from the given declarations
-    func removeExistingCategorySeparators(from typeBody: [Declaration]) -> [Declaration] {
+    func removeExistingCategorySeparators(from typeBody: [Declaration], with mode: DeclarationOrganizationMode) -> [Declaration] {
         var typeBody = typeBody
 
         for (declarationIndex, declaration) in typeBody.enumerated() {
@@ -2062,13 +2145,21 @@ extension Formatter {
                 tokensToInspect = open
             }
 
-            let potentialCategorySeparators = Category.allCases.flatMap {
+            // Current amount of variants to pair visibility-type is over 300,
+            // so we take only categories that could provide typemark that we want to erase
+            let potentialCategorySeparators = (
+                VisibilityType.allCases.map {
+                    Category(visibility: $0, type: .classMethod, order: 0)
+                } + DeclarationType.allCases.map {
+                    Category(visibility: .visibility(.open), type: $0, order: 0)
+                }
+            ).flatMap {
                 Array(Set([
                     // The user's specific category separator template
-                    $0.markComment(from: options.categoryMarkComment),
+                    $0.markComment(from: options.categoryMarkComment, with: mode),
                     // Other common variants that we would want to replace with the correct variant
-                    $0.markComment(from: "%c"),
-                    $0.markComment(from: "// MARK: %c"),
+                    $0.markComment(from: "%c", with: mode),
+                    $0.markComment(from: "// MARK: %c", with: mode),
                 ]))
             }.compactMap { $0 }
 
@@ -2159,6 +2250,8 @@ extension Formatter {
             organizationThreshold = 0
         }
 
+        let mode = options.organizationMode
+
         // Count the number of lines in this declaration
         let lineCount = typeDeclaration.body
             .flatMap { $0.tokens }
@@ -2175,13 +2268,13 @@ extension Formatter {
 
         // Remove all of the existing category separators, so they can be readded
         // at the correct location after sorting the declarations.
-        let bodyWithoutCategorySeparators = removeExistingCategorySeparators(from: typeDeclaration.body)
+        let bodyWithoutCategorySeparators = removeExistingCategorySeparators(from: typeDeclaration.body, with: mode)
 
         // Categorize each of the declarations into their primary groups
-        typealias CategorizedDeclarations = [(declaration: Declaration, category: Category, type: DeclarationType?)]
+        typealias CategorizedDeclarations = [(declaration: Declaration, category: Category)]
 
         let categorizedDeclarations = bodyWithoutCategorySeparators.map {
-            (declaration: $0, category: category(of: $0), type: type(of: $0))
+            (declaration: $0, category: category(of: $0, for: mode))
         }
 
         // If this type has a leading :sort directive, we sort alphabetically
@@ -2191,36 +2284,14 @@ extension Formatter {
         })
 
         // Sorts the given categoried declarations based on their derived metadata
-        func sortDeclarations(
-            _ declarations: CategorizedDeclarations,
-            byCategory sortByCategory: Bool,
-            byType sortByType: Bool
-        ) -> CategorizedDeclarations {
+        func sortDeclarations(_ declarations: CategorizedDeclarations) -> CategorizedDeclarations {
             declarations.enumerated()
                 .sorted(by: { lhs, rhs in
                     let (lhsOriginalIndex, lhs) = lhs
                     let (rhsOriginalIndex, rhs) = rhs
 
-                    // Sort primarily by category
-                    if sortByCategory,
-                       let lhsCategorySortOrder = Formatter.categoryOrdering.firstIndex(of: lhs.category),
-                       let rhsCategorySortOrder = Formatter.categoryOrdering.firstIndex(of: rhs.category),
-                       lhsCategorySortOrder != rhsCategorySortOrder
-                    {
-                        return lhsCategorySortOrder < rhsCategorySortOrder
-                    }
-
-                    // Within individual categories (excluding .beforeMarks), sort by the declaration type
-                    if sortByType,
-                       lhs.category != .beforeMarks,
-                       rhs.category != .beforeMarks,
-                       let lhsType = lhs.type,
-                       let rhsType = rhs.type,
-                       let lhsTypeSortOrder = Formatter.categorySubordering.firstIndex(of: lhsType),
-                       let rhsTypeSortOrder = Formatter.categorySubordering.firstIndex(of: rhsType),
-                       lhsTypeSortOrder != rhsTypeSortOrder
-                    {
-                        return lhsTypeSortOrder < rhsTypeSortOrder
+                    if lhs.category.order != rhs.category.order {
+                        return lhs.category.order < rhs.category.order
                     }
 
                     // If this type had a :sort directive, we sort alphabetically
@@ -2240,7 +2311,7 @@ extension Formatter {
         }
 
         // Sort the declarations based on their category and type
-        var sortedDeclarations = sortDeclarations(categorizedDeclarations, byCategory: true, byType: true)
+        var sortedDeclarations = sortDeclarations(categorizedDeclarations)
 
         // The compiler will synthesize a memberwise init for `struct`
         // declarations that don't have an `init` declaration.
@@ -2252,13 +2323,13 @@ extension Formatter {
             // the parameters struct's synthesized memberwise initializer
             func affectsSynthesizedMemberwiseInitializer(
                 _ declaration: Declaration,
-                _ type: DeclarationType?
+                _ category: Category
             ) -> Bool {
-                switch type {
-                case .instanceProperty?:
+                switch category.type {
+                case .instanceProperty:
                     return true
 
-                case .instancePropertyWithBody?:
+                case .instancePropertyWithBody:
                     // `instancePropertyWithBody` represents some stored properties,
                     // but also computed properties. Only stored properties,
                     // not computed properties, affect the synthesized init.
@@ -2290,11 +2361,11 @@ extension Formatter {
                 _ rhs: CategorizedDeclarations
             ) -> Bool {
                 let lhsPropertiesOrder = lhs
-                    .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.type) }
+                    .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.category) }
                     .map { $0.declaration }
 
                 let rhsPropertiesOrder = rhs
-                    .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.type) }
+                    .filter { affectsSynthesizedMemberwiseInitializer($0.declaration, $0.category) }
                     .map { $0.declaration }
 
                 return lhsPropertiesOrder == rhsPropertiesOrder
@@ -2304,7 +2375,7 @@ extension Formatter {
                 // If sorting by category and by type could cause compilation failures
                 // by not correctly preserving the synthesized memberwise initializer,
                 // try to sort _only_ by category (so we can try to preserve the correct category separators)
-                sortedDeclarations = sortDeclarations(categorizedDeclarations, byCategory: true, byType: false)
+                sortedDeclarations = sortDeclarations(categorizedDeclarations)
 
                 // If sorting _only_ by category still changes the synthesized memberwise initializer,
                 // then there's nothing we can do to organize this struct.
@@ -2314,58 +2385,56 @@ extension Formatter {
             }
         }
 
-        // Insert comments to separate the categories
-        let numberOfCategories = Formatter.categoryOrdering.filter { category in
-            sortedDeclarations.contains(where: { $0.category == category })
-        }.count
+        let numberOfCategories: Int = {
+            switch mode {
+            case .visibility:
+                Set(sortedDeclarations.map(\.category).map(\.visibility)).count
+            case .type:
+                Set(sortedDeclarations.map(\.category).map(\.type)).count
+            }
+        }()
 
-        for category in Formatter.categoryOrdering {
-            guard let indexOfFirstDeclaration = sortedDeclarations
-                .firstIndex(where: { $0.category == category })
-            else { continue }
+        var formattedCategories: [Category] = []
+        var markedDeclarations: [Declaration] = []
 
-            // Build the MARK declaration, but only when there is more than one category present.
+        for (index, (declaration, category)) in sortedDeclarations.enumerated() {
             if options.markCategories,
                numberOfCategories > 1,
-               let markComment = category.markComment(from: options.categoryMarkComment)
+               let markComment = category.markComment(from: options.categoryMarkComment, with: mode),
+               category.shouldBeMarked(in: Set(formattedCategories), for: mode)
             {
-                let firstDeclaration = sortedDeclarations[indexOfFirstDeclaration].declaration
-                let declarationParser = Formatter(firstDeclaration.tokens)
+                formattedCategories.append(category)
+
+                let declarationParser = Formatter(declaration.tokens)
                 let indentation = declarationParser.currentIndentForLine(at: 0)
 
                 let endMarkDeclaration = options.lineAfterMarks ? "\n\n" : "\n"
                 let markDeclaration = tokenize("\(indentation)\(markComment)\(endMarkDeclaration)")
 
-                sortedDeclarations.insert(
-                    (.declaration(kind: "comment", tokens: markDeclaration), category, nil),
-                    at: indexOfFirstDeclaration
-                )
-
                 // If this declaration is the first declaration in the type scope,
                 // make sure the type's opening sequence of tokens ends with
                 // at least one blank line so the category separator appears balanced
-                if indexOfFirstDeclaration == 0 {
+                if markedDeclarations.isEmpty {
                     typeOpeningTokens = endingWithBlankLine(typeOpeningTokens)
                 }
+
+                markedDeclarations.append(.declaration(kind: "comment", tokens: markDeclaration))
             }
 
-            // Insert newlines to separate declaration types
-            for declarationType in Formatter.categorySubordering {
-                guard let indexOfLastDeclarationWithType = sortedDeclarations
-                    .lastIndex(where: { $0.category == category && $0.type == declarationType }),
-                    indexOfLastDeclarationWithType != sortedDeclarations.indices.last
-                else { continue }
-
-                sortedDeclarations[indexOfLastDeclarationWithType].declaration = mapClosingTokens(
-                    in: sortedDeclarations[indexOfLastDeclarationWithType].declaration)
-                { endingWithBlankLine($0) }
+            if let lastIndexOfSameDeclaration = sortedDeclarations.map(\.category).lastIndex(of: category),
+               lastIndexOfSameDeclaration == index,
+               lastIndexOfSameDeclaration != sortedDeclarations.indices.last
+            {
+                markedDeclarations.append(mapClosingTokens(in: declaration, with: { endingWithBlankLine($0) }))
+            } else {
+                markedDeclarations.append(declaration)
             }
         }
 
         return (
             kind: typeDeclaration.kind,
             open: typeOpeningTokens,
-            body: sortedDeclarations.map { $0.declaration },
+            body: markedDeclarations,
             close: typeClosingTokens
         )
     }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -853,6 +853,12 @@ struct _Descriptors {
         help: "Minimum line count to organize extension body. Defaults to 0",
         keyPath: \.organizeExtensionThreshold
     )
+    let organizationMode = OptionDescriptor(
+        argumentName: "organizationmode",
+        displayName: "Declaration Types Organization Mode",
+        help: "Organization mode for declarations. Defaults to \"visibility\"",
+        keyPath: \.organizationMode
+    )
     let funcAttributes = OptionDescriptor(
         argumentName: "funcattributes",
         displayName: "Function Attributes",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -478,6 +478,14 @@ public enum SpaceAroundDelimiter: String, CaseIterable {
     case leadingTrailing = "leading-trailing"
 }
 
+/// Declaration organization mode
+public enum DeclarationOrganizationMode: String, CaseIterable {
+    /// Organize declarations by visibility
+    case visibility
+    /// Organize declarations by type
+    case type
+}
+
 /// Format to use when printing dates
 public enum DateFormat: Equatable, RawRepresentable, CustomStringConvertible {
     case dayMonthYear
@@ -659,6 +667,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var organizeStructThreshold: Int
     public var organizeEnumThreshold: Int
     public var organizeExtensionThreshold: Int
+    public var organizationMode: DeclarationOrganizationMode
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var redundantType: RedundantType
@@ -776,6 +785,7 @@ public struct FormatOptions: CustomStringConvertible {
                 organizeStructThreshold: Int = 0,
                 organizeEnumThreshold: Int = 0,
                 organizeExtensionThreshold: Int = 0,
+                organizationMode: DeclarationOrganizationMode = .visibility,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 redundantType: RedundantType = .inferLocalsOnly,
@@ -883,6 +893,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.organizeStructThreshold = organizeStructThreshold
         self.organizeEnumThreshold = organizeEnumThreshold
         self.organizeExtensionThreshold = organizeExtensionThreshold
+        self.organizationMode = organizationMode
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
         self.redundantType = redundantType

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5658,7 +5658,7 @@ public struct _FormatRules {
         disabledByDefault: true,
         orderAfter: ["extensionAccessControl", "redundantFileprivate"],
         options: ["categorymark", "markcategories", "beforemarks", "lifecycle", "organizetypes",
-                  "structthreshold", "classthreshold", "enumthreshold", "extensionlength"],
+                  "structthreshold", "classthreshold", "enumthreshold", "extensionlength", "organizationmode"],
         sharedOptions: ["lineaftermarks"]
     ) { formatter in
         guard !formatter.options.fragment else { return }

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -231,6 +231,7 @@ class MetadataTests: XCTestCase {
                         Descriptors.organizeEnumThreshold,
                         Descriptors.organizeExtensionThreshold,
                         Descriptors.lineAfterMarks,
+                        Descriptors.organizationMode,
                     ]
                 case .identifier("removeSelf"):
                     referencedOptions += [

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -88,6 +88,328 @@ class OrganizationTests: RulesTests {
         )
     }
 
+    func testOrganizeClassDeclarationsIntoCategoriesInTypeOrder() {
+        let input = """
+        class Foo {
+            private func privateMethod() {}
+
+            private let bar = 1
+            public let baz = 1
+            open var quack = 2
+            package func packageMethod() {}
+            var quux = 2
+
+            /// `open` is the only visibility keyword that
+            /// can also be used as an identifier.
+            var open = 10
+
+            /*
+             * Block comment
+             */
+
+            init() {}
+
+            /// Doc comment
+            public func publicMethod() {}
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Properties
+
+            open var quack = 2
+
+            public let baz = 1
+
+            var quux = 2
+
+            /// `open` is the only visibility keyword that
+            /// can also be used as an identifier.
+            var open = 10
+
+            private let bar = 1
+
+            // MARK: Lifecycle
+
+            /*
+             * Block comment
+             */
+
+            init() {}
+
+            // MARK: Functions
+
+            /// Doc comment
+            public func publicMethod() {}
+
+            package func packageMethod() {}
+
+            private func privateMethod() {}
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
+    func testOrganizeTypeWithOverridenFieldsInVisibilityOrder() {
+        let input = """
+        class Test {
+
+            var a = ""
+
+            override var b: Any? { nil }
+
+            func foo() -> Foo {
+                Foo()
+            }
+
+            override func bar() -> Bar {
+                Bar()
+            }
+
+            func baaz() -> Baaz {
+                Baaz()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, rule: FormatRules.organizeDeclarations,
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+        )
+    }
+
+    func testOrganizeTypeWithOverridenFieldsInTypeOrder() {
+        let input = """
+        class Test {
+
+            var a = ""
+
+            override var b: Any? { nil }
+
+            func foo() -> Foo {
+                Foo()
+            }
+
+            override func bar() -> Bar {
+                Bar()
+            }
+
+            func baaz() -> Baaz {
+                Baaz()
+            }
+
+        }
+        """
+
+        let output = """
+        class Test {
+
+            // MARK: Overridden Properties
+
+            override var b: Any? { nil }
+
+            // MARK: Properties
+
+            var a = ""
+
+            // MARK: Overridden Functions
+
+            override func bar() -> Bar {
+                Bar()
+            }
+
+            // MARK: Functions
+
+            func foo() -> Foo {
+                Foo()
+            }
+
+            func baaz() -> Baaz {
+                Baaz()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(organizationMode: .type),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+        )
+    }
+
+    func testOrganizeTypeWithSwiftUIMethodInVisibilityOrder() {
+        let input = """
+        class Test {
+
+            func foo() -> Foo {
+                Foo()
+            }
+
+            func bar() -> some View {
+                EmptyView()
+            }
+
+            func baaz() -> Baaz {
+                Baaz()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, rule: FormatRules.organizeDeclarations,
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+        )
+    }
+
+    func testOrganizeSwiftUIViewInTypeOrder() {
+        let input = """
+        struct ContentView: View {
+
+            private var label: String
+
+            @State
+            var isOn: Bool = false
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+            init(label: String) {
+                self.label = label
+            }
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Properties
+
+            @State
+            var isOn: Bool = false
+
+            private var label: String
+
+            // MARK: Lifecycle
+
+            init(label: String) {
+                self.label = label
+            }
+
+            // MARK: Content
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
+    func testOrganizeSwiftUIViewModifierInTypeOrder() {
+        let input = """
+        struct Modifier: ViewModifier {
+
+            private var label: String
+
+            @State
+            var isOn: Bool = false
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+            func body(content: Content) -> some View {
+                content
+                    .overlay {
+                        toggle
+                    }
+            }
+
+            init(label: String) {
+                self.label = label
+            }
+        }
+        """
+
+        let output = """
+        struct Modifier: ViewModifier {
+
+            // MARK: Properties
+
+            @State
+            var isOn: Bool = false
+
+            private var label: String
+
+            // MARK: Lifecycle
+
+            init(label: String) {
+                self.label = label
+            }
+
+            // MARK: Content
+
+            func body(content: Content) -> some View {
+                content
+                    .overlay {
+                        toggle
+                    }
+            }
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
     func testClassNestedInClassIsOrganized() {
         let input = """
         public class Foo {
@@ -296,6 +618,135 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: FormatRules.organizeDeclarations,
             exclude: ["blankLinesAtEndOfScope", "redundantType", "redundantClosure"]
+        )
+    }
+
+    func testSortDeclarationTypesByType() {
+        let input = """
+        class Foo {
+            var a: Int
+            init(a: Int) {
+                self.a = a
+            }
+            private convenience init() {
+                self.init(a: 0)
+            }
+
+            static var a1: Int = 1
+            static var a2: Int = 2
+            var d1: CGFloat {
+                3.141592653589
+            }
+
+            class var b2: String {
+                "class computed property"
+            }
+
+            func g() -> Int {
+                10
+            }
+
+            let c: String = String {
+                "closure body"
+            }()
+
+            static func e() {}
+
+            typealias Bar = Int
+
+            static var b1: String {
+                "static computed property"
+            }
+
+            class func f() -> Foo {
+                Foo()
+            }
+
+            enum NestedEnum {}
+
+            var d2: CGFloat = 3.141592653589 {
+                didSet {}
+            }
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Nested Types
+
+            typealias Bar = Int
+
+            enum NestedEnum {}
+
+            // MARK: Static Properties
+
+            static var a1: Int = 1
+            static var a2: Int = 2
+
+            // MARK: Static Computed Properties
+
+            static var b1: String {
+                "static computed property"
+            }
+
+            // MARK: Class Properties
+
+            class var b2: String {
+                "class computed property"
+            }
+
+            // MARK: Properties
+
+            var a: Int
+            let c: String = String {
+                "closure body"
+            }()
+
+            // MARK: Computed Properties
+
+            var d1: CGFloat {
+                3.141592653589
+            }
+
+            var d2: CGFloat = 3.141592653589 {
+                didSet {}
+            }
+
+            // MARK: Lifecycle
+
+            init(a: Int) {
+                self.a = a
+            }
+
+            private convenience init() {
+                self.init(a: 0)
+            }
+
+            // MARK: Static Functions
+
+            static func e() {}
+
+            // MARK: Class Functions
+
+            class func f() -> Foo {
+                Foo()
+            }
+
+            // MARK: Functions
+
+            func g() -> Int {
+                10
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
+            exclude: ["blankLinesAtEndOfScope", "blankLinesAtStartOfScope", "redundantType", "redundantClosure"]
         )
     }
 


### PR DESCRIPTION
This one will be a longshot 🙃

This PR adds an ability to organize types by `type` rather than `visibility` (but its more like an attempt to make this rule a bit more extensible). Within our project somewhat similar fork lives for around a year atm.

Have no idea of what direction this PR should take, so any comments and suggestions are highly appreciated 🥹