### PR TITLE
Add `—nilinit` for `redundantNilInit` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1511,10 +1511,16 @@ Remove redundant `let error` from `catch` clause.
 
 ## redundantNilInit
 
-Remove redundant `nil` default value (Optional vars are nil by default).
+Remove/insert redundant `nil` default value (Optional vars are nil by default).
+
+Option | Description
+--- | ---
+`--nilinit` | Explicit self: "insert", "remove" (default)
 
 <details>
 <summary>Examples</summary>
+
+`--nilinit remove`
 
 ```diff
 - var foo: Int? = nil
@@ -1529,6 +1535,13 @@ let foo: Int? = nil
 ```diff
 // doesn't affect non-nil initialization
 var foo: Int? = 0
+```
+
+`--nilinit insert`
+
+```diff
+- var foo: Int?
++ var foo: Int? = nil
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -552,6 +552,8 @@ private struct Examples {
     """
 
     let redundantNilInit = """
+    `--nilinit remove`
+
     ```diff
     - var foo: Int? = nil
     + var foo: Int?
@@ -560,6 +562,13 @@ private struct Examples {
     ```diff
     // doesn't apply to `let` properties
     let foo: Int? = nil
+    ```
+
+    `--nilinit insert`
+
+    ```diff
+    - var foo: Int?
+    + var foo: Int? = nil
     ```
 
     ```diff

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -348,6 +348,16 @@ public enum EnumNamespacesMode: String, CaseIterable {
     case structsOnly = "structs-only"
 }
 
+/// When initializing an optional value type,
+/// is it necessary to explicitly declare a default value
+public enum NilInitType: String, CaseIterable {
+    /// Remove redundant `nil` if it is added as default value
+    case remove
+
+    /// Add `nil` as default if not explicitly declared
+    case insert
+}
+
 /// Configuration options for formatting. These aren't actually used by the
 /// Formatter class itself, but it makes them available to the format rules.
 public struct FormatOptions: CustomStringConvertible {
@@ -436,6 +446,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var preserveAnonymousForEach: Bool
     public var preserveSingleLineForEach: Bool
     public var preserveDocComments: Bool
+    public var nilInitType: NilInitType
 
     /// Deprecated
     public var indentComments: Bool
@@ -539,6 +550,7 @@ public struct FormatOptions: CustomStringConvertible {
                 preserveAnonymousForEach: Bool = false,
                 preserveSingleLineForEach: Bool = true,
                 preserveDocComments: Bool = false,
+                nilInitType: NilInitType = .remove,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -632,6 +644,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.preserveAnonymousForEach = preserveAnonymousForEach
         self.preserveSingleLineForEach = preserveSingleLineForEach
         self.preserveDocComments = preserveDocComments
+        self.nilInitType = nilInitType
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2931,23 +2931,33 @@ public struct _FormatRules {
         }
     }
 
-    /// Remove redundant `= nil` initialization for Optional properties
+    /// Remove or insert  redundant `= nil` initialization for Optional properties
     public let redundantNilInit = FormatRule(
-        help: "Remove redundant `nil` default value (Optional vars are nil by default)."
+        help: "Remove/insert redundant `nil` default value (Optional vars are nil by default).",
+        options: ["nilinit"]
     ) { formatter in
         func search(from index: Int) {
             if let optionalIndex = formatter.index(of: .unwrapOperator, after: index) {
                 if formatter.index(of: .endOfStatement, in: index + 1 ..< optionalIndex) != nil {
                     return
                 }
-                if !formatter.tokens[optionalIndex - 1].isSpaceOrCommentOrLinebreak,
-                   let equalsIndex = formatter.index(of: .nonSpaceOrLinebreak, after: optionalIndex, if: {
-                       $0 == .operator("=", .infix)
-                   }), let nilIndex = formatter.index(of: .nonSpaceOrLinebreak, after: equalsIndex, if: {
-                       $0 == .identifier("nil")
-                   })
-                {
-                    formatter.removeTokens(in: optionalIndex + 1 ... nilIndex)
+                if !formatter.tokens[optionalIndex - 1].isSpaceOrCommentOrLinebreak {
+                    let equalsIndex = formatter.index(of: .nonSpaceOrLinebreak, after: optionalIndex, if: {
+                        $0 == .operator("=", .infix)
+                    })
+                    switch formatter.options.nilInitType {
+                    case .remove:
+                        if let equalsIndex, let nilIndex = formatter.index(of: .nonSpaceOrLinebreak, after: equalsIndex, if: {
+                            $0 == .identifier("nil")
+                        }) {
+                            formatter.removeTokens(in: optionalIndex + 1 ... nilIndex)
+                        }
+                    case .insert:
+                        if equalsIndex == nil {
+                            let tokens: [Token] = [.space(" "), .operator("=", .infix), .space(" "), .identifier("nil")]
+                            formatter.insert(tokens, at: optionalIndex + 1)
+                        }
+                    }
                 }
                 search(from: optionalIndex)
             }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1919,7 +1919,7 @@ class RedundancyTests: RulesTests {
         struct TestView: View {
             var body: some View {
                 if true {
-                    var foo: String?
+                    var foo: String? = nil
                     Text(foo ?? "")
                 } else {
                     EmptyView()
@@ -1936,7 +1936,7 @@ class RedundancyTests: RulesTests {
             var body: some View {
                 switch foo {
                 case .bar:
-                    var foo: String?
+                    var foo: String? = nil
                     Text(foo ?? "")
                 default:
                     EmptyView()

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -1791,71 +1791,96 @@ class RedundancyTests: RulesTests {
     func testRemoveRedundantNilInit() {
         let input = "var foo: Int? = nil\nlet bar: Int? = nil"
         let output = "var foo: Int?\nlet bar: Int? = nil"
-        testFormatting(for: input, output, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveLetNilInitAfterVar() {
         let input = "var foo: Int; let bar: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNonNilInit() {
         let input = "var foo: Int? = 0"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testRemoveRedundantImplicitUnwrapInit() {
         let input = "var foo: Int! = nil"
         let output = "var foo: Int!"
-        testFormatting(for: input, output, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testRemoveMultipleRedundantNilInitsInSameLine() {
         let input = "var foo: Int? = nil, bar: Int? = nil"
         let output = "var foo: Int?, bar: Int?"
-        testFormatting(for: input, output, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveLazyVarNilInit() {
         let input = "lazy var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveLazyPublicPrivateSetVarNilInit() {
         let input = "lazy private(set) public var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit, options: options,
                        exclude: ["modifierOrder"])
     }
 
     func testNoRemoveCodableNilInit() {
         let input = "struct Foo: Codable, Bar {\n    enum CodingKeys: String, CodingKey {\n        case bar = \"_bar\"\n    }\n\n    var bar: Int?\n    var baz: String? = nil\n}"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitWithPropertyWrapper() {
         let input = "@Foo var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitWithLowercasePropertyWrapper() {
         let input = "@foo var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitWithPropertyWrapperWithArgument() {
         let input = "@Foo(bar: baz) var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitWithLowercasePropertyWrapperWithArgument() {
         let input = "@foo(bar: baz) var foo: Int? = nil"
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testRemoveNilInitWithObjcAttributes() {
         let input = "@objc var foo: Int? = nil"
         let output = "@objc var foo: Int?"
-        testFormatting(for: input, output, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitInStructWithDefaultInit() {
@@ -1864,7 +1889,9 @@ class RedundancyTests: RulesTests {
             var bar: String? = nil
         }
         """
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testRemoveNilInitInStructWithDefaultInitInSwiftVersion5_2() {
@@ -1878,8 +1905,9 @@ class RedundancyTests: RulesTests {
             var bar: String?
         }
         """
+        let options = FormatOptions(nilInitType: .remove, swiftVersion: "5.2")
         testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
-                       options: FormatOptions(swiftVersion: "5.2"))
+                       options: options)
     }
 
     func testRemoveNilInitInStructWithCustomInit() {
@@ -1899,7 +1927,9 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitInViewBuilder() {
@@ -1911,7 +1941,9 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitInIfStatementInViewBuilder() {
@@ -1927,7 +1959,9 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     func testNoRemoveNilInitInSwitchStatementInViewBuilder() {
@@ -1944,7 +1978,221 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.redundantNilInit)
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    // --nilInitType insert
+
+    func testInsertNilInit() {
+        let input = "var foo: Int?\nlet bar: Int? = nil"
+        let output = "var foo: Int? = nil\nlet bar: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitBeforeLet() {
+        let input = "var foo: Int?; let bar: Int? = nil"
+        let output = "var foo: Int? = nil; let bar: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitAfterLet() {
+        let input = "let bar: Int? = nil; var foo: Int?"
+        let output = "let bar: Int? = nil; var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNonNilInit() {
+        let input = "var foo: Int? = 0"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertRedundantImplicitUnwrapInit() {
+        let input = "var foo: Int!"
+        let output = "var foo: Int! = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertMultipleRedundantNilInitsInSameLine() {
+        let input = "var foo: Int?, bar: Int?"
+        let output = "var foo: Int? = nil, bar: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertLazyVarNilInit() {
+        let input = "lazy var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertLazyPublicPrivateSetVarNilInit() {
+        let input = "lazy private(set) public var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit, options: options,
+                       exclude: ["modifierOrder"])
+    }
+
+    func testNoInsertCodableNilInit() {
+        let input = "struct Foo: Codable, Bar {\n    enum CodingKeys: String, CodingKey {\n        case bar = \"_bar\"\n    }\n\n    var bar: Int?\n    var baz: String? = nil\n}"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitWithPropertyWrapper() {
+        let input = "@Foo var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitWithLowercasePropertyWrapper() {
+        let input = "@foo var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitWithPropertyWrapperWithArgument() {
+        let input = "@Foo(bar: baz) var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitWithLowercasePropertyWrapperWithArgument() {
+        let input = "@foo(bar: baz) var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitWithObjcAttributes() {
+        let input = "@objc var foo: Int?"
+        let output = "@objc var foo: Int? = nil"
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitInStructWithDefaultInit() {
+        let input = """
+        struct Foo {
+            var bar: String?
+        }
+        """
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitInStructWithDefaultInitInSwiftVersion5_2() {
+        let input = """
+        struct Foo {
+            var bar: String?
+            var foo: String? = nil
+        }
+        """
+        let output = """
+        struct Foo {
+            var bar: String? = nil
+            var foo: String? = nil
+        }
+        """
+        let options = FormatOptions(nilInitType: .insert, swiftVersion: "5.2")
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitInStructWithCustomInit() {
+        let input = """
+        struct Foo {
+            var bar: String?
+            var foo: String? = nil
+            init() {
+                bar = "bar"
+                foo = "foo"
+            }
+        }
+        """
+        let output = """
+        struct Foo {
+            var bar: String? = nil
+            var foo: String? = nil
+            init() {
+                bar = "bar"
+                foo = "foo"
+            }
+        }
+        """
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitInViewBuilder() {
+        let input = """
+        struct TestView: View {
+            var body: some View {
+                var foo: String?
+                Text(foo ?? "")
+            }
+        }
+        """
+        let options = FormatOptions(nilInitType: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitInIfStatementInViewBuilder() {
+        let input = """
+        struct TestView: View {
+            var body: some View {
+                if true {
+                    var foo: String?
+                    Text(foo ?? "")
+                } else {
+                    EmptyView()
+                }
+            }
+        }
+        """
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitInSwitchStatementInViewBuilder() {
+        let input = """
+        struct TestView: View {
+            var body: some View {
+                switch foo {
+                case .bar:
+                    var foo: String?
+                    Text(foo ?? "")
+                default:
+                    EmptyView()
+                }
+            }
+        }
+        """
+        let options = FormatOptions(nilInitType: .remove)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
     }
 
     // MARK: - redundantLet


### PR DESCRIPTION
Related https://github.com/nicklockwood/SwiftFormat/issues/1677 .

Added `—nilinit` option to `redundantNilInit` rule, its value includes `insert` and `remove`. Among them, `remove` is consistent with the previous logic, and `insert` is a new logic. It will add `nil` as the default value after the optional value type according to the opposite rules of `remove`.

> I did not implement the `properties-only` option mentioned in the issue, firstly because I did not need it, and secondly because I was not familiar enough with this project.

I added documentation and test cases and all of them passed.

This is my first PR for this project. If I did something wrong or if there is anything else that needs to be modified, please let me know.