### PR TITLE
Fix redundantInit bug in ternary operators

### DIFF
--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1692,6 +1692,13 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo!")
     }
 
+    func testDoesntParseTernaryOperatorAsType() {
+        let formatter = Formatter(tokenize("""
+        Foo.bar ? .foo : .bar
+        """))
+        XCTAssertEqual(formatter.parseType(at: 0)?.name, "Foo.bar")
+    }
+
     func testDoesntParseMacroInvocationAsType() {
         let formatter = Formatter(tokenize("""
         let foo = #colorLiteral(1, 2, 3)

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -934,6 +934,13 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantInit, exclude: ["typeSugar", "propertyType"])
     }
 
+    func testPreserveNonRedundantInitInTernaryOperator() {
+        let input = """
+        let bar: Bar = (foo.isBar && bar.isBaaz) ? .init() : nil
+        """
+        testFormatting(for: input, rule: FormatRules.redundantInit)
+    }
+
     // MARK: - redundantLetError
 
     func testCatchLetError() {


### PR DESCRIPTION
This PR fixes a bug in the `redundantInit` rule for `.init` calls in ternary operators. It was unexpectedly converting code like:

```swift
let bar: Bar = (foo.isBar && bar.isBaaz) ? .init() : nil
```

to

```swift
let bar: Bar = (foo.isBar && bar.isBaaz) ? () : nil
```