### PR TITLE
Fix bug in `unusedArguments` when shadowing function argument with conditional assignment declaration

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3432,7 +3432,11 @@ public struct _FormatRules {
             }
             var i = range.lowerBound
             while i < range.upperBound {
-                if formatter.isStartOfStatement(at: i, treatingCollectionKeysAsStart: false) {
+                if formatter.isStartOfStatement(at: i, treatingCollectionKeysAsStart: false),
+                   // Immediately following an `=` operator, if or switch keywords
+                   // are expressions rather than statements.
+                   formatter.lastToken(before: i, where: { !$0.isSpaceOrCommentOrLinebreak })?.isOperator("=") != true
+                {
                     pushLocals()
                     wasDeclaration = false
                 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -8410,6 +8410,68 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.unusedArguments)
     }
 
+    func testUnusedArgumentWithClosureShadowingParamName() {
+        let input = """
+        func test(foo: Foo) {
+            let foo = {
+                if foo.bar {
+                    baaz
+                } else {
+                    bar
+                }
+            }()
+            print(foo)
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedArguments)
+    }
+
+    func testUnusedArgumentWithConditionalAssignmentShadowingParamName() {
+        let input = """
+        func test(foo: Foo) {
+            let foo =
+                if foo.bar {
+                    baaz
+                } else {
+                    bar
+                }
+            print(foo)
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedArguments)
+    }
+
+    func testUnusedArgumentWithSwitchAssignmentShadowingParamName() {
+        let input = """
+        func test(foo: Foo) {
+            let foo =
+                switch foo.bar {
+                case true:
+                    baaz
+                case false:
+                    bar
+                }
+            print(foo)
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedArguments)
+    }
+
+    func testUnusedArgumentWithConditionalAssignmentNotShadowingParamName() {
+        let input = """
+        func test(bar: Bar) {
+            let quux =
+                if foo {
+                    bar
+                } else {
+                    baaz
+                }
+            print(quux)
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedArguments)
+    }
+
     // MARK: redundantClosure
 
     func testRemoveRedundantClosureInSingleLinePropertyDeclaration() {


### PR DESCRIPTION
This PR fixes a bug in the `unusedArguments` rule when shadowing a function argument with a declaration where the value is an if or switch expression. 

## Before (argument unexpectedly marked as unused)

```swift
func test(foo _: Foo) {
    let foo =
        if foo.bar {
            baaz
        } else {
            bar
        }
    print(foo)
}
```

## After (preserved)

```swift
func test(foo: Foo) {
    let foo =
        if foo.bar {
            baaz
        } else {
            bar
        }
    print(foo)
}
```