### PR TITLE
`modifierOrder` option documentation clarification

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1082,6 +1082,9 @@ Option | Description
 + private convenience init()
 ```
 
+**NOTE:** If the option value is empty, the following order will be used by default:
+override,private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix
+
 </details>
 <br/>
 

--- a/Rules.md
+++ b/Rules.md
@@ -1083,7 +1083,7 @@ Option | Description
 ```
 
 **NOTE:** If the option value is empty, the following order will be used by default:
-override,private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix
+`override,private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix`
 
 </details>
 <br/>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -928,6 +928,9 @@ private struct Examples {
     - convenience private init()
     + private convenience init()
     ```
+
+    **NOTE:** If the option value is empty, the following order will be used by default:
+    \(_FormatRules.defaultModifierOrder.flatMap { $0 }.joined(separator: ","))
     """
 
     let strongifiedSelf = """

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -930,7 +930,7 @@ private struct Examples {
     ```
 
     **NOTE:** If the option value is empty, the following order will be used by default:
-    \(_FormatRules.defaultModifierOrder.flatMap { $0 }.joined(separator: ","))
+    `\(_FormatRules.defaultModifierOrder.flatMap { $0 }.joined(separator: ","))`
     """
 
     let strongifiedSelf = """


### PR DESCRIPTION
Related: https://github.com/nicklockwood/SwiftFormat/issues/849

Added an example syntax for the `modifiersOrder` option and separate section about default order by groups in the Rules.md doc.