### PR TITLE
Support SE-0430 `sending` in spaceAroundBrackets/Parens

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -261,7 +261,8 @@ public struct _FormatRules {
                  .identifier("any") where formatter.isTypePosition(at: index),
                  .identifier("borrowing") where formatter.isTypePosition(at: index),
                  .identifier("consuming") where formatter.isTypePosition(at: index),
-                 .identifier("isolated") where formatter.isTypePosition(at: index):
+                 .identifier("isolated") where formatter.isTypePosition(at: index),
+                 .identifier("sending") where formatter.isTypePosition(at: index):
                 formatter.insert(.space(" "), at: i)
             case .space:
                 let index = i - 2
@@ -273,7 +274,8 @@ public struct _FormatRules {
                      .identifier("any") where formatter.isTypePosition(at: index),
                      .identifier("borrowing") where formatter.isTypePosition(at: index),
                      .identifier("consuming") where formatter.isTypePosition(at: index),
-                     .identifier("isolated") where formatter.isTypePosition(at: index):
+                     .identifier("isolated") where formatter.isTypePosition(at: index),
+                     .identifier("sending") where formatter.isTypePosition(at: index):
                     break
                 case let .keyword(string) where !spaceAfter(string, index: index):
                     fallthrough
@@ -343,14 +345,16 @@ public struct _FormatRules {
             switch prevToken {
             case .keyword,
                  .identifier("borrowing") where formatter.isTypePosition(at: index),
-                 .identifier("consuming") where formatter.isTypePosition(at: index):
+                 .identifier("consuming") where formatter.isTypePosition(at: index),
+                 .identifier("sending") where formatter.isTypePosition(at: index):
                 formatter.insert(.space(" "), at: i)
             case .space:
                 let index = i - 2
                 if let token = formatter.token(at: index) {
                     switch token {
                     case .identifier("borrowing") where formatter.isTypePosition(at: index),
-                         .identifier("consuming") where formatter.isTypePosition(at: index):
+                         .identifier("consuming") where formatter.isTypePosition(at: index),
+                         .identifier("sending") where formatter.isTypePosition(at: index):
                         break
                     case .identifier, .number, .endOfScope("]"), .endOfScope("}"), .endOfScope(")"):
                         formatter.removeToken(at: i - 1)

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -341,6 +341,12 @@ class SpacingTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.spaceAroundParens)
     }
 
+    func testAddSpaceBetweenParenAndSending() {
+        let input = "func foo(_: sending(any Foo)) {}"
+        let output = "func foo(_: sending (any Foo)) {}"
+        testFormatting(for: input, output, rule: FormatRules.spaceAroundParens)
+    }
+
     // MARK: - spaceInsideParens
 
     func testSpaceInsideParens() {
@@ -437,6 +443,12 @@ class SpacingTests: RulesTests {
         let output = "func foo(arg _: borrowing [String]) {}"
         testFormatting(for: input, output, rule: FormatRules.spaceAroundBrackets,
                        exclude: ["noExplicitOwnership"])
+    }
+
+    func testAddSpaceBetweenSendingAndStringArray() {
+        let input = "func foo(arg _: sending[String]) {}"
+        let output = "func foo(arg _: sending [String]) {}"
+        testFormatting(for: input, output, rule: FormatRules.spaceAroundBrackets)
     }
 
     // MARK: - spaceInsideBrackets


### PR DESCRIPTION
SE-0430 has been [accepted](https://forums.swift.org/t/accepted-with-modifications-se-0430-second-review-sendable-parameter-and-result-values/71850) which adds the `sending` keyword.

This PR adds support for the keyword to the spaceAroundParens & spaceAroundBrackets rules.