### PR TITLE
Add "~" to the allowed operators in generic scopes

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1783,7 +1783,7 @@ public func tokenize(_ source: String) -> [Token] {
                 switch token {
                 case let .operator(string, _):
                     switch string {
-                    case ".", "==", "?", "!", "&", "->":
+                    case ".", "==", "?", "!", "&", "->", "~":
                         if index(of: .nonSpaceOrCommentOrLinebreak, before: count - 1) == scopeIndex {
                             // These are allowed in a generic, but not as the first character
                             fallthrough

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -828,6 +828,11 @@ class SpacingTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.spaceAroundOperators)
     }
 
+    func testNoSpaceAroundInitWithGenericAndSuppressedConstraint() {
+        let input = "init<T: ~Copyable>()"
+        testFormatting(for: input, rule: FormatRules.spaceAroundOperators)
+    }
+
     func testSpaceAfterOptionalAs() {
         let input = "foo as?[String]"
         let output = "foo as? [String]"
@@ -842,6 +847,11 @@ class SpacingTests: RulesTests {
 
     func testNoSpaceAroundGenerics() {
         let input = "Foo<String>"
+        testFormatting(for: input, rule: FormatRules.spaceAroundOperators)
+    }
+
+    func testNoSpaceAroundGenericsWithSuppressedConstraint() {
+        let input = "Foo<String: ~Copyable>"
         testFormatting(for: input, rule: FormatRules.spaceAroundOperators)
     }
 

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -4491,7 +4491,7 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
-    // MARK: Noncopyable
+    // MARK: Supressed Conformances
 
     func testNoncopyableStructDeclaration() {
         let input = "struct Foo: ~Copyable {}"
@@ -4506,6 +4506,51 @@ class TokenizerTests: XCTestCase {
             .space(" "),
             .startOfScope("{"),
             .endOfScope("}"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
+    func testSuppressedConformanceInWhereCondition() {
+        let input = "Foo<T> where T: ~Copyable"
+        let output: [Token] = [
+            .identifier("Foo"),
+            .startOfScope("<"),
+            .identifier("T"),
+            .endOfScope(">"),
+            .space(" "),
+            .keyword("where"),
+            .space(" "),
+            .identifier("T"),
+            .delimiter(":"),
+            .space(" "),
+            .operator("~", .prefix),
+            .identifier("Copyable"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
+    func testSuppressedConformancesOnGenericParameters() {
+        let input = "Foo<T: ~Copyable, U: Sendable & ~Escapable>"
+        let output: [Token] = [
+            .identifier("Foo"),
+            .startOfScope("<"),
+            .identifier("T"),
+            .delimiter(":"),
+            .space(" "),
+            .operator("~", .prefix),
+            .identifier("Copyable"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("U"),
+            .delimiter(":"),
+            .space(" "),
+            .identifier("Sendable"),
+            .space(" "),
+            .operator("&", .infix),
+            .space(" "),
+            .operator("~", .prefix),
+            .identifier("Escapable"),
+            .endOfScope(">"),
         ]
         XCTAssertEqual(tokenize(input), output)
     }


### PR DESCRIPTION
`~` is used in generic scopes to [suppress conformances (SE-0427)](https://github.com/apple/swift-evolution/blob/main/proposals/0427-noncopyable-generics.md).

```swift
func foo<T: ~Copyable>() {}
```

This ensures generic scopes containing `~` are parsed as generic scopes, otherwise the `<` and `>`are interpreted as operators.

I added a basic tokenizer test and some tests for the `spaceAroundOperators` rule for cases that incorrectly add space around `<` and `>` without this change. Feel free to let me know if there are other tests I should add as well.

It probably makes sense to hold off on merging this until SE-0427 has been accepted.