### PR TITLE
Fix closure argument list parsing bug in preferForLoop rule

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1860,8 +1860,19 @@ extension Formatter {
                 return (argumentNames: [], inKeywordIndex: inKeywordIndex)
             }
 
-            let argumentTokens = tokens[firstTokenInArgumentsList ... endOfArgumentsScopeIndex].split(separator: .delimiter(","))
-            argumentNames = argumentTokens.compactMap { $0.first(where: \.isIdentifier)?.string ?? $0[0].string }
+            // Parse the comma-separated list of arguments
+            var currentArgIndex = firstTokenInArgumentsList
+            while tokens[currentArgIndex].isIdentifierOrKeyword {
+                argumentNames.append(tokens[currentArgIndex].string)
+
+                guard let nextComma = index(of: .delimiter(","), in: currentArgIndex ..< endOfArgumentsScopeIndex),
+                      let nextArgLabel = index(of: .identifierOrKeyword, in: nextComma ..< endOfArgumentsScopeIndex)
+                else {
+                    break
+                }
+
+                currentArgIndex = nextArgLabel
+            }
         }
 
         // Otherwise this is an anonymous closure

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -4896,6 +4896,28 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.preferForLoop)
     }
 
+    func testForEachOverDictionary() {
+        let input = """
+        let dict = ["a": "b"]
+
+        dict.forEach { (header: (key: String, value: String)) in
+            print(header.key)
+            print(header.value)
+        }
+        """
+
+        let output = """
+        let dict = ["a": "b"]
+
+        for header in dict {
+            print(header.key)
+            print(header.value)
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.preferForLoop)
+    }
+
     // MARK: propertyType
 
     func testConvertsExplicitTypeToInferredType() {


### PR DESCRIPTION
This PR fixes #1709.

This code was being parsed incorrectly:

```swift
dict.forEach { (header: (key: String, value: String)) in
    print(header.key)
    print(header.value)
}
```

so was unexpectedly converted to:

```swift
for (header, value) in dict {
    print(header.key)
    print(header.value)
}
```

instead of:

```swift
for header in dict {
    print(header.key)
    print(header.value)
}
```