### PR TITLE
Improve attribute handling in opaqueGenericParameters rule

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -6627,9 +6627,7 @@ public struct _FormatRules {
                 genericSignatureStartIndex < paramListStartIndex,
                 genericSignatureEndIndex < paramListStartIndex,
                 let openBraceIndex = formatter.index(of: .startOfScope("{"), after: paramListEndIndex),
-                let closeBraceIndex = formatter.endOfScope(at: openBraceIndex),
-                // Ignore anything with attributes
-                !formatter.modifiersForDeclaration(at: keywordIndex, contains: { $1.hasPrefix("@") })
+                let closeBraceIndex = formatter.endOfScope(at: openBraceIndex)
             else { return }
 
             var genericTypes = [Formatter.GenericType]()
@@ -6697,6 +6695,14 @@ public struct _FormatRules {
 
                 // If the generic type occurs in the body of the function, then it can't be removed
                 if bodyTokens.contains(where: { $0.string == genericType.name }) {
+                    genericType.eligibleToRemove = false
+                    continue
+                }
+
+                // If the generic type is referenced in any attributes, then it can't be removed
+                let startOfModifiers = formatter.startOfModifiers(at: keywordIndex, includingAttributes: true)
+                let modifierTokens = formatter.tokens[startOfModifiers ..< keywordIndex]
+                if modifierTokens.contains(where: { $0.string == genericType.name }) {
                     genericType.eligibleToRemove = false
                     continue
                 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -2867,6 +2867,37 @@ class SyntaxTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.opaqueGenericParameters, options: options)
     }
 
+    func testGenericSimplifiedInMethodWithAttributeOrMacro() {
+        let input = """
+        @MyResultBuilder
+        func foo<T: Foo, U: Bar>(foo: T, bar: U) -> MyResult {
+            foo
+            bar
+        }
+
+        @MyFunctionBodyMacro(withArgument: true)
+        func foo<T: Foo, U: Bar>(foo: T, bar: U) {
+            print(foo, bar)
+        }
+        """
+
+        let output = """
+        @MyResultBuilder
+        func foo(foo: some Foo, bar: some Bar) -> MyResult {
+            foo
+            bar
+        }
+
+        @MyFunctionBodyMacro(withArgument: true)
+        func foo(foo: some Foo, bar: some Bar) {
+            print(foo, bar)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: FormatRules.opaqueGenericParameters, options: options)
+    }
+
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {


### PR DESCRIPTION
This PR improves attribute handling in the `opaqueGenericParameters` rule.

To fix #1684, https://github.com/nicklockwood/SwiftFormat/commit/383fd4813c7fb45e4e996242b6c7c919133f5dc1 made it so the `opaqueGenericParameters` was disabled for all functions with attributes. However, in most cases attributes don't cause any issues. For example:

```swift
@MyResultBuilder
func foo<T: Foo, U: Bar>(foo: T, bar: U) -> MyResult {
    foo
    bar
}

@MyFunctionBodyMacro(withArgument: true)
func foo<T: Foo, U: Bar>(foo: T, bar: U) {
    print(foo, bar)
}
```

This PR tweaks the existing fix to check the tokens of the attributes, and whether or not they reference any of the generic arguments. #1684 remains fixed, and the above examples are now updated as expected:

```swift
@MyResultBuilder
func foo(foo: some Foo, bar: some Bar) -> MyResult {
    foo
    bar
}

@MyFunctionBodyMacro(withArgument: true)
func foo(foo: some Foo, bar: some Bar) {
    print(foo, bar)
}
```