### PR TITLE
Fix issue where conditional compilation blocks would be sorted incorrectly

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2099,8 +2099,14 @@ extension Formatter {
                 return .beforeMarks
             }
 
-        case .conditionalCompilation:
-            return .conditionalCompilation
+        case let .conditionalCompilation(_, body, _):
+            // Prefer treating conditional compliation blocks as having
+            // the property type of the first declaration in their body.
+            if let firstDeclarationInBlock = body.first {
+                return type(of: firstDeclarationInBlock, for: mode)
+            } else {
+                return .conditionalCompilation
+            }
         }
     }
 

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1284,6 +1284,12 @@ class OrganizationTests: RulesTests {
             init() {}
 
             var quuz = "quux"
+
+            #if DEBUG
+            struct Test {
+                let foo: Bar
+            }
+            #endif
         }
         """
 
@@ -1295,8 +1301,6 @@ class OrganizationTests: RulesTests {
             init() {}
 
             // MARK: Public
-
-            public var bar = "bar"
 
             #if DEBUG
             public struct DebugFoo {
@@ -1315,17 +1319,26 @@ class OrganizationTests: RulesTests {
             private let other = "other"
             #endif
 
+            public var bar = "bar"
+
             // MARK: Internal
+
+            #if DEBUG
+            struct Test {
+                let foo: Bar
+            }
+            #endif
 
             var baz = "baz"
 
             var quuz = "quux"
+
         }
         """
 
         testFormatting(for: input, output, rule: FormatRules.organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope", "propertyType"])
+                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "propertyType"])
     }
 
     func testOrganizesTypeBelowSymbolImport() {
@@ -1783,6 +1796,52 @@ class OrganizationTests: RulesTests {
             rule: FormatRules.organizeDeclarations,
             options: FormatOptions(markCategories: false)
         )
+    }
+
+    func testOrganizeConditionalInitDeclaration() {
+        let input = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            #if DEBUG
+            init() {
+                print("Debug")
+            }
+            #endif
+
+            // MARK: Internal
+
+            func test() {}
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+    }
+
+    func testOrganizeConditionalPublicFunction() {
+        let input = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Public
+
+            #if DEBUG
+            public func publicTest() {}
+            #endif
+
+            // MARK: Internal
+
+            func internalTest() {}
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
     }
 
     // MARK: extensionAccessControl .onDeclarations


### PR DESCRIPTION
This PR fixes a regression introduced by #1678 where conditional compilation blocks would be sorted incorrectly (always at the bottom).

Previously the `organizeDeclarations` rule supported a partial ordering, where any declaration without a defined type would just preserve its existing relative ordering. The architecture changes to the `organizeDeclaration` rule now require a total ordering of declarations, so every declaration must have a well defined type.

Since conditional compilation blocks can have multiple nested declarations with different types, we previously just used `type: nil` for these. #1678 made these a type of their own which was sorted last. Now, we instead use the type of the first declaration in the conditional compilation block. This better matches the previous behavior.

### Before

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    // MARK: Internal

    func test() {}

    #if DEBUG
    init() {
        print("Debug")
    }
    #endif

}
```

### After

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    #if DEBUG
    init() {
        print("Debug")
    }
    #endif

    // MARK: Internal

    func test() {}
}
```