### PR TITLE
Add redundant typed throws rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -56,6 +56,7 @@
 * [redundantSelf](#redundantSelf)
 * [redundantStaticSelf](#redundantStaticSelf)
 * [redundantType](#redundantType)
+* [redundantTypedThrows](#redundantTypedThrows)
 * [redundantVoidReturnType](#redundantVoidReturnType)
 * [semicolons](#semicolons)
 * [sortDeclarations](#sortDeclarations)
@@ -2082,6 +2083,28 @@ Option | Description
   } else {
 -     Foo("bar")
 +     .init("foo")
+  }
+```
+
+</details>
+<br/>
+
+## redundantTypedThrows
+
+Converts `throws(any Error)` to `throws`, and converts `throws(Never)` to non-throwing functions.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- func foo() throws(Never) -> Int {
++ func foo() -> Int {
+      return 0
+  }
+
+- func foo() throws(any Error) -> Int {
++ func foo() throws -> Int {
+      throw MyError.foo
   }
 ```
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1935,4 +1935,18 @@ private struct Examples {
       }
     ```
     """
+
+    let redundantTypedThrows = """
+    ```diff
+    - func foo() throws(Never) -> Int {
+    + func foo() -> Int {
+          return 0
+      }
+
+    - func foo() throws(any Error) -> Int {
+    + func foo() throws -> Int {
+          throw MyError.foo
+      }
+    ```
+    """
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -8207,4 +8207,33 @@ public struct _FormatRules {
             )
         }
     }
+
+    public let redundantTypedThrows = FormatRule(help: "Converts `throws(any Error)` to `throws`, and converts `throws(Never)` to non-throwing functions.") { formatter in
+
+        formatter.forEach(.keyword("throws")) { throwsIndex, _ in
+            guard // Typed throws was added in Swift 6.0: https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md
+                formatter.options.swiftVersion >= "6.0",
+                let startOfScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: throwsIndex),
+                formatter.tokens[startOfScope] == .startOfScope("("),
+                let endOfScope = formatter.endOfScope(at: startOfScope)
+            else { return }
+
+            let throwsTypeRange = (startOfScope + 1) ..< endOfScope
+            let throwsType: String = formatter.tokens[throwsTypeRange].map { $0.string }.joined()
+
+            if throwsType == "Never" {
+                if formatter.tokens[endOfScope + 1].isSpace {
+                    formatter.removeTokens(in: throwsIndex ... endOfScope + 1)
+                } else {
+                    formatter.removeTokens(in: throwsIndex ... endOfScope)
+                }
+            }
+
+            // We don't remove `(Error)` because we can't guarantee it will reference the `Swift.Error` protocol
+            // (it's relatively common to define a custom error like `enum Error: Swift.Error { ... }`).
+            if throwsType == "any Error" || throwsType == "any Swift.Error" || throwsType == "Swift.Error" {
+                formatter.removeTokens(in: startOfScope ... endOfScope)
+            }
+        }
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10147,7 +10147,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.redundantTypedThrows, options: options)
     }
 
-    func testDontRemovesRegularErrorTypeThrows() {
+    func testDontRemovesNonRedundantErrorTypeThrows() {
         let input = """
         func bar() throws(BarError) -> Foo {
             throw .foo
@@ -10158,17 +10158,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        let output = """
-        func bar() throws(BarError) -> Foo {
-            throw .foo
-        }
-
-        func foo() throws(Error) -> Int {
-            throw MyError.foo
-        }
-        """
-
         let options = FormatOptions(swiftVersion: "6.0")
-        testFormatting(for: input, output, rule: FormatRules.redundantTypedThrows, options: options)
+        testFormatting(for: input, rule: FormatRules.redundantTypedThrows, options: options)
     }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10110,4 +10110,65 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.redundantProperty)
     }
+
+    // MARK: - redundantTypedThrows
+
+    func testRemovesRedundantNeverTypeThrows() {
+        let input = """
+        func foo() throws(Never) -> Int {
+            0
+        }
+        """
+
+        let output = """
+        func foo() -> Int {
+            0
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "6.0")
+        testFormatting(for: input, output, rule: FormatRules.redundantTypedThrows, options: options)
+    }
+
+    func testRemovesRedundantAnyErrorTypeThrows() {
+        let input = """
+        func foo() throws(any Error) -> Int {
+            throw MyError.foo
+        }
+        """
+
+        let output = """
+        func foo() throws -> Int {
+            throw MyError.foo
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "6.0")
+        testFormatting(for: input, output, rule: FormatRules.redundantTypedThrows, options: options)
+    }
+
+    func testDontRemovesRegularErrorTypeThrows() {
+        let input = """
+        func bar() throws(BarError) -> Foo {
+            throw .foo
+        }
+
+        func foo() throws(Error) -> Int {
+            throw MyError.foo
+        }
+        """
+
+        let output = """
+        func bar() throws(BarError) -> Foo {
+            throw .foo
+        }
+
+        func foo() throws(Error) -> Int {
+            throw MyError.foo
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "6.0")
+        testFormatting(for: input, output, rule: FormatRules.redundantTypedThrows, options: options)
+    }
 }


### PR DESCRIPTION
This PR adds a new `redundantTypedThrows` rule, which removes a typed throws (introduced in Swift 6.0) if it is redundant. 

For example:

```diff
- func foo() throws(Never) -> Int {
+ func foo() -> Int {
      return 0
  }

- func foo() throws(any Error) -> Int {
+ func foo() throws -> Int {
      throw MyError.foo
  }
```
We don't remove `(Error)` because we can't guarantee it will reference the `Swift.Error` protocol
(it's relatively common to define a custom error like `enum Error: Swift.Error { ... }`).