### PR TITLE
Fix bug where if statement body could be incorrectly parsed as trailing closure

### DIFF
--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10110,4 +10110,20 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.redundantProperty)
     }
+
+    func testPreservesUnwrapConditionInIfStatement() {
+        let input = """
+        func foo() -> Foo {
+            let foo = Foo(bar: bar, baaz: baaz)
+
+            if let foo = foo.nestedFoo {
+                print(foo)
+            }
+
+            return foo
+        }
+        """
+
+        testFormatting(for: input, rule: FormatRules.redundantProperty)
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where the body of an if statement could be incorrectly parsed as a trailing closure.

This fixes an issue where the `redundantProperty` rule would incorrectly convert this code:

```swift
func foo() -> Foo {
    let foo = Foo(bar: bar, baaz: baaz)

    if let foo = foo.nestedFoo {
        print(foo)
    }

    return foo
}
```

to:

```swift
func foo() -> Foo {
    let foo = Foo(bar: bar, baaz: baaz)

    if return foo.nestedFoo {
        print(foo)
    }
}
```