### PR TITLE
Add CI job to build and upload artifact bundle for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+on:
+  release:
+    types: [created]
+name: Build Release Artifacts
+jobs:
+  macos:
+    name: Build macOS binary
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build macOS binary
+        run: swift build -c release --arch arm64 --arch x86
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: swiftformat_macos
+          path: .build/apple/Products/Release/swiftformat
+          retention-days: 5
+
+  linux:
+    name: Build SwiftFormat for Linux
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build it
+        run: |
+          swift build --configuration release --static-swift-stdlib --enable-dead-strip
+          SWIFTFORMAT_BIN_PATH=`swift build --configuration release --show-bin-path`
+          mv $SWIFTFORMAT_BIN_PATH/swiftformat "${HOME}/swiftformat_linux"
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: swiftformat_linux
+          path: ~/swiftformat_linux
+          retention-days: 5
+
+  upload:
+    name: Upload release artifactsts
+    runs-on: ubuntu-latest
+    needs: [macos, linux]
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v4
+        with:
+          path: downloaded_artifacts
+      - name: Display structure of downloaded files
+        run: ls -R downloaded_artifacts
+      - name: Build artifact bundle
+        run: ./Scripts/spm-artifact-bundle.sh ${{ github.event.release.name }} downloaded_artifacts/swiftformat_macos/swiftformat downloaded_artifacts/swiftformat_linux/swiftformat_linux
+      - name: Upload artifact bundle
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: 'swiftformat.artifactbundle.zip'

--- a/Scripts/spm-artifact-bundle.sh
+++ b/Scripts/spm-artifact-bundle.sh
@@ -2,11 +2,20 @@
 
 set -e
 
+# By default, parses the current version from `Sources/SwiftFormat.swift`.
+# Can be overridden by passing in custom version number as argument, e.g.
+# `./Scripts/spm-artifact-bundle.sh VERSION_NUMBER`.
+VERSION=${1:-$(./Scripts/get-version.sh)}
+MAC_EXECUTABLE=${2:-CommandLineTool/swiftformat}
+LINUX_EXECUTABLE=${3:-CommandLineTool/swiftformat_linux}
+
 ARTIFACT_BUNDLE=swiftformat.artifactbundle
 INFO_TEMPLATE=Scripts/spm-artifact-bundle-info.template
-VERSION=$(./Scripts/get-version.sh)
 MAC_BINARY_OUTPUT_DIR=$ARTIFACT_BUNDLE/swiftformat-$VERSION-macos/bin
 LINUX_BINARY_OUTPUT_DIR=$ARTIFACT_BUNDLE/swiftformat-$VERSION-linux-gnu/bin
+
+rm -rf swiftformat.artifactbundle
+rm -rf swiftformat.artifactbundle.zip
 
 mkdir $ARTIFACT_BUNDLE
 
@@ -17,12 +26,14 @@ cp LICENSE.md $ARTIFACT_BUNDLE
 sed 's/__VERSION__/'"${VERSION}"'/g' $INFO_TEMPLATE > "${ARTIFACT_BUNDLE}/info.json"
 
 # Copy macOS SwiftFormat binary into bundle
+chmod +x $MAC_EXECUTABLE
 mkdir -p $MAC_BINARY_OUTPUT_DIR
-cp CommandLineTool/swiftformat $MAC_BINARY_OUTPUT_DIR
+cp $MAC_EXECUTABLE $MAC_BINARY_OUTPUT_DIR
 
 # Copy Linux SwiftFormat binary into bundle
+chmod +x $LINUX_EXECUTABLE
 mkdir -p $LINUX_BINARY_OUTPUT_DIR
-cp CommandLineTool/swiftformat_linux $LINUX_BINARY_OUTPUT_DIR
+cp $LINUX_EXECUTABLE $LINUX_BINARY_OUTPUT_DIR
 
 # Create ZIP
 zip -yr - $ARTIFACT_BUNDLE > "${ARTIFACT_BUNDLE}.zip"


### PR DESCRIPTION
This PR adds a GitHub Actions CI job that builds `swiftformat.artifactbundle.zip` for each new release and automatically uploads / attached it to the release page.

- Here's an example release using this: https://github.com/calda/SwiftFormat/releases/tag/0.54-test-upload-release-artifact-3
- And here's the action run that buildtand uploaded the `swiftformat.artifactbundle.zip` file to that release: https://github.com/calda/SwiftFormat/actions/runs/9454508406

I cut new releases regularly over in https://github.com/calda/SwiftFormat/releases, so automating this process would be helpful. To use this job in that repo I have to upstream it here. I don't know how you're managing this today, but hopefully automating this is helpful for you as well!

I verified that the artifact bundle can be consumed properly by Swift Package Manager.