### PR TITLE
Support comments when removing spaces between chained functions

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1190,9 +1190,10 @@ public struct _FormatRules {
             let endOfLine = formatter.endOfLine(at: i)
             if let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfLine),
                formatter.tokens[nextIndex] == .operator(".", .infix),
-               let commentIndex = formatter.index(of: .nonSpaceOrLinebreak, after: endOfLine)
+               // Make sure to preserve any code comment between the two lines
+               let nextTokenOrComment = formatter.index(of: .nonSpaceOrLinebreak, after: endOfLine)
             {
-                let startOfLine = formatter.startOfLine(at: commentIndex)
+                let startOfLine = formatter.startOfLine(at: nextTokenOrComment)
                 formatter.removeTokens(in: endOfLine + 1 ..< startOfLine)
             }
         }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -1188,10 +1188,11 @@ public struct _FormatRules {
     ) { formatter in
         formatter.forEach(.operator(".", .infix)) { i, _ in
             let endOfLine = formatter.endOfLine(at: i)
-            if let nextIndex = formatter.index(of: .nonSpaceOrLinebreak, after: endOfLine, if: {
-                $0 == .operator(".", .infix)
-            }) {
-                let startOfLine = formatter.startOfLine(at: nextIndex)
+            if let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfLine),
+               formatter.tokens[nextIndex] == .operator(".", .infix),
+               let commentIndex = formatter.index(of: .nonSpaceOrLinebreak, after: endOfLine)
+            {
+                let startOfLine = formatter.startOfLine(at: commentIndex)
                 formatter.removeTokens(in: endOfLine + 1 ..< startOfLine)
             }
         }

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -394,6 +394,23 @@ class LinebreakTests: RulesTests {
         testFormatting(for: input, [output1, output2], rules: [FormatRules.blankLinesBetweenChainedFunctions])
     }
 
+    func testBlankLinesWithCommentsBetweenChainedFunctions() {
+        let input = """
+        [0, 1, 2]
+            .map { $0 * 2 }
+
+            // Multiplies by 3
+            .map { $0 * 3 }
+        """
+        let output = """
+        [0, 1, 2]
+            .map { $0 * 2 }
+            // Multiplies by 3
+            .map { $0 * 3 }
+        """
+        testFormatting(for: input, output, rule: FormatRules.blankLinesBetweenChainedFunctions)
+    }
+
     // MARK: - blankLineAfterImports
 
     func testBlankLineAfterImport() {


### PR DESCRIPTION
Updating the `blankLinesBetweenChainedFunctions` rule to take comments into account when removing blank lines between chained functions.

So this:
```swift

[0, 1, 2]
    .map { $0 * 2 }

    // Multiplies by 3
    .map { $0 * 3 }
```

Will turn into:

```swift
[0, 1, 2]
    .map { $0 * 2 }
    // Multiplies by 3
    .map { $0 * 3 }
```

cc @calda 