### PR TITLE
Update trigger for release action from `created` to `published`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build macOS binary
-        run: swift build -c release --arch arm64 --arch x86
+        run: swift build -c release --arch arm64 --arch x86_64
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [created]
+    types: [published]
 name: Build Release Artifacts
 jobs:
   macos:


### PR DESCRIPTION
The release new action from #1721 didn't trigger properly for 0.54.0. 

Right now the job uses a `release: [created]` trigger. The [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) says:

> Note: Workflows are not triggered for the `created`, `edited`, or `deleted` activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.

This is probably the most likely explanation for why it didn't work.

It sounds like the recommended trigger is `published` rather than `created`:

```
on:
  release:
    types: [published]
```

so this PR updates the trigger. Hopefully now it'll work for 0.54.1!