### PR TITLE
Fix `--nilInit insert` being applied to computed property

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2966,7 +2966,7 @@ public struct _FormatRules {
                             formatter.removeTokens(in: optionalIndex + 1 ... nilIndex)
                         }
                     case .insert:
-                        if equalsIndex == nil {
+                        if formatter.isStoredProperty(atIntroducerIndex: index) && equalsIndex == nil {
                             let tokens: [Token] = [.space(" "), .operator("=", .infix), .space(" "), .identifier("nil")]
                             formatter.insert(tokens, at: optionalIndex + 1)
                         }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2949,7 +2949,7 @@ public struct _FormatRules {
         help: "Remove/insert redundant `nil` default value (Optional vars are nil by default).",
         options: ["nilinit"]
     ) { formatter in
-        func search(from index: Int) {
+        func search(from index: Int, isStoredProperty: Bool) {
             if let optionalIndex = formatter.index(of: .unwrapOperator, after: index) {
                 if formatter.index(of: .endOfStatement, in: index + 1 ..< optionalIndex) != nil {
                     return
@@ -2966,13 +2966,13 @@ public struct _FormatRules {
                             formatter.removeTokens(in: optionalIndex + 1 ... nilIndex)
                         }
                     case .insert:
-                        if formatter.isStoredProperty(atIntroducerIndex: index) && equalsIndex == nil {
+                        if isStoredProperty && equalsIndex == nil {
                             let tokens: [Token] = [.space(" "), .operator("=", .infix), .space(" "), .identifier("nil")]
                             formatter.insert(tokens, at: optionalIndex + 1)
                         }
                     }
                 }
-                search(from: optionalIndex)
+                search(from: optionalIndex, isStoredProperty: isStoredProperty)
             }
         }
 
@@ -3004,7 +3004,7 @@ public struct _FormatRules {
                 }
             }
             // Find the nil
-            search(from: i)
+            search(from: i, isStoredProperty: formatter.isStoredProperty(atIntroducerIndex: i))
         }
     }
 

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2045,14 +2045,14 @@ class RedundancyTests: RulesTests {
     }
 
     func testNoInsertLazyVarNilInit() {
-        let input = "lazy var foo: Int? = nil"
+        let input = "lazy var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }
 
     func testNoInsertLazyPublicPrivateSetVarNilInit() {
-        let input = "lazy private(set) public var foo: Int? = nil"
+        let input = "lazy private(set) public var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit, options: options,
                        exclude: ["modifierOrder"])
@@ -2066,28 +2066,28 @@ class RedundancyTests: RulesTests {
     }
 
     func testNoInsertNilInitWithPropertyWrapper() {
-        let input = "@Foo var foo: Int? = nil"
+        let input = "@Foo var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithLowercasePropertyWrapper() {
-        let input = "@foo var foo: Int? = nil"
+        let input = "@foo var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithPropertyWrapperWithArgument() {
-        let input = "@Foo(bar: baz) var foo: Int? = nil"
+        let input = "@Foo(bar: baz) var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithLowercasePropertyWrapperWithArgument() {
-        let input = "@foo(bar: baz) var foo: Int? = nil"
+        let input = "@foo(bar: baz) var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
@@ -2157,6 +2157,7 @@ class RedundancyTests: RulesTests {
     }
 
     func testNoInsertNilInitInViewBuilder() {
+        // Not insert `nil` in result builder
         let input = """
         struct TestView: View {
             var body: some View {
@@ -2170,7 +2171,8 @@ class RedundancyTests: RulesTests {
                        options: options)
     }
 
-    func testInsertNilInitInIfStatementInViewBuilder() {
+    func testNoInsertNilInitInIfStatementInViewBuilder() {
+        // Not insert `nil` in result builder
         let input = """
         struct TestView: View {
             var body: some View {
@@ -2183,12 +2185,13 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(nilInit: .remove)
+        let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }
 
-    func testInsertNilInitInSwitchStatementInViewBuilder() {
+    func testNoInsertNilInitInSwitchStatementInViewBuilder() {
+        // Not insert `nil` in result builder
         let input = """
         struct TestView: View {
             var body: some View {
@@ -2203,7 +2206,7 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        let options = FormatOptions(nilInit: .remove)
+        let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: FormatRules.redundantNilInit,
                        options: options)
     }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2211,6 +2211,61 @@ class RedundancyTests: RulesTests {
                        options: options)
     }
 
+    func testNoInsertNilInitInSingleLineComputedProperty() {
+        let input = """
+        var bar: String? { "some string" }
+        var foo: String? { nil }
+        """
+        let options = FormatOptions(nilInit: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitInMultilineComputedProperty() {
+        let input = """
+        var foo: String? {
+            print("some")
+        }
+
+        var bar: String? {
+            nil
+        }
+        """
+        let options = FormatOptions(nilInit: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testNoInsertNilInitInCustomGetterAndSetterProperty() {
+        let input = """
+        var _foo: String? = nil
+        var foo: String? {
+            set { _foo = newValue }
+            get { newValue }
+        }
+        """
+        let options = FormatOptions(nilInit: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
+    func testInsertNilInitInInstancePropertyWithBody() {
+        let input = """
+        var foo: String? {
+            didSet { print(foo) }
+        }
+        """
+
+        let output = """
+        var foo: String? = nil {
+            didSet { print(foo) }
+        }
+        """
+        let options = FormatOptions(nilInit: .insert)
+        testFormatting(for: input, output, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
     // MARK: - redundantLet
 
     func testRemoveRedundantLet() {


### PR DESCRIPTION
## Fixed

This PR mainly fixes the following issues:

- Fixed the issue that the newly added `--nilInit insert` option for `redundantNilInit` in 0.54.0 was incorrectly applied to computed properties.

Also I fixed some test case errors related to `--nilInit insert`.
