### PR TITLE
Fixes linting with stdin

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -707,9 +707,18 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
                         if !dryrun, (try? String(contentsOf: outputURL)) != output {
                             try write(output, to: outputURL)
                         }
-                    } else {
+                    } else if !lint {
                         // Write to stdout
                         print(dryrun ? input : output, as: .raw)
+                    } else {
+                        if let reporterOutput = try reporter.write() {
+                            if let reportURL = reportURL {
+                                print("Writing report file to \(reportURL.path)")
+                                try reporterOutput.write(to: reportURL, options: .atomic)
+                            } else {
+                                print(String(decoding: reporterOutput, as: UTF8.self), as: .raw)
+                            }
+                        }
                     }
                     let exitCode: ExitCode
                     if lint, output != input {


### PR DESCRIPTION
closes #1741

This PR improves support for running `--lint` when providing input from stdin. The reporter.write is now invoked similarly to how it is when the file is read directly from disk.

There is still one issue I've not figured out. The `indent` rule is flagged for every single line of the input when supplied via stdin. Must be something to do with how it is read/how the rule detects newlines/indentation.

However, I think that could warrant its own issue and PR if this one is accepted.

As an aside, I don't use xcode, just the swift cli and swift package manager, so not sure if anything else is required for this change.