### PR TITLE
Add SwiftUI Property Wrapper declaration type

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2062,11 +2062,10 @@ extension Formatter {
                 return declarationParser.index(of: .identifier("View"), after: someKeywordIndex) != nil
             }()
 
-            let isSwiftUIPropertyWrapper = mode == .visibility && { () -> Bool in
+            let isSwiftUIPropertyWrapper = mode == .visibility &&
                 declarationParser.modifiersForDeclaration(at: declarationTypeTokenIndex, contains: { _, modifier in
                     swiftUIPropertyWrappers.contains(modifier)
                 })
-            }()
 
             switch declarationTypeToken {
             // Properties and property-like declarations

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1921,7 +1921,7 @@ extension Formatter {
     }
 
     /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.
-    enum SwiftUIProperty: String, CaseIterable {
+    enum SwiftUIPropertyWrapper: String, CaseIterable {
         case accessibilityFocusState = "@AccessibilityFocusState"
         case appStorage = "@AppStorage"
         case binding = "@Binding"
@@ -2058,8 +2058,8 @@ extension Formatter {
                 return declarationParser.index(of: .identifier("View"), after: someKeywordIndex) != nil
             }()
 
-            let isSwiftUIDynamicProperty = {
-                for dynamicProperty in SwiftUIProperty.allCases {
+            let isSwiftUIPropertyWrapper = { () -> Bool in
+                for dynamicProperty in SwiftUIPropertyWrapper.allCases {
                     if declarationParser.index(
                         of: .keyword(dynamicProperty.rawValue),
                         before: declarationTypeTokenIndex
@@ -2106,7 +2106,7 @@ extension Formatter {
                     return .classPropertyWithBody
                 } else if isViewDeclaration {
                     return .swiftUIProperty
-                } else if !hasBody, isSwiftUIDynamicProperty {
+                } else if !hasBody, isSwiftUIPropertyWrapper {
                     return .swiftUIPropertyWrapper
                 } else {
                     if hasBody {

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1370,6 +1370,36 @@ extension Formatter {
         return branches
     }
 
+    /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.
+    /// Most of these are listed here: https://developer.apple.com/documentation/swiftui/dynamicproperty
+    private var swiftUIPropertyWrappers: Set<String> {
+        [
+            "@AccessibilityFocusState",
+            "@AppStorage",
+            "@Binding",
+            "@Environment",
+            "@EnvironmentObject",
+            "@NSApplicationDelegateAdaptor",
+            "@FetchRequest",
+            "@FocusedBinding",
+            "@FocusedState",
+            "@FocusedValue",
+            "@FocusedObject",
+            "@GestureState",
+            "@Namespace",
+            "@ObservedObject",
+            "@PhysicalMetric",
+            "@Query",
+            "@ScaledMetric",
+            "@SceneStorage",
+            "@SectionedFetchRequest",
+            "@State",
+            "@StateObject",
+            "@UIApplicationDelegateAdaptor",
+            "@WKExtensionDelegateAdaptor",
+        ]
+    }
+
     /// Parses the switch statement case starting at the given index,
     /// which should be one of: `case`, `default`, or `@unknown`.
     private func parseSwitchStatementCase(caseOrDefaultIndex: Int) -> (startOfBody: Int, endOfBody: Int)? {
@@ -1920,33 +1950,6 @@ extension Formatter {
         }
     }
 
-    /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.
-    enum SwiftUIPropertyWrapper: String, CaseIterable {
-        case accessibilityFocusState = "@AccessibilityFocusState"
-        case appStorage = "@AppStorage"
-        case binding = "@Binding"
-        case environment = "@Environment"
-        case environmentObject = "@EnvironmentObject"
-        case nsApplicationDelegateAdaptor = "@NSApplicationDelegateAdaptor"
-        case fetchRequest = "@FetchRequest"
-        case focusedBinding = "@FocusedBinding"
-        case focusedState = "@FocusedState"
-        case focusedValue = "@FocusedValue"
-        case focusedObject = "@FocusedObject"
-        case gestureState = "@GestureState"
-        case namespace = "@Namespace"
-        case observedObject = "@ObservedObject"
-        case physicalMetric = "@PhysicalMetric"
-        case query = "@Query"
-        case scaledMetric = "@ScaledMetric"
-        case sceneStorage = "@SceneStorage"
-        case sectionedFetchRequest = "@SectionedFetchRequest"
-        case state = "@State"
-        case stateObject = "@StateObject"
-        case uiApplicationDelegateAdaptor = "@UIApplicationDelegateAdaptor"
-        case wkExtensionDelegateAdaptor = "@WKExtensionDelegateAdaptor"
-    }
-
     func category(of declaration: Declaration, for mode: DeclarationOrganizationMode) -> Category {
         let visibility = self.visibility(of: declaration) ?? .internal
         let type = self.type(of: declaration, for: mode)
@@ -2060,15 +2063,9 @@ extension Formatter {
             }()
 
             let isSwiftUIPropertyWrapper = mode == .visibility && { () -> Bool in
-                for dynamicProperty in SwiftUIPropertyWrapper.allCases {
-                    if declarationParser.index(
-                        of: .keyword(dynamicProperty.rawValue),
-                        before: declarationTypeTokenIndex
-                    ) != nil {
-                        return true
-                    }
-                }
-                return false
+                declarationParser.modifiersForDeclaration(at: declarationTypeTokenIndex, contains: { _, modifier in
+                    swiftUIPropertyWrappers.contains(modifier)
+                })
             }()
 
             switch declarationTypeToken {

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1859,7 +1859,7 @@ extension Formatter {
         case staticPropertyWithBody
         case classPropertyWithBody
         case overriddenProperty
-        case swiftUIDynamicProperty
+        case swiftUIPropertyWrapper
         case instanceProperty
         case instancePropertyWithBody
         case instanceLifecycle
@@ -1891,8 +1891,8 @@ extension Formatter {
                 return "Overridden Functions"
             case .swiftUIProperty, .swiftUIMethod:
                 return "Content"
-            case .swiftUIDynamicProperty:
-                return "SwiftUI Dynamic Properties"
+            case .swiftUIPropertyWrapper:
+                return "SwiftUI Properties"
             case .instanceProperty:
                 return "Properties"
             case .instancePropertyWithBody:
@@ -1920,13 +1920,30 @@ extension Formatter {
         }
     }
 
-    /// Represents all the native  instance properties that rely on the `DynamicProperty` to cause a SwiftUI view to re-render.
-    enum SwiftUIDynamicProperty: String, CaseIterable {
-        case state = "@State"
-        case stateObject = "@StateObject"
+    /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.
+    enum SwiftUIProperty: String, CaseIterable {
+        case accessibilityFocusState = "@AccessibilityFocusState"
+        case appStorage = "@AppStorage"
         case binding = "@Binding"
         case environment = "@Environment"
         case environmentObject = "@EnvironmentObject"
+        case nsApplicationDelegateAdaptor = "@NSApplicationDelegateAdaptor"
+        case fetchRequest = "@FetchRequest"
+        case focusedBinding = "@FocusedBinding"
+        case focusedState = "@FocusedState"
+        case focusedValue = "@FocusedValue"
+        case focusedObject = "@FocusedObject"
+        case gestureState = "@GestureState"
+        case namespace = "@Namespace"
+        case observedObject = "@ObservedObject"
+        case physicalMetric = "@PhysicalMetric"
+        case scaledMetric = "@ScaledMetric"
+        case sceneStorage = "@SceneStorage"
+        case sectionedFetchRequest = "@SectionedFetchRequest"
+        case state = "@State"
+        case stateObject = "@StateObject"
+        case uiApplicationDelegateAdaptor = "@UIApplicationDelegateAdaptor"
+        case wkExtensionDelegateAdaptor = "@WKExtensionDelegateAdaptor"
     }
 
     func category(of declaration: Declaration, for mode: DeclarationOrganizationMode) -> Category {
@@ -2041,8 +2058,8 @@ extension Formatter {
                 return declarationParser.index(of: .identifier("View"), after: someKeywordIndex) != nil
             }()
 
-            let isSwiftUIDynamicProperty = mode == .type && {
-                for dynamicProperty in SwiftUIDynamicProperty.allCases {
+            let isSwiftUIDynamicProperty = {
+                for dynamicProperty in SwiftUIProperty.allCases {
                     if declarationParser.index(
                         of: .keyword(dynamicProperty.rawValue),
                         before: declarationTypeTokenIndex
@@ -2090,8 +2107,7 @@ extension Formatter {
                 } else if isViewDeclaration {
                     return .swiftUIProperty
                 } else if !hasBody, isSwiftUIDynamicProperty {
-                    declarationParser.token(at: declarationTypeTokenIndex)
-                    return .swiftUIDynamicProperty
+                    return .swiftUIPropertyWrapper
                 } else {
                     if hasBody {
                         return .instancePropertyWithBody

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1937,6 +1937,7 @@ extension Formatter {
         case namespace = "@Namespace"
         case observedObject = "@ObservedObject"
         case physicalMetric = "@PhysicalMetric"
+        case query = "@Query"
         case scaledMetric = "@ScaledMetric"
         case sceneStorage = "@SceneStorage"
         case sectionedFetchRequest = "@SectionedFetchRequest"
@@ -2058,7 +2059,7 @@ extension Formatter {
                 return declarationParser.index(of: .identifier("View"), after: someKeywordIndex) != nil
             }()
 
-            let isSwiftUIPropertyWrapper = { () -> Bool in
+            let isSwiftUIPropertyWrapper = mode == .visibility && { () -> Bool in
                 for dynamicProperty in SwiftUIPropertyWrapper.allCases {
                     if declarationParser.index(
                         of: .keyword(dynamicProperty.rawValue),

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -4565,9 +4565,9 @@ class OrganizationTests: RulesTests {
         struct ContentView: View {
 
             let foo: Foo
-            @State let bar: Bar
+            @State var bar: Bar
             let baaz: Baaz
-            @State let quux: Quux
+            @State var quux: Quux
 
             @ViewBuilder
             private var toggle: some View {
@@ -4586,8 +4586,8 @@ class OrganizationTests: RulesTests {
 
             // MARK: Internal
 
-            @State let bar: Bar
-            @State let quux: Quux
+            @State var bar: Bar
+            @State var quux: Quux
 
             let foo: Foo
             let baaz: Baaz
@@ -4620,7 +4620,7 @@ class OrganizationTests: RulesTests {
         struct ContentView: View {
 
             let foo: Foo
-            @State private let bar: Bar
+            @State private var bar: Bar
             private let baaz: Baaz
             @Binding var isOn: Bool
 
@@ -4652,9 +4652,64 @@ class OrganizationTests: RulesTests {
 
             // MARK: Private
 
-            @State private let bar: Bar
+            @State private var bar: Bar
 
             private let baaz: Baaz
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
+    func testSortSwiftUIPropertyWrappersWithArguments() {
+        let input = """
+        struct ContentView: View {
+
+            let foo: Foo
+            @Environment(\\.colorScheme) var colorScheme
+            let baaz: Baaz
+            @Environment(\\.quux) let quux: Quux
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Internal
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) let quux: Quux
+
+            let foo: Foo
+            let baaz: Baaz
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+
+            // MARK: Private
 
             @ViewBuilder
             private var toggle: some View {

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -4516,11 +4516,6 @@ class OrganizationTests: RulesTests {
             @ViewBuilder
             private var toggle: some View {
                 Toggle(label, isOn: $isOn)
-                    .fixedSize()
-            }
-
-            init(label: String) {
-                self.label = label
             }
 
             @ViewBuilder
@@ -4533,34 +4528,25 @@ class OrganizationTests: RulesTests {
         let output = """
         struct ContentView: View {
 
-            // MARK: SwiftUI Dynamic Properties
-
-            @State
-            private var isOn: Bool = false
-
-            // MARK: Properties
-
-            private var label: String
-
-            private var foo = true
-
-            // MARK: Lifecycle
-
-            init(label: String) {
-                self.label = label
-            }
-
-            // MARK: Content
+            // MARK: Internal
 
             @ViewBuilder
             var body: some View {
                 toggle
             }
 
+            // MARK: Private
+
+            @State
+            private var isOn: Bool = false
+
+            private var label: String
+
+            private var foo = true
+
             @ViewBuilder
             private var toggle: some View {
                 Toggle(label, isOn: $isOn)
-                    .fixedSize()
             }
 
         }
@@ -4569,7 +4555,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: FormatRules.organizeDeclarations,
-            options: FormatOptions(categoryMarkComment: "MARK: %c", organizeTypes: ["struct"], organizationMode: .type),
+            options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
             exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
         )
     }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -4501,4 +4501,76 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
     }
+
+    func testSortSwiftUIDynamicProperties() {
+        let input = """
+        struct ContentView: View {
+
+            private var label: String
+
+            @State
+            private var isOn: Bool = false
+
+            private var foo = true
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+            init(label: String) {
+                self.label = label
+            }
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: SwiftUI Dynamic Properties
+
+            @State
+            private var isOn: Bool = false
+
+            // MARK: Properties
+
+            private var label: String
+
+            private var foo = true
+
+            // MARK: Lifecycle
+
+            init(label: String) {
+                self.label = label
+            }
+
+            // MARK: Content
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+                    .fixedSize()
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(categoryMarkComment: "MARK: %c", organizeTypes: ["struct"], organizationMode: .type),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
 }

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -4502,7 +4502,7 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.sortTypealiases)
     }
 
-    func testSortSwiftUIDynamicProperties() {
+    func testSortSingleSwiftUIPropertyWrapper() {
         let input = """
         struct ContentView: View {
 
@@ -4543,6 +4543,118 @@ class OrganizationTests: RulesTests {
             private var label: String
 
             private var foo = true
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
+    func testSortMultipleSwiftUIPropertyWrappers() {
+        let input = """
+        struct ContentView: View {
+
+            let foo: Foo
+            @State let bar: Bar
+            let baaz: Baaz
+            @State let quux: Quux
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Internal
+
+            @State let bar: Bar
+            @State let quux: Quux
+
+            let foo: Foo
+            let baaz: Baaz
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+
+            // MARK: Private
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: FormatRules.organizeDeclarations,
+            options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
+            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+        )
+    }
+
+    func testSortSwiftUIPropertyWrappersWithDifferentVisibility() {
+        let input = """
+        struct ContentView: View {
+
+            let foo: Foo
+            @State private let bar: Bar
+            private let baaz: Baaz
+            @Binding var isOn: Bool
+
+            @ViewBuilder
+            private var toggle: some View {
+                Toggle(label, isOn: $isOn)
+            }
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Internal
+
+            @Binding var isOn: Bool
+
+            let foo: Foo
+
+            @ViewBuilder
+            var body: some View {
+                toggle
+            }
+
+            // MARK: Private
+
+            @State private let bar: Bar
+
+            private let baaz: Baaz
 
             @ViewBuilder
             private var toggle: some View {


### PR DESCRIPTION
Add a new SwiftUI Property wrapper declaration type to allow sorting instance properties based on this new declaration type. For Example

```diff
 struct ContentView: View {
-    let foo: Foo
     @State let isOn: Bool
+    @State let quux: Quux
+    let foo: Foo
     let baaz: Baaz
-    @State let quux: Quux

     @ViewBuilder
     private var toggle: some View {
         Toggle(label, isOn: $isOn)
     }

     @ViewBuilder
     var body: some View {
         toggle
     }
 }
```

