### PR TITLE
Add unusedPrivateDeclaration rule to remove unused private and fileprivate declarations

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -81,7 +81,6 @@
 * [trailingSpace](#trailingSpace)
 * [typeSugar](#typeSugar)
 * [unusedArguments](#unusedArguments)
-* [unusedPrivateDeclaration](#unusedPrivateDeclaration)
 * [void](#void)
 * [wrap](#wrap)
 * [wrapArguments](#wrapArguments)
@@ -105,6 +104,7 @@
 * [propertyType](#propertyType)
 * [redundantProperty](#redundantProperty)
 * [sortSwitchCases](#sortSwitchCases)
+* [unusedPrivateDeclaration](#unusedPrivateDeclaration)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
 * [wrapMultilineConditionalAssignment](#wrapMultilineConditionalAssignment)
@@ -2726,6 +2726,20 @@ Option | Description
 ## unusedPrivateDeclaration
 
 Remove unused private and fileprivate declarations.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+struct Foo {
+--    fileprivate var foo = "foo"
+--    fileprivate var baz = "baz"
+    var bar = "bar"
+}
+```
+
+</details>
+<br/>
 
 ## void
 

--- a/Rules.md
+++ b/Rules.md
@@ -2731,11 +2731,11 @@ Remove unused private and fileprivate declarations.
 <summary>Examples</summary>
 
 ```diff
-struct Foo {
---    fileprivate var foo = "foo"
---    fileprivate var baz = "baz"
-    var bar = "bar"
-}
+  struct Foo {
+-     fileprivate var foo = "foo"
+-     fileprivate var baz = "baz"
+      var bar = "bar"
+  }
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -81,6 +81,7 @@
 * [trailingSpace](#trailingSpace)
 * [typeSugar](#typeSugar)
 * [unusedArguments](#unusedArguments)
+* [unusedPrivateDeclaration](#unusedPrivateDeclaration)
 * [void](#void)
 * [wrap](#wrap)
 * [wrapArguments](#wrapArguments)
@@ -2721,6 +2722,10 @@ Option | Description
 
 </details>
 <br/>
+
+## unusedPrivateDeclaration
+
+Remove unused private and fileprivate declarations
 
 ## void
 

--- a/Rules.md
+++ b/Rules.md
@@ -2725,7 +2725,7 @@ Option | Description
 
 ## unusedPrivateDeclaration
 
-Remove unused private and fileprivate declarations
+Remove unused private and fileprivate declarations.
 
 ## void
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1971,4 +1971,14 @@ private struct Examples {
         }
     ```
     """
+
+    let unusedPrivateDeclaration = """
+    ```diff
+    struct Foo {
+    --    fileprivate var foo = "foo"
+    --    fileprivate var baz = "baz"
+        var bar = "bar"
+    }
+    ```
+    """
 }

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1974,11 +1974,11 @@ private struct Examples {
 
     let unusedPrivateDeclaration = """
     ```diff
-    struct Foo {
-    --    fileprivate var foo = "foo"
-    --    fileprivate var baz = "baz"
-        var bar = "bar"
-    }
+      struct Foo {
+    -     fileprivate var foo = "foo"
+    -     fileprivate var baz = "baz"
+          var bar = "bar"
+      }
     ```
     """
 }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1651,6 +1651,24 @@ extension Formatter {
 
 /// Helpers for recursively traversing the declaration hierarchy
 extension Formatter {
+    /// Applies `forEachRecursiveDeclarations` in place
+    func forEachRecursiveDeclarations(_ operation: (Declaration) -> Void) {
+        forEachRecursiveDeclarations(parseDeclarations(), operation)
+    }
+
+    /// Applies `operation` to every recursive declaration of the given declarations
+    func forEachRecursiveDeclarations(
+        _ declarations: [Declaration],
+        _ operation: (Declaration) -> Void
+    ) {
+        for declaration in declarations {
+            operation(declaration)
+            if let body = declaration.body {
+                forEachRecursiveDeclarations(body, operation)
+            }
+        }
+    }
+
     /// Applies `mapRecursiveDeclarations` in place
     func mapRecursiveDeclarations(with transform: (Declaration) -> Declaration) {
         let updatedDeclarations = mapRecursiveDeclarations(parseDeclarations()) { declaration, _ in

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1651,8 +1651,8 @@ extension Formatter {
 
 /// Helpers for recursively traversing the declaration hierarchy
 extension Formatter {
-    /// Applies `forEachRecursiveDeclarations` in place
-    func forEachRecursiveDeclarations(_ operation: (Declaration) -> Void) {
+    /// Recursively calls the `operation` for every declaration in the source file
+    func forEachRecursiveDeclaration(_ operation: (Declaration) -> Void) {
         forEachRecursiveDeclarations(parseDeclarations(), operation)
     }
 

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1981,7 +1981,8 @@ extension Formatter {
         var name: String? {
             let parser = Formatter(openTokens)
             guard let keywordIndex = openTokens.firstIndex(of: .keyword(keyword)),
-                  let nameIndex = parser.index(of: .identifier, after: keywordIndex)
+                  let nameIndex = parser.index(of: .nonSpaceOrCommentOrLinebreak, after: keywordIndex),
+                  parser.tokens[nameIndex].isIdentifierOrKeyword
             else {
                 return nil
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5146,13 +5146,14 @@ public struct _FormatRules {
 
     /// Remove unused private and fileprivate declarations
     public let unusedPrivateDeclaration = FormatRule(
-        help: "Remove unused private and fileprivate declarations."
+        help: "Remove unused private and fileprivate declarations.",
+        disabledByDefault: true
     ) { formatter in
         guard !formatter.options.fragment else { return }
         var privateDeclarations: [Formatter.Declaration] = []
         var usage: [String: Int] = [:]
 
-        formatter.forEachRecursiveDeclarations { declaration in
+        formatter.forEachRecursiveDeclaration { declaration in
             switch formatter.visibility(of: declaration) {
             case .fileprivate, .private:
                 privateDeclarations.append(declaration)

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5146,7 +5146,7 @@ public struct _FormatRules {
 
     /// Remove unused private and fileprivate declarations
     public let unusedPrivateDeclaration = FormatRule(
-        help: "Remove unused private and fileprivate declarations"
+        help: "Remove unused private and fileprivate declarations."
     ) { formatter in
         guard !formatter.options.fragment else { return }
         let parsedDeclarations = formatter.parseDeclarations()

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5152,52 +5152,41 @@ public struct _FormatRules {
         var propertyTokens: [(name: String, range: ClosedRange<Int>)] = []
         var indexToSkip: [Int] = []
 
+        var fileprivateDeclarations: [Formatter.Declaration] = []
+        // 1 collect fileprivate declarations
         func collectFileprivateDeclarations() {
-            formatter.forEach(.keyword("fileprivate")) { i, _ in
-                guard !indexToSkip.contains(i) else { return }
-                if let identifierIndex = formatter.index(of: .identifier, after: i) {
-                    // Skip this token because it is name of the fileprivate var
-                    // TODO: For functions, check that this is the name of the function?
-                    indexToSkip.append(identifierIndex)
-
-                    let identifier = formatter.tokens[identifierIndex].string
-                    fileprivatePropertyUsage[identifier] = 1
-
-                    let startOfLine = formatter.startOfLine(at: identifierIndex)
-                    let endOfLine = formatter.endOfLine(at: identifierIndex)
-                    propertyTokens.append((name: identifier, range: startOfLine ... endOfLine))
-                }
-            }
+//            formatter.forEachRecursiveDeclarations { declaration in
+//                if case .fileprivate = formatter.visibility(of: declaration) {
+//                    fileprivateDeclarations.append(declaration)
+//                }
+//            }
         }
 
+        // 2 Count usage and delete
         func fileprivateUsage() {
-            formatter.forEach(.identifier) { i, token in
-                guard !indexToSkip.contains(i) else { return }
-                if fileprivatePropertyUsage.keys.contains(token.string) {
-                    if let count = fileprivatePropertyUsage[token.string] {
-                        fileprivatePropertyUsage[token.string] = count + 1
-                    }
-                }
-            }
+//            for fileprivateDeclaration in fileprivateDeclarations {
+//                if let filePrivateName = fileprivateDeclaration.name {
+//                    let usageCount = formatter.tokens.filter { token in
+//                        token == .identifier(filePrivateName)
+//                    }.count
+//
+//                    if usageCount < 2 {
+//                        // delete
+//                        print("declaration.originalRange:", fileprivateDeclaration.originalRange)
+//                        formatter.removeTokens(in: fileprivateDeclaration.originalRange)
+//                    }
+//                }
+//            }
         }
 
-        func removeUnusedFileprivateDeclarations() {
-            // Sort property tokens in reverse order of their range's start index so that when tokens are deleted, it does not shift the index of previous tokens
-            let sortedPropertyTokens = propertyTokens.sorted(by: { $0.range.lowerBound > $1.range.lowerBound })
-
-            for property in sortedPropertyTokens {
-                if let count = fileprivatePropertyUsage[property.name], count == 1 {
-                    formatter.removeTokens(in: property.range)
-                }
-            }
-        }
-
-        // 1. First pass: collect fileprivate name and index
+        // 0. Parse declarations
+        let parsedDeclarations = formatter.parseDeclarations()
+        // 1. First pass: collect fileprivate declaration name and index
         collectFileprivateDeclarations()
         // 2. Second pass: Identify usage of fileprivate properties
         fileprivateUsage()
         // 3. Remove unused fileprivate declarations
-        removeUnusedFileprivateDeclarations()
+//        removeUnusedFileprivateDeclarations()
     }
 
     /// Replace `fileprivate` with `private` where possible

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5149,9 +5149,7 @@ public struct _FormatRules {
         help: "Remove unused private and fileprivate declarations."
     ) { formatter in
         guard !formatter.options.fragment else { return }
-        let parsedDeclarations = formatter.parseDeclarations()
         var privateDeclarations: [Formatter.Declaration] = []
-
         var usage: [String: Int] = [:]
 
         formatter.forEachRecursiveDeclarations { declaration in

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5167,9 +5167,15 @@ public struct _FormatRules {
         }
 
         for declaration in privateDeclarations.reversed() {
-            if let name = declaration.name, let count = usage[name] {
-                if count < 2 {
-                    formatter.removeTokens(in: declaration.originalRange)
+            if let name = declaration.name,
+               let count = usage[name],
+               count < 2
+            {
+                switch declaration {
+                case let .declaration(_, _, originalRange):
+                    formatter.removeTokens(in: originalRange)
+                case .type, .conditionalCompilation:
+                    break
                 }
             }
         }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10474,4 +10474,20 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration, exclude: ["emptyBraces"])
     }
+
+    func testRemovePrivateDeclarationButDoNotRemovePrivateExtension() {
+        let input = """
+        private extension Foo {
+            private func doSomething() {}
+            func anotherFunction() {}
+        }
+        """
+        let output = """
+        private extension Foo {
+            func anotherFunction() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10447,4 +10447,15 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, [output], rules: [FormatRules.unusedPrivateDeclaration, FormatRules.blankLinesAtEndOfScope])
     }
+
+    func testDoNotRemoveUnusedFileprivateOperatorDefinition() {
+        let input = """
+        private class Foo: Equatable {
+            fileprivate static func == (_: Foo, _: Foo) -> Bool {
+                return true
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10458,4 +10458,20 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testRemovePrivateDeclarationButDoNotRemoveUnusedPrivateType() {
+        let input = """
+        private struct Foo {
+            private func bar() {
+                print("test")
+            }
+        }
+        """
+        let output = """
+        private struct Foo {
+        }
+        """
+
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration, exclude: ["emptyBraces"])
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10292,7 +10292,22 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantTypedThrows, options: options)
     }
 
-    // MARK: - unusedFileprivate
+    // MARK: - unusedPrivateDeclaration
+
+    func testRemoveUnusedPrivate() {
+        let input = """
+        struct Foo {
+            private var foo = "foo"
+            var bar = "bar"
+        }
+        """
+        let output = """
+        struct Foo {
+            var bar = "bar"
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
+    }
 
     func testRemoveUnusedFilePrivate() {
         let input = """
@@ -10306,7 +10321,7 @@ class RedundancyTests: RulesTests {
             var bar = "bar"
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
     }
 
     func testDoNotRemoveUsedFilePrivate() {
@@ -10320,7 +10335,7 @@ class RedundancyTests: RulesTests {
             let localFoo = Foo().foo
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 
     func testRemoveMultipleUnusedFilePrivate() {
@@ -10336,7 +10351,7 @@ class RedundancyTests: RulesTests {
             var bar = "bar"
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
     }
 
     func testRemoveMixedUsedAndUnusedFilePrivate() {
@@ -10361,7 +10376,7 @@ class RedundancyTests: RulesTests {
             let localFoo = Foo().foo
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
     }
 
     func testDoNotRemoveFilePrivateUsedInSameStruct() {
@@ -10375,53 +10390,9 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 
-    // Question: How to make this pass?
-    // With
-    /*
-     let output = """
-     struct Foo {
-         var bar = "bar"
-
-         struct Inner {}
-     }
-     """
-     */
-
-    // The test fails with diff
-    /*
-     struct Foo {
-         var bar = "bar"
-
-         struct Inner {
-         }
-     }
-     */
-
-    // And if I edit output to
-    /*
-     let output = """
-     struct Foo {
-         var bar = "bar"
-
-         struct Inner {
-         }
-     }
-     """
-     */
-
-    // then I get error:
-    // XCTAssertEqual failed: ("[SwiftFormat.Formatter.Change(line: 4, rule: emptyBraces, filePath: nil), SwiftFormat.Formatter.Change(line: 5, rule: emptyBraces, filePath: nil)]") is not equal to ("[]")
-    // with diff:
-    /*
-     XCTAssertEqual failed: ("struct Foo {
-         var bar = "bar"
-
-         struct Inner {}
-     }
-     */
     func testRemoveUnusedFilePrivateInNestedStruct() {
         let input = """
         struct Foo {
@@ -10436,10 +10407,11 @@ class RedundancyTests: RulesTests {
         struct Foo {
             var bar = "bar"
 
-            struct Inner {}
+            struct Inner {
+            }
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration, exclude: ["emptyBraces"])
     }
 
     func testDoNotRemoveFilePrivateUsedInNestedStruct() {
@@ -10455,25 +10427,9 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 
-    // Question: How to delete function body as well?
-    // Currently, the output is:
-    /*
-     struct Foo {
-         var bar = "bar"
-
-             print("hi")
-         }
-     */
-
-    // Using `formatter.endOfScope(at:)` instead of `formatter.endOfLine(at:)`
-    /*
-     struct Foo {
-         var bar = "bar"
-
-     */
     func testRemoveUnusedFileprivateFunction() {
         let input = """
         struct Foo {
@@ -10489,6 +10445,6 @@ class RedundancyTests: RulesTests {
             var bar = "bar"
         }
         """
-        testFormatting(for: input, output, rule: FormatRules.unusedFileprivate)
+        testFormatting(for: input, [output], rules: [FormatRules.unusedPrivateDeclaration, FormatRules.blankLinesAtEndOfScope])
     }
 }

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -76,6 +76,7 @@ class RulesTests: XCTestCase {
             + (rules.first?.name == "extensionAccessControl" ? [] : ["extensionAccessControl"])
             + (rules.first?.name == "markTypes" ? [] : ["markTypes"])
             + (rules.first?.name == "blockComments" ? [] : ["blockComments"])
+            + (rules.first?.name == "unusedPrivateDeclaration" ? [] : ["unusedPrivateDeclaration"])
         XCTAssertEqual(try format(input, rules: rules, options: options), output, file: file, line: line)
         XCTAssertEqual(try format(input, rules: FormatRules.all(except: exclude), options: options),
                        output2, file: file, line: line)


### PR DESCRIPTION
Rule to remove unused `private` and `fileprivate` declarations

```diff
struct Foo {
--    fileprivate var foo = "foo"
--    fileprivate var baz = "baz"
    var bar = "bar"
}

struct Foo {
    var bar = "bar"
--
--    fileprivate func sayHi() {
--        print("hi")
--    }
}

```

@calda 