### PR TITLE
Fix `--nilInit insert` being applied to `as` keyword

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -2959,7 +2959,8 @@ public struct _FormatRules {
                 if formatter.index(of: .endOfStatement, in: index + 1 ..< optionalIndex) != nil {
                     return
                 }
-                if !formatter.tokens[optionalIndex - 1].isSpaceOrCommentOrLinebreak {
+                let previousToken = formatter.tokens[optionalIndex - 1]
+                if !previousToken.isSpaceOrCommentOrLinebreak && previousToken != .keyword("as") {
                     let equalsIndex = formatter.index(of: .nonSpaceOrLinebreak, after: optionalIndex, if: {
                         $0 == .operator("=", .infix)
                     })

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -2266,6 +2266,16 @@ class RedundancyTests: RulesTests {
                        options: options)
     }
 
+    func testNoInsertNilInitInAs() {
+        let input = """
+        let json: Any = ["key": 1]
+        var jsonObject = json as? [String: Int]
+        """
+        let options = FormatOptions(nilInit: .insert)
+        testFormatting(for: input, rule: FormatRules.redundantNilInit,
+                       options: options)
+    }
+
     // MARK: - redundantLet
 
     func testRemoveRedundantLet() {


### PR DESCRIPTION
See the newly added unit tests for details.

As of version 0.54.1, `--nilInit insert` will incorrectly make the following changes:

```diff
- var jsonObject = json as? [String: Int]
+ var jsonObject = json as? = nil [String: Int] // ❌ Wrong, should not be replaced
```

This PR fixes this issue