### PR TITLE
Include original token range when parsing declarations

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1668,19 +1668,21 @@ extension Formatter {
         declarations.map { declaration in
             let mapped = transform(declaration, stack)
             switch mapped {
-            case let .type(kind, open, body, close):
+            case let .type(kind, open, body, close, originalRange):
                 return .type(
                     kind: kind,
                     open: open,
                     body: mapRecursiveDeclarations(body, in: stack + [mapped], with: transform),
-                    close: close
+                    close: close,
+                    originalRange: originalRange
                 )
 
-            case let .conditionalCompilation(open, body, close):
+            case let .conditionalCompilation(open, body, close, originalRange):
                 return .conditionalCompilation(
                     open: open,
                     body: mapRecursiveDeclarations(body, in: stack + [mapped], with: transform),
-                    close: close
+                    close: close,
+                    originalRange: originalRange
                 )
 
             case .declaration:
@@ -1697,19 +1699,21 @@ extension Formatter {
         with transform: (Declaration) -> Declaration
     ) -> Declaration {
         switch declaration {
-        case let .type(kind, open, body, close):
+        case let .type(kind, open, body, close, originalRange):
             return .type(
                 kind: kind,
                 open: open,
                 body: mapBodyDeclarations(body, with: transform),
-                close: close
+                close: close,
+                originalRange: originalRange
             )
 
-        case let .conditionalCompilation(open, body, close):
+        case let .conditionalCompilation(open, body, close, originalRange):
             return .conditionalCompilation(
                 open: open,
                 body: mapBodyDeclarations(body, with: transform),
-                close: close
+                close: close,
+                originalRange: originalRange
             )
 
         case .declaration:
@@ -1747,7 +1751,7 @@ extension Formatter {
             switch declaration {
             case .declaration, .type:
                 return [transform(declaration)]
-            case let .conditionalCompilation(_, body, _):
+            case let .conditionalCompilation(_, body, _, _):
                 return mapDeclarations(body, with: transform)
             }
         }
@@ -1761,25 +1765,28 @@ extension Formatter {
         with transform: ([Token]) -> [Token]
     ) -> Declaration {
         switch declaration {
-        case let .type(kind, open, body, close):
+        case let .type(kind, open, body, close, originalRange):
             return .type(
                 kind: kind,
                 open: transform(open),
                 body: body,
-                close: close
+                close: close,
+                originalRange: originalRange
             )
 
-        case let .conditionalCompilation(open, body, close):
+        case let .conditionalCompilation(open, body, close, originalRange):
             return .conditionalCompilation(
                 open: transform(open),
                 body: body,
-                close: close
+                close: close,
+                originalRange: originalRange
             )
 
-        case let .declaration(kind, tokens):
+        case let .declaration(kind, tokens, originalRange):
             return .declaration(
                 kind: kind,
-                tokens: transform(tokens)
+                tokens: transform(tokens),
+                originalRange: originalRange
             )
         }
     }
@@ -1792,25 +1799,28 @@ extension Formatter {
         with transform: ([Token]) -> [Token]
     ) -> Declaration {
         switch declaration {
-        case let .type(kind, open, body, close):
+        case let .type(kind, open, body, close, originalRange):
             return .type(
                 kind: kind,
                 open: open,
                 body: body,
-                close: transform(close)
+                close: transform(close),
+                originalRange: originalRange
             )
 
-        case let .conditionalCompilation(open, body, close):
+        case let .conditionalCompilation(open, body, close, originalRange):
             return .conditionalCompilation(
                 open: open,
                 body: body,
-                close: transform(close)
+                close: transform(close),
+                originalRange: originalRange
             )
 
-        case let .declaration(kind, tokens):
+        case let .declaration(kind, tokens, originalRange):
             return .declaration(
                 kind: kind,
-                tokens: transform(tokens)
+                tokens: transform(tokens),
+                originalRange: originalRange
             )
         }
     }
@@ -1985,7 +1995,7 @@ extension Formatter {
 
     func visibility(of declaration: Declaration) -> Visibility? {
         switch declaration {
-        case let .declaration(keyword, tokens), let .type(keyword, open: tokens, _, _):
+        case let .declaration(keyword, tokens, _), let .type(keyword, open: tokens, _, _, _):
             guard let keywordIndex = tokens.firstIndex(of: .keyword(keyword)) else {
                 return nil
             }
@@ -2005,7 +2015,7 @@ extension Formatter {
             }
 
             return nil
-        case let .conditionalCompilation(_, body, _):
+        case let .conditionalCompilation(_, body, _, _):
             // Conditional compilation blocks themselves don't have a category or visbility-level,
             // but we still have to assign them a category for the sorting algorithm to function.
             // A reasonable heuristic here is to simply use the category of the first declaration
@@ -2020,10 +2030,10 @@ extension Formatter {
 
     func type(of declaration: Declaration, for mode: DeclarationOrganizationMode) -> DeclarationType {
         switch declaration {
-        case let .type(keyword, _, _, _):
+        case let .type(keyword, _, _, _, _):
             return options.beforeMarks.contains(keyword) ? .beforeMarks : .nestedType
 
-        case let .declaration(keyword, tokens):
+        case let .declaration(keyword, tokens, _):
             guard let declarationTypeTokenIndex = tokens.firstIndex(of: .keyword(keyword)) else {
                 return .beforeMarks
             }
@@ -2149,7 +2159,7 @@ extension Formatter {
                 return .beforeMarks
             }
 
-        case let .conditionalCompilation(_, body, _):
+        case let .conditionalCompilation(_, body, _, _):
             // Prefer treating conditional compliation blocks as having
             // the property type of the first declaration in their body.
             if let firstDeclarationInBlock = body.first {
@@ -2197,9 +2207,9 @@ extension Formatter {
         for (declarationIndex, declaration) in typeBody.enumerated() {
             let tokensToInspect: [Token]
             switch declaration {
-            case let .declaration(_, tokens):
+            case let .declaration(_, tokens, _):
                 tokensToInspect = tokens
-            case let .type(_, open, _, _), let .conditionalCompilation(open, _, _):
+            case let .type(_, open, _, _, _), let .conditionalCompilation(open, _, _, _):
                 // Only inspect the opening tokens of declarations with a body
                 tokensToInspect = open
             }
@@ -2493,7 +2503,11 @@ extension Formatter {
                     typeOpeningTokens = endingWithBlankLine(typeOpeningTokens)
                 }
 
-                markedDeclarations.append(.declaration(kind: "comment", tokens: markDeclaration))
+                markedDeclarations.append(.declaration(
+                    kind: "comment",
+                    tokens: markDeclaration,
+                    originalRange: 0 ... 1 // placeholder value
+                ))
             }
 
             if let lastIndexOfSameDeclaration = sortedDeclarations.map(\.category).lastIndex(of: category),

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1893,21 +1893,36 @@ extension Formatter {
 
     enum Declaration: Equatable {
         /// A type-like declaration with body of additional declarations (`class`, `struct`, etc)
-        indirect case type(kind: String, open: [Token], body: [Declaration], close: [Token])
+        indirect case type(
+            kind: String,
+            open: [Token],
+            body: [Declaration],
+            close: [Token],
+            originalRange: ClosedRange<Int>
+        )
 
         /// A simple declaration (like a property or function)
-        case declaration(kind: String, tokens: [Token])
+        case declaration(
+            kind: String,
+            tokens: [Token],
+            originalRange: ClosedRange<Int>
+        )
 
         /// A #if ... #endif conditional compilation block with a body of additional declarations
-        indirect case conditionalCompilation(open: [Token], body: [Declaration], close: [Token])
+        indirect case conditionalCompilation(
+            open: [Token],
+            body: [Declaration],
+            close: [Token],
+            originalRange: ClosedRange<Int>
+        )
 
         /// The tokens in this declaration
         var tokens: [Token] {
             switch self {
-            case let .declaration(_, tokens):
+            case let .declaration(_, tokens, _):
                 return tokens
-            case let .type(_, openTokens, bodyDeclarations, closeTokens),
-                 let .conditionalCompilation(openTokens, bodyDeclarations, closeTokens):
+            case let .type(_, openTokens, bodyDeclarations, closeTokens, _),
+                 let .conditionalCompilation(openTokens, bodyDeclarations, closeTokens, _):
                 return openTokens + bodyDeclarations.flatMap { $0.tokens } + closeTokens
             }
         }
@@ -1917,8 +1932,8 @@ extension Formatter {
             switch self {
             case .declaration:
                 return tokens
-            case let .type(_, open, _, _),
-                 let .conditionalCompilation(open, _, _):
+            case let .type(_, open, _, _, _),
+                 let .conditionalCompilation(open, _, _, _):
                 return open
             }
         }
@@ -1928,8 +1943,8 @@ extension Formatter {
             switch self {
             case .declaration:
                 return nil
-            case let .type(_, _, body, _),
-                 let .conditionalCompilation(_, body, _):
+            case let .type(_, _, body, _, _),
+                 let .conditionalCompilation(_, body, _, _):
                 return body
             }
         }
@@ -1939,8 +1954,8 @@ extension Formatter {
             switch self {
             case .declaration:
                 return []
-            case let .type(_, _, _, close),
-                 let .conditionalCompilation(_, _, close):
+            case let .type(_, _, _, close, _),
+                 let .conditionalCompilation(_, _, close, _):
                 return close
             }
         }
@@ -1949,8 +1964,8 @@ extension Formatter {
         /// (`class`, `func`, `let`, `var`, etc.)
         var keyword: String {
             switch self {
-            case let .declaration(kind, _),
-                 let .type(kind, _, _, _):
+            case let .declaration(kind, _, _),
+                 let .type(kind, _, _, _, _):
                 return kind
             case .conditionalCompilation:
                 return "#if"
@@ -1972,6 +1987,16 @@ extension Formatter {
             }
 
             return parser.fullyQualifiedName(startingAt: nameIndex).name
+        }
+
+        /// The original range of the tokens of this declaration in the original source file
+        var originalRange: ClosedRange<Int> {
+            switch self {
+            case let .type(_, _, _, _, originalRange),
+                 let .declaration(_, _, originalRange),
+                 let .conditionalCompilation(_, _, _, originalRange):
+                return originalRange
+            }
         }
     }
 
@@ -2124,12 +2149,19 @@ extension Formatter {
         return nil
     }
 
-    /// Parse all declarations in the formatter's token range
+    /// Parses all of the declarations in the file
     func parseDeclarations() -> [Declaration] {
+        guard !tokens.isEmpty else { return [] }
+        return parseDeclarations(in: ClosedRange(0 ..< tokens.count))
+    }
+
+    /// Parses the declarations in the given range.
+    func parseDeclarations(in range: ClosedRange<Int>) -> [Declaration] {
         var declarations = [Declaration]()
-        var startOfDeclaration = 0
+        var startOfDeclaration = range.lowerBound
         forEachToken(onlyWhereEnabled: false) { i, token in
-            guard i >= startOfDeclaration,
+            guard range.contains(i),
+                  i >= startOfDeclaration,
                   token.isDeclarationTypeKeyword || token == .startOfScope("#if")
             else {
                 return
@@ -2138,76 +2170,109 @@ extension Formatter {
             let declarationKeyword = declarationType(at: i) ?? "#if"
             let endOfDeclaration = self.endOfDeclaration(atDeclarationKeyword: i, fallBackToEndOfScope: false)
 
-            let declarationRange = startOfDeclaration ... min(endOfDeclaration ?? .max, tokens.count - 1)
+            let declarationRange = startOfDeclaration ... min(endOfDeclaration ?? .max, range.upperBound)
             startOfDeclaration = declarationRange.upperBound + 1
-            let declaration = Array(tokens[declarationRange])
-            declarations.append(.declaration(kind: isEnabled ? declarationKeyword : "", tokens: declaration))
+
+            declarations.append(.declaration(
+                kind: isEnabled ? declarationKeyword : "",
+                tokens: Array(tokens[declarationRange]),
+                originalRange: declarationRange
+            ))
         }
-        if startOfDeclaration < tokens.count {
-            let declaration = Array(tokens[startOfDeclaration...])
-            declarations.append(.declaration(kind: "", tokens: declaration))
+        if startOfDeclaration < range.upperBound {
+            let declarationRange = startOfDeclaration ..< tokens.count
+            declarations.append(.declaration(
+                kind: "",
+                tokens: Array(tokens[declarationRange]),
+                originalRange: ClosedRange(declarationRange)
+            ))
         }
 
         return declarations.map { declaration in
-            let declarationParser = Formatter(declaration.tokens)
-
             // Parses this declaration into a body of declarations separate from the start and end tokens
-            func parseBody(in bodyRange: ClosedRange<Int>) -> (start: [Token], body: [Declaration], end: [Token]) {
-                var startTokens = declarationParser.tokens[...bodyRange.lowerBound]
-                var bodyTokens = declarationParser.tokens[bodyRange.lowerBound + 1 ..< bodyRange.upperBound]
-                var endTokens = declarationParser.tokens[bodyRange.upperBound...]
+            func parseBody(in bodyRange: Range<Int>) -> (start: [Token], body: [Declaration], end: [Token]) {
+                var startTokens = Array(tokens[declaration.originalRange.lowerBound ..< bodyRange.lowerBound])
+                var endTokens = Array(tokens[bodyRange.upperBound ... declaration.originalRange.upperBound])
+
+                guard !bodyRange.isEmpty else {
+                    return (start: startTokens, body: [], end: endTokens)
+                }
+
+                var bodyRange = ClosedRange(bodyRange)
 
                 // Move the leading newlines from the `body` into the `start` tokens
                 // so the first body token is the start of the first declaration
-                while bodyTokens.first?.isLinebreak == true {
-                    startTokens.append(bodyTokens.removeFirst())
+                while tokens[bodyRange].first?.isLinebreak == true {
+                    startTokens.append(tokens[bodyRange.lowerBound])
+
+                    if bodyRange.count > 1 {
+                        bodyRange = (bodyRange.lowerBound + 1) ... bodyRange.upperBound
+                    } else {
+                        // If this was the last remaining token in the body, just return now.
+                        // We can't have an empty `bodyRange`.
+                        return (start: startTokens, body: [], end: endTokens)
+                    }
                 }
 
                 // Move the closing brace's indentation token from the `body` into the `end` tokens
-                if bodyTokens.last?.isSpace == true {
-                    endTokens.insert(bodyTokens.removeLast(), at: endTokens.startIndex)
+                if tokens[bodyRange].last?.isSpace == true {
+                    endTokens.insert(tokens[bodyRange.upperBound], at: endTokens.startIndex)
+
+                    if bodyRange.count > 1 {
+                        bodyRange = bodyRange.lowerBound ... (bodyRange.upperBound - 1)
+                    } else {
+                        // If this was the last remaining token in the body, just return now.
+                        // We can't have an empty `bodyRange`.
+                        return (start: startTokens, body: [], end: endTokens)
+                    }
                 }
 
                 // Parse the inner body declarations of the type
-                let bodyDeclarations = Formatter(Array(bodyTokens)).parseDeclarations()
+                let bodyDeclarations = parseDeclarations(in: bodyRange)
 
-                return (Array(startTokens), bodyDeclarations, Array(endTokens))
+                return (startTokens, bodyDeclarations, endTokens)
             }
 
             // If this declaration represents a type, we need to parse its inner declarations as well.
             let typelikeKeywords = ["class", "actor", "struct", "enum", "protocol", "extension"]
 
             if typelikeKeywords.contains(declaration.keyword),
-               let declarationTypeKeywordIndex = declarationParser
-               .index(after: -1, where: { $0.string == declaration.keyword }),
-               let startOfBody = declarationParser
-               .index(of: .startOfScope("{"), after: declarationTypeKeywordIndex),
-               let endOfBody = declarationParser.endOfScope(at: startOfBody)
+               let declarationTypeKeywordIndex = index(
+                   in: Range(declaration.originalRange),
+                   where: { $0.string == declaration.keyword }
+               ),
+               let bodyOpenBrace = index(of: .startOfScope("{"), after: declarationTypeKeywordIndex),
+               let bodyClosingBrace = endOfScope(at: bodyOpenBrace)
             {
-                let (startTokens, bodyDeclarations, endTokens) = parseBody(in: startOfBody ... endOfBody)
+                let bodyRange = (bodyOpenBrace + 1) ..< bodyClosingBrace
+                let (startTokens, bodyDeclarations, endTokens) = parseBody(in: bodyRange)
 
                 return .type(
                     kind: declaration.keyword,
                     open: startTokens,
                     body: bodyDeclarations,
-                    close: endTokens
+                    close: endTokens,
+                    originalRange: declaration.originalRange
                 )
             }
 
             // If this declaration represents a conditional compilation block,
             // we also have to parse its inner declarations.
             else if declaration.keyword == "#if",
-                    let declarationTypeKeywordIndex = declarationParser
-                    .index(after: -1, where: { $0.string == declaration.keyword }),
-                    let endOfBody = declarationParser.endOfScope(at: declarationTypeKeywordIndex)
+                    let declarationTypeKeywordIndex = index(
+                        in: Range(declaration.originalRange),
+                        where: { $0.string == "#if" }
+                    ),
+                    let endOfBody = endOfScope(at: declarationTypeKeywordIndex)
             {
-                let startOfBody = declarationParser.endOfLine(at: declarationTypeKeywordIndex)
-                let (startTokens, bodyDeclarations, endTokens) = parseBody(in: startOfBody ... endOfBody)
+                let startOfBody = endOfLine(at: declarationTypeKeywordIndex)
+                let (startTokens, bodyDeclarations, endTokens) = parseBody(in: startOfBody ..< endOfBody)
 
                 return .conditionalCompilation(
                     open: startTokens,
                     body: bodyDeclarations,
-                    close: endTokens
+                    close: endTokens,
+                    originalRange: declaration.originalRange
                 )
             } else {
                 return declaration

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5677,13 +5677,14 @@ public struct _FormatRules {
         formatter.mapRecursiveDeclarations { declaration in
             switch declaration {
             // Organize the body of type declarations
-            case let .type(kind, open, body, close):
+            case let .type(kind, open, body, close, originalRange):
                 let organizedType = formatter.organizeType((kind, open, body, close))
                 return .type(
                     kind: organizedType.kind,
                     open: organizedType.open,
                     body: organizedType.body,
-                    close: organizedType.close
+                    close: organizedType.close,
+                    originalRange: originalRange
                 )
 
             case .conditionalCompilation, .declaration:
@@ -5700,7 +5701,7 @@ public struct _FormatRules {
 
         let declarations = formatter.parseDeclarations()
         let updatedDeclarations = formatter.mapRecursiveDeclarations(declarations) { declaration, _ in
-            guard case let .type("extension", open, body, close) = declaration else {
+            guard case let .type("extension", open, body, close, _) = declaration else {
                 return declaration
             }
 
@@ -5743,7 +5744,7 @@ public struct _FormatRules {
                 if memberVisibility > extensionVisibility ?? .internal {
                     // Check type being extended does not have lower visibility
                     for d in declarations where d.name == declaration.name {
-                        if case let .type(kind, _, _, _) = d {
+                        if case let .type(kind, _, _, _, _) = d {
                             if kind != "extension", formatter.visibility(of: d) ?? .internal < memberVisibility {
                                 // Cannot make extension with greater visibility than type being extended
                                 return declaration
@@ -5818,7 +5819,7 @@ public struct _FormatRules {
         }
 
         for (index, declaration) in declarations.enumerated() {
-            guard case let .type(kind, open, body, close) = declaration else { continue }
+            guard case let .type(kind, open, body, close, _) = declaration else { continue }
 
             guard var typeName = declaration.name else {
                 continue

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1551,6 +1551,68 @@ class ParsingHelpersTests: XCTestCase {
         _ = Formatter(tokens).parseDeclarations()
     }
 
+    func testParseDeclarationRangesInType() {
+        let input = """
+        class Foo {
+            let bar = "bar"
+            let baaz = "baaz"
+        }
+        """
+
+        let formatter = Formatter(tokenize(input))
+        let declarations = formatter.parseDeclarations()
+
+        XCTAssertEqual(declarations.count, 1)
+        XCTAssertEqual(declarations[0].originalRange, 0 ... 28)
+
+        XCTAssertEqual(declarations[0].body?.count, 2)
+
+        let barDeclarationRange = declarations[0].body![0].originalRange
+        XCTAssertEqual(barDeclarationRange, 6 ... 16)
+        XCTAssertEqual(
+            sourceCode(for: Array(formatter.tokens[barDeclarationRange])),
+            "    let bar = \"bar\"\n"
+        )
+
+        let baazDeclarationRange = declarations[0].body![1].originalRange
+        XCTAssertEqual(baazDeclarationRange, 17 ... 27)
+        XCTAssertEqual(
+            sourceCode(for: Array(formatter.tokens[baazDeclarationRange])),
+            "    let baaz = \"baaz\"\n"
+        )
+    }
+
+    func testParseDeclarationRangesInConditionalCompilation() {
+        let input = """
+        #if DEBUG
+        let bar = "bar"
+        let baaz = "baaz"
+        #endif
+        """
+
+        let formatter = Formatter(tokenize(input))
+        let declarations = formatter.parseDeclarations()
+
+        XCTAssertEqual(declarations.count, 1)
+        XCTAssertEqual(declarations[0].originalRange, 0 ... 24)
+
+        XCTAssertEqual(declarations[0].body?.count, 2)
+
+        let barDeclarationRange = declarations[0].body![0].originalRange
+        XCTAssertEqual(barDeclarationRange, 4 ... 13)
+        XCTAssertEqual(
+            sourceCode(for: Array(formatter.tokens[barDeclarationRange])),
+            "let bar = \"bar\"\n"
+        )
+
+        let baazDeclarationRange = declarations[0].body![1].originalRange
+        XCTAssertEqual(baazDeclarationRange, 14 ... 23)
+        XCTAssertEqual(
+            sourceCode(for: Array(formatter.tokens[baazDeclarationRange])),
+            "let baaz = \"baaz\"\n"
+        )
+    }
+
     // MARK: declarationScope
 
     func testDeclarationScope_classAndGlobals() {


### PR DESCRIPTION
This PR adds a new `originalRange` property to the `Declaration` type.

This makes it easier to use `parseDeclarations()` to implement new rules, since now you know where the individual declarations actually are in the source file. @mannylopez will use this functionality in a new rule he's working on.