### PR TITLE
Improve expressiveness of --typeorder and --visibilityorder options

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1378,17 +1378,23 @@ Option | Description
 <details>
 <summary>Examples</summary>
 
-Default value for `--visibilityorder`:
+Default value for `--visibilityorder` when using `--organizationmode visibility`:
 `beforeMarks, instanceLifecycle, open, public, package, internal, fileprivate, private`
 
-**NOTE:** When providing custom arguments for `--visibilityorder` the following entries **should** be included:
+Default value for `--visibilityorder` when using `--organizationmode type`:
 `open, public, package, internal, fileprivate, private`
 
-Default value for `--typeorder`:
-`beforeMarks, nestedType, staticProperty, staticPropertyWithBody, classPropertyWithBody, overriddenProperty, swiftUIPropertyWrapper, instanceProperty, instancePropertyWithBody, instanceLifecycle, swiftUIProperty, swiftUIMethod, overriddenMethod, staticMethod, classMethod, instanceMethod, conditionalCompilation`
+**NOTE:** When providing custom arguments for `--visibilityorder` the following entries must be included:
+`open, public, package, internal, fileprivate, private`
 
-**NOTE:** When providing custom arguments for `--typeorder` the following entries **should** be included:
-`beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod, conditionalCompilation`
+Default value for `--typeorder` when using `--organizationmode visibility`:
+`nestedType, staticProperty, staticPropertyWithBody, classPropertyWithBody, overriddenProperty, swiftUIPropertyWrapper, instanceProperty, instancePropertyWithBody, swiftUIProperty, swiftUIMethod, overriddenMethod, staticMethod, classMethod, instanceMethod`
+
+Default value for `--typeorder` when using `--organizationmode type`:
+`beforeMarks, nestedType, staticProperty, staticPropertyWithBody, classPropertyWithBody, overriddenProperty, swiftUIPropertyWrapper, instanceProperty, instancePropertyWithBody, instanceLifecycle, swiftUIProperty, swiftUIMethod, overriddenMethod, staticMethod, classMethod, instanceMethod`
+
+**NOTE:** The follow declaration types must be included in either `--typeorder` or `--visibilityorder`:
+`beforeMarks, nestedType, instanceLifecycle, instanceProperty, instanceMethod`
 
 `--organizationmode visibility` (default)
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1291,17 +1291,23 @@ private struct Examples {
     """
 
     let organizeDeclarations = """
-    Default value for `--visibilityorder`:
-    `\(Formatter.VisibilityType.allCases.reduce(into: "") { $0 += ", \($1.rawValue)" }.dropFirst(2))`
+    Default value for `--visibilityorder` when using `--organizationmode visibility`:
+    `\(Formatter.VisibilityType.defaultOrdering(for: .visibility).map { $0.rawValue }.joined(separator: ", "))`
 
-    **NOTE:** When providing custom arguments for `--visibilityorder` the following entries **should** be included:
-    `\(Formatter.VisibilityType.essentialCases.reduce(into: "") { $0 += ", \($1.rawValue)" }.dropFirst(2))`
+    Default value for `--visibilityorder` when using `--organizationmode type`:
+    `\(Formatter.VisibilityType.defaultOrdering(for: .type).map { $0.rawValue }.joined(separator: ", "))`
 
-    Default value for `--typeorder`:
-    `\(Formatter.DeclarationType.allCases.reduce(into: "") { $0 += ", \($1.rawValue)" }.dropFirst(2))`
+    **NOTE:** When providing custom arguments for `--visibilityorder` the following entries must be included:
+    `\(Formatter.VisibilityType.essentialCases.map { $0.rawValue }.joined(separator: ", "))`
 
-    **NOTE:** When providing custom arguments for `--typeorder` the following entries **should** be included:
-    `\(Formatter.DeclarationType.essentialCases.reduce(into: "") { $0 += ", \($1.rawValue)" }.dropFirst(2))`
+    Default value for `--typeorder` when using `--organizationmode visibility`:
+    `\(Formatter.DeclarationType.defaultOrdering(for: .visibility).map { $0.rawValue }.joined(separator: ", "))`
+
+    Default value for `--typeorder` when using `--organizationmode type`:
+    `\(Formatter.DeclarationType.defaultOrdering(for: .type).map { $0.rawValue }.joined(separator: ", "))`
+
+    **NOTE:** The follow declaration types must be included in either `--typeorder` or `--visibilityorder`:
+    `\(Formatter.DeclarationType.essentialCases.map { $0.rawValue }.joined(separator: ", "))`
 
     `--organizationmode visibility` (default)
 

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1853,16 +1853,18 @@ extension Formatter {
         var order: Int
         var comment: String? = nil
 
-        func shouldBeMarked(in categories: Set<Category>, for mode: DeclarationOrganizationMode) -> Bool {
+        /// Whether or not a mark comment should be added for this category,
+        /// given the set of existing categories with existing mark comments
+        func shouldBeMarked(in categoriesWithMarkComment: Set<Category>, for mode: DeclarationOrganizationMode) -> Bool {
             guard type != .beforeMarks else {
                 return false
             }
 
             switch mode {
             case .type:
-                return !categories.contains(where: { $0.type == type })
+                return !categoriesWithMarkComment.contains(where: { $0.type == type || $0.visibility == .explicit(type) })
             case .visibility:
-                return !categories.contains(where: { $0.visibility == visibility })
+                return !categoriesWithMarkComment.contains(where: { $0.visibility == visibility })
             }
         }
 
@@ -1926,12 +1928,23 @@ extension Formatter {
         }
 
         public static var allCases: [VisibilityType] {
-            [.explicit(.beforeMarks), .explicit(.instanceLifecycle)] + Visibility.allCases
-                .map { .visibility($0) }
+            Visibility.allCases.map { .visibility($0) }
         }
 
         public static var essentialCases: [VisibilityType] {
             Visibility.allCases.map { .visibility($0) }
+        }
+
+        public static func defaultOrdering(for mode: DeclarationOrganizationMode) -> [VisibilityType] {
+            switch mode {
+            case .type:
+                return allCases
+            case .visibility:
+                return [
+                    .explicit(.beforeMarks),
+                    .explicit(.instanceLifecycle),
+                ] + allCases
+            }
         }
     }
 
@@ -1955,7 +1968,6 @@ extension Formatter {
         case staticMethod
         case classMethod
         case instanceMethod
-        case conditionalCompilation
 
         var markComment: String {
             switch self {
@@ -1991,8 +2003,6 @@ extension Formatter {
                 return "Class Functions"
             case .instanceMethod:
                 return "Functions"
-            case .conditionalCompilation:
-                return "Conditional Compilation"
             }
         }
 
@@ -2000,11 +2010,23 @@ extension Formatter {
             [
                 .beforeMarks,
                 .nestedType,
-                .instanceProperty,
                 .instanceLifecycle,
+                .instanceProperty,
                 .instanceMethod,
-                .conditionalCompilation,
             ]
+        }
+
+        public static func defaultOrdering(for mode: DeclarationOrganizationMode) -> [DeclarationType] {
+            switch mode {
+            case .type:
+                return allCases
+            case .visibility:
+                return allCases.filter { type in
+                    // Exclude beforeMarks and instanceLifecycle, since by default
+                    // these are instead treated as top-level categories
+                    type != .beforeMarks && type != .instanceLifecycle
+                }
+            }
         }
     }
 
@@ -2036,12 +2058,21 @@ extension Formatter {
         typealias ParsedVisibilityMarks = [VisibilityType: String]
         typealias ParsedTypeMarks = [DeclarationType: String]
 
-        let visibilityTypes = options.visibilityOrder
-            .map { VisibilityType(rawValue: $0) }
-            .compactMap { $0 }
-        let declarationTypes = options.typeOrder
-            .map { DeclarationType(rawValue: $0) }
-            .compactMap { $0 }
+        let visibilityTypes = options.visibilityOrder?.compactMap { VisibilityType(rawValue: $0) }
+            ?? VisibilityType.defaultOrdering(for: mode)
+
+        let declarationTypes = options.typeOrder?.compactMap { DeclarationType(rawValue: $0) }
+            ?? DeclarationType.defaultOrdering(for: mode)
+
+        // Validate that every essential declaration type is included in either `declarationTypes` or `visibilityTypes`.
+        // Otherwise, we will just crash later when we find a declaration with this type.
+        for essentialDeclarationType in DeclarationType.essentialCases {
+            guard declarationTypes.contains(essentialDeclarationType)
+                || visibilityTypes.contains(.explicit(essentialDeclarationType))
+            else {
+                Swift.fatalError("\(essentialDeclarationType.rawValue) must be included in either --typeorder or --visibilityorder")
+            }
+        }
 
         let customVisibilityMarks = options.customVisibilityMarks
         let customTypeMarks = options.customTypeMarks
@@ -2051,25 +2082,46 @@ extension Formatter {
 
         switch mode {
         case .visibility:
-            return flatten(primary: visibilityTypes, using: declarationTypes)
-                .map { offset, element in
-                    Category(
-                        visibility: element.0,
-                        type: element.1,
-                        order: offset,
-                        comment: parsedVisibilityMarks[element.0]
-                    )
+            let categoryPairings = visibilityTypes.flatMap { visibilityType -> [(VisibilityType, DeclarationType)] in
+                switch visibilityType {
+                case let .visibility(visibility):
+                    // Each visibility / access control level pairs with all of the declaration types
+                    return declarationTypes.compactMap { declarationType in
+                        (.visibility(visibility), declarationType)
+                    }
+
+                case let .explicit(explicitDeclarationType):
+                    // Each top-level declaration category pairs with all of the visibility types
+                    return visibilityTypes.map { visibilityType in
+                        (visibilityType, explicitDeclarationType)
+                    }
                 }
+            }
+
+            return categoryPairings.enumerated().map { offset, element in
+                Category(
+                    visibility: element.0,
+                    type: element.1,
+                    order: offset,
+                    comment: parsedVisibilityMarks[element.0]
+                )
+            }
+
         case .type:
-            return flatten(primary: declarationTypes, using: visibilityTypes)
-                .map { offset, element in
-                    Category(
-                        visibility: element.1,
-                        type: element.0,
-                        order: offset,
-                        comment: parsedTypeMarks[element.0]
-                    )
+            let categoryPairings = declarationTypes.flatMap { declarationType -> [(VisibilityType, DeclarationType)] in
+                visibilityTypes.map { visibilityType in
+                    (visibilityType, declarationType)
                 }
+            }
+
+            return categoryPairings.enumerated().map { offset, element in
+                Category(
+                    visibility: element.0,
+                    type: element.1,
+                    order: offset,
+                    comment: parsedTypeMarks[element.1]
+                )
+            }
         }
     }
 
@@ -2093,26 +2145,20 @@ extension Formatter {
         }
     }
 
-    func flatten<C1: Collection, C2: Collection>(
-        primary: C1,
-        using secondary: C2
-    ) -> EnumeratedSequence<[(C1.Element, C2.Element)]> {
-        primary
-            .map { p in
-                secondary.map { s in
-                    (p, s)
-                }
-            }
-            .reduce([], +)
-            .enumerated()
-    }
-
     func category(
         from order: ParsedOrder,
         for visibility: VisibilityType,
         with type: DeclarationType
     ) -> Category {
-        order.first { $0.visibility == visibility && $0.type == type }!
+        guard let category = order.first(where: { entry in
+            entry.visibility == visibility && entry.type == type
+                || (entry.visibility == .explicit(type) && entry.type == type)
+        })
+        else {
+            Swift.fatalError("Cannot determine ordering for declaration with visibility=\(visibility.rawValue) and type=\(type.rawValue).")
+        }
+
+        return category
     }
 
     func visibility(of declaration: Declaration) -> Visibility? {
@@ -2163,10 +2209,12 @@ extension Formatter {
             return type(of: keyword, with: tokens, mapping: availableTypes)
 
         case let .conditionalCompilation(_, body, _, _):
-            // Prefer treating conditional compliation blocks as having
+            // Prefer treating conditional compilation blocks as having
             // the property type of the first declaration in their body.
             guard let firstDeclarationInBlock = body.first else {
-                return .conditionalCompilation
+                // It's unusual to have an empty conditional compilation block.
+                // Pick an arbitrary declaration type as a fallback.
+                return .nestedType
             }
 
             return type(of: firstDeclarationInBlock, for: mode, mapping: availableTypes)
@@ -2356,11 +2404,10 @@ extension Formatter {
             // Current amount of variants to pair visibility-type is over 300,
             // so we take only categories that could provide typemark that we want to erase
             let potentialCategorySeparators = (
-                VisibilityType.allCases.map {
-                    Category(visibility: $0, type: .classMethod, order: 0)
-                } + DeclarationType.allCases.map {
-                    Category(visibility: .visibility(.open), type: $0, order: 0)
-                } + order.filter { $0.comment != nil }
+                VisibilityType.allCases.map { Category(visibility: $0, type: .classMethod, order: 0) }
+                    + DeclarationType.allCases.map { Category(visibility: .visibility(.open), type: $0, order: 0) }
+                    + DeclarationType.allCases.map { Category(visibility: .explicit($0), type: .classMethod, order: 0) }
+                    + order.filter { $0.comment != nil }
             ).flatMap {
                 Array(Set([
                     // The user's specific category separator template

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -653,8 +653,8 @@ public struct FormatOptions: CustomStringConvertible {
     public var organizeEnumThreshold: Int
     public var organizeExtensionThreshold: Int
     public var organizationMode: DeclarationOrganizationMode
-    public var visibilityOrder: [String]
-    public var typeOrder: [String]
+    public var visibilityOrder: [String]?
+    public var typeOrder: [String]?
     public var customVisibilityMarks: Set<String>
     public var customTypeMarks: Set<String>
     public var alphabeticallySortedDeclarationPatterns: Set<String>
@@ -776,8 +776,8 @@ public struct FormatOptions: CustomStringConvertible {
                 organizeEnumThreshold: Int = 0,
                 organizeExtensionThreshold: Int = 0,
                 organizationMode: DeclarationOrganizationMode = .visibility,
-                visibilityOrder: [String] = Formatter.VisibilityType.allCases.map(\.rawValue),
-                typeOrder: [String] = Formatter.DeclarationType.allCases.map(\.rawValue),
+                visibilityOrder: [String]? = nil,
+                typeOrder: [String]? = nil,
                 customVisibilityMarks: Set<String> = [],
                 customTypeMarks: Set<String> = [],
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -284,7 +284,7 @@ class OptionDescriptorTests: XCTestCase {
     }
 
     func testTypeOrder() {
-        let argument = "beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod, conditionalCompilation"
+        let argument = "beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod"
 
         let descriptor = Descriptors.typeOrder
         var options = FormatOptions()
@@ -292,19 +292,31 @@ class OptionDescriptorTests: XCTestCase {
     }
 
     func testTypeOrderUnparseableArgument() {
-        let argument = "_beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod, conditionalCompilation"
+        let argument = "_beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod"
 
         let descriptor = Descriptors.typeOrder
         var options = FormatOptions()
         XCTAssertThrowsError(try descriptor.toOptions(argument, &options))
     }
 
-    func testTypeOrderMissingEssentials() {
-        let argument = "beforeMarks, nestedType, instanceProperty, instanceLifecycle, instanceMethod"
+    func testAcceptsAirbnbSwiftStyleGuideVisibilityOrder() {
+        // The `visibilityorder` configuration used in Airbnb's Swift Style Guide,
+        // as defined here: https://github.com/airbnb/swift#subsection-organization
+        let argument = "beforeMarks,instanceLifecycle,open,public,package,internal,private,fileprivate"
+
+        let descriptor = Descriptors.visibilityOrder
+        var options = FormatOptions()
+        XCTAssertNoThrow(try descriptor.toOptions(argument, &options))
+    }
+
+    func testAcceptsAirbnbSwiftStyleGuideTypeOrder() {
+        // The `typeorder` configuration used in Airbnb's Swift Style Guide,
+        // as defined here: https://github.com/airbnb/swift#subsection-organization
+        let argument = "nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod"
 
         let descriptor = Descriptors.typeOrder
         var options = FormatOptions()
-        XCTAssertThrowsError(try descriptor.toOptions(argument, &options))
+        XCTAssertNoThrow(try descriptor.toOptions(argument, &options))
     }
 
     func testFormatOptionsDescriptionConsistency() {


### PR DESCRIPTION
This PR improves the expressiveness of the `organizeDeclaration` rule's `--typeorder` and `--visibilityorder` options.

The `--typeorder` and `--visibilityorder` arguments that best correspond to the behavior [defined](https://github.com/airbnb/swift#subsection-organization) in Airbnb's style guide would be:
```
--visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,private,fileprivate
--typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod
```

However this is not currently allowed, because `--typeorder` is currently required to contain `beforeMarks` and `instanceLifecycle`. Additionally, `beforeMarks` and `instanceLifecycle` are hardcoded to always be enabled in `--visibilityorder`.

This PR reworks the support for top-level `DeclarationType` categories so that:
 1. You can omit required declaration types from `--typeorder` as long as they're included in `--visibilityorder` instead
 2. `beforeMarks` and `instanceLifecycle` are not special-cased or hardcoded anywhere
 3. You can use any declaration type in `--visibilityorder` and it will behave as expected

A consequence of #2 is that the default behavior for the `organizeDeclarations` rule would change pretty dramatically from what it was before (`instanceLifecycle` would not be a top-level category by default). Instead, this PR makes it so that the default behavior of `--typeorder` and `--visibilityorder` depend on the current `--organizationmode`. 

Please review: @oiuhr