### PR TITLE
Add allowList to unusedPrivateDeclaration

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5150,6 +5150,7 @@ public struct _FormatRules {
         disabledByDefault: true
     ) { formatter in
         guard !formatter.options.fragment else { return }
+        let allowList = ["let", "var", "func"]
         var privateDeclarations: [Formatter.Declaration] = []
         var usage: [String: Int] = [:]
 
@@ -5172,7 +5173,8 @@ public struct _FormatRules {
                count < 2
             {
                 switch declaration {
-                case let .declaration(_, _, originalRange):
+                case let .declaration(kind, _, originalRange):
+                    guard allowList.contains(kind) else { break }
                     formatter.removeTokens(in: originalRange)
                 case .type, .conditionalCompilation:
                     break

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10490,4 +10490,14 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoNotRemovePrivateTypealias() {
+        let input = """
+        enum Foo {
+            struct Bar {}
+            private typealias Baz = Bar
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }


### PR DESCRIPTION
@calda pointed out that it's safer to remove unused private `let`, `var`, and `func` declarations lest we remove something that is indeed being used.

To ensure this, I'm adding `let allowList = ["let", "var", "func"]` and `guard allowList.contains(kind) else { break }` to rule `unusedPrivateDeclaration`.

---

For reference, this is what we are using as declarations:

```swift
// ParsingHelpers.swift
...
static var declarationTypeKeywords: Set<String> {
      swiftTypeKeywords.union([
          "import", "let", "var", "typealias", "func", "enum", "case",
          "struct", "class", "actor", "protocol", "init", "deinit",
          "extension", "subscript", "operator", "precedencegroup",
          "associatedtype", "macro",
      ])
  }
```