### PR TITLE
Fix issue where redundantInternal would unexpectedly remove internal access control from declaration in public extension with where clause

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7583,7 +7583,7 @@ public struct _FormatRules {
 
             // If we're inside an extension, then `internal` is only redundant if the extension itself is `internal`.
             if let startOfScope = formatter.startOfScope(at: internalKeywordIndex),
-               let typeKeywordIndex = formatter.indexOfLastSignificantKeyword(at: startOfScope),
+               let typeKeywordIndex = formatter.indexOfLastSignificantKeyword(at: startOfScope, excluding: ["where"]),
                formatter.tokens[typeKeywordIndex] == .keyword("extension"),
                // In the language grammar, the ACL level always directly precedes the
                // `extension` keyword if present.

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10015,6 +10015,21 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.redundantInternal)
     }
 
+    func testPreservesInternalInPublicExtensionWithWhereClause() {
+        let input = """
+        public extension SomeProtocol where SomeAssociatedType == SomeOtherType {
+            internal func fun1() {}
+            func fun2() {}
+        }
+
+        public extension OtherProtocol<GenericArgument> {
+            internal func fun1() {}
+            func fun2() {}
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.redundantInternal)
+    }
+
     // MARK: - noExplicitOwnership
 
     func testRemovesOwnershipKeywordsFromFunc() {


### PR DESCRIPTION
This PR fixes #1754