### PR TITLE
Add typealias to unusedPrivateDeclaration allowlist

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5150,11 +5150,18 @@ public struct _FormatRules {
         disabledByDefault: true
     ) { formatter in
         guard !formatter.options.fragment else { return }
-        let allowList = ["let", "var", "func"]
-        var privateDeclarations: [Formatter.Declaration] = []
-        var usage: [String: Int] = [:]
 
+        // Only remove unused properties, functions, or typealiases.
+        //  - This rule doesn't currently support removing unused types,
+        //    and it's more difficult to track the usage of other declaration
+        //    types like `init`, `subscript`, `operator`, etc.
+        let allowlist = ["let", "var", "func", "typealias"]
+
+        // Collect all of the `private` or `fileprivate` declarations in the file
+        var privateDeclarations: [Formatter.Declaration] = []
         formatter.forEachRecursiveDeclaration { declaration in
+            guard allowlist.contains(declaration.keyword) else { return }
+
             switch formatter.visibility(of: declaration) {
             case .fileprivate, .private:
                 privateDeclarations.append(declaration)
@@ -5163,23 +5170,21 @@ public struct _FormatRules {
             }
         }
 
+        // Count the usage of each identifier in the file
+        var usage: [String: Int] = [:]
         formatter.forEach(.identifier) { _, token in
             usage[token.string, default: 0] += 1
         }
 
+        // Remove any private or fileprivate declaration whose name only
+        // appears a single time in the source file
         for declaration in privateDeclarations.reversed() {
-            if let name = declaration.name,
-               let count = usage[name],
-               count < 2
-            {
-                switch declaration {
-                case let .declaration(kind, _, originalRange):
-                    guard allowList.contains(kind) else { break }
-                    formatter.removeTokens(in: originalRange)
-                case .type, .conditionalCompilation:
-                    break
-                }
-            }
+            guard let name = declaration.name,
+                  let count = usage[name],
+                  count <= 1
+            else { continue }
+
+            formatter.removeTokens(in: declaration.originalRange)
         }
     }
 

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10491,13 +10491,39 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
     }
 
-    func testDoNotRemovePrivateTypealias() {
+    func testRemovesPrivateTypealias() {
         let input = """
         enum Foo {
             struct Bar {}
             private typealias Baz = Bar
         }
         """
+        let output = """
+        enum Foo {
+            struct Bar {}
+        }
+        """
+        testFormatting(for: input, output, rule: FormatRules.unusedPrivateDeclaration)
+    }
+
+    func testDoesntRemoveFileprivateInit() {
+        let input = """
+        struct Foo {
+            fileprivate init() {}
+            static let foo = Foo()
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration, exclude: ["propertyType"])
+    }
+
+    func testCanDisableUnusedPrivateDeclarationRule() {
+        let input = """
+        private enum Foo {
+            // swiftformat:disable:next unusedPrivateDeclaration
+            fileprivate static func bar() {}
+        }
+        """
+
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 }


### PR DESCRIPTION
After talking to @mannylopez about https://github.com/nicklockwood/SwiftFormat/pull/1761 we realized that `typealias` could also go in the `unusedPrivateDeclaration` allowlist. 

I also wanted to double-check that `// swiftformat:disable:next unusedPrivateDeclaration` worked as expected, so I added a test case for that.