### PR TITLE
Add docCommentBeforeAttributes rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -15,6 +15,7 @@
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
 * [consistentSwitchCaseSpacing](#consistentSwitchCaseSpacing)
+* [docCommentBeforeAttributes](#docCommentBeforeAttributes)
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
@@ -646,6 +647,23 @@ Ensures consistent spacing among all of the cases in a switch statement.
   case .neptune:
       "Neptune"
   }
+```
+
+</details>
+<br/>
+
+## docCommentBeforeAttributes
+
+Place doc comments on declarations before any attributes.
+
+<details>
+<summary>Examples</summary>
+
+```diff
++ /// Doc comment on this function declaration
+  @MainActor
+- /// Doc comment on this function declaration
+  func foo() {}
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -1999,4 +1999,13 @@ private struct Examples {
       }
     ```
     """
+
+    let docCommentBeforeAttributes = """
+    ```diff
+    + /// Doc comment on this function declaration
+      @MainActor
+    - /// Doc comment on this function declaration
+      func foo() {}
+    ```
+    """
 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -847,6 +847,34 @@ extension Formatter {
         }
     }
 
+    /// Parses the list of attributes on a declaration, starting at the given index.
+    func attributes(startingAt index: Int) -> [(startIndex: Int, endIndex: Int, tokens: [Token])] {
+        assert(tokens[index].isAttribute)
+
+        var attributes: [(startIndex: Int, endIndex: Int, tokens: [Token])] = []
+
+        var nextAttributeStartIndex = index
+        while tokens[nextAttributeStartIndex].isAttribute {
+            guard let endOfAttribute = endOfAttribute(at: nextAttributeStartIndex) else {
+                return attributes
+            }
+
+            attributes.append((
+                startIndex: nextAttributeStartIndex,
+                endIndex: endOfAttribute,
+                tokens: Array(tokens[nextAttributeStartIndex ... endOfAttribute])
+            ))
+
+            guard let nextIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfAttribute) else {
+                return attributes
+            }
+
+            nextAttributeStartIndex = nextIndex
+        }
+
+        return attributes
+    }
+
     /// Whether or not this property at the given introducer index (either `var` or `let`)
     /// is a stored property or a computed property.
     func isStoredProperty(atIntroducerIndex introducerIndex: Int) -> Bool {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -8306,4 +8306,39 @@ public struct _FormatRules {
             }
         }
     }
+
+    public let docCommentBeforeAttributes = FormatRule(
+        help: "Place doc comments on declarations before any attributes."
+    ) { formatter in
+        formatter.forEachToken(where: \.isDeclarationTypeKeyword) { keywordIndex, _ in
+            // Parse the attributes on this declaration if present
+            let startOfAttributes = formatter.startOfModifiers(at: keywordIndex, includingAttributes: true)
+            guard formatter.tokens[startOfAttributes].isAttribute else { return }
+
+            let attributes = formatter.attributes(startingAt: startOfAttributes)
+            guard !attributes.isEmpty else { return }
+
+            let tokenBeforeAttributes = formatter.lastToken(before: startOfAttributes, where: { !$0.isSpaceOrLinebreak })
+            let attributesRange = attributes.first!.startIndex ... attributes.last!.endIndex
+
+            // Make sure there are no comments immediately before, or within, the set of attributes.
+            guard tokenBeforeAttributes?.isComment != true,
+                  !formatter.tokens[attributesRange].contains(where: \.isComment)
+            else { return }
+
+            // If there's a comment between the attributes and the rest of the declaration,
+            // move it above the attributes.
+            guard let indexAfterAttributes = formatter.index(of: .nonSpaceOrLinebreak, after: attributesRange.upperBound),
+                  let restOfDeclaration = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: attributesRange.upperBound),
+                  formatter.tokens[indexAfterAttributes].isComment,
+                  formatter.tokens[indexAfterAttributes ..< restOfDeclaration].allSatisfy(\.isSpaceOrCommentOrLinebreak)
+            else { return }
+
+            let commentRange = indexAfterAttributes ..< restOfDeclaration
+            let comment = formatter.tokens[commentRange]
+
+            formatter.removeTokens(in: commentRange)
+            formatter.insert(comment, at: startOfAttributes)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new `docCommentBeforeAttributes` rule that ensures any doc comments on a declaration come before, not after, the declaration's attributes. For example:

```diff
+ /// Doc comment on this function declaration
  @MainActor
- /// Doc comment on this function declaration
  func foo() {}
```