### PR TITLE
Improve docCommentsBeforeAttributes rule, fix support for declarations after MARK comments

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -15,7 +15,7 @@
 * [consecutiveBlankLines](#consecutiveBlankLines)
 * [consecutiveSpaces](#consecutiveSpaces)
 * [consistentSwitchCaseSpacing](#consistentSwitchCaseSpacing)
-* [docCommentBeforeAttributes](#docCommentBeforeAttributes)
+* [docCommentsBeforeAttributes](#docCommentsBeforeAttributes)
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
@@ -652,23 +652,6 @@ Ensures consistent spacing among all of the cases in a switch statement.
 </details>
 <br/>
 
-## docCommentBeforeAttributes
-
-Place doc comments on declarations before any attributes.
-
-<details>
-<summary>Examples</summary>
-
-```diff
-+ /// Doc comment on this function declaration
-  @MainActor
-- /// Doc comment on this function declaration
-  func foo() {}
-```
-
-</details>
-<br/>
-
 ## docComments
 
 Use doc comments for API declarations, otherwise use regular comments.
@@ -691,6 +674,23 @@ Option | Description
 +         // TODO: implement Foo.bar() algorithm
       }
   }
+```
+
+</details>
+<br/>
+
+## docCommentsBeforeAttributes
+
+Place doc comments on declarations before any attributes.
+
+<details>
+<summary>Examples</summary>
+
+```diff
++ /// Doc comment on this function declaration
+  @MainActor
+- /// Doc comment on this function declaration
+  func foo() {}
 ```
 
 </details>

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -2000,7 +2000,7 @@ private struct Examples {
     ```
     """
 
-    let docCommentBeforeAttributes = """
+    let docCommentsBeforeAttributes = """
     ```diff
     + /// Doc comment on this function declaration
       @MainActor

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -8320,7 +8320,7 @@ public struct _FormatRules {
         }
     }
 
-    public let docCommentBeforeAttributes = FormatRule(
+    public let docCommentsBeforeAttributes = FormatRule(
         help: "Place doc comments on declarations before any attributes."
     ) { formatter in
         formatter.forEachToken(where: \.isDeclarationTypeKeyword) { keywordIndex, _ in
@@ -8331,20 +8331,15 @@ public struct _FormatRules {
             let attributes = formatter.attributes(startingAt: startOfAttributes)
             guard !attributes.isEmpty else { return }
 
-            let tokenBeforeAttributes = formatter.lastToken(before: startOfAttributes, where: { !$0.isSpaceOrLinebreak })
             let attributesRange = attributes.first!.startIndex ... attributes.last!.endIndex
-
-            // Make sure there are no comments immediately before, or within, the set of attributes.
-            guard tokenBeforeAttributes?.isComment != true,
-                  !formatter.tokens[attributesRange].contains(where: \.isComment)
-            else { return }
 
             // If there's a comment between the attributes and the rest of the declaration,
             // move it above the attributes.
-            guard let indexAfterAttributes = formatter.index(of: .nonSpaceOrLinebreak, after: attributesRange.upperBound),
+            guard let linebreakAfterAttributes = formatter.index(of: .linebreak, after: attributesRange.upperBound),
+                  let indexAfterAttributes = formatter.index(of: .nonSpaceOrLinebreak, after: linebreakAfterAttributes),
+                  indexAfterAttributes < keywordIndex,
                   let restOfDeclaration = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: attributesRange.upperBound),
-                  formatter.tokens[indexAfterAttributes].isComment,
-                  formatter.tokens[indexAfterAttributes ..< restOfDeclaration].allSatisfy(\.isSpaceOrCommentOrLinebreak)
+                  formatter.tokens[indexAfterAttributes].isComment
             else { return }
 
             let commentRange = indexAfterAttributes ..< restOfDeclaration

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -1643,7 +1643,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, rule: FormatRules.organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: ["blankLinesAtStartOfScope", "docCommentsBeforeAttributes"])
     }
 
     func testHandlesTrailingCommentCorrectly() {


### PR DESCRIPTION
This PR makes a few follow-up improvements to the new `docCommentsBeforeAttributes` rule, including fixing an issue where the rule wasn't applied following `// MARK:` or `// TODO` comments.

