### PR TITLE
Update unusedPrivateDeclaration and handle false positives

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2767,6 +2767,10 @@ Option | Description
 
 Remove unused private and fileprivate declarations.
 
+Option | Description
+--- | ---
+`--preservedecls` | Comma separated list of declaration names to exclude
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1301,4 +1301,10 @@ struct _Descriptors {
             }
         }
     ).renamed(to: "modifierOrder")
+    let preservedPrivateDeclarations = OptionDescriptor(
+        argumentName: "preservedecls",
+        displayName: "Private Declarations to Exclude",
+        help: "Comma separated list of declaration names to exclude",
+        keyPath: \.preservedPrivateDeclarations
+    )
 }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1185,6 +1185,12 @@ struct _Descriptors {
         help: "\"remove\" (default) redundant nil or \"insert\" missing nil",
         keyPath: \.nilInit
     )
+    let preservedPrivateDeclarations = OptionDescriptor(
+        argumentName: "preservedecls",
+        displayName: "Private Declarations to Exclude",
+        help: "Comma separated list of declaration names to exclude",
+        keyPath: \.preservedPrivateDeclarations
+    )
 
     // MARK: - Internal
 
@@ -1301,10 +1307,4 @@ struct _Descriptors {
             }
         }
     ).renamed(to: "modifierOrder")
-    let preservedPrivateDeclarations = OptionDescriptor(
-        argumentName: "preservedecls",
-        displayName: "Private Declarations to Exclude",
-        help: "Comma separated list of declaration names to exclude",
-        keyPath: \.preservedPrivateDeclarations
-    )
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -819,13 +819,13 @@ public struct FormatOptions: CustomStringConvertible {
                 dateFormat: DateFormat = .system,
                 timeZone: FormatTimeZone = .system,
                 nilInit: NilInitType = .remove,
+                preservedPrivateDeclarations: Set<String> = [],
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
                 swiftVersion: Version = .undefined,
                 fileInfo: FileInfo = FileInfo(),
-                timeout: TimeInterval = 1,
-                preservedPrivateDeclarations: Set<String> = [])
+                timeout: TimeInterval = 1)
     {
         self.lineAfterMarks = lineAfterMarks
         self.indent = indent
@@ -933,13 +933,13 @@ public struct FormatOptions: CustomStringConvertible {
         self.dateFormat = dateFormat
         self.timeZone = timeZone
         self.nilInit = nilInit
+        self.preservedPrivateDeclarations = preservedPrivateDeclarations
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers
         self.swiftVersion = swiftVersion
         self.fileInfo = fileInfo
         self.timeout = timeout
-        self.preservedPrivateDeclarations = preservedPrivateDeclarations
     }
 
     public var useTabs: Bool {

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -695,6 +695,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var dateFormat: DateFormat
     public var timeZone: FormatTimeZone
     public var nilInit: NilInitType
+    public var preservedPrivateDeclarations: Set<String>
 
     /// Deprecated
     public var indentComments: Bool
@@ -823,7 +824,8 @@ public struct FormatOptions: CustomStringConvertible {
                 ignoreConflictMarkers: Bool = false,
                 swiftVersion: Version = .undefined,
                 fileInfo: FileInfo = FileInfo(),
-                timeout: TimeInterval = 1)
+                timeout: TimeInterval = 1,
+                preservedPrivateDeclarations: Set<String> = [])
     {
         self.lineAfterMarks = lineAfterMarks
         self.indent = indent
@@ -937,6 +939,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.swiftVersion = swiftVersion
         self.fileInfo = fileInfo
         self.timeout = timeout
+        self.preservedPrivateDeclarations = preservedPrivateDeclarations
     }
 
     public var useTabs: Bool {

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5193,14 +5193,11 @@ public struct _FormatRules {
         // Remove any private or fileprivate declaration whose name only
         // appears a single time in the source file
         for declaration in privateDeclarations.reversed() {
-            guard let name = declaration.name else { continue }
-            // Strip backticks from name for a normalized base name
-            let baseName = name.trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+            // Strip backticks from name for a normalized base name for cases like `default`
+            guard let name = declaration.name?.trimmingCharacters(in: CharacterSet(charactersIn: "`")) else { continue }
             // Check for regular usage, common property wrapper prefixes, and protected names
-            let count = (usage[baseName] ?? 0)
-                + (usage["_\(baseName)"] ?? 0)
-                + (usage["$\(baseName)"] ?? 0)
-                + (usage["`\(baseName)`"] ?? 0)
+            let variants = [name, "_\(name)", "$\(name)", "`\(name)`"]
+            let count = variants.compactMap { usage[$0] }.reduce(0, +)
             if count <= 1 {
                 formatter.removeTokens(in: declaration.originalRange)
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5185,9 +5185,17 @@ public struct _FormatRules {
         }
 
         // Count the usage of each identifier in the file
+        let propertyWrapperPrefixes: [Character] = ["_", "$"]
         var usage: [String: Int] = [:]
         formatter.forEach(.identifier) { _, token in
-            usage[token.string, default: 0] += 1
+            var identifier = token.string
+            // Handle property wrapper prefixes, such as `_showButton = .init(initialValue: false)`, and remove the prefix to count the usage properly
+            if let firstChar = token.string.first,
+               propertyWrapperPrefixes.contains(firstChar)
+            {
+                identifier.removeFirst()
+            }
+            usage[identifier, default: 0] += 1
         }
 
         // Remove any private or fileprivate declaration whose name only

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5194,8 +5194,13 @@ public struct _FormatRules {
         // appears a single time in the source file
         for declaration in privateDeclarations.reversed() {
             guard let name = declaration.name else { continue }
-            // Check for common property wrapper prefixes as well as regular usage
-            let count = (usage[name] ?? 0) + (usage["_\(name)"] ?? 0) + (usage["$\(name)"] ?? 0)
+            // Strip backticks from name for a normalized base name
+            let baseName = name.trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+            // Check for regular usage, common property wrapper prefixes, and protected names
+            let count = (usage[baseName] ?? 0)
+                + (usage["_\(baseName)"] ?? 0)
+                + (usage["$\(baseName)"] ?? 0)
+                + (usage["`\(baseName)`"] ?? 0)
             if count <= 1 {
                 formatter.removeTokens(in: declaration.originalRange)
             }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5161,7 +5161,8 @@ public struct _FormatRules {
     /// Remove unused private and fileprivate declarations
     public let unusedPrivateDeclaration = FormatRule(
         help: "Remove unused private and fileprivate declarations.",
-        disabledByDefault: true
+        disabledByDefault: true,
+        options: ["preservedecls"]
     ) { formatter in
         guard !formatter.options.fragment else { return }
 
@@ -5174,7 +5175,10 @@ public struct _FormatRules {
         // Collect all of the `private` or `fileprivate` declarations in the file
         var privateDeclarations: [Declaration] = []
         formatter.forEachRecursiveDeclaration { declaration in
-            guard allowlist.contains(declaration.keyword) else { return }
+            guard allowlist.contains(declaration.keyword),
+                  let name = declaration.name,
+                  !(formatter.options.preservedPrivateDeclarations.contains(name))
+            else { return }
 
             switch formatter.visibility(of: declaration) {
             case .fileprivate, .private:

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10589,7 +10589,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 
-    func testDoesNotRemoveUBacktickDeclarationIfUsed() {
+    func testDoesNotRemoveBacktickDeclarationIfUsed() {
         let input = """
         struct Foo {
             fileprivate static var `default`: Bool = true

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10601,6 +10601,18 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
 
+    func testDoesNotRemoveBacktickUsage() {
+        let input = """
+        struct Foo {
+            fileprivate static var foo = true
+            func printDefault() {
+                print(Foo.`foo`)
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration, exclude: ["redundantBackticks"])
+    }
+
     func testDoNotRemovePreservedPrivateDeclarations() {
         let input = """
         enum Foo {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10568,12 +10568,22 @@ class RedundancyTests: RulesTests {
 
     func testDoesNotRemovePropertyWrapperPrefixesIfUsed() {
         let input = """
-        struct ContentView {
+        struct ContentView: View {
             public init() {
                 _showButton = .init(initialValue: false)
             }
 
             @State private var showButton: Bool
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
+
+    func testDoesNotRemoveUnderscoredDeclarationIfUsed() {
+        let input = """
+        struct Foo {
+            private var _showButton: Bool = true
+            print(_showButton)
         }
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10565,4 +10565,17 @@ class RedundancyTests: RulesTests {
 
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoesNotRemovePropertyWrapperPrefixesIfUsed() {
+        let input = """
+        struct ContentView {
+            public init() {
+                _showButton = .init(initialValue: false)
+            }
+
+            @State private var showButton: Bool
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10588,4 +10588,16 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoesNotRemoveUBacktickDeclarationIfUsed() {
+        let input = """
+        struct Foo {
+            fileprivate static var `default`: Bool = true
+            func printDefault() {
+                print(Foo.default)
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10600,4 +10600,14 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoNotRemovePreservedPrivateDeclarations() {
+        let input = """
+        enum Foo {
+            private static let registryAssociation = false
+        }
+        """
+        let options = FormatOptions(preservedPrivateDeclarations: ["registryAssociation", "hello"])
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration, options: options)
+    }
 }


### PR DESCRIPTION
This PR will fix some false-positives found when using the `unusedPrivateDeclaration` rule.

1. 
#### Handle property wrapper prefixes prefixes like `_` and `$`
```swift
struct ContentView: View {
    public init() {
        _showButton = .init(initialValue: false)
    }

    @State private var showButton: Bool
}
```

2. 
#### Handle backticks properly, for reserved keywords such as `default`
```swift
// Declaration
extension CGSize {
  fileprivate static var `default`: CGSize { .init(width: 10, height: 10) }
}

// Usage
let defaultSize = CGSize.default
```

3.
#### Add `preservedPrivateDeclarations` FormatOption and OptionDescriptor