### PR TITLE
Update docCommentsBeforeAttributes rule to only apply to doc comments

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -7205,10 +7205,12 @@ public struct _FormatRules {
                 return
             }
 
-            if let commentBody = formatter.token(at: index + 1),
-               case .commentBody = commentBody
+            let isDocComment = formatter.isDocComment(startOfComment: index)
+
+            if isDocComment,
+               let commentBody = formatter.token(at: index + 1),
+               commentBody.isCommentBody
             {
-                let isDocComment = commentBody.string.hasPrefix(startOfDocCommentBody)
                 if useDocComment, !isDocComment, !preserveRegularComments {
                     let updatedCommentBody = "\(startOfDocCommentBody)\(commentBody.string)"
                     formatter.replaceToken(at: index + 1, with: .commentBody(updatedCommentBody))
@@ -8327,7 +8329,8 @@ public struct _FormatRules {
     }
 
     public let docCommentsBeforeAttributes = FormatRule(
-        help: "Place doc comments on declarations before any attributes."
+        help: "Place doc comments on declarations before any attributes.",
+        orderAfter: ["docComments"]
     ) { formatter in
         formatter.forEachToken(where: \.isDeclarationTypeKeyword) { keywordIndex, _ in
             // Parse the attributes on this declaration if present
@@ -8339,13 +8342,13 @@ public struct _FormatRules {
 
             let attributesRange = attributes.first!.startIndex ... attributes.last!.endIndex
 
-            // If there's a comment between the attributes and the rest of the declaration,
+            // If there's a doc comment between the attributes and the rest of the declaration,
             // move it above the attributes.
             guard let linebreakAfterAttributes = formatter.index(of: .linebreak, after: attributesRange.upperBound),
                   let indexAfterAttributes = formatter.index(of: .nonSpaceOrLinebreak, after: linebreakAfterAttributes),
                   indexAfterAttributes < keywordIndex,
                   let restOfDeclaration = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: attributesRange.upperBound),
-                  formatter.tokens[indexAfterAttributes].isComment
+                  formatter.isDocComment(startOfComment: indexAfterAttributes)
             else { return }
 
             let commentRange = indexAfterAttributes ..< restOfDeclaration

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -5548,7 +5548,7 @@ class SyntaxTests: RulesTests {
         @MainActor
         @Macro(argument: true)
         @available(*, deprecated)
-        // Comment on this function declaration after several attributes
+        /// Doc comment on this function declaration after several attributes
         public func bar() {}
         """
 
@@ -5557,14 +5557,14 @@ class SyntaxTests: RulesTests {
         @MainActor @Macro(argument: true) @available(*, deprecated)
         public func foo() {}
 
-        // Comment on this function declaration after several attributes
+        /// Doc comment on this function declaration after several attributes
         @MainActor
         @Macro(argument: true)
         @available(*, deprecated)
         public func bar() {}
         """
 
-        testFormatting(for: input, output, rule: FormatRules.docCommentsBeforeAttributes, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: FormatRules.docCommentsBeforeAttributes)
     }
 
     func testUpdatesCommentsAfterMark() {
@@ -5587,7 +5587,7 @@ class SyntaxTests: RulesTests {
 
             // TODO: This function also has a TODO comment.
             @MainActor
-            // Comment on this function declaration.
+            /// Doc comment on this function declaration.
             private func bar() {}
 
         }
@@ -5611,40 +5611,40 @@ class SyntaxTests: RulesTests {
             // MARK: Private
 
             // TODO: This function also has a TODO comment.
-            // Comment on this function declaration.
+            /// Doc comment on this function declaration.
             @MainActor
             private func bar() {}
 
         }
         """
 
-        testFormatting(for: input, output, rule: FormatRules.docCommentsBeforeAttributes, exclude: ["docComments", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, output, rule: FormatRules.docCommentsBeforeAttributes, exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
     }
 
     func testPreservesCommentsBetweenAttributes() {
         let input = """
         @MainActor
-        // Comment between attributes
+        /// Doc comment between attributes
         @available(*, deprecated)
-        /// Comment before declaration
+        /// Doc comment before declaration
         func bar() {}
 
-        @MainActor // Comment after main actor attribute
-        @available(*, deprecated) // Comment after deprecation attribute
-        /// Comment before declaration
+        @MainActor /// Doc comment after main actor attribute
+        @available(*, deprecated) /// Doc comment after deprecation attribute
+        /// Doc comment before declaration
         func bar() {}
         """
 
         let output = """
-        /// Comment before declaration
+        /// Doc comment before declaration
         @MainActor
-        // Comment between attributes
+        /// Doc comment between attributes
         @available(*, deprecated)
         func bar() {}
 
-        /// Comment before declaration
-        @MainActor // Comment after main actor attribute
-        @available(*, deprecated) // Comment after deprecation attribute
+        /// Doc comment before declaration
+        @MainActor /// Doc comment after main actor attribute
+        @available(*, deprecated) /// Doc comment after deprecation attribute
         func bar() {}
         """
 
@@ -5653,10 +5653,36 @@ class SyntaxTests: RulesTests {
 
     func testPreservesCommentOnSameLineAsAttribute() {
         let input = """
-        @MainActor // comment trailing attributes
+        @MainActor /// Doc comment trailing attributes
         func foo() {}
         """
 
-        testFormatting(for: input, rule: FormatRules.docCommentsBeforeAttributes)
+        testFormatting(for: input, rule: FormatRules.docCommentsBeforeAttributes, exclude: ["docComments"])
+    }
+
+    func testPreservesRegularComments() {
+        let input = """
+        @MainActor
+        // Comment after attribute
+        func foo() {}
+        """
+
+        testFormatting(for: input, rule: FormatRules.docCommentsBeforeAttributes, exclude: ["docComments"])
+    }
+
+    func testCombinesWithDocCommentsRule() {
+        let input = """
+        @MainActor
+        // Comment after attribute
+        func foo() {}
+        """
+
+        let output = """
+        /// Comment after attribute
+        @MainActor
+        func foo() {}
+        """
+
+        testFormatting(for: input, [output], rules: [FormatRules.docComments, FormatRules.docCommentsBeforeAttributes])
     }
 }


### PR DESCRIPTION
This PR updates the `docCommentsBeforeAttributes` rule to only apply to doc comments. Previously it also applied to regular comments, which is unexpected given the name of the rule. https://github.com/nicklockwood/SwiftFormat/pull/1770#discussion_r1687510809