### PR TITLE
Fix issue where `--wrapeffects never` could unexpectedly remove unrelated code

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -365,7 +365,11 @@ extension Formatter {
                     }
                 case .never:
                     if startOfLine(at: endOfFunctionScope) != startOfLine(at: effectIndex) {
-                        replaceTokens(in: endOfLine(at: endOfFunctionScope) ..< effectIndex, with: [.space(" ")])
+                        let rangeToRemove = endOfLine(at: endOfFunctionScope) ..< effectIndex
+
+                        if tokens[rangeToRemove].allSatisfy(\.isSpaceOrCommentOrLinebreak) {
+                            replaceTokens(in: rangeToRemove, with: [.space(" ")])
+                        }
                     }
                 }
             }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2238,6 +2238,26 @@ class WrappingTests: RulesTests {
                        exclude: ["wrap", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
     }
 
+    func testWrapArgumentsDoesntBreakFunctionDeclaration_issue_1776() {
+        let input = """
+        struct OpenAPIController: RouteCollection {
+            let info = InfoObject(title: "Swagger {{cookiecutter.service_name}} - OpenAPI",
+                                  description: "{{cookiecutter.description}}",
+                                  contact: .init(email: "{{cookiecutter.email}}"),
+                                  version: Version(0, 0, 1))
+            func boot(routes: RoutesBuilder) throws {
+                routes.get("swagger", "swagger.json") {
+                    $0.application.routes.openAPI(info: info)
+                }
+                .excludeFromOpenAPI()
+            }
+        }
+        """
+
+        let options = FormatOptions(wrapEffects: .never)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["propertyType"])
+    }
+
     // MARK: closingParenPosition = true
 
     func testParenOnSameLineWhenWrapAfterFirstConvertedToWrapBefore() {


### PR DESCRIPTION
This PR fixes an issue where `--wrapeffects never` could unexpectedly remove unrelated code, breaking the build.

Fixes #1776.