### PR TITLE
Add exceptions to unusedPrivateDeclaration rule

### DIFF
--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -1561,4 +1561,9 @@ extension Formatter {
             return openTokensFormatter.tokens
         }
     }
+
+    /// Check if the declaration has the `@objc`attribute
+    func hasObjcAttribute(_ declaration: Declaration) -> Bool {
+        declaration.tokens.contains { $0 == .keyword("@objc") }
+    }
 }

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -1562,8 +1562,11 @@ extension Formatter {
         }
     }
 
-    /// Check if the declaration has the `@objc`attribute
-    func hasObjcAttribute(_ declaration: Declaration) -> Bool {
-        declaration.tokens.contains { $0 == .keyword("@objc") }
+    func declarationContainsKeywords(_ declaration: Declaration, keywords: [String]) -> Bool {
+        keywords.contains { declarationContainsKeyword(declaration, keyword: $0) }
+    }
+
+    func declarationContainsKeyword(_ declaration: Declaration, keyword: String) -> Bool {
+        declaration.tokens.contains { $0 == .keyword(keyword) }
     }
 }

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -125,6 +125,20 @@ enum Declaration: Equatable {
             return originalRange
         }
     }
+
+    var modifiers: [String] {
+        let parser = Formatter(openTokens)
+        guard let keywordIndex = parser.index(of: .keyword(keyword), after: 0) else {
+            return []
+        }
+
+        var allModifiers = [String]()
+        _ = parser.modifiersForDeclaration(at: keywordIndex, contains: { _, modifier in
+            allModifiers.append(modifier)
+            return false
+        })
+        return allModifiers
+    }
 }
 
 extension Formatter {
@@ -1560,13 +1574,5 @@ extension Formatter {
 
             return openTokensFormatter.tokens
         }
-    }
-
-    func declarationContainsKeywords(_ declaration: Declaration, keywords: [String]) -> Bool {
-        keywords.contains { declarationContainsKeyword(declaration, keyword: $0) }
-    }
-
-    func declarationContainsKeyword(_ declaration: Declaration, keyword: String) -> Bool {
-        declaration.tokens.contains { $0 == .keyword(keyword) }
     }
 }

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5179,7 +5179,7 @@ public struct _FormatRules {
             guard allowlist.contains(declaration.keyword),
                   let name = declaration.name,
                   !(formatter.options.preservedPrivateDeclarations.contains(name)),
-                  !formatter.hasObjcAttribute(declaration)
+                  !formatter.declarationContainsKeywords(declaration, keywords: ["@objc", "@IBAction"])
             else { return }
 
             // Do not collect any `override` method or property declarations

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5178,7 +5178,8 @@ public struct _FormatRules {
         formatter.forEachRecursiveDeclaration { declaration in
             guard allowlist.contains(declaration.keyword),
                   let name = declaration.name,
-                  !(formatter.options.preservedPrivateDeclarations.contains(name))
+                  !(formatter.options.preservedPrivateDeclarations.contains(name)),
+                  !formatter.hasObjcAttribute(declaration)
             else { return }
 
             // Do not collect any `override` method or property declarations

--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -5171,6 +5171,7 @@ public struct _FormatRules {
         //    and it's more difficult to track the usage of other declaration
         //    types like `init`, `subscript`, `operator`, etc.
         let allowlist = ["let", "var", "func", "typealias"]
+        let overrideList: [DeclarationType] = [.overriddenProperty, .overriddenMethod]
 
         // Collect all of the `private` or `fileprivate` declarations in the file
         var privateDeclarations: [Declaration] = []
@@ -5179,6 +5180,10 @@ public struct _FormatRules {
                   let name = declaration.name,
                   !(formatter.options.preservedPrivateDeclarations.contains(name))
             else { return }
+
+            // Do not collect any `override` method or property declarations
+            let declarationType = formatter.declarationType(of: declaration.keyword, with: declaration.tokens, allowlist: overrideList)
+            guard !(overrideList.contains(declarationType)) else { return }
 
             switch formatter.visibility(of: declaration) {
             case .fileprivate, .private:

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10664,4 +10664,15 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoNotRemoveIBActionPrivateFunctionDeclaration() {
+        let input = """
+        class FooViewController: UIViewController {
+            @IBAction private func buttonPressed(_: UIButton) {
+                print("Button pressed!")
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10644,4 +10644,24 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
     }
+
+    func testDoNotRemoveObjcPrivatePropertyDeclaration() {
+        let input = """
+        struct Foo {
+            @objc
+            private var bar = "bar"
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
+
+    func testDoNotRemoveObjcPrivateFunctionDeclaration() {
+        let input = """
+        struct Foo {
+            @objc
+            private func doSomething() {}
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -10622,4 +10622,26 @@ class RedundancyTests: RulesTests {
         let options = FormatOptions(preservedPrivateDeclarations: ["registryAssociation", "hello"])
         testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration, options: options)
     }
+
+    func testDoNotRemoveOverridePrivateMethodDeclarations() {
+        let input = """
+        class Poodle: Dog {
+            override private func makeNoise() {
+                print("Yip!")
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
+
+    func testDoNotRemoveOverridePrivatePropertyDeclarations() {
+        let input = """
+        class Poodle: Dog {
+            override private var age: Int {
+                7
+            }
+        }
+        """
+        testFormatting(for: input, rule: FormatRules.unusedPrivateDeclaration)
+    }
 }


### PR DESCRIPTION
Adding exceptions to the `unusedPrivateDeclaration` rule

**`override`**
```swift
private class CustomClass: UIAccessibilityElement {
    override private func accessibilityIncrement() { ... }
}
```
Overriden methods and properties are not used in the file but could be called by the base class.

**`@objc`, IBAction, IBSegueAction, IBOutlet, IBDesignable, IBInspectable, NSManaged, or GKInspectable attribute.**

You can access a private `@objc` Swift member via `Selector`. Also skipping any declarations with any of the above attributes.

To help figure out if a `Declaration` has an `@objc`, or any of the other attributes, I'm adding the following declaration helper
```swift
enum Declaration: {
    ...
    var modifiers: [String] {
        let parser = Formatter(openTokens)
        guard let keywordIndex = parser.index(of: .keyword(keyword), after: 0) else {
            return []
        }

        var allModifiers = [String]()
        _ = parser.modifiersForDeclaration(at: keywordIndex, contains: { _, modifier in
            allModifiers.append(modifier)
            return false
        })
        return allModifiers
    }
}
```

@calda 