### PR TITLE
Update --wrapeffects never to not delete comments

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -367,7 +367,7 @@ extension Formatter {
                     if startOfLine(at: endOfFunctionScope) != startOfLine(at: effectIndex) {
                         let rangeToRemove = endOfLine(at: endOfFunctionScope) ..< effectIndex
 
-                        if tokens[rangeToRemove].allSatisfy(\.isSpaceOrCommentOrLinebreak) {
+                        if tokens[rangeToRemove].allSatisfy(\.isSpaceOrLinebreak) {
                             replaceTokens(in: rangeToRemove, with: [.space(" ")])
                         }
                     }

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -2238,26 +2238,6 @@ class WrappingTests: RulesTests {
                        exclude: ["wrap", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
     }
 
-    func testWrapArgumentsDoesntBreakFunctionDeclaration_issue_1776() {
-        let input = """
-        struct OpenAPIController: RouteCollection {
-            let info = InfoObject(title: "Swagger {{cookiecutter.service_name}} - OpenAPI",
-                                  description: "{{cookiecutter.description}}",
-                                  contact: .init(email: "{{cookiecutter.email}}"),
-                                  version: Version(0, 0, 1))
-            func boot(routes: RoutesBuilder) throws {
-                routes.get("swagger", "swagger.json") {
-                    $0.application.routes.openAPI(info: info)
-                }
-                .excludeFromOpenAPI()
-            }
-        }
-        """
-
-        let options = FormatOptions(wrapEffects: .never)
-        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["propertyType"])
-    }
-
     // MARK: closingParenPosition = true
 
     func testParenOnSameLineWhenWrapAfterFirstConvertedToWrapBefore() {
@@ -3182,6 +3162,39 @@ class WrappingTests: RulesTests {
         )
 
         testFormatting(for: input, output, rule: FormatRules.wrapArguments, options: options)
+    }
+
+    func testWrapArgumentsDoesntBreakFunctionDeclaration_issue_1776() {
+        let input = """
+        struct OpenAPIController: RouteCollection {
+            let info = InfoObject(title: "Swagger {{cookiecutter.service_name}} - OpenAPI",
+                                  description: "{{cookiecutter.description}}",
+                                  contact: .init(email: "{{cookiecutter.email}}"),
+                                  version: Version(0, 0, 1))
+            func boot(routes: RoutesBuilder) throws {
+                routes.get("swagger", "swagger.json") {
+                    $0.application.routes.openAPI(info: info)
+                }
+                .excludeFromOpenAPI()
+            }
+        }
+        """
+
+        let options = FormatOptions(wrapEffects: .never)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options, exclude: ["propertyType"])
+    }
+
+    func testWrapEffectsNeverPreservesComments() {
+        let input = """
+        func multilineFunction(
+            foo _: String,
+            bar _: String)
+            // Comment here between the parameters and effects
+            async throws -> String {}
+        """
+
+        let options = FormatOptions(closingParenPosition: .sameLine, wrapEffects: .never)
+        testFormatting(for: input, rule: FormatRules.wrapArguments, options: options)
     }
 
     func testWrapReturnOnMultilineFunctionDeclarationWithAfterFirst() {


### PR DESCRIPTION
Follow-up to https://github.com/nicklockwood/SwiftFormat/pull/1778#discussion_r1693425905: the `--wrapeffects never` option shouldn't delete comments within the function declaration.