### PR TITLE
Build all targets in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,62 @@ jobs:
           branch: ${{ matrix.branch }}
       - uses: actions/checkout@v3
       - run: swift test
+
+  command-line-tool:
+    strategy:
+      fail-fast: false
+      matrix:
+        macos:
+          - 13
+        xcode:
+          - latest-stable
+    runs-on: macos-${{ matrix.macos }}
+    steps:
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Command Line Tool
+        run: xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat (Command Line Tool)" -sdk macosx clean build
+
+  swiftformat-for-xcode:
+    strategy:
+      fail-fast: false
+      matrix:
+        macos:
+          - 13
+        xcode:
+          - latest-stable
+    runs-on: macos-${{ matrix.macos }}
+    steps:
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Swift Format for Xcode app
+        run: xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat for Xcode" -sdk macosx clean build
+
+  editor-extension:
+    strategy:
+      fail-fast: false
+      matrix:
+        macos:
+          - 13
+        xcode:
+          - latest-stable
+    runs-on: macos-${{ matrix.macos }}
+    steps:
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Editor Extension
+        run: xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat (Editor Extension)" -sdk macosx clean build
+
+        

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Editor Extension).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Editor Extension).xcscheme
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
@@ -40,7 +40,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
This PR adds CI jobs that build the following targets:
 - SwiftFormat (Command Line Tool)
 - SwiftFormat for Xcode
 - SwiftFormat (Editor Extension)

We currently don't build these in CI, making it easy to break them on accident. I've done this twice recently, including today while working on the first draft of https://github.com/nicklockwood/SwiftFormat/pull/1782.