### PR TITLE
Fix focus state typo

### DIFF
--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -612,7 +612,7 @@ extension Formatter {
             "@NSApplicationDelegateAdaptor",
             "@FetchRequest",
             "@FocusedBinding",
-            "@FocusedState",
+            "@FocusState",
             "@FocusedValue",
             "@FocusedObject",
             "@GestureState",


### PR DESCRIPTION
There is a typo in the [FocusState](https://developer.apple.com/documentation/swiftui/focusstate) SwiftUI property wrapper.