### PR TITLE
Update `exclude` and `orderAfter` to reference rules by static member lookup

### DIFF
--- a/Sources/Rules/blankLineAfterSwitchCase.swift
+++ b/Sources/Rules/blankLineAfterSwitchCase.swift
@@ -15,7 +15,7 @@ public extension FormatRule {
         which is followed by a closing brace).
         """,
         disabledByDefault: true,
-        orderAfter: ["redundantBreak"]
+        orderAfter: [.redundantBreak]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in
             guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }

--- a/Sources/Rules/blankLinesAtEndOfScope.swift
+++ b/Sources/Rules/blankLinesAtEndOfScope.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
     /// unless it's followed by more code on the same line (e.g. } else { )
     static let blankLinesAtEndOfScope = FormatRule(
         help: "Remove trailing blank line at the end of a scope.",
-        orderAfter: ["organizeDeclarations"],
+        orderAfter: [.organizeDeclarations],
         sharedOptions: ["typeblanklines"]
     ) { formatter in
         formatter.forEach(.startOfScope) { startOfScopeIndex, _ in

--- a/Sources/Rules/blankLinesAtStartOfScope.swift
+++ b/Sources/Rules/blankLinesAtStartOfScope.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     /// Remove blank lines immediately after an opening brace, bracket, paren or chevron
     static let blankLinesAtStartOfScope = FormatRule(
         help: "Remove leading blank line at the start of a scope.",
-        orderAfter: ["organizeDeclarations"],
+        orderAfter: [.organizeDeclarations],
         options: ["typeblanklines"]
     ) { formatter in
         formatter.forEach(.startOfScope) { i, token in

--- a/Sources/Rules/braces.swift
+++ b/Sources/Rules/braces.swift
@@ -75,8 +75,9 @@ public extension FormatRule {
                 }
 
                 // Avoid conflicts with wrapMultilineStatementBraces
-                let ruleName = FormatRule.wrapMultilineStatementBraces.name
-                if formatter.options.enabledRules.contains(ruleName),
+                // (Can't refer to `FormatRule.wrapMultilineStatementBraces` directly
+                // because it creates a cicrcular reference)
+                if formatter.options.enabledRules.contains("wrapMultilineStatementBraces"),
                    formatter.shouldWrapMultilineStatementBrace(at: i)
                 {
                     return

--- a/Sources/Rules/conditionalAssignment.swift
+++ b/Sources/Rules/conditionalAssignment.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let conditionalAssignment = FormatRule(
         help: "Assign properties using if / switch expressions.",
-        orderAfter: ["redundantReturn"],
+        orderAfter: [.redundantReturn],
         options: ["condassignment"]
     ) { formatter in
         // If / switch expressions were added in Swift 5.9 (SE-0380)

--- a/Sources/Rules/consistentSwitchCaseSpacing.swift
+++ b/Sources/Rules/consistentSwitchCaseSpacing.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let consistentSwitchCaseSpacing = FormatRule(
         help: "Ensures consistent spacing among all of the cases in a switch statement.",
-        orderAfter: ["blankLineAfterSwitchCase"]
+        orderAfter: [.blankLineAfterSwitchCase]
     ) { formatter in
         formatter.forEach(.keyword("switch")) { switchIndex, _ in
             guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }

--- a/Sources/Rules/docComments.swift
+++ b/Sources/Rules/docComments.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     static let docComments = FormatRule(
         help: "Use doc comments for API declarations, otherwise use regular comments.",
         disabledByDefault: true,
-        orderAfter: ["fileHeader"],
+        orderAfter: [.fileHeader],
         options: ["doccomments"]
     ) { formatter in
         formatter.forEach(.startOfScope) { index, token in

--- a/Sources/Rules/docCommentsBeforeAttributes.swift
+++ b/Sources/Rules/docCommentsBeforeAttributes.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let docCommentsBeforeAttributes = FormatRule(
         help: "Place doc comments on declarations before any attributes.",
-        orderAfter: ["docComments"]
+        orderAfter: [.docComments]
     ) { formatter in
         formatter.forEachToken(where: \.isDeclarationTypeKeyword) { keywordIndex, _ in
             // Parse the attributes on this declaration if present

--- a/Sources/Rules/elseOnSameLine.swift
+++ b/Sources/Rules/elseOnSameLine.swift
@@ -17,7 +17,7 @@ public extension FormatRule {
         Place `else`, `catch` or `while` keyword in accordance with current style (same or
         next line).
         """,
-        orderAfter: ["wrapMultilineStatementBraces"],
+        orderAfter: [.wrapMultilineStatementBraces],
         options: ["elseposition", "guardelse"],
         sharedOptions: ["allman", "linebreaks"]
     ) { formatter in

--- a/Sources/Rules/headerFileName.swift
+++ b/Sources/Rules/headerFileName.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
     static let headerFileName = FormatRule(
         help: "Ensure file name in header comment matches the actual file name.",
         runOnceOnly: true,
-        orderAfter: ["fileHeader"]
+        orderAfter: [.fileHeader]
     ) { formatter in
         guard let fileName = formatter.options.fileInfo.fileName,
               let headerRange = formatter.headerCommentTokenRange(includingDirectives: ["*"]),

--- a/Sources/Rules/indent.swift
+++ b/Sources/Rules/indent.swift
@@ -14,7 +14,7 @@ public extension FormatRule {
     /// indenting can be configured with the `options` parameter of the formatter.
     static let indent = FormatRule(
         help: "Indent code in accordance with the scope level.",
-        orderAfter: ["trailingSpace", "wrap", "wrapArguments"],
+        orderAfter: [.trailingSpace, .wrap, .wrapArguments],
         options: ["indent", "tabwidth", "smarttabs", "indentcase", "ifdef", "xcodeindentation", "indentstrings"],
         sharedOptions: ["trimwhitespace", "allman", "wrapconditions", "wrapternary"]
     ) { formatter in

--- a/Sources/Rules/organizeDeclarations.swift
+++ b/Sources/Rules/organizeDeclarations.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
         help: "Organize declarations within class, struct, enum, actor, and extension bodies.",
         runOnceOnly: true,
         disabledByDefault: true,
-        orderAfter: ["extensionAccessControl", "redundantFileprivate"],
+        orderAfter: [.extensionAccessControl, .redundantFileprivate],
         options: [
             "categorymark", "markcategories", "beforemarks",
             "lifecycle", "organizetypes", "structthreshold", "classthreshold",

--- a/Sources/Rules/propertyType.swift
+++ b/Sources/Rules/propertyType.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     static let propertyType = FormatRule(
         help: "Convert property declarations to use inferred types (`let foo = Foo()`) or explicit types (`let foo: Foo = .init()`).",
         disabledByDefault: true,
-        orderAfter: ["redundantType"],
+        orderAfter: [.redundantType],
         options: ["inferredtypes", "preservesymbols"],
         sharedOptions: ["redundanttype"]
     ) { formatter in

--- a/Sources/Rules/redundantClosure.swift
+++ b/Sources/Rules/redundantClosure.swift
@@ -15,7 +15,7 @@ public extension FormatRule {
         which are called immediately.
         """,
         disabledByDefault: false,
-        orderAfter: ["redundantReturn"]
+        orderAfter: [.redundantReturn]
     ) { formatter in
         formatter.forEach(.startOfScope("{")) { closureStartIndex, _ in
             var startIndex = closureStartIndex

--- a/Sources/Rules/redundantInit.swift
+++ b/Sources/Rules/redundantInit.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     /// Strip redundant `.init` from type instantiations
     static let redundantInit = FormatRule(
         help: "Remove explicit `init` if not required.",
-        orderAfter: ["propertyType"]
+        orderAfter: [.propertyType]
     ) { formatter in
         formatter.forEach(.identifier("init")) { initIndex, _ in
             guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: initIndex, if: {

--- a/Sources/Rules/redundantOptionalBinding.swift
+++ b/Sources/Rules/redundantOptionalBinding.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
         help: "Remove redundant identifiers in optional binding conditions.",
         // We can convert `if let foo = self.foo` to just `if let foo`,
         // but only if `redundantSelf` can first remove the `self.`.
-        orderAfter: ["redundantSelf"]
+        orderAfter: [.redundantSelf]
     ) { formatter in
         formatter.forEachToken { i, token in
             // `if let foo` conditions were added in Swift 5.7 (SE-0345)

--- a/Sources/Rules/redundantProperty.swift
+++ b/Sources/Rules/redundantProperty.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     static let redundantProperty = FormatRule(
         help: "Simplifies redundant property definitions that are immediately returned.",
         disabledByDefault: true,
-        orderAfter: ["propertyType"]
+        orderAfter: [.propertyType]
     ) { formatter in
         formatter.forEach(.keyword) { introducerIndex, introducerToken in
             // Find properties like `let identifier = value` followed by `return identifier`

--- a/Sources/Rules/trailingSpace.swift
+++ b/Sources/Rules/trailingSpace.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
     /// meaning and leads to noise in commits.
     static let trailingSpace = FormatRule(
         help: "Remove trailing space at end of a line.",
-        orderAfter: ["wrap", "wrapArguments"],
+        orderAfter: [.wrap, .wrapArguments],
         options: ["trimwhitespace"]
     ) { formatter in
         formatter.forEach(.space) { i, _ in

--- a/Sources/Rules/wrapArguments.swift
+++ b/Sources/Rules/wrapArguments.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     /// Normalize argument wrapping style
     static let wrapArguments = FormatRule(
         help: "Align wrapped function arguments or collection elements.",
-        orderAfter: ["wrap"],
+        orderAfter: [.wrap],
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "callsiteparen",
                   "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapeffects", "conditionswrap"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",

--- a/Sources/Rules/wrapLoopBodies.swift
+++ b/Sources/Rules/wrapLoopBodies.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let wrapLoopBodies = FormatRule(
         help: "Wrap the bodies of inline loop statements onto a new line.",
-        orderAfter: ["preferForLoop"],
+        orderAfter: [.preferForLoop],
         sharedOptions: ["linebreaks", "indent"]
     ) { formatter in
         formatter.forEachToken(where: { [

--- a/Sources/Rules/wrapMultilineConditionalAssignment.swift
+++ b/Sources/Rules/wrapMultilineConditionalAssignment.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     static let wrapMultilineConditionalAssignment = FormatRule(
         help: "Wrap multiline conditional assignment expressions after the assignment operator.",
         disabledByDefault: true,
-        orderAfter: ["conditionalAssignment"],
+        orderAfter: [.conditionalAssignment],
         sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.keyword) { startOfCondition, keywordToken in

--- a/Sources/Rules/wrapMultilineStatementBraces.swift
+++ b/Sources/Rules/wrapMultilineStatementBraces.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let wrapMultilineStatementBraces = FormatRule(
         help: "Wrap the opening brace of multiline statements.",
-        orderAfter: ["braces", "indent", "wrapArguments"],
+        orderAfter: [.braces, .indent, .wrapArguments],
         sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.startOfScope("{")) { i, _ in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -355,16 +355,6 @@ class MetadataTests: XCTestCase {
         }
     }
 
-    // MARK: order
-
-    func testRuleOrderNamesAreValid() {
-        for rule in FormatRules.all {
-            for name in rule.orderAfter {
-                XCTAssert(FormatRules.byName[name] != nil, "\(name) rule does not exist")
-            }
-        }
-    }
-
     // MARK: releases
 
     func testLatestVersionInChangelog() {

--- a/Tests/RulesTests+Braces.swift
+++ b/Tests/RulesTests+Braces.swift
@@ -62,7 +62,7 @@ class BracesTests: RulesTests {
 
     func testKnRExtraSpaceNotAddedBeforeBrace() {
         let input = "foo({ bar })"
-        testFormatting(for: input, rule: .braces, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .braces, exclude: [.trailingClosures])
     }
 
     func testKnRLinebreakNotRemovedBeforeInlineBlockNot() {
@@ -81,7 +81,7 @@ class BracesTests: RulesTests {
             }(),
         ]
         """
-        testFormatting(for: input, rule: .braces, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .braces, exclude: [.redundantClosure])
     }
 
     func testKnRNoMangleClosureReturningClosure() {
@@ -142,7 +142,7 @@ class BracesTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 15)
-        testFormatting(for: input, rule: .braces, options: options, exclude: ["indent"])
+        testFormatting(for: input, rule: .braces, options: options, exclude: [.indent])
     }
 
     func testKnRClosingBraceWrapped() {
@@ -291,7 +291,7 @@ class BracesTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .braces,
-                       exclude: ["wrapMultilineStatementBraces"])
+                       exclude: [.wrapMultilineStatementBraces])
     }
 
     func testBraceNotUnwrappedIfWrapMultilineStatementBracesRuleDisabled() {
@@ -342,7 +342,7 @@ class BracesTests: RulesTests {
         let input = "foo({\n    bar\n})"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .braces, options: options,
-                       exclude: ["trailingClosures"])
+                       exclude: [.trailingClosures])
     }
 
     func testAllmanBraceDoClauseIndent() {
@@ -357,7 +357,7 @@ class BracesTests: RulesTests {
         let output = "do\n{\n    try foo\n}\ncatch\n{\n}"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testAllmanBraceDoThrowsCatchClauseIndent() {
@@ -365,7 +365,7 @@ class BracesTests: RulesTests {
         let output = "do throws(Foo)\n{\n    try foo\n}\ncatch\n{\n}"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testAllmanBraceRepeatWhileIndent() {

--- a/Tests/RulesTests+General.swift
+++ b/Tests/RulesTests+General.swift
@@ -42,7 +42,7 @@ class GeneralTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .initCoderUnavailable,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testInitCoderUnavailableFatalErrorNilDisabled() {
@@ -157,7 +157,7 @@ class GeneralTests: RulesTests {
         """
         let options = FormatOptions(initCoderNil: true)
         testFormatting(for: input, output, rule: .initCoderUnavailable,
-                       options: options, exclude: ["modifierOrder"])
+                       options: options, exclude: [.modifierOrder])
     }
 
     // MARK: - trailingCommas
@@ -277,7 +277,7 @@ class GeneralTests: RulesTests {
             Int
         ]).self
         """
-        testFormatting(for: input, rule: .trailingCommas, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .trailingCommas, exclude: [.propertyType])
     }
 
     func testTrailingCommaNotAddedToTypeDeclaration() {
@@ -324,7 +324,7 @@ class GeneralTests: RulesTests {
             String: Int
         ]]()
         """
-        testFormatting(for: input, rule: .trailingCommas, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .trailingCommas, exclude: [.propertyType])
     }
 
     func testTrailingCommaNotAddedToTypeDeclaration6() {
@@ -337,7 +337,7 @@ class GeneralTests: RulesTests {
             ])
         ]]()
         """
-        testFormatting(for: input, rule: .trailingCommas, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .trailingCommas, exclude: [.propertyType])
     }
 
     func testTrailingCommaNotAddedToTypeDeclaration7() {
@@ -446,7 +446,7 @@ class GeneralTests: RulesTests {
         let input = "// foobar"
         let options = FormatOptions(fileHeader: "// foobar")
         testFormatting(for: input, rule: .fileHeader, options: options,
-                       exclude: ["linebreakAtEndOfFile"])
+                       exclude: [.linebreakAtEndOfFile])
     }
 
     func testReplaceHeaderWhenFileContainsNoCode2() {
@@ -535,7 +535,7 @@ class GeneralTests: RulesTests {
     func testNoStripHeaderDocWithNewlineBeforeCode() {
         let input = "/// Header doc\n\nclass Foo {}"
         let options = FormatOptions(fileHeader: "")
-        testFormatting(for: input, rule: .fileHeader, options: options, exclude: ["docComments"])
+        testFormatting(for: input, rule: .fileHeader, options: options, exclude: [.docComments])
     }
 
     func testNoDuplicateHeaderIfMissingTrailingBlankLine() {
@@ -986,7 +986,7 @@ class GeneralTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "4.2")
         testFormatting(for: input, output, rule: .strongifiedSelf, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testBacktickedSelfConvertedToSelfInIf() {
@@ -1002,7 +1002,7 @@ class GeneralTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "4.2")
         testFormatting(for: input, output, rule: .strongifiedSelf, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testBacktickedSelfNotConvertedIfVersionLessThan4_2() {
@@ -1013,7 +1013,7 @@ class GeneralTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "4.1.5")
         testFormatting(for: input, rule: .strongifiedSelf, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testBacktickedSelfNotConvertedIfVersionUnspecified() {
@@ -1023,7 +1023,7 @@ class GeneralTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .strongifiedSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testBacktickedSelfNotConvertedIfNotConditional() {
@@ -1184,7 +1184,7 @@ class GeneralTests: RulesTests {
         let input = "if [0] == foo.bar[0]\n{ baz() }"
         let output = "if foo.bar[0] == [0]\n{ baz() }"
         testFormatting(for: input, output, rule: .yodaConditions,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testYodaConditionInSecondClauseOfIfStatement() {

--- a/Tests/RulesTests+Hoisting.swift
+++ b/Tests/RulesTests+Hoisting.swift
@@ -39,7 +39,7 @@ class HoistingTests: RulesTests {
         """
         testFormatting(for: input, output, rule: .hoistTry,
                        options: FormatOptions(swiftVersion: "5.5"),
-                       exclude: ["hoistAwait"])
+                       exclude: [.hoistAwait])
     }
 
     func testHoistTryInsideStringInterpolation3() {
@@ -111,7 +111,7 @@ class HoistingTests: RulesTests {
         let output = """
         try array.append(contentsOf: await asyncFunction(param1: param1))
         """
-        testFormatting(for: input, output, rule: .hoistTry, exclude: ["hoistAwait"])
+        testFormatting(for: input, output, rule: .hoistTry, exclude: [.hoistAwait])
     }
 
     func testNoHoistTryInsideXCTAssert() {
@@ -160,21 +160,21 @@ class HoistingTests: RulesTests {
         let input = "let foo=bar(contentsOf:try baz())"
         let output = "let foo=try bar(contentsOf:baz())"
         testFormatting(for: input, output, rule: .hoistTry,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testHoistTryInExpressionWithExcessSpaces() {
         let input = "let foo = bar ( contentsOf: try baz() )"
         let output = "let foo = try bar ( contentsOf: baz() )"
         testFormatting(for: input, output, rule: .hoistTry,
-                       exclude: ["spaceAroundParens", "spaceInsideParens"])
+                       exclude: [.spaceAroundParens, .spaceInsideParens])
     }
 
     func testHoistTryWithReturn() {
         let input = "return .enumCase(try await service.greet())"
         let output = "return try .enumCase(await service.greet())"
         testFormatting(for: input, output, rule: .hoistTry,
-                       exclude: ["hoistAwait"])
+                       exclude: [.hoistAwait])
     }
 
     func testHoistDeeplyNestedTrys() {
@@ -205,14 +205,14 @@ class HoistingTests: RulesTests {
         let input = "let variable = String(try await asyncFunction())"
         let output = "let variable = try String(await asyncFunction())"
         testFormatting(for: input, output, rule: .hoistTry,
-                       exclude: ["hoistAwait"])
+                       exclude: [.hoistAwait])
     }
 
     func testHoistTryWithAssignment() {
         let input = "let variable = (try await asyncFunction())"
         let output = "let variable = try (await asyncFunction())"
         testFormatting(for: input, output, rule: .hoistTry,
-                       exclude: ["hoistAwait"])
+                       exclude: [.hoistAwait])
     }
 
     func testHoistTryOnlyOne() {
@@ -454,7 +454,7 @@ class HoistingTests: RulesTests {
         let output = "if await !(isSomething()) {}"
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"),
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testHoistAwaitInsideArgument() {
@@ -465,7 +465,7 @@ class HoistingTests: RulesTests {
         await array.append(contentsOf: try asyncFunction(param1: param1))
         """
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["hoistTry"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistAwaitInsideStringInterpolation() {
@@ -483,7 +483,7 @@ class HoistingTests: RulesTests {
         await "Hello \\(try someValue())"
         """
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["hoistTry"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testNoHoistAwaitInsideDo() {
@@ -520,7 +520,7 @@ class HoistingTests: RulesTests {
         let input = "let foo=bar(contentsOf:await baz())"
         let output = "let foo=await bar(contentsOf:baz())"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["spaceAroundOperators"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.spaceAroundOperators])
     }
 
     func testHoistAwaitInExpressionWithExcessSpaces() {
@@ -528,14 +528,14 @@ class HoistingTests: RulesTests {
         let output = "let foo = await bar ( contentsOf: baz() )"
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"),
-                       exclude: ["spaceAroundParens", "spaceInsideParens"])
+                       exclude: [.spaceAroundParens, .spaceInsideParens])
     }
 
     func testHoistAwaitWithReturn() {
         let input = "return .enumCase(try await service.greet())"
         let output = "return await .enumCase(try service.greet())"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["hoistTry"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistDeeplyNestedAwaits() {
@@ -576,14 +576,14 @@ class HoistingTests: RulesTests {
         let input = "let variable = String(try await asyncFunction())"
         let output = "let variable = await String(try asyncFunction())"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["hoistTry"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistAwaitWithAssignment() {
         let input = "let variable = (try await asyncFunction())"
         let output = "let variable = await (try asyncFunction())"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["hoistTry"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistAwaitInRedundantScopePriorToNumber() {
@@ -642,14 +642,14 @@ class HoistingTests: RulesTests {
         let input = "let foo = bar + (await baz)"
         let output = "let foo = await bar + (baz)"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["redundantParens"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.redundantParens])
     }
 
     func testHoistAwaitAfterUnknownOperator() {
         let input = "let foo = bar ??? (await baz)"
         let output = "let foo = await bar ??? (baz)"
         testFormatting(for: input, output, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["redundantParens"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.redundantParens])
     }
 
     func testNoHoistAwaitAfterCapturingOperator() {
@@ -661,7 +661,7 @@ class HoistingTests: RulesTests {
     func testNoHoistAwaitInMacroArgument() {
         let input = "#expect (await monitor.isAvailable == false)"
         testFormatting(for: input, rule: .hoistAwait,
-                       options: FormatOptions(swiftVersion: "5.5"), exclude: ["spaceAroundParens"])
+                       options: FormatOptions(swiftVersion: "5.5"), exclude: [.spaceAroundParens])
     }
 
     // MARK: - hoistPatternLet
@@ -716,7 +716,7 @@ class HoistingTests: RulesTests {
     func testHoistIfArgIsNamespacedEnumCaseLiteralInParens() {
         let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
         let output = "switch foo {\ncase let (Foo.bar(baz)):\n}"
-        testFormatting(for: input, output, rule: .hoistPatternLet, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .hoistPatternLet, exclude: [.redundantParens])
     }
 
     func testHoistIfFirstArgIsUnderscore() {
@@ -741,7 +741,7 @@ class HoistingTests: RulesTests {
         let input = "switch foo {\ncase .foo(let bar), .bar(let bar):\n}"
         let output = "switch foo {\ncase let .foo(bar), let .bar(bar):\n}"
         testFormatting(for: input, output, rule: .hoistPatternLet,
-                       exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testHoistNewlineSeparatedSwitchCaseLets() {
@@ -760,7 +760,7 @@ class HoistingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .hoistPatternLet,
-                       exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testHoistCatchLet() {
@@ -776,7 +776,7 @@ class HoistingTests: RulesTests {
 
     func testNoHoistClosureVariables() {
         let input = "foo({ let bar = 5 })"
-        testFormatting(for: input, rule: .hoistPatternLet, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .hoistPatternLet, exclude: [.trailingClosures])
     }
 
     // TODO: this should actually hoist the let, but that's tricky to implement without
@@ -784,20 +784,20 @@ class HoistingTests: RulesTests {
     func testHoistSwitchCaseWithNestedParens() {
         let input = "import Foo\nswitch (foo, bar) {\ncase (.baz(let quux), Foo.bar): break\n}"
         testFormatting(for: input, rule: .hoistPatternLet,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     // TODO: this could actually hoist the let by one level, but that's tricky to implement
     func testNoOverHoistSwitchCaseWithNestedParens() {
         let input = "import Foo\nswitch (foo, bar) {\ncase (.baz(let quux), bar): break\n}"
         testFormatting(for: input, rule: .hoistPatternLet,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testNoHoistLetWithEmptArg() {
         let input = "if .foo(let _) = bar {}"
         testFormatting(for: input, rule: .hoistPatternLet,
-                       exclude: ["redundantLet", "redundantPattern"])
+                       exclude: [.redundantLet, .redundantPattern])
     }
 
     func testHoistLetWithNoSpaceAfterCase() {
@@ -828,7 +828,7 @@ class HoistingTests: RulesTests {
         // Hoisting in this case causes a compilation error as-of Swift 5.3
         // See: https://github.com/nicklockwood/SwiftFormat/issues/768
         let input = "if case .some(Optional<Any>.some(let foo)) = bar else {}"
-        testFormatting(for: input, rule: .hoistPatternLet, exclude: ["typeSugar"])
+        testFormatting(for: input, rule: .hoistPatternLet, exclude: [.typeSugar])
     }
 
     // hoist = false
@@ -878,7 +878,7 @@ class HoistingTests: RulesTests {
         """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoUnhoistSwitchCaseLetFollowedByWhere() {
@@ -922,7 +922,7 @@ class HoistingTests: RulesTests {
         let output = "switch foo {\ncase (.bar(let baz)):\n}"
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testUnhoistIfArgIsNamespacedEnumCaseLiteral() {
@@ -937,7 +937,7 @@ class HoistingTests: RulesTests {
         let output = "switch foo {\ncase (Foo.bar(let baz)):\n}"
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testUnhoistIfArgIsUnderscore() {
@@ -959,7 +959,7 @@ class HoistingTests: RulesTests {
         let output = "switch foo {\ncase .foo(let bar), .bar(let bar):\n}"
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
-                       exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testUnhoistCommaSeparatedSwitchCaseLets2() {
@@ -967,7 +967,7 @@ class HoistingTests: RulesTests {
         let output = "switch foo {\ncase Foo.foo(let bar), Foo.bar(let bar):\n}"
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
-                       exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testUnhoistCatchLet() {
@@ -999,7 +999,7 @@ class HoistingTests: RulesTests {
         let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testNoDeleteCommentWhenUnhoistingWrappedLet() {
@@ -1017,7 +1017,7 @@ class HoistingTests: RulesTests {
 
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet,
-                       options: options, exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       options: options, exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testMultilineGuardLet() {

--- a/Tests/RulesTests+Indentation.swift
+++ b/Tests/RulesTests+Indentation.swift
@@ -35,7 +35,7 @@ class IndentTests: RulesTests {
     func testNestedScope() {
         let input = "foo(\nbar {\n}\n)"
         let output = "foo(\n    bar {\n    }\n)"
-        testFormatting(for: input, output, rule: .indent, exclude: ["emptyBraces"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.emptyBraces])
     }
 
     func testNestedScopeOnSameLine() {
@@ -88,7 +88,7 @@ class IndentTests: RulesTests {
                                           paymentFormURL: .paymentForm)
         """
         let options = FormatOptions(wrapParameters: .preserve)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentPreservedForNestedWrappedParameters2() {
@@ -99,7 +99,7 @@ class IndentTests: RulesTests {
                                                            paymentFormURL: .paymentForm))
         """
         let options = FormatOptions(wrapParameters: .preserve)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentPreservedForNestedWrappedParameters3() {
@@ -112,7 +112,7 @@ class IndentTests: RulesTests {
         )
         """
         let options = FormatOptions(wrapParameters: .preserve)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentTrailingClosureInParensContainingUnwrappedArguments() {
@@ -206,7 +206,7 @@ class IndentTests: RulesTests {
     func testNoIndentBlankLines() {
         let input = "{\n\n// foo\n}"
         let output = "{\n\n    // foo\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["blankLinesAtStartOfScope"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.blankLinesAtStartOfScope])
     }
 
     func testNestedBraces() {
@@ -224,13 +224,13 @@ class IndentTests: RulesTests {
     func testBraceIndentAfterClosingScope() {
         let input = "foo(bar(baz), {\nquux\nbleem\n})"
         let output = "foo(bar(baz), {\n    quux\n    bleem\n})"
-        testFormatting(for: input, output, rule: .indent, exclude: ["trailingClosures"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.trailingClosures])
     }
 
     func testBraceIndentAfterLineWithParens() {
         let input = "({\nfoo()\nbar\n})"
         let output = "({\n    foo()\n    bar\n})"
-        testFormatting(for: input, output, rule: .indent, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
     func testUnindentClosingParenAroundBraces() {
@@ -298,7 +298,7 @@ class IndentTests: RulesTests {
             }
         )
         """
-        testFormatting(for: input, rule: .indent, exclude: ["wrapArguments"])
+        testFormatting(for: input, rule: .indent, exclude: [.wrapArguments])
     }
 
     func testIndentWrappedClosureParameters() {
@@ -346,7 +346,7 @@ class IndentTests: RulesTests {
             return x + y
         }
         """
-        testFormatting(for: input, rule: .indent, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, exclude: [.propertyType])
     }
 
     func testIndentWrappedClosureCaptureListWithUnwrappedParameters() {
@@ -373,7 +373,7 @@ class IndentTests: RulesTests {
             }
         """
         let options = FormatOptions(closingParenPosition: .sameLine)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentAllmanTrailingClosureArguments() {
@@ -389,7 +389,7 @@ class IndentTests: RulesTests {
             }
         """
         let options = FormatOptions(allmanBraces: true)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentAllmanTrailingClosureArguments2() {
@@ -423,7 +423,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["redundantReturn"])
+                       exclude: [.redundantReturn])
     }
 
     func testNoDoubleIndentClosureArguments() {
@@ -448,7 +448,7 @@ class IndentTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["braces", "wrapMultilineStatementBraces", "redundantProperty"])
+                       exclude: [.braces, .wrapMultilineStatementBraces, .redundantProperty])
     }
 
     func testIndentLineAfterIndentedInlineClosure() {
@@ -460,7 +460,7 @@ class IndentTests: RulesTests {
             return viewController
         }
         """
-        testFormatting(for: input, rule: .indent, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .indent, exclude: [.redundantProperty])
     }
 
     func testIndentLineAfterNonIndentedClosure() {
@@ -473,7 +473,7 @@ class IndentTests: RulesTests {
             return viewController
         }
         """
-        testFormatting(for: input, rule: .indent, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .indent, exclude: [.redundantProperty])
     }
 
     func testIndentMultilineStatementDoesntFailToTerminate() {
@@ -498,25 +498,25 @@ class IndentTests: RulesTests {
     func testSwitchWrappedCaseIndenting() {
         let input = "switch x {\ncase foo,\nbar,\n    baz:\n    break\ndefault:\n    break\n}"
         let output = "switch x {\ncase foo,\n     bar,\n     baz:\n    break\ndefault:\n    break\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIndenting() {
         let input = "switch x {\ncase .foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
         let output = "switch x {\ncase .foo,\n     .bar,\n     .baz:\n    break\ndefault:\n    break\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIndentingVariant2() {
         let input = "switch x {\ncase\n.foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
         let output = "switch x {\ncase\n    .foo,\n    .bar,\n    .baz:\n    break\ndefault:\n    break\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIsIndenting() {
         let input = "switch x {\ncase is Foo.Type,\n    is Bar.Type:\n    break\ndefault:\n    break\n}"
         let output = "switch x {\ncase is Foo.Type,\n     is Bar.Type:\n    break\ndefault:\n    break\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchCaseIsDictionaryIndenting() {
@@ -539,7 +539,7 @@ class IndentTests: RulesTests {
                  Baz
         }
         """
-        testFormatting(for: input, output, rule: .indent, exclude: ["wrapEnumCases"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.wrapEnumCases])
     }
 
     func testGenericEnumCaseIndenting() {
@@ -550,18 +550,18 @@ class IndentTests: RulesTests {
 
     func testIndentSwitchAfterRangeCase() {
         let input = "switch x {\ncase 0 ..< 2:\n    switch y {\n    default:\n        break\n    }\ndefault:\n    break\n}"
-        testFormatting(for: input, rule: .indent, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentEnumDeclarationInsideSwitchCase() {
         let input = "switch x {\ncase y:\nenum Foo {\ncase z\n}\nbar()\ndefault: break\n}"
         let output = "switch x {\ncase y:\n    enum Foo {\n        case z\n    }\n    bar()\ndefault: break\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentEnumCaseBodyAfterWhereClause() {
         let input = "switch foo {\ncase _ where baz < quux:\n    print(1)\n    print(2)\ndefault:\n    break\n}"
-        testFormatting(for: input, rule: .indent, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentSwitchCaseCommentsCorrectly() {
@@ -587,7 +587,7 @@ class IndentTests: RulesTests {
             break
         }
         """
-        testFormatting(for: input, output, rule: .indent, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentMultilineSwitchCaseCommentsCorrectly() {
@@ -654,7 +654,7 @@ class IndentTests: RulesTests {
         let input = "{\nguard case .Foo = error else {}\n}"
         let output = "{\n    guard case .Foo = error else {}\n}"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testIndentIfElse() {
@@ -815,7 +815,7 @@ class IndentTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapMultilineStatementBraces"])
+                       exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrappedClassDeclarationLikeXcode() {
@@ -897,7 +897,7 @@ class IndentTests: RulesTests {
         let input = "switch x {\ncase .foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
         let output = "switch x {\n    case .foo,\n         .bar,\n         .baz:\n        break\n    default:\n        break\n}"
         let options = FormatOptions(indentCase: true)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.sortSwitchCases])
     }
 
     func testIndentMultilineSwitchCaseCommentsWithIndentCaseTrue() {
@@ -997,7 +997,7 @@ class IndentTests: RulesTests {
     func testWrappedBeforeComma() {
         let input = "let a = b\n, b = c"
         let output = "let a = b\n    , b = c"
-        testFormatting(for: input, output, rule: .indent, exclude: ["leadingDelimiters"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.leadingDelimiters])
     }
 
     func testWrappedLineAfterCommaInsideArray() {
@@ -1011,7 +1011,7 @@ class IndentTests: RulesTests {
         let output = "[\n    foo\n    , bar,\n]"
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options,
-                       exclude: ["leadingDelimiters"])
+                       exclude: [.leadingDelimiters])
     }
 
     func testWrappedLineAfterCommaInsideInlineArray() {
@@ -1026,7 +1026,7 @@ class IndentTests: RulesTests {
         let output = "[foo\n , bar]"
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options,
-                       exclude: ["leadingDelimiters"])
+                       exclude: [.leadingDelimiters])
     }
 
     func testWrappedLineAfterColonInFunction() {
@@ -1038,13 +1038,13 @@ class IndentTests: RulesTests {
     func testNoDoubleIndentOfWrapAfterAsAfterOpenScope() {
         let input = "(foo as\nBar)"
         let output = "(foo as\n    Bar)"
-        testFormatting(for: input, output, rule: .indent, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
     func testNoDoubleIndentOfWrapBeforeAsAfterOpenScope() {
         let input = "(foo\nas Bar)"
         let output = "(foo\n    as Bar)"
-        testFormatting(for: input, output, rule: .indent, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
     func testDoubleIndentWhenScopesSeparatedByWrap() {
@@ -1060,14 +1060,14 @@ class IndentTests: RulesTests {
                 baz
             })
         """
-        testFormatting(for: input, output, rule: .indent, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
     func testNoDoubleIndentWhenScopesSeparatedByWrap() {
         let input = "(foo\nas Bar {\nbaz\n}\n)"
         let output = "(foo\n    as Bar {\n        baz\n    }\n)"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["wrapArguments", "redundantParens"])
+                       exclude: [.wrapArguments, .redundantParens])
     }
 
     func testNoPermanentReductionInScopeAfterWrap() {
@@ -1127,14 +1127,14 @@ class IndentTests: RulesTests {
     func testWrappedLineBeforeGuardElse() {
         let input = "guard let foo = bar\nelse { return }"
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testWrappedLineAfterGuardElse() {
         // Don't indent because this case is handled by braces rule
         let input = "guard let foo = bar else\n{ return }"
         testFormatting(for: input, rule: .indent,
-                       exclude: ["elseOnSameLine", "wrapConditionalBodies"])
+                       exclude: [.elseOnSameLine, .wrapConditionalBodies])
     }
 
     func testWrappedLineAfterComment() {
@@ -1157,7 +1157,7 @@ class IndentTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapMultilineStatementBraces", "wrapConditionalBodies"])
+                       exclude: [.wrapMultilineStatementBraces, .wrapConditionalBodies])
     }
 
     func testConsecutiveWraps() {
@@ -1190,7 +1190,7 @@ class IndentTests: RulesTests {
 
     func testNoIndentAfterDefaultAsIdentifier() {
         let input = "let foo = FileManager.default\n/// Comment\nlet bar = 0"
-        testFormatting(for: input, rule: .indent, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, exclude: [.propertyType])
     }
 
     func testIndentClosureStartingOnIndentedLine() {
@@ -1234,7 +1234,7 @@ class IndentTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, output, rule: .indent, exclude: ["andOperator", "wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.andOperator, .wrapMultilineStatementBraces])
     }
 
     func testWrappedEnumThatLooksLikeIf() {
@@ -1313,7 +1313,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(xcodeIndentation: true)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["blankLinesBetweenScopes"])
+                       exclude: [.blankLinesBetweenScopes])
     }
 
     func testChainedFunctionIndents() {
@@ -1392,34 +1392,34 @@ class IndentTests: RulesTests {
     func testChainedFunctionsAfterAnIfStatement() {
         let input = "if foo {}\nbar\n.baz {\n}\n.quux()"
         let output = "if foo {}\nbar\n    .baz {\n    }\n    .quux()"
-        testFormatting(for: input, output, rule: .indent, exclude: ["emptyBraces"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.emptyBraces])
     }
 
     func testIndentInsideWrappedIfStatementWithClosureCondition() {
         let input = "if foo({ 1 }) ||\nbar {\nbaz()\n}"
         let output = "if foo({ 1 }) ||\n    bar {\n    baz()\n}"
-        testFormatting(for: input, output, rule: .indent, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedClassDefinition() {
         let input = "class Foo\n: Bar {\nbaz()\n}"
         let output = "class Foo\n    : Bar {\n    baz()\n}"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["leadingDelimiters", "wrapMultilineStatementBraces"])
+                       exclude: [.leadingDelimiters, .wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedProtocolDefinition() {
         let input = "protocol Foo\n: Bar, Baz {\nbaz()\n}"
         let output = "protocol Foo\n    : Bar, Baz {\n    baz()\n}"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["leadingDelimiters", "wrapMultilineStatementBraces"])
+                       exclude: [.leadingDelimiters, .wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedVarStatement() {
         let input = "var Foo:\nBar {\nreturn 5\n}"
         let output = "var Foo:\n    Bar {\n    return 5\n}"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["wrapMultilineStatementBraces"])
+                       exclude: [.wrapMultilineStatementBraces])
     }
 
     func testNoIndentAfterOperatorDeclaration() {
@@ -1456,7 +1456,7 @@ class IndentTests: RulesTests {
         let input = "foobar(baz: { a &&\nb })"
         let output = "foobar(baz: { a &&\n        b })"
         testFormatting(for: input, output, rule: .indent,
-                       exclude: ["trailingClosures", "braces"])
+                       exclude: [.trailingClosures, .braces])
     }
 
     func testIndentWrappedFunctionWithClosureArgument() {
@@ -1527,7 +1527,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .balanced)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testSingleIndentTrailingClosureBody2() {
@@ -1542,7 +1542,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["wrapConditionalBodies", "wrapMultilineStatementBraces"])
+                       exclude: [.wrapConditionalBodies, .wrapMultilineStatementBraces])
     }
 
     func testDoubleIndentTrailingClosureBody() {
@@ -1558,7 +1558,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["wrapConditionalBodies", "wrapMultilineStatementBraces"])
+                       exclude: [.wrapConditionalBodies, .wrapMultilineStatementBraces])
     }
 
     func testDoubleIndentTrailingClosureBody2() {
@@ -1574,7 +1574,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["wrapMultilineStatementBraces"])
+                       exclude: [.wrapMultilineStatementBraces])
     }
 
     func testNoDoubleIndentTrailingClosureBodyIfLineStartsWithClosingBrace() {
@@ -1586,7 +1586,7 @@ class IndentTests: RulesTests {
         }
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testSingleIndentTrailingClosureBodyThatStartsOnFollowingLine() {
@@ -1603,7 +1603,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["braces", "wrapConditionalBodies"])
+                       exclude: [.braces, .wrapConditionalBodies])
     }
 
     func testSingleIndentTrailingClosureBodyOfShortMethod() {
@@ -1615,7 +1615,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .disabled, closingParenPosition: .sameLine)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoDoubleIndentInInsideClosure() {
@@ -1626,7 +1626,7 @@ class IndentTests: RulesTests {
         })
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["trailingClosures"])
+                       exclude: [.trailingClosures])
     }
 
     func testNoDoubleIndentInInsideClosure2() {
@@ -1718,7 +1718,7 @@ class IndentTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapArguments", "wrapMultilineStatementBraces"])
+                       exclude: [.wrapArguments, .wrapMultilineStatementBraces])
     }
 
     func testIndentChainedPropertiesAfterFunctionCall() {
@@ -1729,7 +1729,7 @@ class IndentTests: RulesTests {
         .bar
         .baz
         """
-        testFormatting(for: input, rule: .indent, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, exclude: [.propertyType])
     }
 
     func testIndentChainedPropertiesAfterFunctionCallWithXcodeIndentation() {
@@ -1741,7 +1741,7 @@ class IndentTests: RulesTests {
         .baz
         """
         let options = FormatOptions(xcodeIndentation: true)
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.propertyType])
     }
 
     func testIndentChainedPropertiesAfterFunctionCall2() {
@@ -1753,7 +1753,7 @@ class IndentTests: RulesTests {
         .baz
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["trailingClosures", "propertyType"])
+                       exclude: [.trailingClosures, .propertyType])
     }
 
     func testIndentChainedPropertiesAfterFunctionCallWithXcodeIndentation2() {
@@ -1766,7 +1766,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(xcodeIndentation: true)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["trailingClosures", "propertyType"])
+                       exclude: [.trailingClosures, .propertyType])
     }
 
     func testIndentChainedMethodsAfterTrailingClosure() {
@@ -1915,7 +1915,7 @@ class IndentTests: RulesTests {
         else { return }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testChainedFunctionInGuardWithXcodeIndentation() {
@@ -1935,7 +1935,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(xcodeIndentation: true)
         testFormatting(for: input, output, rule: .indent,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testChainedFunctionInGuardIndentation2() {
@@ -1950,7 +1950,7 @@ class IndentTests: RulesTests {
         else { return }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testChainedFunctionInGuardWithXcodeIndentation2() {
@@ -1977,7 +1977,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(xcodeIndentation: true)
         testFormatting(for: input, output, rule: .indent,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testWrappedChainedFunctionsWithNestedScopeIndent() {
@@ -2207,7 +2207,7 @@ class IndentTests: RulesTests {
                 { print("foo") }
         }
         """
-        testFormatting(for: input, rule: .indent, exclude: ["braces"])
+        testFormatting(for: input, rule: .indent, exclude: [.braces])
     }
 
     func testWrappedMultilineClosureOnNewLine() {
@@ -2219,7 +2219,7 @@ class IndentTests: RulesTests {
                 }
         }
         """
-        testFormatting(for: input, rule: .indent, exclude: ["braces"])
+        testFormatting(for: input, rule: .indent, exclude: [.braces])
     }
 
     func testWrappedMultilineClosureOnNewLineWithAllmanBraces() {
@@ -2233,7 +2233,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["braces"])
+                       exclude: [.braces])
     }
 
     func testIndentChainedPropertiesAfterMultilineStringXcode() {
@@ -2268,7 +2268,7 @@ class IndentTests: RulesTests {
             viewModel.snake,
         ]
         """
-        testFormatting(for: input, rule: .indent, exclude: ["hoistTry"])
+        testFormatting(for: input, rule: .indent, exclude: [.hoistTry])
     }
 
     func testIndentChainedFunctionAfterTryInParens() {
@@ -2965,14 +2965,14 @@ class IndentTests: RulesTests {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\ncase .bar:\n    #if x\n        bar()\n    #endif\n    baz()\ncase .baz: break\n}"
         let options = FormatOptions(indentCase: false)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testSwitchIfEndifInsideCaseIndenting2() {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\n    case .bar:\n        #if x\n            bar()\n        #endif\n        baz()\n    case .baz: break\n}"
         let options = FormatOptions(indentCase: true)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIfUnknownCaseEndifIndenting() {
@@ -3207,14 +3207,14 @@ class IndentTests: RulesTests {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\ncase .bar:\n    #if x\n    bar()\n    #endif\n    baz()\ncase .baz: break\n}"
         let options = FormatOptions(indentCase: false, ifdefIndent: .noIndent)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIfEndifInsideCaseNoIndenting2() {
         let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
         let output = "switch foo {\n    case .bar:\n        #if x\n        bar()\n        #endif\n        baz()\n    case .baz: break\n}"
         let options = FormatOptions(indentCase: true, ifdefIndent: .noIndent)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testSwitchCaseInIfEndif() {
@@ -3578,7 +3578,7 @@ class IndentTests: RulesTests {
         let output = "class Foo {\n\n    func foo() {\n        bar()\n    }"
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .indent, options: options,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOverTerminatedFragment() {
@@ -3650,7 +3650,7 @@ class IndentTests: RulesTests {
         }
         """
         let options = FormatOptions(indent: "\t", tabWidth: 2, smartTabs: true)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.sortSwitchCases])
     }
 
     func testTabIndentCaseWithoutSmartTabs() {
@@ -3669,7 +3669,7 @@ class IndentTests: RulesTests {
         }
         """
         let options = FormatOptions(indent: "\t", tabWidth: 2, smartTabs: false)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.sortSwitchCases])
     }
 
     func testTabIndentCaseWithoutSmartTabs2() {
@@ -3689,7 +3689,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(indent: "\t", indentCase: true,
                                     tabWidth: 2, smartTabs: false)
-        testFormatting(for: input, output, rule: .indent, options: options, exclude: ["sortSwitchCases"])
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.sortSwitchCases])
     }
 
     // indent blank lines
@@ -3720,7 +3720,7 @@ class IndentTests: RulesTests {
         """
         let options = FormatOptions(indent: "\t", truncateBlankLines: false, tabWidth: 2)
         testFormatting(for: input, rule: .indent, options: options,
-                       exclude: ["consecutiveBlankLines", "wrapConditionalBodies"])
+                       exclude: [.consecutiveBlankLines, .wrapConditionalBodies])
     }
 
     // async
@@ -3836,7 +3836,7 @@ class IndentTests: RulesTests {
         print(foo)
         """
 
-        testFormatting(for: input, output, rule: .indent, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testIndentIfExpressionAssignmentOnSameLine() {
@@ -3854,7 +3854,7 @@ class IndentTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .indent, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, rule: .indent, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testIndentSwitchExpressionAssignment() {
@@ -3914,7 +3914,7 @@ class IndentTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .indent, exclude: ["redundantProperty"])
+        testFormatting(for: input, output, rule: .indent, exclude: [.redundantProperty])
     }
 
     func testIndentNestedSwitchExpressionAssignment() {
@@ -4016,7 +4016,7 @@ class IndentTests: RulesTests {
         print(foo)
         """
 
-        testFormatting(for: input, rule: .indent, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testIndentMultilineIfExpression() {
@@ -4037,7 +4037,7 @@ class IndentTests: RulesTests {
         print(foo)
         """
 
-        testFormatting(for: input, rule: .indent, exclude: ["braces"])
+        testFormatting(for: input, rule: .indent, exclude: [.braces])
     }
 
     func testIndentNestedIfExpressionWithComments() {
@@ -4062,7 +4062,7 @@ class IndentTests: RulesTests {
         print(foo)
         """
 
-        testFormatting(for: input, rule: .indent, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testIndentIfExpressionWithMultilineComments() {
@@ -4094,6 +4094,6 @@ class IndentTests: RulesTests {
         print(bullet)
         """
         let options = FormatOptions()
-        testFormatting(for: input, rule: .indent, options: options, exclude: ["wrapConditionalBodies", "andOperator", "redundantParens"])
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.wrapConditionalBodies, .andOperator, .redundantParens])
     }
 }

--- a/Tests/RulesTests+Linebreaks.swift
+++ b/Tests/RulesTests+Linebreaks.swift
@@ -134,7 +134,7 @@ class LinebreakTests: RulesTests {
 
     func testBlankLinesNotRemovedBetweenElementsInsideBrackets() {
         let input = "[foo,\n\n bar]"
-        testFormatting(for: input, rule: .blankLinesAtStartOfScope, exclude: ["wrapArguments"])
+        testFormatting(for: input, rule: .blankLinesAtStartOfScope, exclude: [.wrapArguments])
     }
 
     func testBlankLineRemovedFromStartOfTypeByDefault() {
@@ -232,7 +232,7 @@ class LinebreakTests: RulesTests {
         let input = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n\n}"
         let output = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n}"
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testBlankLineRemovedFromEndOfTypeByDefault() {
@@ -530,38 +530,38 @@ class LinebreakTests: RulesTests {
         let input = "func foo() {\n}\nfunc bar() {\n}"
         let output = "func foo() {\n}\n\nfunc bar() {\n}"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoBlankLineBetweenPropertyAndFunction() {
         let input = "var foo: Int\nfunc bar() {\n}"
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: ["emptyBraces"])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testBlankLineBetweenFunctionsIsBeforeComment() {
         let input = "func foo() {\n}\n/// headerdoc\nfunc bar() {\n}"
         let output = "func foo() {\n}\n\n/// headerdoc\nfunc bar() {\n}"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testBlankLineBeforeAtObjcOnLineBeforeProtocol() {
         let input = "@objc\nprotocol Foo {\n}\n@objc\nprotocol Bar {\n}"
         let output = "@objc\nprotocol Foo {\n}\n\n@objc\nprotocol Bar {\n}"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testBlankLineBeforeAtAvailabilityOnLineBeforeClass() {
         let input = "protocol Foo {\n}\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
         let output = "protocol Foo {\n}\n\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoExtraBlankLineBetweenFunctions() {
         let input = "func foo() {\n}\n\nfunc bar() {\n}"
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: ["emptyBraces"])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testNoBlankLineBetweenFunctionsInProtocol() {
@@ -578,7 +578,7 @@ class LinebreakTests: RulesTests {
         let input = "protocol Foo {\n}\nvar bar: String"
         let output = "protocol Foo {\n}\n\nvar bar: String"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoExtraBlankLineAfterSingleLineComment() {
@@ -603,33 +603,33 @@ class LinebreakTests: RulesTests {
 
     func testNoBlankLineBetweenIfStatements() {
         let input = "func foo() {\n    if x {\n    }\n    if y {\n    }\n}"
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: ["emptyBraces"])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testNoBlanksInsideClassFunc() {
         let input = "class func foo {\n    if x {\n    }\n    if y {\n    }\n}"
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoBlanksInsideClassVar() {
         let input = "class var foo: Int {\n    if x {\n    }\n    if y {\n    }\n}"
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testBlankLineBetweenCalledClosures() {
         let input = "class Foo {\n    var foo = {\n    }()\n    func bar {\n    }\n}"
         let output = "class Foo {\n    var foo = {\n    }()\n\n    func bar {\n    }\n}"
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoBlankLineAfterCalledClosureAtEndOfScope() {
         let input = "class Foo {\n    var foo = {\n    }()\n}"
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: ["emptyBraces"])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testNoBlankLineBeforeWhileInRepeatWhile() {
@@ -640,7 +640,7 @@ class LinebreakTests: RulesTests {
         { print("bar") }()
         """
         let options = FormatOptions(allmanBraces: true)
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options, exclude: ["redundantClosure", "wrapLoopBodies"])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options, exclude: [.redundantClosure, .wrapLoopBodies])
     }
 
     func testBlankLineBeforeWhileIfNotRepeatWhile() {
@@ -648,7 +648,7 @@ class LinebreakTests: RulesTests {
         let output = "func foo(x)\n{\n}\n\nwhile true\n{\n}"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes, options: options,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoInsertBlankLinesInConditionalCompilation() {
@@ -664,7 +664,7 @@ class LinebreakTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .blankLinesBetweenScopes,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testNoInsertBlankLineAfterBraceBeforeSourceryComment() {

--- a/Tests/RulesTests+Organization.swift
+++ b/Tests/RulesTests+Organization.swift
@@ -105,7 +105,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -211,7 +211,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: airbnbVisibilityOrder.components(separatedBy: ","),
                 typeOrder: airbnbTypeOrder.components(separatedBy: ",")
             ),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -282,7 +282,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -311,7 +311,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .sortImports]
         )
     }
 
@@ -372,7 +372,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizationMode: .type),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .sortImports]
         )
     }
 
@@ -397,7 +397,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "sortImports"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .sortImports]
         )
     }
 
@@ -465,7 +465,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -539,7 +539,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -576,7 +576,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: ["private", "internal", "public"],
                 typeOrder: DeclarationType.allCases.map(\.rawValue)
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -626,7 +626,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: ["private", "internal", "public"],
                 typeOrder: ["beforeMarks", "nestedType", "instanceLifecycle", "instanceMethod", "instanceProperty"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -674,7 +674,7 @@ class OrganizationTests: RulesTests {
                 organizationMode: .type,
                 typeOrder: ["beforeMarks", "instanceLifecycle", "instanceMethod", "nestedType", "instanceProperty", "overriddenMethod"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -719,7 +719,7 @@ class OrganizationTests: RulesTests {
                 organizationMode: .type,
                 typeOrder: ["beforeMarks", "nestedType", "instanceLifecycle", "instanceMethod", "instanceProperty"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -771,7 +771,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: ["private", "internal", "public"],
                 typeOrder: ["beforeMarks", "nestedType", "instanceLifecycle", "instanceMethod", "instanceProperty", "overriddenMethod"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -804,7 +804,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: ["instanceMethod"] + Visibility.allCases.map(\.rawValue),
                 typeOrder: DeclarationType.allCases.map(\.rawValue).filter { $0 != "instanceMethod" }
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -837,7 +837,7 @@ class OrganizationTests: RulesTests {
                 visibilityOrder: Visibility.allCases.map(\.rawValue),
                 typeOrder: DeclarationType.allCases.map(\.rawValue)
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -878,7 +878,7 @@ class OrganizationTests: RulesTests {
                 organizationMode: .visibility,
                 customVisibilityMarks: ["instanceLifecycle:Init", "public:Public_Group"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -919,7 +919,7 @@ class OrganizationTests: RulesTests {
                 organizationMode: .type,
                 customTypeMarks: ["instanceLifecycle:Init", "instanceProperty:Bar_Bar", "instanceMethod:Buuuz Lightyeeeaaar"]
             ),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -958,7 +958,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "enumNamespaces"]
+            exclude: [.blankLinesAtStartOfScope, .enumNamespaces]
         )
     }
 
@@ -1010,7 +1010,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -1040,7 +1040,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "redundantInternal"]
+            exclude: [.blankLinesAtStartOfScope, .redundantInternal]
         )
     }
 
@@ -1130,7 +1130,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtEndOfScope", "redundantType", "redundantClosure"]
+            exclude: [.blankLinesAtEndOfScope, .redundantType, .redundantClosure]
         )
     }
 
@@ -1259,7 +1259,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "MARK: %c", organizationMode: .type),
-            exclude: ["blankLinesAtEndOfScope", "blankLinesAtStartOfScope", "redundantType", "redundantClosure"]
+            exclude: [.blankLinesAtEndOfScope, .blankLinesAtStartOfScope, .redundantType, .redundantClosure]
         )
     }
 
@@ -1294,7 +1294,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output,
             rule: .organizeDeclarations,
-            exclude: ["blankLinesAtEndOfScope", "unusedArguments"]
+            exclude: [.blankLinesAtEndOfScope, .unusedArguments]
         )
     }
 
@@ -1329,7 +1329,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(beforeMarks: ["typealias", "struct"]),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -1382,7 +1382,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(lifecycleMethods: ["viewDidLoad", "viewWillAppear", "viewDidAppear"]),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -1411,7 +1411,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(categoryMarkComment: "- %c"),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -1454,7 +1454,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizeStructThreshold: 2),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -1535,7 +1535,7 @@ class OrganizationTests: RulesTests {
             options: FormatOptions(
                 organizeTypes: ["class", "struct", "enum", "extension"],
                 organizeExtensionThreshold: 2
-            ), exclude: ["blankLinesAtStartOfScope"]
+            ), exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -1557,7 +1557,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testUpdatesMalformedMarks() {
@@ -1612,7 +1612,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testDoesntAttemptToUpdateMarksNotAtTopLevel() {
@@ -1643,7 +1643,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "docCommentsBeforeAttributes"])
+                       exclude: [.blankLinesAtStartOfScope, .docCommentsBeforeAttributes])
     }
 
     func testHandlesTrailingCommentCorrectly() {
@@ -1672,7 +1672,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testDoesntInsertMarkWhenOnlyOneCategory() {
@@ -1739,7 +1739,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOrganizesTypesBelowConditionalCompilationBlock() {
@@ -1773,7 +1773,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOrganizesNestedTypesWithinConditionalCompilationBlock() {
@@ -1851,7 +1851,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
                        options: FormatOptions(ifdefIndent: .noIndent),
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "propertyType"])
+                       exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .propertyType])
     }
 
     func testOrganizesTypeBelowSymbolImport() {
@@ -1895,7 +1895,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "sortImports"]
+            exclude: [.blankLinesAtStartOfScope, .sortImports]
         )
     }
 
@@ -1967,7 +1967,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -1993,7 +1993,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -2015,7 +2015,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -2063,7 +2063,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .organizeDeclarations,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -2095,7 +2095,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, rule: .organizeDeclarations,
             options: FormatOptions(organizeStructThreshold: 20),
-            exclude: ["blankLinesAtStartOfScope"]
+            exclude: [.blankLinesAtStartOfScope]
         )
     }
 
@@ -2142,7 +2142,7 @@ class OrganizationTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .organizeDeclarations, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .organizeDeclarations, exclude: [.redundantClosure])
     }
 
     func testFuncWithNestedInitNotTreatedAsLifecycle() {
@@ -2166,7 +2166,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOrganizeRuleNotConfusedByClassProtocol() {
@@ -2199,7 +2199,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope"])
+                       exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOrganizeClassDeclarationsIntoCategoriesWithNoBlankLineAfterMark() {
@@ -2249,7 +2249,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: options,
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -2331,7 +2331,7 @@ class OrganizationTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, rule: .organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     func testOrganizeConditionalPublicFunction() {
@@ -2354,7 +2354,7 @@ class OrganizationTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, rule: .organizeDeclarations, options: FormatOptions(ifdefIndent: .noIndent), exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     // MARK: extensionAccessControl .onDeclarations
@@ -2385,7 +2385,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output, rule: .extensionAccessControl,
             options: FormatOptions(extensionACLPlacement: .onDeclarations),
-            exclude: ["redundantInternal"]
+            exclude: [.redundantInternal]
         )
     }
 
@@ -2532,7 +2532,7 @@ class OrganizationTests: RulesTests {
         testFormatting(
             for: input, output, rule: .extensionAccessControl,
             options: FormatOptions(extensionACLPlacement: .onDeclarations, swiftVersion: "4"),
-            exclude: ["propertyType"]
+            exclude: [.propertyType]
         )
     }
 
@@ -2671,7 +2671,7 @@ class OrganizationTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .extensionAccessControl,
-                       exclude: ["redundantFileprivate"])
+                       exclude: [.redundantFileprivate])
     }
 
     func testDoesntHoistPrivateVisibilityFromExtensionBodyDeclarations() {
@@ -2749,7 +2749,7 @@ class OrganizationTests: RulesTests {
             func bar() {}
         }
         """
-        testFormatting(for: input, rule: .extensionAccessControl, exclude: ["redundantInternal"])
+        testFormatting(for: input, rule: .extensionAccessControl, exclude: [.redundantInternal])
     }
 
     func testNoHoistAccessModifierForExtensionThatAddsProtocolConformance() {
@@ -3268,7 +3268,7 @@ class OrganizationTests: RulesTests {
         let options = FormatOptions(markTypes: .never)
         testFormatting(
             for: input, rule: .markTypes, options: options,
-            exclude: ["emptyBraces", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "blankLinesBetweenScopes"]
+            exclude: [.emptyBraces, .blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .blankLinesBetweenScopes]
         )
     }
 
@@ -3301,7 +3301,7 @@ class OrganizationTests: RulesTests {
         let options = FormatOptions(markTypes: .ifNotEmpty)
         testFormatting(
             for: input, output, rule: .markTypes, options: options,
-            exclude: ["emptyBraces", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "blankLinesBetweenScopes"]
+            exclude: [.emptyBraces, .blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .blankLinesBetweenScopes]
         )
     }
 
@@ -3320,7 +3320,7 @@ class OrganizationTests: RulesTests {
         let options = FormatOptions(markExtensions: .never)
         testFormatting(
             for: input, rule: .markTypes, options: options,
-            exclude: ["emptyBraces", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "blankLinesBetweenScopes"]
+            exclude: [.emptyBraces, .blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .blankLinesBetweenScopes]
         )
     }
 
@@ -3353,7 +3353,7 @@ class OrganizationTests: RulesTests {
         let options = FormatOptions(markExtensions: .ifNotEmpty)
         testFormatting(
             for: input, output, rule: .markTypes, options: options,
-            exclude: ["emptyBraces", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope", "blankLinesBetweenScopes"]
+            exclude: [.emptyBraces, .blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .blankLinesBetweenScopes]
         )
     }
 
@@ -3650,14 +3650,14 @@ class OrganizationTests: RulesTests {
         let input = "import Foo\n// important comment\n// (very important)\nimport Bar"
         let output = "// important comment\n// (very important)\nimport Bar\nimport Foo"
         testFormatting(for: input, output, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsKeepsPreviousCommentWithImport2() {
         let input = "// important comment\n// (very important)\nimport Foo\nimport Bar"
         let output = "import Bar\n// important comment\n// (very important)\nimport Foo"
         testFormatting(for: input, output, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsDoesntMoveHeaderComment() {
@@ -3670,7 +3670,7 @@ class OrganizationTests: RulesTests {
         let input = "// header comment\n\n// important comment\nimport Foo\nimport Bar"
         let output = "// header comment\n\nimport Bar\n// important comment\nimport Foo"
         testFormatting(for: input, output, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsOnSameLine() {
@@ -3682,7 +3682,7 @@ class OrganizationTests: RulesTests {
     func testSortImportsWithSemicolonAndCommentOnSameLine() {
         let input = "import Foo; // foobar\nimport Bar\nimport Baz"
         let output = "import Bar\nimport Baz\nimport Foo; // foobar"
-        testFormatting(for: input, output, rule: .sortImports, exclude: ["semicolons"])
+        testFormatting(for: input, output, rule: .sortImports, exclude: [.semicolons])
     }
 
     func testSortImportEnum() {
@@ -3756,14 +3756,14 @@ class OrganizationTests: RulesTests {
     func testNoDeleteCodeBetweenImports() {
         let input = "import Foo\nfunc bar() {}\nimport Bar"
         testFormatting(for: input, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testNoDeleteCodeBetweenImports2() {
         let input = "import Foo\nimport Bar\nfoo = bar\nimport Bar"
         let output = "import Bar\nimport Foo\nfoo = bar\nimport Bar"
         testFormatting(for: input, output, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testNoDeleteCodeBetweenImports3() {
@@ -3785,7 +3785,7 @@ class OrganizationTests: RulesTests {
         let input = "import Foo\nimport Bar\nfunc bar() {}\nimport Quux\nimport Baz"
         let output = "import Bar\nimport Foo\nfunc bar() {}\nimport Baz\nimport Quux"
         testFormatting(for: input, output, rule: .sortImports,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testNoMangleImportsPrecededByComment() {
@@ -3864,7 +3864,7 @@ class OrganizationTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .sortSwitchCases, exclude: ["redundantSelf"])
+        testFormatting(for: input, rule: .sortSwitchCases, exclude: [.redundantSelf])
     }
 
     func testSortedSwitchCaseMultilineWithOneComment() {
@@ -3900,7 +3900,7 @@ class OrganizationTests: RulesTests {
             break
         }
         """
-        testFormatting(for: input, output, rule: .sortSwitchCases, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .sortSwitchCases, exclude: [.indent])
     }
 
     func testSortedSwitchCaseMultilineWithCommentsAndMoreThanOneCasePerLine() {
@@ -3956,7 +3956,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortedSwitchCaseOneLineWithoutSpaces() {
@@ -3973,7 +3973,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases", "spaceAroundOperators"])
+                       exclude: [.wrapSwitchCases, .spaceAroundOperators])
     }
 
     func testSortedSwitchCaseLet() {
@@ -3990,7 +3990,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortedSwitchCaseOneCaseDoesNothing() {
@@ -4017,7 +4017,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortedSwitchWhereConditionNotLastCase() {
@@ -4029,7 +4029,7 @@ class OrganizationTests: RulesTests {
         """
         testFormatting(for: input,
                        rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortedSwitchWhereConditionLastCase() {
@@ -4046,7 +4046,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortNumericSwitchCases() {
@@ -4063,7 +4063,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     func testSortedSwitchTuples() {
@@ -4169,7 +4169,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .sortSwitchCases,
-                       exclude: ["wrapSwitchCases"])
+                       exclude: [.wrapSwitchCases])
     }
 
     // MARK: - modifierOrder
@@ -4236,7 +4236,7 @@ class OrganizationTests: RulesTests {
         let input = "consuming public func close()"
         let output = "public consuming func close()"
         let options = FormatOptions(modifierOrder: ["public", "consuming"])
-        testFormatting(for: input, output, rule: .modifierOrder, options: options, exclude: ["noExplicitOwnership"])
+        testFormatting(for: input, output, rule: .modifierOrder, options: options, exclude: [.noExplicitOwnership])
     }
 
     func testNoConfusePostfixIdentifierWithKeyword() {
@@ -4378,7 +4378,7 @@ class OrganizationTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .sortDeclarations, exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, output, rule: .sortDeclarations, exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     func testSortClassWithMixedDeclarationTypes() {
@@ -4416,7 +4416,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, [output],
                        rules: [.sortDeclarations, .consecutiveBlankLines],
-                       exclude: ["blankLinesBetweenScopes", "propertyType"])
+                       exclude: [.blankLinesBetweenScopes, .propertyType])
     }
 
     func testSortBetweenDirectiveCommentsInType() {
@@ -4552,7 +4552,7 @@ class OrganizationTests: RulesTests {
 
         testFormatting(for: input, [output],
                        rules: [.organizeDeclarations, .blankLinesBetweenScopes],
-                       exclude: ["blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtEndOfScope])
     }
 
     func testSortsWithinOrganizeDeclarationsByClassName() {
@@ -4599,7 +4599,7 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.organizeDeclarations, .blankLinesBetweenScopes],
                        options: .init(alphabeticallySortedDeclarationPatterns: ["FeatureFlags"]),
-                       exclude: ["blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtEndOfScope])
     }
 
     func testSortsWithinOrganizeDeclarationsByPartialClassName() {
@@ -4646,7 +4646,7 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.organizeDeclarations, .blankLinesBetweenScopes],
                        options: .init(alphabeticallySortedDeclarationPatterns: ["ureFla"]),
-                       exclude: ["blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtEndOfScope])
     }
 
     func testDontSortsWithinOrganizeDeclarationsByClassNameInComment() {
@@ -4673,7 +4673,7 @@ class OrganizationTests: RulesTests {
         testFormatting(for: input,
                        rules: [.organizeDeclarations, .blankLinesBetweenScopes],
                        options: .init(alphabeticallySortedDeclarationPatterns: ["Comment"]),
-                       exclude: ["blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtEndOfScope])
     }
 
     func testSortDeclarationsSortsByNamePattern() {
@@ -4807,7 +4807,7 @@ class OrganizationTests: RulesTests {
 
         let options = FormatOptions(organizeTypes: ["extension"])
         testFormatting(for: input, output, rule: .organizeDeclarations, options: options,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     func testOrganizeDeclarationsContainingNonisolated() {
@@ -4844,7 +4844,7 @@ class OrganizationTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .organizeDeclarations,
-                       exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     func testSortStructPropertiesWithAttributes() {
@@ -4884,7 +4884,7 @@ class OrganizationTests: RulesTests {
         """
         let options = FormatOptions(indent: "  ", organizeTypes: ["struct"])
         testFormatting(for: input, output, rule: .organizeDeclarations,
-                       options: options, exclude: ["blankLinesAtStartOfScope"])
+                       options: options, exclude: [.blankLinesAtStartOfScope])
     }
 
     // MARK: - sortTypealiases
@@ -5109,7 +5109,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -5164,7 +5164,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -5221,7 +5221,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
@@ -5276,7 +5276,7 @@ class OrganizationTests: RulesTests {
             for: input, output,
             rule: .organizeDeclarations,
             options: FormatOptions(organizeTypes: ["struct"], organizationMode: .visibility),
-            exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"]
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 }

--- a/Tests/RulesTests+Parens.swift
+++ b/Tests/RulesTests+Parens.swift
@@ -63,7 +63,7 @@ class ParensTests: RulesTests {
     func testRequiredParensNotRemoved3() {
         let input = "x+(-5)"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testRedundantParensAroundIsNotRemoved() {
@@ -116,7 +116,7 @@ class ParensTests: RulesTests {
 
     func testMeaningfulParensNotRemovedAroundFileLiteral() {
         let input = "func foo(_ file: String = (#file)) {}"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["unusedArguments"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testMeaningfulParensNotRemovedAroundOperator() {
@@ -127,13 +127,13 @@ class ParensTests: RulesTests {
     func testMeaningfulParensNotRemovedAroundOperatorWithSpaces() {
         let input = "let foo: (Int, Int) -> Bool = ( < )"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators", "spaceInsideParens"])
+                       exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensNotRemovedAroundPrefixOperator() {
         let input = "let foo: (Int) -> Int = ( -)"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators", "spaceInsideParens"])
+                       exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensAroundPrefixExpressionFollowedByDotNotRemoved() {
@@ -144,7 +144,7 @@ class ParensTests: RulesTests {
     func testMeaningfulParensAroundPrefixExpressionWithSpacesFollowedByDotNotRemoved() {
         let input = "let foo = ( !bar ).description"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators", "spaceInsideParens"])
+                       exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensAroundPrefixExpressionFollowedByPostfixExpressionNotRemoved() {
@@ -332,7 +332,7 @@ class ParensTests: RulesTests {
     func testOuterParensRemovedInWhile() {
         let input = "while ((x || y) && z) {}"
         let output = "while (x || y) && z {}"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["andOperator"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testOuterParensRemovedInIf() {
@@ -344,7 +344,7 @@ class ParensTests: RulesTests {
     func testCaseOuterParensRemoved() {
         let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
         let output = "switch foo {\ncase Foo.bar(let baz):\n}"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["hoistPatternLet"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.hoistPatternLet])
     }
 
     func testCaseLetOuterParensRemoved() {
@@ -363,7 +363,7 @@ class ParensTests: RulesTests {
         let input = "guard (x == y) else { return }"
         let output = "guard x == y else { return }"
         testFormatting(for: input, output, rule: .redundantParens,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testForValueParensRemoved() {
@@ -374,7 +374,7 @@ class ParensTests: RulesTests {
 
     func testParensForLoopWhereClauseMethodNotRemoved() {
         let input = "for foo in foos where foo.method() { print(foo) }"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.wrapLoopBodies])
     }
 
     func testSpaceInsertedWhenRemovingParens() {
@@ -467,7 +467,7 @@ class ParensTests: RulesTests {
 
     func testRequiredParensNotRemovedAroundOptionalClosureType() {
         let input = "let foo = (() -> ())?"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["void"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testRequiredParensNotRemovedAroundOptionalRange() {
@@ -478,7 +478,7 @@ class ParensTests: RulesTests {
     func testRedundantParensRemovedAroundOptionalUnwrap() {
         let input = "let foo = (bar!)+5"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testRedundantParensRemovedAroundOptionalOptional() {
@@ -539,7 +539,7 @@ class ParensTests: RulesTests {
     func testRedundantParensRemovedAroundOptionalClosureType() {
         let input = "let foo = ((() -> ()))?"
         let output = "let foo = (() -> ())?"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["void"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.void])
     }
 
     func testRequiredParensNotRemovedAfterClosureArgument() {
@@ -564,12 +564,12 @@ class ParensTests: RulesTests {
 
     func testRequiredParensNotRemovedAfterClosureInsideArrayWithTrailingComma() {
         let input = "[{ /* code */ }(),]"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["trailingCommas"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.trailingCommas])
     }
 
     func testRequiredParensNotRemovedAfterClosureInWhereClause() {
         let input = "case foo where { x == y }():"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.redundantClosure])
     }
 
     // around closure arguments
@@ -577,19 +577,19 @@ class ParensTests: RulesTests {
     func testSingleClosureArgumentUnwrapped() {
         let input = "{ (foo) in }"
         let output = "{ foo in }"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleMainActorClosureArgumentUnwrapped() {
         let input = "{ @MainActor (foo) in }"
         let output = "{ @MainActor foo in }"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleClosureArgumentWithReturnValueUnwrapped() {
         let input = "{ (foo) -> Int in 5 }"
         let output = "{ foo -> Int in 5 }"
-        testFormatting(for: input, output, rule: .redundantParens, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleAnonymousClosureArgumentUnwrapped() {
@@ -600,7 +600,7 @@ class ParensTests: RulesTests {
 
     func testSingleAnonymousClosureArgumentNotUnwrapped() {
         let input = "{ (_ foo) in }"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["unusedArguments"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testTypedClosureArgumentNotUnwrapped() {
@@ -707,12 +707,12 @@ class ParensTests: RulesTests {
 
     func testParensNotRemovedBeforeIfBody2() {
         let input = "if try foo as Bar && baz() { /* some code */ }"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["andOperator"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testParensNotRemovedBeforeIfBody3() {
         let input = "if #selector(foo(_:)) && bar() { /* some code */ }"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["andOperator"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testParensNotRemovedBeforeIfBody4() {
@@ -761,7 +761,7 @@ class ParensTests: RulesTests {
 
     func testParensNotRemovedAfterAnonymousClosureInsideIfStatementBody() {
         let input = "if let foo = bar(), { x == y }() {}"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.redundantClosure])
     }
 
     func testParensNotRemovedInGenericInit() {
@@ -786,12 +786,12 @@ class ParensTests: RulesTests {
 
     func testParensNotRemovedInGenericInstantiation() {
         let input = "let foo = Foo<T>()"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.propertyType])
     }
 
     func testParensNotRemovedInGenericInstantiation2() {
         let input = "let foo = Foo<T>(bar)"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.propertyType])
     }
 
     func testRedundantParensRemovedAfterGenerics() {
@@ -931,17 +931,17 @@ class ParensTests: RulesTests {
 
     func testParensNotRemovedAroundVoidGenerics() {
         let input = "let foo = Foo<Bar, (), ()>"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["void"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testParensNotRemovedAroundTupleGenerics() {
         let input = "let foo = Foo<Bar, (Int, String), ()>"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["void"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testParensNotRemovedAroundLabeledTupleGenerics() {
         let input = "let foo = Foo<Bar, (a: Int, b: String), ()>"
-        testFormatting(for: input, rule: .redundantParens, exclude: ["void"])
+        testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     // after indexed tuple
@@ -985,13 +985,13 @@ class ParensTests: RulesTests {
         let input = "(a)...(b)"
         let output = "a...b"
         testFormatting(for: input, output, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testParensNotRemovedAroundRangeArgumentBeginningWithDot() {
         let input = "a...(.b)"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testParensNotRemovedAroundTrailingRangeFollowedByDot() {
@@ -1002,7 +1002,7 @@ class ParensTests: RulesTests {
     func testParensNotRemovedAroundRangeArgumentBeginningWithPrefixOperator() {
         let input = "a...(-b)"
         testFormatting(for: input, rule: .redundantParens,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testParensRemovedAroundRangeArgumentBeginningWithDot() {

--- a/Tests/RulesTests+Redundancy.swift
+++ b/Tests/RulesTests+Redundancy.swift
@@ -76,7 +76,7 @@ class RedundancyTests: RulesTests {
         case 1: print(1);
         }
         """
-        testFormatting(for: input, output, rule: .redundantBreak, exclude: ["semicolons"])
+        testFormatting(for: input, output, rule: .redundantBreak, exclude: [.semicolons])
     }
 
     // MARK: - redundantExtensionACL
@@ -226,7 +226,7 @@ class RedundancyTests: RulesTests {
         let kFoo = Foo().foo
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateVarNotChangedToPrivateIfAccessedFromAVar() {
@@ -262,7 +262,7 @@ class RedundancyTests: RulesTests {
         print({ Foo().foo }())
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.redundantClosure])
     }
 
     func testFileprivateVarNotChangedToPrivateIfAccessedFromAnExtensionOnAnotherType() {
@@ -333,7 +333,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "4")
         testFormatting(for: input, output, rule: .redundantFileprivate, options: options,
-                       exclude: ["redundantSelf"])
+                       exclude: [.redundantSelf])
     }
 
     func testFileprivateMultiLetNotChangedToPrivateIfAccessedOutsideType() {
@@ -382,7 +382,7 @@ class RedundancyTests: RulesTests {
         let foo = Foo()
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateInitNotChangedToPrivateIfConstructorCalledOutsideType2() {
@@ -396,7 +396,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateStructMemberNotChangedToPrivateIfConstructorCalledOutsideType() {
@@ -408,7 +408,7 @@ class RedundancyTests: RulesTests {
         let foo = Foo(bar: "test")
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateClassMemberChangedToPrivateEvenIfConstructorCalledOutsideType() {
@@ -427,7 +427,7 @@ class RedundancyTests: RulesTests {
         let foo = Foo()
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, output, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateExtensionFuncNotChangedToPrivateIfPartOfProtocolConformance() {
@@ -460,7 +460,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input,
                        rule: .redundantFileprivate,
                        options: options,
-                       exclude: ["wrapEnumCases"])
+                       exclude: [.wrapEnumCases])
     }
 
     func testFileprivateClassTypeMemberNotChangedToPrivate() {
@@ -531,7 +531,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantFileprivate, options: options, exclude: [.propertyType])
     }
 
     func testFileprivateInitNotChangedToPrivateWhenUsingTrailingClosureInit() {
@@ -679,7 +679,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "4")
         testFormatting(for: input, rule: .redundantFileprivate,
-                       options: options, exclude: ["typeSugar"])
+                       options: options, exclude: [.typeSugar])
     }
 
     // MARK: - redundantGet
@@ -829,7 +829,7 @@ class RedundancyTests: RulesTests {
         let Foo = Foo.self
         let foo = Foo.init()
         """
-        testFormatting(for: input, rule: .redundantInit, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantInit, exclude: [.propertyType])
     }
 
     func testNoRemoveInitForLocalLetType2() {
@@ -854,7 +854,7 @@ class RedundancyTests: RulesTests {
             #endif
         }
         """
-        testFormatting(for: input, rule: .redundantInit, exclude: ["indent"])
+        testFormatting(for: input, rule: .redundantInit, exclude: [.indent])
     }
 
     func testNoRemoveInitInsideIfdef2() {
@@ -867,7 +867,7 @@ class RedundancyTests: RulesTests {
             #endif
         }
         """
-        testFormatting(for: input, rule: .redundantInit, exclude: ["indent"])
+        testFormatting(for: input, rule: .redundantInit, exclude: [.indent])
     }
 
     func testRemoveInitAfterCollectionLiterals() {
@@ -885,7 +885,7 @@ class RedundancyTests: RulesTests {
         let tupleArray = [(key: String, value: Int)]()
         let dictionary = [String: Int]()
         """
-        testFormatting(for: input, output, rule: .redundantInit, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantInit, exclude: [.propertyType])
     }
 
     func testPreservesInitAfterTypeOfCall() {
@@ -906,7 +906,7 @@ class RedundancyTests: RulesTests {
         // (String!.init("Foo") isn't valid Swift code, so we don't test for it)
         """
 
-        testFormatting(for: input, output, rule: .redundantInit, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantInit, exclude: [.propertyType])
     }
 
     func testPreservesTryBeforeInit() {
@@ -931,7 +931,7 @@ class RedundancyTests: RulesTests {
         let atomicDictionary = Atomic<[String: Int]>()
         """
 
-        testFormatting(for: input, output, rule: .redundantInit, exclude: ["typeSugar", "propertyType"])
+        testFormatting(for: input, output, rule: .redundantInit, exclude: [.typeSugar, .propertyType])
     }
 
     func testPreserveNonRedundantInitInTernaryOperator() {
@@ -1253,14 +1253,14 @@ class RedundancyTests: RulesTests {
         let input = "let foo: Void = Void()"
         let options = FormatOptions(redundantType: .inferred)
         testFormatting(for: input, rule: .redundantType,
-                       options: options, exclude: ["void"])
+                       options: options, exclude: [.void])
     }
 
     func testNoRemoveRedundantTypeIfVoid2() {
         let input = "let foo: () = ()"
         let options = FormatOptions(redundantType: .inferred)
         testFormatting(for: input, rule: .redundantType,
-                       options: options, exclude: ["void"])
+                       options: options, exclude: [.void])
     }
 
     func testNoRemoveRedundantTypeIfVoid3() {
@@ -1273,7 +1273,7 @@ class RedundancyTests: RulesTests {
         let input = "let foo: Array<Void> = Array<Void>()"
         let options = FormatOptions(redundantType: .inferred)
         testFormatting(for: input, rule: .redundantType,
-                       options: options, exclude: ["typeSugar"])
+                       options: options, exclude: [.typeSugar])
     }
 
     func testNoRemoveRedundantTypeIfVoid5() {
@@ -1286,7 +1286,7 @@ class RedundancyTests: RulesTests {
         let input = "let foo: Optional<Void> = Optional<Void>.none"
         let options = FormatOptions(redundantType: .inferred)
         testFormatting(for: input, rule: .redundantType,
-                       options: options, exclude: ["typeSugar"])
+                       options: options, exclude: [.typeSugar])
     }
 
     func testRedundantTypeWithLiterals() {
@@ -1368,7 +1368,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testRedundantTypeWithIfExpression_inferred() {
@@ -1387,7 +1387,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testRedundantTypeWithIfExpression_explicit() {
@@ -1406,7 +1406,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment", "propertyType"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment, .propertyType])
     }
 
     func testRedundantTypeWithNestedIfExpression_inferred() {
@@ -1445,7 +1445,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testRedundantTypeWithNestedIfExpression_explicit() {
@@ -1484,7 +1484,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment", "propertyType"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment, .propertyType])
     }
 
     func testRedundantTypeWithLiteralsInIfExpression() {
@@ -1503,7 +1503,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(redundantType: .inferred, swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     // --redundanttype explicit
@@ -1513,7 +1513,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testVarRedundantTypeRemovalExplicitType2() {
@@ -1521,7 +1521,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = .init /* foo */()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["spaceAroundComments", "propertyType"])
+                       options: options, exclude: [.spaceAroundComments, .propertyType])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitType() {
@@ -1529,7 +1529,7 @@ class RedundancyTests: RulesTests {
         let output = "let relay: BehaviourRelay<Int?> = .init(value: nil)"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitTypeIfValueOnNextLine() {
@@ -1537,7 +1537,7 @@ class RedundancyTests: RulesTests {
         let output = "let relay: Foo<Int?> = \n    .default"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["trailingSpace", "propertyType"])
+                       options: options, exclude: [.trailingSpace, .propertyType])
     }
 
     func testVarNonRedundantTypeDoesNothingExplicitType() {
@@ -1551,7 +1551,7 @@ class RedundancyTests: RulesTests {
         let output = "let view: UIView = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovedIfValueOnNextLineExplicitType() {
@@ -1565,7 +1565,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovedIfValueOnNextLine2ExplicitType() {
@@ -1579,7 +1579,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovalWithCommentExplicitType() {
@@ -1587,7 +1587,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView /* view */ = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovalWithComment2ExplicitType() {
@@ -1595,7 +1595,7 @@ class RedundancyTests: RulesTests {
         let output = "var view: UIView = /* view */ .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovalWithStaticMember() {
@@ -1617,7 +1617,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovalWithStaticFunc() {
@@ -1639,13 +1639,13 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember() {
         let input = "let session: URLSession = URLSession.default.makeCopy()"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantRedundantChainedMemberTypeRemovedOnSwift5_4() {
@@ -1653,44 +1653,44 @@ class RedundancyTests: RulesTests {
         let output = "let session: URLSession = .default.makeCopy()"
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.4")
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember2() {
         let input = "let color: UIColor = UIColor.red.withAlphaComponent(0.5)"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember3() {
         let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeRemovedWithChainedMemberOnSwift5_4() {
         let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
         let output = "let url: URL = .init(fileURLWithPath: #file).deletingLastPathComponent()"
         let options = FormatOptions(redundantType: .explicit, swiftVersion: "5.4")
-        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingIfLet() {
         let input = "if let foo: Foo = Foo() {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingGuardLet() {
         let input = "guard let foo: Foo = Foo() else {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeDoesNothingIfLetAfterComma() {
         let input = "if check == true, let foo: Foo = Foo() {}"
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .redundantType, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeWorksAfterIf() {
@@ -1704,7 +1704,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeIfVoid() {
@@ -1712,7 +1712,7 @@ class RedundancyTests: RulesTests {
         let output = "let foo: [Void] = .init()"
         let options = FormatOptions(redundantType: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantTypeWithIntegerLiteralNotMangled() {
@@ -1794,7 +1794,7 @@ class RedundancyTests: RulesTests {
 
         let options = FormatOptions(redundantType: .inferLocalsOnly)
         testFormatting(for: input, output, rule: .redundantType,
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     // MARK: - redundantNilInit
@@ -1848,7 +1848,7 @@ class RedundancyTests: RulesTests {
         let input = "lazy private(set) public var foo: Int? = nil"
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit, options: options,
-                       exclude: ["modifierOrder"])
+                       exclude: [.modifierOrder])
     }
 
     func testNoRemoveCodableNilInit() {
@@ -2055,7 +2055,7 @@ class RedundancyTests: RulesTests {
         let input = "lazy private(set) public var foo: Int?"
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit, options: options,
-                       exclude: ["modifierOrder"])
+                       exclude: [.modifierOrder])
     }
 
     func testNoInsertCodableNilInit() {
@@ -2292,7 +2292,7 @@ class RedundancyTests: RulesTests {
     func testRemoveRedundantLetInCase() {
         let input = "if case .foo(let _) = bar {}"
         let output = "if case .foo(_) = bar {}"
-        testFormatting(for: input, output, rule: .redundantLet, exclude: ["redundantPattern"])
+        testFormatting(for: input, output, rule: .redundantLet, exclude: [.redundantPattern])
     }
 
     func testRemoveRedundantVarsInCase() {
@@ -2314,7 +2314,7 @@ class RedundancyTests: RulesTests {
     func testNoRemoveLetInGuard() {
         let input = "guard let _ = foo else {}"
         testFormatting(for: input, rule: .redundantLet,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveLetInWhile() {
@@ -2434,7 +2434,7 @@ class RedundancyTests: RulesTests {
     func testSimplifyLetPattern() {
         let input = "let(_, _) = bar"
         let output = "let _ = bar"
-        testFormatting(for: input, output, rule: .redundantPattern, exclude: ["redundantLet"])
+        testFormatting(for: input, output, rule: .redundantPattern, exclude: [.redundantLet])
     }
 
     func testNoRemoveVoidFunctionCall() {
@@ -2459,14 +2459,14 @@ class RedundancyTests: RulesTests {
         let input = "enum Foo: String { case bar = \"bar\", baz = \"baz\" }"
         let output = "enum Foo: String { case bar, baz }"
         testFormatting(for: input, output, rule: .redundantRawValues,
-                       exclude: ["wrapEnumCases"])
+                       exclude: [.wrapEnumCases])
     }
 
     func testRemoveBacktickCaseRawStringCases() {
         let input = "enum Foo: String { case `as` = \"as\", `let` = \"let\" }"
         let output = "enum Foo: String { case `as`, `let` }"
         testFormatting(for: input, output, rule: .redundantRawValues,
-                       exclude: ["wrapEnumCases"])
+                       exclude: [.wrapEnumCases])
     }
 
     func testNoRemoveRawStringIfNameDoesntMatch() {
@@ -2563,13 +2563,13 @@ class RedundancyTests: RulesTests {
     func testRemoveRedundantReturnInClosure() {
         let input = "foo(with: { return 5 })"
         let output = "foo(with: { 5 })"
-        testFormatting(for: input, output, rule: .redundantReturn, exclude: ["trailingClosures"])
+        testFormatting(for: input, output, rule: .redundantReturn, exclude: [.trailingClosures])
     }
 
     func testRemoveRedundantReturnInClosureWithArgs() {
         let input = "foo(with: { foo in return foo })"
         let output = "foo(with: { foo in foo })"
-        testFormatting(for: input, output, rule: .redundantReturn, exclude: ["trailingClosures"])
+        testFormatting(for: input, output, rule: .redundantReturn, exclude: [.trailingClosures])
     }
 
     func testRemoveRedundantReturnInMap() {
@@ -2611,13 +2611,13 @@ class RedundancyTests: RulesTests {
     func testRemoveReturnInVarClosure() {
         let input = "var foo = { return 5 }()"
         let output = "var foo = { 5 }()"
-        testFormatting(for: input, output, rule: .redundantReturn, exclude: ["redundantClosure"])
+        testFormatting(for: input, output, rule: .redundantReturn, exclude: [.redundantClosure])
     }
 
     func testRemoveReturnInParenthesizedClosure() {
         let input = "var foo = ({ return 5 }())"
         let output = "var foo = ({ 5 }())"
-        testFormatting(for: input, output, rule: .redundantReturn, exclude: ["redundantParens", "redundantClosure"])
+        testFormatting(for: input, output, rule: .redundantReturn, exclude: [.redundantParens, .redundantClosure])
     }
 
     func testNoRemoveReturnInFunction() {
@@ -2634,7 +2634,7 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveReturnInOperatorFunction() {
         let input = "func + (lhs: Int, rhs: Int) -> Int { return 5 }"
-        testFormatting(for: input, rule: .redundantReturn, exclude: ["unusedArguments"])
+        testFormatting(for: input, rule: .redundantReturn, exclude: [.unusedArguments])
     }
 
     func testRemoveReturnInOperatorFunction() {
@@ -2642,7 +2642,7 @@ class RedundancyTests: RulesTests {
         let output = "func + (lhs: Int, rhs: Int) -> Int { 5 }"
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testNoRemoveReturnInFailableInit() {
@@ -2692,7 +2692,7 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveReturnInSubscript() {
         let input = "subscript(index: Int) -> String { return nil }"
-        testFormatting(for: input, rule: .redundantReturn, exclude: ["unusedArguments"])
+        testFormatting(for: input, rule: .redundantReturn, exclude: [.unusedArguments])
     }
 
     func testRemoveReturnInSubscript() {
@@ -2700,7 +2700,7 @@ class RedundancyTests: RulesTests {
         let output = "subscript(index: Int) -> String { nil }"
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testNoRemoveReturnInDoCatch() {
@@ -2761,30 +2761,30 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveReturnInForIn() {
         let input = "for foo in bar { return 5 }"
-        testFormatting(for: input, rule: .redundantReturn, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantReturn, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveReturnInForWhere() {
         let input = "for foo in bar where baz { return 5 }"
-        testFormatting(for: input, rule: .redundantReturn, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantReturn, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveReturnInIfLetTry() {
         let input = "if let foo = try? bar() { return 5 }"
         testFormatting(for: input, rule: .redundantReturn,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnInMultiIfLetTry() {
         let input = "if let foo = bar, let bar = baz { return 5 }"
         testFormatting(for: input, rule: .redundantReturn,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnAfterMultipleAs() {
         let input = "if foo as? bar as? baz { return 5 }"
         testFormatting(for: input, rule: .redundantReturn,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testRemoveVoidReturn() {
@@ -2796,13 +2796,13 @@ class RedundancyTests: RulesTests {
     func testNoRemoveReturnAfterKeyPath() {
         let input = "func foo() { if bar == #keyPath(baz) { return 5 } }"
         testFormatting(for: input, rule: .redundantReturn,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnAfterParentheses() {
         let input = "if let foo = (bar as? String) { return foo }"
         testFormatting(for: input, rule: .redundantReturn,
-                       exclude: ["redundantParens", "wrapConditionalBodies"])
+                       exclude: [.redundantParens, .wrapConditionalBodies])
     }
 
     func testRemoveReturnInTupleVarGetter() {
@@ -2824,7 +2824,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, rule: .redundantReturn, options: options,
-                       exclude: ["spaceAroundBraces", "spaceAroundParens"])
+                       exclude: [.spaceAroundBraces, .spaceAroundParens])
     }
 
     func testNoRemoveReturnInIfWithUnParenthesizedClosure() {
@@ -2849,7 +2849,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .redundantReturn,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testRemoveRedundantReturnInFunctionWithWhereClause() {
@@ -2892,7 +2892,7 @@ class RedundancyTests: RulesTests {
             return bar
         }()
         """
-        testFormatting(for: input, rule: .redundantReturn, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .redundantReturn, exclude: [.redundantProperty])
     }
 
     func testNoRemoveReturnInForWhereLoop() {
@@ -2919,7 +2919,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .redundantReturn,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testRedundantReturnInVoidFunction2() {
@@ -2990,7 +2990,7 @@ class RedundancyTests: RulesTests {
         """
         testFormatting(for: input, rule: .redundantReturn,
                        options: FormatOptions(swiftVersion: "5.1"),
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnInForCasewhere() {
@@ -3015,7 +3015,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .redundantReturn,
-                       options: FormatOptions(swiftVersion: "5.1"), exclude: ["redundantProperty"])
+                       options: FormatOptions(swiftVersion: "5.1"), exclude: [.redundantProperty])
     }
 
     func testNoRemoveRequiredReturnInIfClosure() {
@@ -3165,7 +3165,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantReturn, options: options,
-                       exclude: ["conditionalAssignment"])
+                       exclude: [.conditionalAssignment])
     }
 
     func testRedundantIfStatementReturnInClosure() {
@@ -3205,7 +3205,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantReturn, options: options,
-                       exclude: ["conditionalAssignment"])
+                       exclude: [.conditionalAssignment])
     }
 
     func testNoRemoveReturnInConsecutiveIfStatements() {
@@ -3246,7 +3246,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.redundantReturn, .conditionalAssignment,
                                .redundantClosure, .indent],
-                       options: options, exclude: ["wrapMultilineConditionalAssignment"])
+                       options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testRedundantSwitchStatementReturnInFunction() {
@@ -3289,7 +3289,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantReturn, options: options,
-                       exclude: ["conditionalAssignment"])
+                       exclude: [.conditionalAssignment])
     }
 
     func testClosureAroundConditionalAssignmentNotRedundantForExplicitReturn() {
@@ -3306,7 +3306,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantClosure, options: options,
-                       exclude: ["redundantReturn", "propertyType"])
+                       exclude: [.redundantReturn, .propertyType])
     }
 
     func testNonRedundantSwitchStatementReturnInFunction() {
@@ -3615,7 +3615,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantReturn, options: options,
-                       exclude: ["wrapSwitchCases", "sortSwitchCases"])
+                       exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testDoesntRemoveReturnFromIfExpressionConditionalCastInSwift5_9() {
@@ -3824,7 +3824,7 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveBackticksAroundTypeInsideType() {
         let input = "struct Foo {\n    enum `Type` {}\n}"
-        testFormatting(for: input, rule: .redundantBackticks, exclude: ["enumNamespaces"])
+        testFormatting(for: input, rule: .redundantBackticks, exclude: [.enumNamespaces])
     }
 
     func testNoRemoveBackticksAroundLetArgument() {
@@ -3851,7 +3851,7 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveBackticksAroundTypePropertyInsideType() {
         let input = "struct Foo {\n    enum `Type` {}\n}"
-        testFormatting(for: input, rule: .redundantBackticks, exclude: ["enumNamespaces"])
+        testFormatting(for: input, rule: .redundantBackticks, exclude: [.enumNamespaces])
     }
 
     func testNoRemoveBackticksAroundTrueProperty() {
@@ -3863,19 +3863,19 @@ class RedundancyTests: RulesTests {
         let input = "var type = Foo.`true`"
         let output = "var type = Foo.true"
         let options = FormatOptions(swiftVersion: "4")
-        testFormatting(for: input, output, rule: .redundantBackticks, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantBackticks, options: options, exclude: [.propertyType])
     }
 
     func testRemoveBackticksAroundProperty() {
         let input = "var type = Foo.`bar`"
         let output = "var type = Foo.bar"
-        testFormatting(for: input, output, rule: .redundantBackticks, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantBackticks, exclude: [.propertyType])
     }
 
     func testRemoveBackticksAroundKeywordProperty() {
         let input = "var type = Foo.`default`"
         let output = "var type = Foo.default"
-        testFormatting(for: input, output, rule: .redundantBackticks, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantBackticks, exclude: [.propertyType])
     }
 
     func testRemoveBackticksAroundKeypathProperty() {
@@ -3899,7 +3899,7 @@ class RedundancyTests: RulesTests {
     func testNoRemoveBackticksAroundInitPropertyInSwift5() {
         let input = "let foo: Foo = .`init`"
         let options = FormatOptions(swiftVersion: "5")
-        testFormatting(for: input, rule: .redundantBackticks, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantBackticks, options: options, exclude: [.propertyType])
     }
 
     func testNoRemoveBackticksAroundAnyProperty() {
@@ -4101,7 +4101,7 @@ class RedundancyTests: RulesTests {
     func testNoRemoveSelfInClosureInsideIf() {
         let input = "if foo { bar { self.baz() } }"
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveSelfForErrorInCatch() {
@@ -4146,12 +4146,12 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveSelfForIndexVarInFor() {
         let input = "for foo in bar { self.foo = foo }"
-        testFormatting(for: input, rule: .redundantSelf, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveSelfForKeyValueTupleInFor() {
         let input = "for (foo, bar) in baz { self.foo = foo; self.bar = bar }"
-        testFormatting(for: input, rule: .redundantSelf, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testRemoveSelfFromComputedVar() {
@@ -4230,7 +4230,7 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveSelfFromLazyVarClosure() {
         let input = "lazy var foo = { self.bar }()"
-        testFormatting(for: input, rule: .redundantSelf, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .redundantSelf, exclude: [.redundantClosure])
     }
 
     func testNoRemoveSelfFromLazyVarClosure2() {
@@ -4289,13 +4289,13 @@ class RedundancyTests: RulesTests {
     func testNoRemoveSelfInLocalVarPrecededByIfLetContainingClosure() {
         let input = "func foo() {\n    if let bar = 5 { baz { _ in } }\n    let quux = self.quux\n}"
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveSelfForVarCreatedInGuardScope() {
         let input = "func foo() {\n    guard let bar = 5 else {}\n    let baz = self.bar\n}"
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testRemoveSelfForVarCreatedInIfScope() {
@@ -4306,13 +4306,13 @@ class RedundancyTests: RulesTests {
 
     func testNoRemoveSelfForVarDeclaredInWhileCondition() {
         let input = "while let foo = bar { self.foo = foo }"
-        testFormatting(for: input, rule: .redundantSelf, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testRemoveSelfForVarNotDeclaredInWhileCondition() {
         let input = "while let foo == bar { self.baz = 5 }"
         let output = "while let foo == bar { baz = 5 }"
-        testFormatting(for: input, output, rule: .redundantSelf, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, output, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveSelfForVarDeclaredInSwitchCase() {
@@ -4334,14 +4334,14 @@ class RedundancyTests: RulesTests {
     func testRemoveSelfInStaticFunction() {
         let input = "struct Foo {\n    static func foo() {\n        func bar() { self.foo() }\n    }\n}"
         let output = "struct Foo {\n    static func foo() {\n        func bar() { foo() }\n    }\n}"
-        testFormatting(for: input, output, rule: .redundantSelf, exclude: ["enumNamespaces"])
+        testFormatting(for: input, output, rule: .redundantSelf, exclude: [.enumNamespaces])
     }
 
     func testRemoveSelfInClassFunctionWithModifiers() {
         let input = "class Foo {\n    class private func foo() {\n        func bar() { self.foo() }\n    }\n}"
         let output = "class Foo {\n    class private func foo() {\n        func bar() { foo() }\n    }\n}"
         testFormatting(for: input, output, rule: .redundantSelf,
-                       exclude: ["modifierOrder"])
+                       exclude: [.modifierOrder])
     }
 
     func testNoRemoveSelfInClassFunction() {
@@ -4481,7 +4481,7 @@ class RedundancyTests: RulesTests {
         let vc = UIHostingController(rootView: InspectionView(inspection: self.inspection))
         """
         let options = FormatOptions(selfRequired: ["InspectionView"])
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.propertyType])
     }
 
     func testNoMistakeProtocolClassModifierForClassFunction() {
@@ -4799,7 +4799,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.3")
-        testFormatting(for: input, output, rule: .redundantSelf, options: options, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .redundantSelf, options: options, exclude: [.unusedArguments])
     }
 
     func testRedundantSelfRemovesSelfInClosureWithNestedExplicitStrongCapture() {
@@ -4996,7 +4996,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(swiftVersion: "5.8")
         testFormatting(for: input, output, rule: .redundantSelf,
-                       options: options, exclude: ["redundantOptionalBinding"])
+                       options: options, exclude: [.redundantOptionalBinding])
     }
 
     func testWeakSelfNotRemovedIfNotUnwrapped() {
@@ -5108,7 +5108,7 @@ class RedundancyTests: RulesTests {
     func testRedundantSelfDoesntGetStuckIfNoParensFound() {
         let input = "init<T>_ foo: T {}"
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testNoRemoveSelfInIfLetSelf() {
@@ -5304,7 +5304,7 @@ class RedundancyTests: RulesTests {
         }) {}
         """
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testStructSelfRemovedInTrailingClosureInIfCase() {
@@ -5449,7 +5449,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveSelfInAssignmentInsideIfAsStatement() {
@@ -5497,7 +5497,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .redundantSelf,
-                       exclude: ["hoistPatternLet"])
+                       exclude: [.hoistPatternLet])
     }
 
     func testRedundantSelfParsingBug2() {
@@ -5683,7 +5683,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.redundantProperty])
     }
 
     func testDisableRedundantSelfDirective() {
@@ -5697,7 +5697,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.redundantProperty])
     }
 
     func testDisableRedundantSelfDirective2() {
@@ -5712,7 +5712,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.redundantProperty])
     }
 
     func testSelfInsertDirective() {
@@ -5726,7 +5726,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.4")
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.redundantProperty])
     }
 
     func testNoRemoveVariableShadowedLaterInScopeInOlderSwiftVersions() {
@@ -5938,7 +5938,7 @@ class RedundancyTests: RulesTests {
     func testNoInsertSelfForNestedVarReference() {
         let input = "class Foo {\n    func bar() {\n        var bar = 5\n        repeat { bar = 6 } while true\n    }\n}"
         let options = FormatOptions(explicitSelf: .insert)
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.wrapLoopBodies])
     }
 
     func testNoInsertSelfInSwitchCaseLet() {
@@ -5951,7 +5951,7 @@ class RedundancyTests: RulesTests {
         let input = "import class Foo.Bar\nfunc foo() {\n    var bar = 5\n    if true {\n        bar = 6\n    }\n}"
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testNoInsertSelfForSubscriptGetSet() {
@@ -5965,7 +5965,7 @@ class RedundancyTests: RulesTests {
         let input = "enum Foo {\n    case bar(Int)\n    var value: Int? {\n        if case let .bar(value) = self { return value }\n    }\n}"
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoInsertSelfForPatternLet() {
@@ -6358,7 +6358,7 @@ class RedundancyTests: RulesTests {
         """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options,
-                       exclude: ["hoistPatternLet"])
+                       exclude: [.hoistPatternLet])
     }
 
     func testNoInsertSelfForVarDefinedInFor() {
@@ -6717,7 +6717,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(explicitSelf: .initOnly)
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["redundantClosure"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.redundantClosure])
     }
 
     func testRedundantSelfRuleFailsInInitOnlyMode2() {
@@ -6888,7 +6888,7 @@ class RedundancyTests: RulesTests {
         })
         """
         testFormatting(for: input, rule: .redundantSelf,
-                       exclude: ["hoistPatternLet"])
+                       exclude: [.hoistPatternLet])
     }
 
     func testSelfRemovalParsingBug7() {
@@ -7325,7 +7325,7 @@ class RedundancyTests: RulesTests {
         }
         """
         let options = FormatOptions(explicitSelf: .insert)
-        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: ["enumNamespaces"])
+        testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.enumNamespaces])
     }
 
     func testRedundantSelfNotConfusedByMainActor() {
@@ -7456,7 +7456,7 @@ class RedundancyTests: RulesTests {
 
     func testStaticSelfNotRemovedWhenUsedAsExplicitInitializer() {
         let input = "enum E { static func foo() { Self.init().bar() } }"
-        testFormatting(for: input, rule: .redundantStaticSelf, exclude: ["redundantInit"])
+        testFormatting(for: input, rule: .redundantStaticSelf, exclude: [.redundantInit])
     }
 
     func testPreservesStaticSelfInFunctionAfterStaticVar() {
@@ -7477,7 +7477,7 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantStaticSelf, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .redundantStaticSelf, exclude: [.propertyType])
     }
 
     func testPreserveStaticSelfInInstanceFunction() {
@@ -7854,7 +7854,7 @@ class RedundancyTests: RulesTests {
             return parser
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty", "propertyType"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty, .propertyType])
     }
 
     func testShadowedClosureArgument2() {
@@ -7864,7 +7864,7 @@ class RedundancyTests: RulesTests {
             return input
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty])
     }
 
     func testUnusedPropertyWrapperArgument() {
@@ -8052,7 +8052,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .unusedArguments,
-                       exclude: ["hoistPatternLet"])
+                       exclude: [.hoistPatternLet])
     }
 
     // functions
@@ -8118,7 +8118,7 @@ class RedundancyTests: RulesTests {
     func testLabelsAreNotArguments() {
         let input = "func foo(bar: Int, baz: String) {\n    bar: while true { print(baz) }\n}"
         let output = "func foo(bar _: Int, baz: String) {\n    bar: while true { print(baz) }\n}"
-        testFormatting(for: input, output, rule: .unusedArguments, exclude: ["wrapLoopBodies"])
+        testFormatting(for: input, output, rule: .unusedArguments, exclude: [.wrapLoopBodies])
     }
 
     func testDictionaryLiteralsRuinEverything() {
@@ -8254,7 +8254,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .unusedArguments,
-                       exclude: ["sortSwitchCases"])
+                       exclude: [.sortSwitchCases])
     }
 
     func testTryArgumentNotMarkedUnused() {
@@ -8265,7 +8265,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty])
     }
 
     func testTryAwaitArgumentNotMarkedUnused() {
@@ -8276,7 +8276,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty])
     }
 
     func testTypedTryAwaitArgumentNotMarkedUnused() {
@@ -8287,7 +8287,7 @@ class RedundancyTests: RulesTests {
             return bar
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty])
     }
 
     func testConditionalIfLetMarkedAsUnused() {
@@ -8509,7 +8509,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .unusedArguments,
-                       exclude: ["braces", "wrapArguments"])
+                       exclude: [.braces, .wrapArguments])
     }
 
     func testArgumentUsedInDictionaryLiteral() {
@@ -8524,7 +8524,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .unusedArguments,
-                       exclude: ["trailingCommas"])
+                       exclude: [.trailingCommas])
     }
 
     func testArgumentUsedAfterIfDefInsideSwitchBlock() {
@@ -8551,7 +8551,7 @@ class RedundancyTests: RulesTests {
             file.close()
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["noExplicitOwnership"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.noExplicitOwnership])
     }
 
     func testUsedConsumingBorrowingArguments() {
@@ -8561,7 +8561,7 @@ class RedundancyTests: RulesTests {
             borrow(b)
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["noExplicitOwnership"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.noExplicitOwnership])
     }
 
     func testUnusedConsumingArgument() {
@@ -8575,7 +8575,7 @@ class RedundancyTests: RulesTests {
             print("no-op")
         }
         """
-        testFormatting(for: input, output, rule: .unusedArguments, exclude: ["noExplicitOwnership"])
+        testFormatting(for: input, output, rule: .unusedArguments, exclude: [.noExplicitOwnership])
     }
 
     func testUnusedConsumingBorrowingArguments() {
@@ -8589,7 +8589,7 @@ class RedundancyTests: RulesTests {
             print("no-op")
         }
         """
-        testFormatting(for: input, output, rule: .unusedArguments, exclude: ["noExplicitOwnership"])
+        testFormatting(for: input, output, rule: .unusedArguments, exclude: [.noExplicitOwnership])
     }
 
     func testFunctionArgumentUsedInGuardNotRemoved() {
@@ -8643,7 +8643,7 @@ class RedundancyTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .unusedArguments,
-                       exclude: ["wrapArguments", "wrapConditionalBodies", "indent"])
+                       exclude: [.wrapArguments, .wrapConditionalBodies, .indent])
     }
 
     // functions (closure-only)
@@ -8774,7 +8774,7 @@ class RedundancyTests: RulesTests {
             self?.configure(update)
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantParens"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantParens])
     }
 
     func testIssue1696() {
@@ -8787,7 +8787,7 @@ class RedundancyTests: RulesTests {
             return parameter
         }
         """
-        testFormatting(for: input, rule: .unusedArguments, exclude: ["redundantProperty"])
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.redundantProperty])
     }
 
     // MARK: redundantClosure
@@ -8839,7 +8839,7 @@ class RedundancyTests: RulesTests {
 
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [.redundantReturn, .redundantClosure],
-                       options: options, exclude: ["indent", "wrapMultilineConditionalAssignment"])
+                       options: options, exclude: [.indent, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantClosureWithExplicitReturn2() {
@@ -8906,7 +8906,7 @@ class RedundancyTests: RulesTests {
         lazy var bar = Bar()
         """
 
-        testFormatting(for: input, output, rule: .redundantClosure, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantClosure, exclude: [.propertyType])
     }
 
     func testRemoveRedundantClosureInMultiLinePropertyDeclarationWithString() {
@@ -8943,7 +8943,7 @@ class RedundancyTests: RulesTests {
         """
 
         testFormatting(for: input, [output], rules: [.redundantReturn, .redundantClosure,
-                                                     .semicolons], exclude: ["propertyType"])
+                                                     .semicolons], exclude: [.propertyType])
     }
 
     func testRemoveRedundantClosureInWrappedPropertyDeclaration_beforeFirst() {
@@ -8964,7 +8964,7 @@ class RedundancyTests: RulesTests {
         let options = FormatOptions(wrapArguments: .beforeFirst, closingParenPosition: .sameLine)
         testFormatting(for: input, [output],
                        rules: [.redundantClosure, .wrapArguments],
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRemoveRedundantClosureInWrappedPropertyDeclaration_afterFirst() {
@@ -8983,7 +8983,7 @@ class RedundancyTests: RulesTests {
         let options = FormatOptions(wrapArguments: .afterFirst, closingParenPosition: .sameLine)
         testFormatting(for: input, [output],
                        rules: [.redundantClosure, .wrapArguments],
-                       options: options, exclude: ["propertyType"])
+                       options: options, exclude: [.propertyType])
     }
 
     func testRedundantClosureKeepsMultiStatementClosureThatSetsProperty() {
@@ -9071,7 +9071,7 @@ class RedundancyTests: RulesTests {
         """
 
         testFormatting(for: input, rule: .redundantClosure,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testRemovesClosureWithIfStatementInsideOtherClosure() {
@@ -9137,7 +9137,7 @@ class RedundancyTests: RulesTests {
         """
 
         testFormatting(for: input, rule: .redundantClosure,
-                       exclude: ["redundantReturn"])
+                       exclude: [.redundantReturn])
     }
 
     func testRemovesClosureThatHasNestedFatalError() {
@@ -9151,7 +9151,7 @@ class RedundancyTests: RulesTests {
         lazy var foo = Foo(handle: { fatalError() })
         """
 
-        testFormatting(for: input, output, rule: .redundantClosure, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .redundantClosure, exclude: [.propertyType])
     }
 
     func testPreservesClosureWithMultipleVoidMethodCalls() {
@@ -9185,7 +9185,7 @@ class RedundancyTests: RulesTests {
         })
         """
 
-        testFormatting(for: input, [output], rules: [.redundantClosure, .indent], exclude: ["redundantType"])
+        testFormatting(for: input, [output], rules: [.redundantClosure, .indent], exclude: [.redundantType])
     }
 
     func testKeepsClosureThatThrowsError() {
@@ -9238,7 +9238,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.redundantReturn, .conditionalAssignment,
                                .redundantClosure],
-                       options: options, exclude: ["indent", "wrapMultilineConditionalAssignment"])
+                       options: options, exclude: [.indent, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantClosureDoesntLeaveStrayTryAwait() {
@@ -9262,7 +9262,7 @@ class RedundancyTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.redundantReturn, .conditionalAssignment,
                                .redundantClosure],
-                       options: options, exclude: ["indent", "wrapMultilineConditionalAssignment"])
+                       options: options, exclude: [.indent, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantClosureDoesntLeaveInvalidSwitchExpressionInOperatorChain() {
@@ -9380,7 +9380,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["indent", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.indent, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantClosureDoesntLeaveInvalidSwitchExpressionInArray() {
@@ -9428,7 +9428,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["redundantReturn", "indent"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.redundantReturn, .indent])
     }
 
     func testRedundantClosureRemovesClosureAsReturnTryStatement2() {
@@ -9455,7 +9455,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["redundantReturn", "indent"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.redundantReturn, .indent])
     }
 
     func testRedundantClosureRemovesClosureAsReturnTryStatement3() {
@@ -9482,7 +9482,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["redundantReturn", "indent"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.redundantReturn, .indent])
     }
 
     func testRedundantClosureRemovesClosureAsReturnTryStatement4() {
@@ -9509,7 +9509,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["redundantReturn", "indent"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.redundantReturn, .indent])
     }
 
     func testRedundantClosureRemovesClosureAsReturnStatement() {
@@ -9537,7 +9537,7 @@ class RedundancyTests: RulesTests {
 
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, [output], rules: [.redundantClosure],
-                       options: options, exclude: ["redundantReturn", "indent"])
+                       options: options, exclude: [.redundantReturn, .indent])
     }
 
     func testRedundantClosureRemovesClosureAsImplicitReturnStatement() {
@@ -9564,7 +9564,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.indent])
     }
 
     func testClosureNotRemovedAroundIfExpressionInGuard() {
@@ -9715,7 +9715,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.10")
-        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: ["indent", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .redundantClosure, options: options, exclude: [.indent, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantClosureDoesntBreakBuildWithRedundantReturnRuleDisabled() {
@@ -9741,7 +9741,7 @@ class RedundancyTests: RulesTests {
 
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, output, rule: .redundantClosure, options: options,
-                       exclude: ["redundantReturn", "blankLinesBetweenScopes", "propertyType"])
+                       exclude: [.redundantReturn, .blankLinesBetweenScopes, .propertyType])
     }
 
     func testRedundantClosureWithSwitchExpressionDoesntBreakBuildWithRedundantReturnRuleDisabled() {
@@ -9781,8 +9781,8 @@ class RedundancyTests: RulesTests {
                        rules: [.redundantReturn, .conditionalAssignment,
                                .redundantClosure],
                        options: options,
-                       exclude: ["indent", "blankLinesBetweenScopes", "wrapMultilineConditionalAssignment",
-                                 "propertyType"])
+                       exclude: [.indent, .blankLinesBetweenScopes, .wrapMultilineConditionalAssignment,
+                                 .propertyType])
     }
 
     func testRemovesRedundantClosureWithGenericExistentialTypes() {
@@ -9911,7 +9911,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options, exclude: ["elseOnSameLine"])
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options, exclude: [.elseOnSameLine])
     }
 
     func testRemovesMultipleOptionalBindings() {
@@ -10010,7 +10010,7 @@ class RedundancyTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, rule: .redundantOptionalBinding, options: options, exclude: ["redundantSelf"])
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options, exclude: [.redundantSelf])
     }
 
     func testRedundantSelfAndRedundantOptionalTogether() {
@@ -10119,7 +10119,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .redundantInternal, exclude: ["redundantExtensionACL"])
+        testFormatting(for: input, output, rule: .redundantInternal, exclude: [.redundantExtensionACL])
     }
 
     func testPreserveInternalImport() {
@@ -10155,7 +10155,7 @@ class RedundancyTests: RulesTests {
         func myMethod(consuming foo: Foo, borrowing bars: [Bar]) {}
         """
 
-        testFormatting(for: input, output, rule: .noExplicitOwnership, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .noExplicitOwnership, exclude: [.unusedArguments])
     }
 
     func testRemovesOwnershipKeywordsFromClosure() {
@@ -10179,7 +10179,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .noExplicitOwnership, exclude: ["unusedArguments"])
+        testFormatting(for: input, output, rule: .noExplicitOwnership, exclude: [.unusedArguments])
     }
 
     func testRemovesOwnershipKeywordsFromType() {
@@ -10212,7 +10212,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .redundantProperty, exclude: ["redundantReturn"])
+        testFormatting(for: input, output, rule: .redundantProperty, exclude: [.redundantReturn])
     }
 
     func testRemovesRedundantPropertyWithIfExpression() {
@@ -10287,7 +10287,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, [output], rules: [.propertyType, .redundantProperty, .redundantInit], exclude: ["redundantReturn"])
+        testFormatting(for: input, [output], rules: [.propertyType, .redundantProperty, .redundantInit], exclude: [.redundantReturn])
     }
 
     func testRemovesRedundantPropertyWithComments() {
@@ -10308,7 +10308,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .redundantProperty, exclude: ["redundantReturn"])
+        testFormatting(for: input, output, rule: .redundantProperty, exclude: [.redundantReturn])
     }
 
     func testRemovesRedundantPropertyFollowingOtherProperty() {
@@ -10538,7 +10538,7 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, output, rule: .unusedPrivateDeclaration, exclude: ["emptyBraces"])
+        testFormatting(for: input, output, rule: .unusedPrivateDeclaration, exclude: [.emptyBraces])
     }
 
     func testDoNotRemoveFilePrivateUsedInNestedStruct() {
@@ -10599,7 +10599,7 @@ class RedundancyTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .unusedPrivateDeclaration, exclude: ["emptyBraces"])
+        testFormatting(for: input, output, rule: .unusedPrivateDeclaration, exclude: [.emptyBraces])
     }
 
     func testRemovePrivateDeclarationButDoNotRemovePrivateExtension() {
@@ -10640,7 +10640,7 @@ class RedundancyTests: RulesTests {
             static let foo = Foo()
         }
         """
-        testFormatting(for: input, rule: .unusedPrivateDeclaration, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .unusedPrivateDeclaration, exclude: [.propertyType])
     }
 
     func testCanDisableUnusedPrivateDeclarationRule() {
@@ -10698,7 +10698,7 @@ class RedundancyTests: RulesTests {
             }
         }
         """
-        testFormatting(for: input, rule: .unusedPrivateDeclaration, exclude: ["redundantBackticks"])
+        testFormatting(for: input, rule: .unusedPrivateDeclaration, exclude: [.redundantBackticks])
     }
 
     func testDoNotRemovePreservedPrivateDeclarations() {

--- a/Tests/RulesTests+Spacing.swift
+++ b/Tests/RulesTests+Spacing.swift
@@ -73,12 +73,12 @@ class SpacingTests: RulesTests {
 
     func testSpaceBetweenParenAndAs() {
         let input = "(foo.bar) as? String"
-        testFormatting(for: input, rule: .spaceAroundParens, exclude: ["redundantParens"])
+        testFormatting(for: input, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testNoSpaceAfterParenAtEndOfFile() {
         let input = "(foo.bar)"
-        testFormatting(for: input, rule: .spaceAroundParens, exclude: ["redundantParens"])
+        testFormatting(for: input, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testSpaceBetweenParenAndFoo() {
@@ -160,19 +160,19 @@ class SpacingTests: RulesTests {
     func testAddSpaceBetweenCaptureListAndArguments() {
         let input = "{ [weak self](foo) in print(foo) }"
         let output = "{ [weak self] (foo) in print(foo) }"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments2() {
         let input = "{ [weak self]() -> Void in }"
         let output = "{ [weak self] () -> Void in }"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments3() {
         let input = "{ [weak self]() throws -> Void in }"
         let output = "{ [weak self] () throws -> Void in }"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments4() {
@@ -196,13 +196,13 @@ class SpacingTests: RulesTests {
     func testAddSpaceBetweenCaptureListAndArguments7() {
         let input = "Foo<Bar>(0) { [weak self]() -> Void in }"
         let output = "Foo<Bar>(0) { [weak self] () -> Void in }"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments8() {
         let input = "{ [weak self]() throws(Foo) -> Void in }"
         let output = "{ [weak self] () throws(Foo) -> Void in }"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenEscapingAndParenthesizedClosure() {
@@ -226,13 +226,13 @@ class SpacingTests: RulesTests {
     func testNoSpaceBetweenClosingBraceAndParens() {
         let input = "{ block } ()"
         let output = "{ block }()"
-        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: ["redundantClosure"])
+        testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantClosure])
     }
 
     func testDontRemoveSpaceBetweenOpeningBraceAndParens() {
         let input = "a = (b + c)"
         testFormatting(for: input, rule: .spaceAroundParens,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testKeywordAsIdentifierParensSpacing() {
@@ -332,7 +332,7 @@ class SpacingTests: RulesTests {
         let input = "func foo(_: borrowing(any Foo)) {}"
         let output = "func foo(_: borrowing (any Foo)) {}"
         testFormatting(for: input, output, rule: .spaceAroundParens,
-                       exclude: ["noExplicitOwnership"])
+                       exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenParenAndIsolated() {
@@ -435,14 +435,14 @@ class SpacingTests: RulesTests {
         let input = "func foo(arg _: consuming[String]) {}"
         let output = "func foo(arg _: consuming [String]) {}"
         testFormatting(for: input, output, rule: .spaceAroundBrackets,
-                       exclude: ["noExplicitOwnership"])
+                       exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenBorrowingAndStringArray() {
         let input = "func foo(arg _: borrowing[String]) {}"
         let output = "func foo(arg _: borrowing [String]) {}"
         testFormatting(for: input, output, rule: .spaceAroundBrackets,
-                       exclude: ["noExplicitOwnership"])
+                       exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenSendingAndStringArray() {
@@ -478,13 +478,13 @@ class SpacingTests: RulesTests {
         let input = "if x{ y }else{ z }"
         let output = "if x { y } else { z }"
         testFormatting(for: input, output, rule: .spaceAroundBraces,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testNoSpaceAroundClosureInsiderParens() {
         let input = "foo({ $0 == 5 })"
         testFormatting(for: input, rule: .spaceAroundBraces,
-                       exclude: ["trailingClosures"])
+                       exclude: [.trailingClosures])
     }
 
     func testNoExtraSpaceAroundBracesAtStartOrEndOfFile() {
@@ -531,17 +531,17 @@ class SpacingTests: RulesTests {
     func testSpaceInsideBraces() {
         let input = "foo({bar})"
         let output = "foo({ bar })"
-        testFormatting(for: input, output, rule: .spaceInsideBraces, exclude: ["trailingClosures"])
+        testFormatting(for: input, output, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoExtraSpaceInsidebraces() {
         let input = "{ foo }"
-        testFormatting(for: input, rule: .spaceInsideBraces, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoSpaceAddedInsideEmptybraces() {
         let input = "foo({})"
-        testFormatting(for: input, rule: .spaceInsideBraces, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoSpaceAddedBetweenDoublebraces() {
@@ -559,7 +559,7 @@ class SpacingTests: RulesTests {
 
     func testSpaceAroundGenericsFollowedByAndOperator() {
         let input = "if foo is Foo<Bar> && baz {}"
-        testFormatting(for: input, rule: .spaceAroundGenerics, exclude: ["andOperator"])
+        testFormatting(for: input, rule: .spaceAroundGenerics, exclude: [.andOperator])
     }
 
     func testSpaceAroundGenericResultBuilder() {
@@ -649,7 +649,7 @@ class SpacingTests: RulesTests {
     func testNoRemoveSpaceAroundEnumInBrackets() {
         let input = "[ .red ]"
         testFormatting(for: input, rule: .spaceAroundOperators,
-                       exclude: ["spaceInsideBrackets"])
+                       exclude: [.spaceInsideBrackets])
     }
 
     func testSpaceBetweenSemicolonAndEnumValue() {
@@ -695,7 +695,7 @@ class SpacingTests: RulesTests {
         let input = "print(foo\n      ,bar)"
         let output = "print(foo\n      , bar)"
         testFormatting(for: input, output, rule: .spaceAroundOperators,
-                       exclude: ["leadingDelimiters"])
+                       exclude: [.leadingDelimiters])
     }
 
     func testSpaceAroundInfixMinus() {
@@ -882,14 +882,14 @@ class SpacingTests: RulesTests {
         let input = "foo/* hello */-bar"
         let output = "foo/* hello */ -bar"
         testFormatting(for: input, output, rule: .spaceAroundOperators,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundCommentsInInfixExpression() {
         let input = "a/* */+/* */b"
         let output = "a/* */ + /* */b"
         testFormatting(for: input, output, rule: .spaceAroundOperators,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundCommentInPrefixExpression() {
@@ -962,7 +962,7 @@ class SpacingTests: RulesTests {
 
     func testNoAddSpaceAroundOperatorInsideParens() {
         let input = "(!=)"
-        testFormatting(for: input, rule: .spaceAroundOperators, exclude: ["redundantParens"])
+        testFormatting(for: input, rule: .spaceAroundOperators, exclude: [.redundantParens])
     }
 
     func testSpaceAroundPlusBeforeHash() {
@@ -1077,28 +1077,28 @@ class SpacingTests: RulesTests {
         let input = "let range = 0 +\n4"
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testSpaceOnOneSideOfPlusMatchedByLinebreakNotRemoved2() {
         let input = "let range = 0\n+ 4"
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testSpaceAroundPlusWithLinebreakOnOneSideNotRemoved() {
         let input = "let range = 0 + \n4"
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent", "trailingSpace"])
+                       exclude: [.indent, .trailingSpace])
     }
 
     func testSpaceAroundPlusWithLinebreakOnOneSideNotRemoved2() {
         let input = "let range = 0\n + 4"
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testAddSpaceEvenAfterLHSClosure() {
@@ -1198,56 +1198,56 @@ class SpacingTests: RulesTests {
         let input = "let range = 0 .../* foo */4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByCommentNotRemoved2() {
         let input = "let range = 0/* foo */... 4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved() {
         let input = "let range = 0 ... /* foo */4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved2() {
         let input = "let range = 0/* foo */ ... 4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["spaceAroundComments"])
+                       exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved() {
         let input = "let range = 0 ...\n4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved2() {
         let input = "let range = 0\n... 4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved() {
         let input = "let range = 0 ... \n4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent", "trailingSpace"])
+                       exclude: [.indent, .trailingSpace])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved2() {
         let input = "let range = 0\n ... 4"
         let options = FormatOptions(spaceAroundRangeOperators: false)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
-                       exclude: ["indent"])
+                       exclude: [.indent])
     }
 
     func testSpaceNotRemovedAroundRangeFollowedByPrefixOperator() {
@@ -1325,7 +1325,7 @@ class SpacingTests: RulesTests {
         let input = "(/* foo */)"
         let output = "( /* foo */ )"
         testFormatting(for: input, output, rule: .spaceAroundComments,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testNoSpaceAroundCommentAtStartAndEndOfFile() {
@@ -1373,7 +1373,7 @@ class SpacingTests: RulesTests {
     func testSpaceInsideMultilineHeaderdocComment() {
         let input = "/**foo\n bar*/"
         let output = "/** foo\n bar */"
-        testFormatting(for: input, output, rule: .spaceInsideComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testSpaceInsideMultilineHeaderdocCommentType2() {
@@ -1390,7 +1390,7 @@ class SpacingTests: RulesTests {
 
     func testNoExtraSpaceInsideMultilineHeaderdocComment() {
         let input = "/** foo\n bar */"
-        testFormatting(for: input, rule: .spaceInsideComments, exclude: ["docComments"])
+        testFormatting(for: input, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testNoExtraSpaceInsideMultilineHeaderdocCommentType2() {
@@ -1433,7 +1433,7 @@ class SpacingTests: RulesTests {
 
     func testNoSpaceAddedToFirstLineOfDocComment() {
         let input = "/**\n Comment\n */"
-        testFormatting(for: input, rule: .spaceInsideComments, exclude: ["docComments"])
+        testFormatting(for: input, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testNoSpaceAddedToEmptyDocComment() {
@@ -1451,7 +1451,7 @@ class SpacingTests: RulesTests {
             func bar() {}
         }
         """
-        testFormatting(for: input, rule: .spaceInsideComments, exclude: ["indent"])
+        testFormatting(for: input, rule: .spaceInsideComments, exclude: [.indent])
     }
 
     // MARK: - consecutiveSpaces
@@ -1537,7 +1537,7 @@ class SpacingTests: RulesTests {
     func testTrailingSpaceInArray() {
         let input = "let foo = [\n    1,\n    \n    2,\n]"
         let output = "let foo = [\n    1,\n\n    2,\n]"
-        testFormatting(for: input, output, rule: .trailingSpace, exclude: ["redundantSelf"])
+        testFormatting(for: input, output, rule: .trailingSpace, exclude: [.redundantSelf])
     }
 
     // truncateBlankLines = false
@@ -1788,7 +1788,7 @@ class SpacingTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .blankLineAfterSwitchCase, exclude: ["sortSwitchCases", "wrapSwitchCases", "blockComments"])
+        testFormatting(for: input, rule: .blankLineAfterSwitchCase, exclude: [.sortSwitchCases, .wrapSwitchCases, .blockComments])
     }
 
     func testMixedSingleLineAndMultiLineCases() {
@@ -1829,7 +1829,7 @@ class SpacingTests: RulesTests {
             energyShields.engage()
         }
         """
-        testFormatting(for: input, output, rule: .blankLineAfterSwitchCase, exclude: ["consistentSwitchCaseSpacing"])
+        testFormatting(for: input, output, rule: .blankLineAfterSwitchCase, exclude: [.consistentSwitchCaseSpacing])
     }
 
     func testAllowsBlankLinesAfterSingleLineCases() {
@@ -2166,6 +2166,6 @@ class SpacingTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, rule: .consistentSwitchCaseSpacing, exclude: ["blankLineAfterSwitchCase"])
+        testFormatting(for: input, rule: .consistentSwitchCaseSpacing, exclude: [.blankLineAfterSwitchCase])
     }
 }

--- a/Tests/RulesTests+Syntax.swift
+++ b/Tests/RulesTests+Syntax.swift
@@ -62,7 +62,7 @@ class SyntaxTests: RulesTests {
         /// TODO: foo
         /// Some more docs
         """
-        testFormatting(for: input, rule: .todos, exclude: ["docComments"])
+        testFormatting(for: input, rule: .todos, exclude: [.docComments])
     }
 
     func testTodoNotReplacedAtStartOfDocBlock() {
@@ -70,7 +70,7 @@ class SyntaxTests: RulesTests {
         /// TODO: foo
         /// Some docs
         """
-        testFormatting(for: input, rule: .todos, exclude: ["docComments"])
+        testFormatting(for: input, rule: .todos, exclude: [.docComments])
     }
 
     func testTodoNotReplacedAtEndOfDocBlock() {
@@ -78,7 +78,7 @@ class SyntaxTests: RulesTests {
         /// Some docs
         /// TODO: foo
         """
-        testFormatting(for: input, rule: .todos, exclude: ["docComments"])
+        testFormatting(for: input, rule: .todos, exclude: [.docComments])
     }
 
     func testMarkWithNoSpaceAfterColon() {
@@ -197,7 +197,7 @@ class SyntaxTests: RulesTests {
 
     func testAnonymousVoidArgumentNotConvertedToEmptyParens() {
         let input = "{ (_: Void) -> Void in }"
-        testFormatting(for: input, rule: .void, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, rule: .void, exclude: [.redundantVoidReturnType])
     }
 
     func testFuncWithAnonymousVoidArgumentNotStripped() {
@@ -256,12 +256,12 @@ class SyntaxTests: RulesTests {
     func testEmptyClosureReturnValueConvertedToVoid() {
         let input = "{ () -> () in }"
         let output = "{ () -> Void in }"
-        testFormatting(for: input, output, rule: .void, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .void, exclude: [.redundantVoidReturnType])
     }
 
     func testAnonymousVoidClosureNotChanged() {
         let input = "{ (_: Void) in }"
-        testFormatting(for: input, rule: .void, exclude: ["unusedArguments"])
+        testFormatting(for: input, rule: .void, exclude: [.unusedArguments])
     }
 
     func testVoidLiteralConvertedToParens() {
@@ -379,7 +379,7 @@ class SyntaxTests: RulesTests {
         let input = "{ () -> Void in }"
         let output = "{ () -> () in }"
         let options = FormatOptions(useVoid: false)
-        testFormatting(for: input, output, rule: .void, options: options, exclude: ["redundantVoidReturnType"])
+        testFormatting(for: input, output, rule: .void, options: options, exclude: [.redundantVoidReturnType])
     }
 
     func testNoConvertVoidSelfToTuple() {
@@ -437,7 +437,7 @@ class SyntaxTests: RulesTests {
     func testClosureArgumentAfterLinebreakInGuardNotMadeTrailing() {
         let input = "guard let foo =\n    bar({ /* some code */ })\nelse { return }"
         testFormatting(for: input, rule: .trailingClosures,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testClosureMadeTrailingForNumericTupleMember() {
@@ -488,7 +488,7 @@ class SyntaxTests: RulesTests {
     func testParensAroundTrailingClosureInGuardCaseLetNotRemoved() {
         let input = "guard case let .foo(bar) = baz.filter({ $0 == quux }).isEmpty else {}"
         testFormatting(for: input, rule: .trailingClosures,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testParensAroundTrailingClosureInWhereClauseLetNotRemoved() {
@@ -934,7 +934,7 @@ class SyntaxTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .enumNamespaces,
-                       exclude: ["modifierOrder"])
+                       exclude: [.modifierOrder])
     }
 
     func testOpenClassNotReplacedByEnum() {
@@ -1270,7 +1270,7 @@ class SyntaxTests: RulesTests {
         let input = "guard true && true\nelse { return }"
         let output = "guard true, true\nelse { return }"
         testFormatting(for: input, output, rule: .andOperator,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testWhileAndReplaced() {
@@ -1289,7 +1289,7 @@ class SyntaxTests: RulesTests {
         let input = "if true && (true && true) {}"
         let output = "if true, (true && true) {}"
         testFormatting(for: input, output, rule: .andOperator,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     func testIfFunctionAndReplaced() {
@@ -1345,13 +1345,13 @@ class SyntaxTests: RulesTests {
     func testHandleAndAtStartOfLine() {
         let input = "if a == b\n    && b == c {}"
         let output = "if a == b,\n    b == c {}"
-        testFormatting(for: input, output, rule: .andOperator, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .andOperator, exclude: [.indent])
     }
 
     func testHandleAndAtStartOfLineAfterComment() {
         let input = "if a == b // foo\n    && b == c {}"
         let output = "if a == b, // foo\n    b == c {}"
-        testFormatting(for: input, output, rule: .andOperator, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .andOperator, exclude: [.indent])
     }
 
     func testNoReplaceAndOperatorWhereGenericsAmbiguous() {
@@ -1602,7 +1602,7 @@ class SyntaxTests: RulesTests {
         let output = "import Foundation\nprotocol Foo: AnyObject {}"
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, output, rule: .anyObjectProtocol, options: options,
-                       exclude: ["blankLineAfterImports"])
+                       exclude: [.blankLineAfterImports])
     }
 
     func testClassDeclarationNotReplacedByAnyObject() {
@@ -1806,7 +1806,7 @@ class SyntaxTests: RulesTests {
     func testOptionalTypeInsideCaseConvertedToSugar() {
         let input = "if case .some(Optional<Any>.some(let foo)) = bar else {}"
         let output = "if case .some(Any?.some(let foo)) = bar else {}"
-        testFormatting(for: input, output, rule: .typeSugar, exclude: ["hoistPatternLet"])
+        testFormatting(for: input, output, rule: .typeSugar, exclude: [.hoistPatternLet])
     }
 
     func testSwitchCaseOptionalNotReplaced() {
@@ -1833,17 +1833,17 @@ class SyntaxTests: RulesTests {
 
     func testAvoidSwiftParserBugWithClosuresInsideArrays() {
         let input = "var foo = Array<(_ image: Data?) -> Void>()"
-        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: ["propertyType"])
+        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyType])
     }
 
     func testAvoidSwiftParserBugWithClosuresInsideDictionaries() {
         let input = "var foo = Dictionary<String, (_ image: Data?) -> Void>()"
-        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: ["propertyType"])
+        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyType])
     }
 
     func testAvoidSwiftParserBugWithClosuresInsideOptionals() {
         let input = "var foo = Optional<(_ image: Data?) -> Void>()"
-        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: ["propertyType"])
+        testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyType])
     }
 
     func testDontOverApplyBugWorkaround() {
@@ -1871,21 +1871,21 @@ class SyntaxTests: RulesTests {
         let input = "var foo = Array<(image: Data?) -> Void>()"
         let output = "var foo = [(image: Data?) -> Void]()"
         let options = FormatOptions(shortOptionals: .always)
-        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyType])
     }
 
     func testDontOverApplyBugWorkaround5() {
         let input = "var foo = Array<(Data?) -> Void>()"
         let output = "var foo = [(Data?) -> Void]()"
         let options = FormatOptions(shortOptionals: .always)
-        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyType])
     }
 
     func testDontOverApplyBugWorkaround6() {
         let input = "var foo = Dictionary<Int, Array<(_ image: Data?) -> Void>>()"
         let output = "var foo = [Int: Array<(_ image: Data?) -> Void>]()"
         let options = FormatOptions(shortOptionals: .always)
-        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyType])
     }
 
     // MARK: - preferKeyPath
@@ -1919,7 +1919,7 @@ class SyntaxTests: RulesTests {
         let output = "let foo = bar.map(\\ . foo . bar)"
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
-                       options: options, exclude: ["spaceAroundOperators"])
+                       options: options, exclude: [.spaceAroundOperators])
     }
 
     func testMultilineMapPropertyToKeyPath() {
@@ -2080,7 +2080,7 @@ class SyntaxTests: RulesTests {
         struct ScreenID {}
         """
 
-        testFormatting(for: input, output, rule: .acronyms, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .acronyms, exclude: [.propertyType])
     }
 
     func testUppercaseCustomAcronym() {
@@ -2184,7 +2184,7 @@ class SyntaxTests: RulesTests {
         /// This is a documentation comment,
         /// not a standard comment.
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     func testBlockDocCommentsWithoutAsterisksOnEachLine() {
@@ -2198,7 +2198,7 @@ class SyntaxTests: RulesTests {
         /// This is a documentation comment,
         /// not a standard comment.
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     func testBlockCommentWithBulletPoints() {
@@ -2298,7 +2298,7 @@ class SyntaxTests: RulesTests {
             /// bar.
         }
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     func testLongBlockCommentsWithoutPerLineMarkersFullyConverted() {
@@ -2362,7 +2362,7 @@ class SyntaxTests: RulesTests {
         /// Line 3.
         foo(bar)
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     func testBlockCommentImmediatelyFollowedByCode3() {
@@ -2376,7 +2376,7 @@ class SyntaxTests: RulesTests {
         // bar
         func foo() {}
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     func testBlockCommentFollowedByBlankLine() {
@@ -2396,7 +2396,7 @@ class SyntaxTests: RulesTests {
 
         func foo() {}
         """
-        testFormatting(for: input, output, rule: .blockComments, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .blockComments, exclude: [.docComments])
     }
 
     // MARK: - opaqueGenericParameters
@@ -2912,7 +2912,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Array<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testUpdatesOptionalGenericExtensionToAngleBracketSyntax() {
@@ -2920,7 +2920,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Optional<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testUpdatesArrayGenericExtensionToAngleBracketSyntaxWithSelf() {
@@ -2928,7 +2928,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Array<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testUpdatesArrayWithGenericElement() {
@@ -2936,7 +2936,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Array<Foo<Bar>> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testUpdatesDictionaryGenericExtensionToAngleBracketSyntax() {
@@ -2944,7 +2944,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Dictionary<Foo, Bar> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testRequiresAllGenericTypesToBeProvided() {
@@ -2960,7 +2960,7 @@ class SyntaxTests: RulesTests {
         let output = "extension Array<[[Foo: Bar]]> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: ["typeSugar"])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
     }
 
     func testDoesntUpdateIneligibleConstraints() {
@@ -3178,7 +3178,7 @@ class SyntaxTests: RulesTests {
         let output = "func f<T>(x: some B) -> T where T: A {}"
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .opaqueGenericParameters,
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     // MARK: docComments
@@ -3267,7 +3267,7 @@ class SyntaxTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .docComments,
-                       exclude: ["spaceInsideComments", "propertyType"])
+                       exclude: [.spaceInsideComments, .propertyType])
     }
 
     func testConvertDocCommentsToComments() {
@@ -3342,7 +3342,7 @@ class SyntaxTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .docComments,
-                       exclude: ["spaceInsideComments", "redundantProperty", "propertyType"])
+                       exclude: [.spaceInsideComments, .redundantProperty, .propertyType])
     }
 
     func testPreservesDocComments() {
@@ -3419,7 +3419,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(preserveDocComments: true)
-        testFormatting(for: input, output, rule: .docComments, options: options, exclude: ["spaceInsideComments", "redundantProperty", "propertyType"])
+        testFormatting(for: input, output, rule: .docComments, options: options, exclude: [.spaceInsideComments, .redundantProperty, .propertyType])
     }
 
     func testDoesntConvertCommentBeforeConsecutivePropertiesToDocComment() {
@@ -3782,7 +3782,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["redundantType", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.redundantType, .wrapMultilineConditionalAssignment])
     }
 
     func testConvertsSimpleSwitchStatementAssignment() {
@@ -3804,7 +3804,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["redundantType", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.redundantType, .wrapMultilineConditionalAssignment])
     }
 
     func testConvertsTrivialSwitchStatementAssignment() {
@@ -3822,7 +3822,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testConvertsNestedIfAndStatementAssignments() {
@@ -3874,7 +3874,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["redundantType", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.redundantType, .wrapMultilineConditionalAssignment])
     }
 
     func testConvertsIfStatementAssignmentPreservingComment() {
@@ -3897,7 +3897,7 @@ class SyntaxTests: RulesTests {
         }
         """
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["indent", "redundantType", "wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.indent, .redundantType, .wrapMultilineConditionalAssignment])
     }
 
     func testDoesntConvertsIfStatementAssigningMultipleProperties() {
@@ -4153,7 +4153,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     // TODO: update branches parser to handle this case properly
@@ -4232,7 +4232,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.10")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.wrapMultilineConditionalAssignment])
     }
 
     func testConvertsSwitchWithDefaultCase() {
@@ -4260,7 +4260,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment", "redundantType"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.wrapMultilineConditionalAssignment, .redundantType])
     }
 
     func testConvertsSwitchWithUnknownDefaultCase() {
@@ -4288,7 +4288,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(swiftVersion: "5.9")
-        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: ["wrapMultilineConditionalAssignment", "redundantType"])
+        testFormatting(for: input, output, rule: .conditionalAssignment, options: options, exclude: [.wrapMultilineConditionalAssignment, .redundantType])
     }
 
     func testPreservesSwitchWithReturnInDefaultCase() {
@@ -4617,7 +4617,7 @@ class SyntaxTests: RulesTests {
         potatoes.forEach({ $0.bake() })
         """
 
-        testFormatting(for: input, output, rule: .preferForLoop, exclude: ["trailingClosures"])
+        testFormatting(for: input, output, rule: .preferForLoop, exclude: [.trailingClosures])
     }
 
     func testNoConvertAnonymousForEachToForLoop() {
@@ -4631,7 +4631,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(preserveAnonymousForEach: true, preserveSingleLineForEach: false)
-        testFormatting(for: input, rule: .preferForLoop, options: options, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .preferForLoop, options: options, exclude: [.trailingClosures])
     }
 
     func testConvertSingleLineForEachToForLoop() {
@@ -4640,7 +4640,7 @@ class SyntaxTests: RulesTests {
 
         let options = FormatOptions(preserveSingleLineForEach: false)
         testFormatting(for: input, output, rule: .preferForLoop, options: options,
-                       exclude: ["wrapLoopBodies"])
+                       exclude: [.wrapLoopBodies])
     }
 
     func testConvertSingleLineAnonymousForEachToForLoop() {
@@ -4649,7 +4649,7 @@ class SyntaxTests: RulesTests {
 
         let options = FormatOptions(preserveSingleLineForEach: false)
         testFormatting(for: input, output, rule: .preferForLoop, options: options,
-                       exclude: ["wrapLoopBodies"])
+                       exclude: [.wrapLoopBodies])
     }
 
     func testConvertNestedForEach() {
@@ -4856,7 +4856,7 @@ class SyntaxTests: RulesTests {
             print(item)
         }
         """
-        testFormatting(for: input, output, rule: .preferForLoop, exclude: ["redundantParens"])
+        testFormatting(for: input, output, rule: .preferForLoop, exclude: [.redundantParens])
     }
 
     func testPreservesForEachAfterMultilineChain() {
@@ -4871,7 +4871,7 @@ class SyntaxTests: RulesTests {
             .map({ $0.uppercased() })
             .forEach({ print($0) })
         """
-        testFormatting(for: input, rule: .preferForLoop, exclude: ["trailingClosures"])
+        testFormatting(for: input, rule: .preferForLoop, exclude: [.trailingClosures])
     }
 
     func testPreservesChainWithClosure() {
@@ -5111,7 +5111,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(redundantType: .explicit)
-        testFormatting(for: input, rule: .propertyType, options: options, exclude: ["void"])
+        testFormatting(for: input, rule: .propertyType, options: options, exclude: [.void])
     }
 
     func testPreservesExplicitTypeIfUsingLocalValueOrLiteral() {
@@ -5126,7 +5126,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(redundantType: .inferred)
-        testFormatting(for: input, rule: .propertyType, options: options, exclude: ["redundantType"])
+        testFormatting(for: input, rule: .propertyType, options: options, exclude: [.redundantType])
     }
 
     func testCompatibleWithRedundantTypeInferred() {
@@ -5394,7 +5394,7 @@ class SyntaxTests: RulesTests {
         """
 
         let options = FormatOptions(redundantType: .inferLocalsOnly, preserveSymbols: ["init"])
-        testFormatting(for: input, output, rule: .propertyType, options: options, exclude: ["redundantInit"])
+        testFormatting(for: input, output, rule: .propertyType, options: options, exclude: [.redundantInit])
     }
 
     func testClosureBodyIsConsideredLocal() {
@@ -5618,7 +5618,7 @@ class SyntaxTests: RulesTests {
         }
         """
 
-        testFormatting(for: input, output, rule: .docCommentsBeforeAttributes, exclude: ["blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+        testFormatting(for: input, output, rule: .docCommentsBeforeAttributes, exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     func testPreservesCommentsBetweenAttributes() {
@@ -5648,7 +5648,7 @@ class SyntaxTests: RulesTests {
         func bar() {}
         """
 
-        testFormatting(for: input, output, rule: .docCommentsBeforeAttributes, exclude: ["docComments"])
+        testFormatting(for: input, output, rule: .docCommentsBeforeAttributes, exclude: [.docComments])
     }
 
     func testPreservesCommentOnSameLineAsAttribute() {
@@ -5657,7 +5657,7 @@ class SyntaxTests: RulesTests {
         func foo() {}
         """
 
-        testFormatting(for: input, rule: .docCommentsBeforeAttributes, exclude: ["docComments"])
+        testFormatting(for: input, rule: .docCommentsBeforeAttributes, exclude: [.docComments])
     }
 
     func testPreservesRegularComments() {
@@ -5667,7 +5667,7 @@ class SyntaxTests: RulesTests {
         func foo() {}
         """
 
-        testFormatting(for: input, rule: .docCommentsBeforeAttributes, exclude: ["docComments"])
+        testFormatting(for: input, rule: .docCommentsBeforeAttributes, exclude: [.docComments])
     }
 
     func testCombinesWithDocCommentsRule() {

--- a/Tests/RulesTests+Wrapping.swift
+++ b/Tests/RulesTests+Wrapping.swift
@@ -16,25 +16,25 @@ class WrappingTests: RulesTests {
         let input = "if true {\n    1\n}\nelse { 2 }"
         let output = "if true {\n    1\n} else { 2 }"
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnSameLineOnlyAppliedToDanglingBrace() {
         let input = "if true { 1 }\nelse { 2 }"
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testGuardNotAffectedByElseOnSameLine() {
         let input = "guard true\nelse { return }"
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnSameLineDoesntEatPreviousStatement() {
         let input = "if true {}\nguard true else { return }"
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testElseNotOnSameLineForAllman() {
@@ -42,7 +42,7 @@ class WrappingTests: RulesTests {
         let output = "if true\n{\n    1\n}\nelse { 2 }"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnNextLineOption() {
@@ -50,14 +50,14 @@ class WrappingTests: RulesTests {
         let output = "if true {\n    1\n}\nelse { 2 }"
         let options = FormatOptions(elseOnNextLine: true)
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testGuardNotAffectedByElseOnSameLineForAllman() {
         let input = "guard true else { return }"
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testRepeatWhileNotOnSameLineForAllman() {
@@ -113,7 +113,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(elseOnNextLine: false)
         testFormatting(for: input, rule: .elseOnSameLine, options: options,
-                       exclude: ["braces"])
+                       exclude: [.braces])
     }
 
     // guardelse = auto
@@ -121,20 +121,20 @@ class WrappingTests: RulesTests {
     func testSingleLineGuardElseNotWrappedByDefault() {
         let input = "guard foo = bar else {}"
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseNotUnwrappedByDefault() {
         let input = "guard foo = bar\nelse {}"
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseWrappedByDefaultIfBracesOnNextLine() {
         let input = "guard foo = bar else\n{}"
         let output = "guard foo = bar\nelse {}"
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testMultilineGuardElseNotWrappedByDefault() {
@@ -145,7 +145,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .elseOnSameLine,
-                       exclude: ["wrapMultilineStatementBraces"])
+                       exclude: [.wrapMultilineStatementBraces])
     }
 
     func testMultilineGuardElseWrappedByDefaultIfBracesOnNextLine() {
@@ -194,14 +194,14 @@ class WrappingTests: RulesTests {
         let input = "guard foo = bar else {}"
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseNotUnwrapped() {
         let input = "guard foo = bar\nelse {}"
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseWrappedIfBracesOnNextLine() {
@@ -209,7 +209,7 @@ class WrappingTests: RulesTests {
         let output = "guard foo = bar\nelse {}"
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testMultilineGuardElseWrapped() {
@@ -228,7 +228,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapMultilineStatementBraces"])
+                       options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testMultilineGuardElseEndingInParen() {
@@ -269,7 +269,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(guardElsePosition: .sameLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
-                       options: options, exclude: ["wrapMultilineStatementBraces"])
+                       options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testGuardElseUnwrappedIfBracesOnNextLine() {
@@ -397,13 +397,13 @@ class WrappingTests: RulesTests {
     func testEmptyGuardReturnWithSpaceDoesNothing() {
         let input = "guard let foo = bar else { }"
         testFormatting(for: input, rule: .wrapConditionalBodies,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testEmptyGuardReturnWithoutSpaceDoesNothing() {
         let input = "guard let foo = bar else {}"
         testFormatting(for: input, rule: .wrapConditionalBodies,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testGuardReturnWithValueWraps() {
@@ -457,7 +457,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .wrapConditionalBodies,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testGuardReturnOnNewlineUnchanged() {
@@ -579,13 +579,13 @@ class WrappingTests: RulesTests {
     func testEmptyIfElseBodiesWithSpaceDoNothing() {
         let input = "if foo { } else if baz { } else { }"
         testFormatting(for: input, rule: .wrapConditionalBodies,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testEmptyIfElseBodiesWithoutSpaceDoNothing() {
         let input = "if foo {} else if baz {} else {}"
         testFormatting(for: input, rule: .wrapConditionalBodies,
-                       exclude: ["emptyBraces"])
+                       exclude: [.emptyBraces])
     }
 
     func testGuardElseBraceStartingOnDifferentLine() {
@@ -601,7 +601,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .wrapConditionalBodies,
-                       exclude: ["braces", "indent", "elseOnSameLine"])
+                       exclude: [.braces, .indent, .elseOnSameLine])
     }
 
     func testIfElseBracesStartingOnDifferentLines() {
@@ -628,7 +628,7 @@ class WrappingTests: RulesTests {
             }
         """
         testFormatting(for: input, output, rule: .wrapConditionalBodies,
-                       exclude: ["braces", "indent", "elseOnSameLine"])
+                       exclude: [.braces, .indent, .elseOnSameLine])
     }
 
     // MARK: - wrapLoopBodies
@@ -717,7 +717,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 20)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapClosure() {
@@ -807,7 +807,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 25)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidthWithXcodeIndentation() {
@@ -832,7 +832,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(xcodeIndentation: true, maxWidth: 25)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth2() {
@@ -848,7 +848,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 35)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth2WithXcodeIndentation() {
@@ -870,7 +870,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(xcodeIndentation: true, maxWidth: 35)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth2WithXcodeIndentation2() {
@@ -892,7 +892,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(xcodeIndentation: true, maxWidth: 35)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth3() {
@@ -908,7 +908,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 35)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth3WithXcodeIndentation() {
@@ -930,7 +930,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(xcodeIndentation: true, maxWidth: 35)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth4() {
@@ -946,7 +946,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 35)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapFunctionIfReturnTypeExceedsMaxWidth4WithXcodeIndentation() {
@@ -968,7 +968,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(xcodeIndentation: true, maxWidth: 35)
-        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, [output, output2], rules: [.wrap], options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapChainedFunctionAfterSubscriptCollection() {
@@ -1008,7 +1008,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 42)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testWrapTypedThrowingFunctionIfReturnTypeExceedsMaxWidth() {
@@ -1024,7 +1024,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(maxWidth: 42)
-        testFormatting(for: input, output, rule: .wrap, options: options, exclude: ["wrapMultilineStatementBraces"])
+        testFormatting(for: input, output, rule: .wrap, options: options, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testNoWrapInterpolatedStringLiteral() {
@@ -1040,14 +1040,14 @@ class WrappingTests: RulesTests {
         let output = "let foo =\n    bar+baz+quux"
         let options = FormatOptions(maxWidth: 15)
         testFormatting(for: input, output, rule: .wrap, options: options,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testNoWrapAtUnspacedEquals() {
         let input = "let foo=bar+baz+quux"
         let options = FormatOptions(maxWidth: 15)
         testFormatting(for: input, rule: .wrap, options: options,
-                       exclude: ["spaceAroundOperators"])
+                       exclude: [.spaceAroundOperators])
     }
 
     func testNoWrapSingleParameter() {
@@ -1109,7 +1109,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(maxWidth: 10)
         testFormatting(for: input, output, rule: .wrap, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testNoCrashWrap2() {
@@ -1137,7 +1137,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .preserve, maxWidth: 80)
         testFormatting(for: input, output, rule: .wrap, options: options,
-                       exclude: ["indent", "wrapArguments"])
+                       exclude: [.indent, .wrapArguments])
     }
 
     func testNoCrashWrap3() throws {
@@ -1410,7 +1410,7 @@ class WrappingTests: RulesTests {
             Thing(),
         ])
         """
-        testFormatting(for: input, output, rule: .wrapArguments, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapArguments, exclude: [.propertyType])
     }
 
     func testWrapArgumentsDoesntIndentTrailingComment() {
@@ -1593,7 +1593,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(wrapArguments: .beforeFirst)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.propertyType])
     }
 
     // MARK: wrapParameters
@@ -1682,7 +1682,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 20)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments", "wrap"])
+                       exclude: [.unusedArguments, .wrap])
     }
 
     func testWrapAfterFirstIfMaxLengthExceeded2() {
@@ -1696,7 +1696,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 20)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments", "wrap"])
+                       exclude: [.unusedArguments, .wrap])
     }
 
     func testWrapAfterFirstIfMaxLengthExceeded3() {
@@ -1709,7 +1709,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 32)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments", "wrap"])
+                       exclude: [.unusedArguments, .wrap])
     }
 
     func testWrapAfterFirstIfMaxLengthExceeded3WithWrap() {
@@ -1729,7 +1729,7 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 32)
         testFormatting(for: input, [output, output2],
                        rules: [.wrapArguments, .wrap],
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapAfterFirstIfMaxLengthExceeded4WithWrap() {
@@ -1744,7 +1744,7 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 31)
         testFormatting(for: input, [output],
                        rules: [.wrapArguments, .wrap],
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapAfterFirstIfMaxLengthExceededInClassScopeWithWrap() {
@@ -1772,7 +1772,7 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 31)
         testFormatting(for: input, [output, output2],
                        rules: [.wrapArguments, .wrap],
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapParametersListInClosureType() {
@@ -1813,7 +1813,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .afterFirst, maxWidth: 50)
         testFormatting(for: input, [input, output2], rules: [.wrapArguments],
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapParametersAfterFirstWithSeparatedArgumentLabels() {
@@ -1831,7 +1831,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments,
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     // MARK: beforeFirst
@@ -1961,7 +1961,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInClosureTypeAsFunctionParameterWithOtherParams() {
@@ -1980,7 +1980,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInClosureTypeAsFunctionParameterWithOtherParamsAfterWrappedClosure() {
@@ -1999,7 +1999,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInEscapingClosureTypeAsFunctionParameter() {
@@ -2018,7 +2018,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInNoEscapeClosureTypeAsFunctionParameter() {
@@ -2037,7 +2037,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInEscapingAutoclosureTypeAsFunctionParameter() {
@@ -2056,7 +2056,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output],
                        rules: [.wrapArguments],
                        options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     // MARK: beforeFirst, maxWidth
@@ -2073,7 +2073,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 20)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testNoWrapBeforeFirstIfMaxLengthNotExceeded() {
@@ -2082,7 +2082,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 42)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testNoWrapGenericsIfClosingBracketWithinMaxWidth() {
@@ -2097,7 +2097,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 20)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapAlreadyWrappedArgumentsIfMaxLengthExceeded() {
@@ -2114,7 +2114,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 26)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testWrapParametersBeforeFirstIfMaxLengthExceededInReturnType() {
@@ -2130,7 +2130,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 50)
         testFormatting(for: input, [input, output2], rules: [.wrapArguments],
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapParametersBeforeFirstWithSeparatedArgumentLabels() {
@@ -2148,7 +2148,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst)
         testFormatting(for: input, output, rule: .wrapArguments,
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testWrapParametersListBeforeFirstInClosureTypeWithMaxWidth() {
@@ -2185,35 +2185,35 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapParameters: .beforeFirst, maxWidth: 37)
         testFormatting(for: input, rule: .wrapArguments,
-                       options: options, exclude: ["unusedArguments"])
+                       options: options, exclude: [.unusedArguments])
     }
 
     func testNoWrapSubscriptWithSingleElement() {
         let input = "guard let foo = bar[0] {}"
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 20)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap"])
+                       exclude: [.wrap])
     }
 
     func testNoWrapArrayWithSingleElement() {
         let input = "let foo = [0]"
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 11)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap"])
+                       exclude: [.wrap])
     }
 
     func testNoWrapDictionaryWithSingleElement() {
         let input = "let foo = [bar: baz]"
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 15)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap"])
+                       exclude: [.wrap])
     }
 
     func testNoWrapImageLiteral() {
         let input = "if let image = #imageLiteral(resourceName: \"abc.png\") {}"
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 30)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap"])
+                       exclude: [.wrap])
     }
 
     func testNoWrapColorLiteral() {
@@ -2222,7 +2222,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 30)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap"])
+                       exclude: [.wrap])
     }
 
     func testWrapArgumentsNoIndentBlankLines() {
@@ -2235,7 +2235,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapCollections: .beforeFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["wrap", "blankLinesAtStartOfScope", "blankLinesAtEndOfScope"])
+                       exclude: [.wrap, .blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
 
     // MARK: closingParenPosition = true
@@ -2270,7 +2270,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(indent: "\t", wrapParameters: .afterFirst, tabWidth: 2)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     func testTabIndentWrappedFunctionWithoutSmartTabs() {
@@ -2285,7 +2285,7 @@ class WrappingTests: RulesTests {
         let options = FormatOptions(indent: "\t", wrapParameters: .afterFirst,
                                     tabWidth: 2, smartTabs: false)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments"])
+                       exclude: [.unusedArguments])
     }
 
     // MARK: - wrapArguments --wrapArguments
@@ -2346,7 +2346,7 @@ class WrappingTests: RulesTests {
             ) {}
         """
         let options = FormatOptions(wrapArguments: .afterFirst)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["indent"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.indent])
     }
 
     func testConsecutiveCodeCommentsNotIndented() {
@@ -2373,7 +2373,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .afterFirst, maxWidth: 20)
         testFormatting(for: input, output, rule: .wrapArguments, options: options,
-                       exclude: ["unusedArguments", "wrap"])
+                       exclude: [.unusedArguments, .wrap])
     }
 
     // MARK: beforeFirst
@@ -2382,7 +2382,7 @@ class WrappingTests: RulesTests {
         let input = "foo({\n    bar()\n})"
         let options = FormatOptions(wrapArguments: .beforeFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["trailingClosures"])
+                       exclude: [.trailingClosures])
     }
 
     func testNoMangleCommentedLinesWhenWrappingArguments() {
@@ -2429,7 +2429,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .preserve)
         testFormatting(for: input, rule: .wrapArguments,
-                       options: options, exclude: ["wrapConditionalBodies"])
+                       options: options, exclude: [.wrapConditionalBodies])
     }
 
     // MARK: - --wrapArguments, --wrapParameter
@@ -2444,7 +2444,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(wrapArguments: .beforeFirst, wrapParameters: .beforeFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options,
-                       exclude: ["redundantParens"])
+                       exclude: [.redundantParens])
     }
 
     // MARK: beforeFirst, maxWidth : string interpolation
@@ -2813,7 +2813,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 40)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_multipleTypealiases_beforeFirst() {
@@ -2836,7 +2836,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 45)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_afterFirst() {
@@ -2852,7 +2852,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 40)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_multipleTypealiases_afterFirst() {
@@ -2873,7 +2873,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 45)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth() {
@@ -2882,7 +2882,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 100)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently() {
@@ -2899,7 +2899,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently2() {
@@ -2921,7 +2921,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently3() {
@@ -2939,7 +2939,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistently4() {
@@ -2959,7 +2959,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .afterFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_shorterThanMaxWidth_butWrappedInconsistentlyWithComment() {
@@ -2979,7 +2979,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 200)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_singleTypePreserved() {
@@ -2988,7 +2988,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 10)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["wrap"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.wrap])
     }
 
     func testWrapArguments_typealias_preservesCommentsBetweenTypes() {
@@ -3003,7 +3003,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_preservesCommentsAfterTypes() {
@@ -3015,7 +3015,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 100)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     func testWrapArguments_typealias_withAssociatedType() {
@@ -3032,7 +3032,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapTypealiases: .beforeFirst, maxWidth: 50)
-        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: ["sortTypealiases"])
+        testFormatting(for: input, output, rule: .wrapArguments, options: options, exclude: [.sortTypealiases])
     }
 
     // MARK: - -return wrap-if-multiline
@@ -3181,7 +3181,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(wrapEffects: .never)
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.propertyType])
     }
 
     func testWrapEffectsNeverPreservesComments() {
@@ -3217,7 +3217,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .wrapArguments, options: options,
-            exclude: ["indent"]
+            exclude: [.indent]
         )
     }
 
@@ -3241,7 +3241,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .wrapArguments, options: options,
-            exclude: ["indent"]
+            exclude: [.indent]
         )
     }
 
@@ -3266,7 +3266,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(
             for: input, output, rule: .wrapArguments, options: options,
-            exclude: ["indent"]
+            exclude: [.indent]
         )
     }
 
@@ -3285,7 +3285,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(
             for: input, rule: .wrapArguments, options: options,
-            exclude: ["indent"]
+            exclude: [.indent]
         )
     }
 
@@ -3342,7 +3342,7 @@ class WrappingTests: RulesTests {
             wrapReturnType: .ifMultiline
         )
 
-        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .wrapArguments, options: options, exclude: [.propertyType])
     }
 
     func testPreserveReturnOnMultilineFunctionDeclarationByDefault() {
@@ -3397,7 +3397,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .wrapMultilineStatementBraces,
-                       exclude: ["wrapArguments", "unusedArguments"])
+                       exclude: [.wrapArguments, .unusedArguments])
     }
 
     func testMultilineInitBraceOnNextLine() {
@@ -3415,7 +3415,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .wrapMultilineStatementBraces,
-                       exclude: ["wrapArguments", "unusedArguments"])
+                       exclude: [.wrapArguments, .unusedArguments])
     }
 
     func testMultilineForLoopBraceOnNextLine() {
@@ -3479,7 +3479,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, output, rule: .wrapMultilineStatementBraces,
-                       exclude: ["braces", "elseOnSameLine"])
+                       exclude: [.braces, .elseOnSameLine])
     }
 
     func testInnerMultilineIfBraceOnNextLine() {
@@ -3512,7 +3512,7 @@ class WrappingTests: RulesTests {
             print("statement body")
         }
         """
-        testFormatting(for: input, rule: .wrapMultilineStatementBraces, exclude: ["propertyType"])
+        testFormatting(for: input, rule: .wrapMultilineStatementBraces, exclude: [.propertyType])
     }
 
     func testSingleLineIfBraceOnSameLine() {
@@ -3550,7 +3550,7 @@ class WrappingTests: RulesTests {
               let baz = quux else { return }
         """
         testFormatting(for: input, rule: .wrapMultilineStatementBraces,
-                       exclude: ["wrapConditionalBodies"])
+                       exclude: [.wrapConditionalBodies])
     }
 
     func testMultilineGuardBraceOnSameLineAsElse() {
@@ -3609,7 +3609,7 @@ class WrappingTests: RulesTests {
             closingParenPosition: .sameLine
         )
         testFormatting(for: input, output, rule: .wrapMultilineStatementBraces,
-                       options: options, exclude: ["indent"])
+                       options: options, exclude: [.indent])
     }
 
     func testMultilineBraceAppliedToTrailingClosure2_wrapBeforeFirst() {
@@ -3667,7 +3667,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [output], rules: [
             .wrapMultilineStatementBraces,
             .indent,
-        ], options: options, exclude: ["propertyType"])
+        ], options: options, exclude: [.propertyType])
     }
 
     func testMultilineBraceAppliedToTrailingClosure_wrapAfterFirst() {
@@ -3691,7 +3691,7 @@ class WrappingTests: RulesTests {
             closingParenPosition: .sameLine
         )
         testFormatting(for: input, output, rule: .wrapMultilineStatementBraces,
-                       options: options, exclude: ["indent"])
+                       options: options, exclude: [.indent])
     }
 
     func testMultilineBraceAppliedToGetterBody_wrapAfterFirst() {
@@ -3710,7 +3710,7 @@ class WrappingTests: RulesTests {
         testFormatting(for: input, [], rules: [
             .wrapMultilineStatementBraces,
             .wrapArguments,
-        ], options: options, exclude: ["propertyType"])
+        ], options: options, exclude: [.propertyType])
     }
 
     func testMultilineBraceAppliedToSubscriptBody() {
@@ -3728,7 +3728,7 @@ class WrappingTests: RulesTests {
             closingParenPosition: .sameLine
         )
         testFormatting(for: input, rule: .wrapMultilineStatementBraces,
-                       options: options, exclude: ["trailingClosures"])
+                       options: options, exclude: [.trailingClosures])
     }
 
     func testWrapsMultilineStatementConsistently() {
@@ -4036,7 +4036,7 @@ class WrappingTests: RulesTests {
             closingParenPosition: .sameLine
         )
         testFormatting(for: input, rule: .wrapMultilineStatementBraces,
-                       options: options, exclude: ["trailingClosures"])
+                       options: options, exclude: [.trailingClosures])
     }
 
     func testOpenBraceAfterEqualsInGuardNotWrapped() {
@@ -4054,7 +4054,7 @@ class WrappingTests: RulesTests {
             closingParenPosition: .sameLine
         )
         testFormatting(for: input, rules: [.wrapMultilineStatementBraces, .wrap],
-                       options: options, exclude: ["indent", "redundantClosure", "wrapConditionalBodies"])
+                       options: options, exclude: [.indent, .redundantClosure, .wrapConditionalBodies])
     }
 
     // MARK: wrapConditions before-first
@@ -4086,7 +4086,7 @@ class WrappingTests: RulesTests {
         testFormatting(
             for: input, rules: [.wrapArguments, .indent],
             options: FormatOptions(closingParenPosition: .sameLine, wrapConditions: .beforeFirst),
-            exclude: ["propertyType"]
+            exclude: [.propertyType]
         )
     }
 
@@ -4130,7 +4130,7 @@ class WrappingTests: RulesTests {
         testFormatting(
             for: input, output, rule: .wrapArguments,
             options: FormatOptions(indent: "  ", wrapConditions: .beforeFirst),
-            exclude: ["wrapConditionalBodies"]
+            exclude: [.wrapConditionalBodies]
         )
     }
 
@@ -4153,7 +4153,7 @@ class WrappingTests: RulesTests {
         testFormatting(
             for: input, rule: .wrapArguments,
             options: FormatOptions(indent: "  ", wrapConditions: .beforeFirst),
-            exclude: ["elseOnSameLine", "wrapConditionalBodies"]
+            exclude: [.elseOnSameLine, .wrapConditionalBodies]
         )
     }
 
@@ -4201,7 +4201,7 @@ class WrappingTests: RulesTests {
         testFormatting(
             for: input, output, rule: .wrapArguments,
             options: FormatOptions(indent: "  ", wrapConditions: .afterFirst),
-            exclude: ["wrapConditionalBodies"]
+            exclude: [.wrapConditionalBodies]
         )
     }
 
@@ -4244,7 +4244,7 @@ class WrappingTests: RulesTests {
         testFormatting(
             for: input, [output], rules: [.wrapArguments, .indent],
             options: FormatOptions(wrapConditions: .afterFirst),
-            exclude: ["wrapConditionalBodies"]
+            exclude: [.wrapConditionalBodies]
         )
     }
 
@@ -4463,7 +4463,7 @@ class WrappingTests: RulesTests {
             [output],
             rules: [.wrapArguments],
             options: FormatOptions(indent: "    ", conditionsWrap: .auto, maxWidth: 120),
-            exclude: ["wrapMultilineStatementBraces"]
+            exclude: [.wrapMultilineStatementBraces]
         )
     }
 
@@ -4579,7 +4579,7 @@ class WrappingTests: RulesTests {
         """
         let options = FormatOptions(funcAttributes: .prevLine)
         testFormatting(for: input, output, rule: .wrapAttributes,
-                       options: options, exclude: ["redundantObjc"])
+                       options: options, exclude: [.redundantObjc])
     }
 
     func testFuncAttributeStaysWrapped() {
@@ -4759,7 +4759,7 @@ class WrappingTests: RulesTests {
         let myClass = MyClass()
         """
         let options = FormatOptions(typeAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testClassImportAttributeNotTreatedAsType() {
@@ -4779,7 +4779,7 @@ class WrappingTests: RulesTests {
         private(set) dynamic var foo = Foo()
         """
         let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testWrapPrivateSetVarAttributes() {
@@ -4791,7 +4791,7 @@ class WrappingTests: RulesTests {
         private(set) dynamic var foo = Foo()
         """
         let options = FormatOptions(varAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testDontWrapPrivateSetVarAttributes() {
@@ -4803,7 +4803,7 @@ class WrappingTests: RulesTests {
         @objc private(set) dynamic var foo = Foo()
         """
         let options = FormatOptions(varAttributes: .prevLine, storedVarAttributes: .sameLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testWrapConvenienceInitAttribute() {
@@ -4968,7 +4968,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(storedVarAttributes: .prevLine, computedVarAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testComplexAttributesException() {
@@ -5039,7 +5039,7 @@ class WrappingTests: RulesTests {
         """
 
         let options = FormatOptions(storedVarAttributes: .sameLine, complexAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testEscapingClosureNotMistakenForComplexAttribute() {
@@ -5111,7 +5111,7 @@ class WrappingTests: RulesTests {
         }
         """
         let options = FormatOptions(varAttributes: .sameLine, storedVarAttributes: .sameLine, computedVarAttributes: .prevLine, complexAttributes: .prevLine)
-        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: ["propertyType"])
+        testFormatting(for: input, output, rule: .wrapAttributes, options: options, exclude: [.propertyType])
     }
 
     func testWrapOrDontAttributesInSwiftUIView() {
@@ -5343,7 +5343,7 @@ class WrappingTests: RulesTests {
         }
         """
         testFormatting(for: input, rule: .wrapEnumCases,
-                       exclude: ["hoistPatternLet"])
+                       exclude: [.hoistPatternLet])
     }
 
     func testNoMangleUnindentedEnumCases() {
@@ -5358,7 +5358,7 @@ class WrappingTests: RulesTests {
         case bar
         }
         """
-        testFormatting(for: input, output, rule: .wrapEnumCases, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .wrapEnumCases, exclude: [.indent])
     }
 
     func testNoMangleEnumCaseOnOpeningLine() {
@@ -5374,7 +5374,7 @@ class WrappingTests: RulesTests {
         case desc(String)
         }
         """
-        testFormatting(for: input, output, rule: .wrapEnumCases, exclude: ["indent"])
+        testFormatting(for: input, output, rule: .wrapEnumCases, exclude: [.indent])
     }
 
     func testNoWrapSingleLineEnumCases() {
@@ -5475,7 +5475,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
                        options: FormatOptions(maxWidth: 6),
-                       exclude: ["spaceInsideComments"])
+                       exclude: [.spaceInsideComments])
     }
 
     func testWrapDocComment() {
@@ -5489,7 +5489,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
-                       options: FormatOptions(maxWidth: 7), exclude: ["docComments"])
+                       options: FormatOptions(maxWidth: 7), exclude: [.docComments])
     }
 
     func testWrapDocLineCommentWithNoLeadingSpace() {
@@ -5504,7 +5504,7 @@ class WrappingTests: RulesTests {
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
                        options: FormatOptions(maxWidth: 6),
-                       exclude: ["spaceInsideComments", "docComments"])
+                       exclude: [.spaceInsideComments, .docComments])
     }
 
     func testWrapSingleLineCommentWithIndent() {
@@ -5523,7 +5523,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
-                       options: FormatOptions(maxWidth: 14), exclude: ["docComments"])
+                       options: FormatOptions(maxWidth: 14), exclude: [.docComments])
     }
 
     func testWrapSingleLineCommentAfterCode() {
@@ -5541,7 +5541,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
-                       options: FormatOptions(maxWidth: 29), exclude: ["wrap"])
+                       options: FormatOptions(maxWidth: 29), exclude: [.wrap])
     }
 
     func testWrapDocCommentWithLongURL() {
@@ -5550,7 +5550,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, rule: .wrapSingleLineComments,
-                       options: FormatOptions(maxWidth: 100), exclude: ["docComments"])
+                       options: FormatOptions(maxWidth: 100), exclude: [.docComments])
     }
 
     func testWrapDocCommentWithLongURL2() {
@@ -5572,7 +5572,7 @@ class WrappingTests: RulesTests {
         """
 
         testFormatting(for: input, output, rule: .wrapSingleLineComments,
-                       options: FormatOptions(maxWidth: 40), exclude: ["docComments"])
+                       options: FormatOptions(maxWidth: 40), exclude: [.docComments])
     }
 
     // MARK: - wrapMultilineConditionalAssignment

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -36,7 +36,7 @@ class RulesTests: XCTestCase {
     // MARK: - shared test infra
 
     func testFormatting(for input: String, _ output: String? = nil, rule: FormatRule,
-                        options: FormatOptions = .default, exclude: [String] = [],
+                        options: FormatOptions = .default, exclude: [FormatRule] = [],
                         file: StaticString = #file, line: UInt = #line)
     {
         testFormatting(for: input, output.map { [$0] } ?? [], rules: [rule],
@@ -44,7 +44,7 @@ class RulesTests: XCTestCase {
     }
 
     func testFormatting(for input: String, _ outputs: [String] = [], rules: [FormatRule],
-                        options: FormatOptions = .default, exclude: [String] = [],
+                        options: FormatOptions = .default, exclude: [FormatRule] = [],
                         file: StaticString = #file, line: UInt = #line)
     {
         var options = options
@@ -68,9 +68,9 @@ class RulesTests: XCTestCase {
 
         precondition(input != outputs.first || input != outputs.last, "Redundant output parameter")
         precondition((0 ... 2).contains(outputs.count), "Only 0, 1 or 2 output parameters permitted")
-        precondition(Set(exclude).intersection(rules.map { $0.name }).isEmpty, "Cannot exclude rule under test")
+        precondition(Set(exclude.map(\.name)).intersection(rules.map(\.name)).isEmpty, "Cannot exclude rule under test")
         let output = outputs.first ?? input, output2 = outputs.last ?? input
-        let exclude = exclude + FormatRules.deprecated
+        let exclude = exclude.map(\.name) + FormatRules.deprecated
             + (rules.first?.name == "linebreakAtEndOfFile" ? [] : ["linebreakAtEndOfFile"])
             + (rules.first?.name == "organizeDeclarations" ? [] : ["organizeDeclarations"])
             + (rules.first?.name == "extensionAccessControl" ? [] : ["extensionAccessControl"])


### PR DESCRIPTION
This PR updates the `exclude:` and `orderAfter:` arguments to reference rules via static member lookup instead of using string names. This gives us autocomplete when filling out rule names here, and is less error-prone.