### PR TITLE
Use TitleCase for the name of rule files

### DIFF
--- a/Sources/Rules/acronyms.swift
+++ b/Sources/Rules/acronyms.swift
@@ -1,5 +1,5 @@
 //
-//  acronyms.swift
+//  Acronyms.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/andOperator.swift
+++ b/Sources/Rules/andOperator.swift
@@ -1,5 +1,5 @@
 //
-//  andOperator.swift
+//  AndOperator.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/anyObjectProtocol.swift
+++ b/Sources/Rules/anyObjectProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  anyObjectProtocol.swift
+//  AnyObjectProtocol.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/applicationMain.swift
+++ b/Sources/Rules/applicationMain.swift
@@ -1,5 +1,5 @@
 //
-//  applicationMain.swift
+//  ApplicationMain.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/assertionFailures.swift
+++ b/Sources/Rules/assertionFailures.swift
@@ -1,5 +1,5 @@
 //
-//  assertionFailures.swift
+//  AssertionFailures.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLineAfterImports.swift
+++ b/Sources/Rules/blankLineAfterImports.swift
@@ -1,5 +1,5 @@
 //
-//  blankLineAfterImports.swift
+//  BlankLineAfterImports.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLineAfterSwitchCase.swift
+++ b/Sources/Rules/blankLineAfterSwitchCase.swift
@@ -1,5 +1,5 @@
 //
-//  blankLineAfterSwitchCase.swift
+//  BlankLineAfterSwitchCase.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesAroundMark.swift
+++ b/Sources/Rules/blankLinesAroundMark.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesAroundMark.swift
+//  BlankLinesAroundMark.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesAtEndOfScope.swift
+++ b/Sources/Rules/blankLinesAtEndOfScope.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesAtEndOfScope.swift
+//  BlankLinesAtEndOfScope.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesAtStartOfScope.swift
+++ b/Sources/Rules/blankLinesAtStartOfScope.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesAtStartOfScope.swift
+//  BlankLinesAtStartOfScope.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesBetweenChainedFunctions.swift
+++ b/Sources/Rules/blankLinesBetweenChainedFunctions.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesBetweenChainedFunctions.swift
+//  BlankLinesBetweenChainedFunctions.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesBetweenImports.swift
+++ b/Sources/Rules/blankLinesBetweenImports.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesBetweenImports.swift
+//  BlankLinesBetweenImports.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blankLinesBetweenScopes.swift
+++ b/Sources/Rules/blankLinesBetweenScopes.swift
@@ -1,5 +1,5 @@
 //
-//  blankLinesBetweenScopes.swift
+//  BlankLinesBetweenScopes.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/blockComments.swift
+++ b/Sources/Rules/blockComments.swift
@@ -1,5 +1,5 @@
 //
-//  blockComments.swift
+//  BlockComments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/braces.swift
+++ b/Sources/Rules/braces.swift
@@ -1,5 +1,5 @@
 //
-//  braces.swift
+//  Braces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/conditionalAssignment.swift
+++ b/Sources/Rules/conditionalAssignment.swift
@@ -1,5 +1,5 @@
 //
-//  conditionalAssignment.swift
+//  ConditionalAssignment.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/consecutiveBlankLines.swift
+++ b/Sources/Rules/consecutiveBlankLines.swift
@@ -1,5 +1,5 @@
 //
-//  consecutiveBlankLines.swift
+//  ConsecutiveBlankLines.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/consecutiveSpaces.swift
+++ b/Sources/Rules/consecutiveSpaces.swift
@@ -1,5 +1,5 @@
 //
-//  consecutiveSpaces.swift
+//  ConsecutiveSpaces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/consistentSwitchCaseSpacing.swift
+++ b/Sources/Rules/consistentSwitchCaseSpacing.swift
@@ -1,5 +1,5 @@
 //
-//  consistentSwitchCaseSpacing.swift
+//  ConsistentSwitchCaseSpacing.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/docComments.swift
+++ b/Sources/Rules/docComments.swift
@@ -1,5 +1,5 @@
 //
-//  docComments.swift
+//  DocComments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/docCommentsBeforeAttributes.swift
+++ b/Sources/Rules/docCommentsBeforeAttributes.swift
@@ -1,5 +1,5 @@
 //
-//  docCommentsBeforeAttributes.swift
+//  DocCommentsBeforeAttributes.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/duplicateImports.swift
+++ b/Sources/Rules/duplicateImports.swift
@@ -1,5 +1,5 @@
 //
-//  duplicateImports.swift
+//  DuplicateImports.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/elseOnSameLine.swift
+++ b/Sources/Rules/elseOnSameLine.swift
@@ -1,5 +1,5 @@
 //
-//  elseOnSameLine.swift
+//  ElseOnSameLine.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/emptyBraces.swift
+++ b/Sources/Rules/emptyBraces.swift
@@ -1,5 +1,5 @@
 //
-//  emptyBraces.swift
+//  EmptyBraces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/enumNamespaces.swift
+++ b/Sources/Rules/enumNamespaces.swift
@@ -1,5 +1,5 @@
 //
-//  enumNamespaces.swift
+//  EnumNamespaces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/extensionAccessControl.swift
+++ b/Sources/Rules/extensionAccessControl.swift
@@ -1,5 +1,5 @@
 //
-//  extensionAccessControl.swift
+//  ExtensionAccessControl.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/fileHeader.swift
+++ b/Sources/Rules/fileHeader.swift
@@ -1,5 +1,5 @@
 //
-//  fileHeader.swift
+//  FileHeader.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/genericExtensions.swift
+++ b/Sources/Rules/genericExtensions.swift
@@ -1,5 +1,5 @@
 //
-//  genericExtensions.swift
+//  GenericExtensions.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/headerFileName.swift
+++ b/Sources/Rules/headerFileName.swift
@@ -1,5 +1,5 @@
 //
-//  headerFileName.swift
+//  HeaderFileName.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/hoistAwait.swift
+++ b/Sources/Rules/hoistAwait.swift
@@ -1,5 +1,5 @@
 //
-//  hoistAwait.swift
+//  HoistAwait.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/hoistPatternLet.swift
+++ b/Sources/Rules/hoistPatternLet.swift
@@ -1,5 +1,5 @@
 //
-//  hoistPatternLet.swift
+//  HoistPatternLet.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/hoistTry.swift
+++ b/Sources/Rules/hoistTry.swift
@@ -1,5 +1,5 @@
 //
-//  hoistTry.swift
+//  HoistTry.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/indent.swift
+++ b/Sources/Rules/indent.swift
@@ -1,5 +1,5 @@
 //
-//  indent.swift
+//  Indent.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/27/24.

--- a/Sources/Rules/initCoderUnavailable.swift
+++ b/Sources/Rules/initCoderUnavailable.swift
@@ -1,5 +1,5 @@
 //
-//  initCoderUnavailable.swift
+//  InitCoderUnavailable.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/isEmpty.swift
+++ b/Sources/Rules/isEmpty.swift
@@ -1,5 +1,5 @@
 //
-//  isEmpty.swift
+//  IsEmpty.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/leadingDelimiters.swift
+++ b/Sources/Rules/leadingDelimiters.swift
@@ -1,5 +1,5 @@
 //
-//  leadingDelimiters.swift
+//  LeadingDelimiters.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/linebreakAtEndOfFile.swift
+++ b/Sources/Rules/linebreakAtEndOfFile.swift
@@ -1,5 +1,5 @@
 //
-//  linebreakAtEndOfFile.swift
+//  LinebreakAtEndOfFile.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/linebreaks.swift
+++ b/Sources/Rules/linebreaks.swift
@@ -1,5 +1,5 @@
 //
-//  linebreaks.swift
+//  Linebreaks.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/markTypes.swift
+++ b/Sources/Rules/markTypes.swift
@@ -1,5 +1,5 @@
 //
-//  markTypes.swift
+//  MarkTypes.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/modifierOrder.swift
+++ b/Sources/Rules/modifierOrder.swift
@@ -1,5 +1,5 @@
 //
-//  modifierOrder.swift
+//  ModifierOrder.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/noExplicitOwnership.swift
+++ b/Sources/Rules/noExplicitOwnership.swift
@@ -1,5 +1,5 @@
 //
-//  noExplicitOwnership.swift
+//  NoExplicitOwnership.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/numberFormatting.swift
+++ b/Sources/Rules/numberFormatting.swift
@@ -1,5 +1,5 @@
 //
-//  numberFormatting.swift
+//  NumberFormatting.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/opaqueGenericParameters.swift
+++ b/Sources/Rules/opaqueGenericParameters.swift
@@ -1,5 +1,5 @@
 //
-//  opaqueGenericParameters.swift
+//  OpaqueGenericParameters.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/organizeDeclarations.swift
+++ b/Sources/Rules/organizeDeclarations.swift
@@ -1,5 +1,5 @@
 //
-//  organizeDeclarations.swift
+//  OrganizeDeclarations.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/preferForLoop.swift
+++ b/Sources/Rules/preferForLoop.swift
@@ -1,5 +1,5 @@
 //
-//  preferForLoop.swift
+//  PreferForLoop.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/27/24.

--- a/Sources/Rules/preferKeyPath.swift
+++ b/Sources/Rules/preferKeyPath.swift
@@ -1,5 +1,5 @@
 //
-//  preferKeyPath.swift
+//  PreferKeyPath.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/propertyType.swift
+++ b/Sources/Rules/propertyType.swift
@@ -1,5 +1,5 @@
 //
-//  propertyType.swift
+//  PropertyType.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantBackticks.swift
+++ b/Sources/Rules/redundantBackticks.swift
@@ -1,5 +1,5 @@
 //
-//  redundantBackticks.swift
+//  RedundantBackticks.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantBreak.swift
+++ b/Sources/Rules/redundantBreak.swift
@@ -1,5 +1,5 @@
 //
-//  redundantBreak.swift
+//  RedundantBreak.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantClosure.swift
+++ b/Sources/Rules/redundantClosure.swift
@@ -1,5 +1,5 @@
 //
-//  redundantClosure.swift
+//  RedundantClosure.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantExtensionACL.swift
+++ b/Sources/Rules/redundantExtensionACL.swift
@@ -1,5 +1,5 @@
 //
-//  redundantExtensionACL.swift
+//  RedundantExtensionACL.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantFileprivate.swift
+++ b/Sources/Rules/redundantFileprivate.swift
@@ -1,5 +1,5 @@
 //
-//  redundantFileprivate.swift
+//  RedundantFileprivate.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantGet.swift
+++ b/Sources/Rules/redundantGet.swift
@@ -1,5 +1,5 @@
 //
-//  redundantGet.swift
+//  RedundantGet.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantInit.swift
+++ b/Sources/Rules/redundantInit.swift
@@ -1,5 +1,5 @@
 //
-//  redundantInit.swift
+//  RedundantInit.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantInternal.swift
+++ b/Sources/Rules/redundantInternal.swift
@@ -1,5 +1,5 @@
 //
-//  redundantInternal.swift
+//  RedundantInternal.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantLet.swift
+++ b/Sources/Rules/redundantLet.swift
@@ -1,5 +1,5 @@
 //
-//  redundantLet.swift
+//  RedundantLet.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantLetError.swift
+++ b/Sources/Rules/redundantLetError.swift
@@ -1,5 +1,5 @@
 //
-//  redundantLetError.swift
+//  RedundantLetError.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantNilInit.swift
+++ b/Sources/Rules/redundantNilInit.swift
@@ -1,5 +1,5 @@
 //
-//  redundantNilInit.swift
+//  RedundantNilInit.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantObjc.swift
+++ b/Sources/Rules/redundantObjc.swift
@@ -1,5 +1,5 @@
 //
-//  redundantObjc.swift
+//  RedundantObjc.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantOptionalBinding.swift
+++ b/Sources/Rules/redundantOptionalBinding.swift
@@ -1,5 +1,5 @@
 //
-//  redundantOptionalBinding.swift
+//  RedundantOptionalBinding.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantParens.swift
+++ b/Sources/Rules/redundantParens.swift
@@ -1,5 +1,5 @@
 //
-//  redundantParens.swift
+//  RedundantParens.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantPattern.swift
+++ b/Sources/Rules/redundantPattern.swift
@@ -1,5 +1,5 @@
 //
-//  redundantPattern.swift
+//  RedundantPattern.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantProperty.swift
+++ b/Sources/Rules/redundantProperty.swift
@@ -1,5 +1,5 @@
 //
-//  redundantProperty.swift
+//  RedundantProperty.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantRawValues.swift
+++ b/Sources/Rules/redundantRawValues.swift
@@ -1,5 +1,5 @@
 //
-//  redundantRawValues.swift
+//  RedundantRawValues.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantReturn.swift
+++ b/Sources/Rules/redundantReturn.swift
@@ -1,5 +1,5 @@
 //
-//  redundantReturn.swift
+//  RedundantReturn.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantSelf.swift
+++ b/Sources/Rules/redundantSelf.swift
@@ -1,5 +1,5 @@
 //
-//  redundantSelf.swift
+//  RedundantSelf.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantStaticSelf.swift
+++ b/Sources/Rules/redundantStaticSelf.swift
@@ -1,5 +1,5 @@
 //
-//  redundantStaticSelf.swift
+//  RedundantStaticSelf.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantType.swift
+++ b/Sources/Rules/redundantType.swift
@@ -1,5 +1,5 @@
 //
-//  redundantType.swift
+//  RedundantType.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantTypedThrows.swift
+++ b/Sources/Rules/redundantTypedThrows.swift
@@ -1,5 +1,5 @@
 //
-//  redundantTypedThrows.swift
+//  RedundantTypedThrows.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/redundantVoidReturnType.swift
+++ b/Sources/Rules/redundantVoidReturnType.swift
@@ -1,5 +1,5 @@
 //
-//  redundantVoidReturnType.swift
+//  RedundantVoidReturnType.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/semicolons.swift
+++ b/Sources/Rules/semicolons.swift
@@ -1,5 +1,5 @@
 //
-//  semicolons.swift
+//  Semicolons.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortDeclarations.swift
+++ b/Sources/Rules/sortDeclarations.swift
@@ -1,5 +1,5 @@
 //
-//  sortDeclarations.swift
+//  SortDeclarations.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortImports.swift
+++ b/Sources/Rules/sortImports.swift
@@ -1,5 +1,5 @@
 //
-//  sortImports.swift
+//  SortImports.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortSwitchCases.swift
+++ b/Sources/Rules/sortSwitchCases.swift
@@ -1,5 +1,5 @@
 //
-//  sortSwitchCases.swift
+//  SortSwitchCases.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortTypealiases.swift
+++ b/Sources/Rules/sortTypealiases.swift
@@ -1,5 +1,5 @@
 //
-//  sortTypealiases.swift
+//  SortTypealiases.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortedImports.swift
+++ b/Sources/Rules/sortedImports.swift
@@ -1,5 +1,5 @@
 //
-//  sortedImports.swift
+//  SortedImports.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/sortedSwitchCases.swift
+++ b/Sources/Rules/sortedSwitchCases.swift
@@ -1,5 +1,5 @@
 //
-//  sortedSwitchCases.swift
+//  SortedSwitchCases.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceAroundBraces.swift
+++ b/Sources/Rules/spaceAroundBraces.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundBraces.swift
+//  SpaceAroundBraces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceAroundBrackets.swift
+++ b/Sources/Rules/spaceAroundBrackets.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundBrackets.swift
+//  SpaceAroundBrackets.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceAroundComments.swift
+++ b/Sources/Rules/spaceAroundComments.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundComments.swift
+//  SpaceAroundComments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/27/24.

--- a/Sources/Rules/spaceAroundGenerics.swift
+++ b/Sources/Rules/spaceAroundGenerics.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundGenerics.swift
+//  SpaceAroundGenerics.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceAroundOperators.swift
+++ b/Sources/Rules/spaceAroundOperators.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundOperators.swift
+//  SpaceAroundOperators.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceAroundParens.swift
+++ b/Sources/Rules/spaceAroundParens.swift
@@ -1,5 +1,5 @@
 //
-//  spaceAroundParens.swift
+//  SpaceAroundParens.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceInsideBraces.swift
+++ b/Sources/Rules/spaceInsideBraces.swift
@@ -1,5 +1,5 @@
 //
-//  spaceInsideBraces.swift
+//  SpaceInsideBraces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceInsideBrackets.swift
+++ b/Sources/Rules/spaceInsideBrackets.swift
@@ -1,5 +1,5 @@
 //
-//  spaceInsideBrackets.swift
+//  SpaceInsideBrackets.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceInsideComments.swift
+++ b/Sources/Rules/spaceInsideComments.swift
@@ -1,5 +1,5 @@
 //
-//  spaceInsideComments.swift
+//  SpaceInsideComments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceInsideGenerics.swift
+++ b/Sources/Rules/spaceInsideGenerics.swift
@@ -1,5 +1,5 @@
 //
-//  spaceInsideGenerics.swift
+//  SpaceInsideGenerics.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/spaceInsideParens.swift
+++ b/Sources/Rules/spaceInsideParens.swift
@@ -1,5 +1,5 @@
 //
-//  spaceInsideParens.swift
+//  SpaceInsideParens.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/specifiers.swift
+++ b/Sources/Rules/specifiers.swift
@@ -1,5 +1,5 @@
 //
-//  specifiers.swift
+//  Specifiers.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/strongOutlets.swift
+++ b/Sources/Rules/strongOutlets.swift
@@ -1,5 +1,5 @@
 //
-//  strongOutlets.swift
+//  StrongOutlets.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/strongifiedSelf.swift
+++ b/Sources/Rules/strongifiedSelf.swift
@@ -1,5 +1,5 @@
 //
-//  strongifiedSelf.swift
+//  StrongifiedSelf.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/todos.swift
+++ b/Sources/Rules/todos.swift
@@ -1,5 +1,5 @@
 //
-//  todos.swift
+//  Todos.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/trailingClosures.swift
+++ b/Sources/Rules/trailingClosures.swift
@@ -1,5 +1,5 @@
 //
-//  trailingClosures.swift
+//  TrailingClosures.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/trailingCommas.swift
+++ b/Sources/Rules/trailingCommas.swift
@@ -1,5 +1,5 @@
 //
-//  trailingCommas.swift
+//  TrailingCommas.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/trailingSpace.swift
+++ b/Sources/Rules/trailingSpace.swift
@@ -1,5 +1,5 @@
 //
-//  trailingSpace.swift
+//  TrailingSpace.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/typeSugar.swift
+++ b/Sources/Rules/typeSugar.swift
@@ -1,5 +1,5 @@
 //
-//  typeSugar.swift
+//  TypeSugar.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/unusedArguments.swift
+++ b/Sources/Rules/unusedArguments.swift
@@ -1,5 +1,5 @@
 //
-//  unusedArguments.swift
+//  UnusedArguments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/unusedPrivateDeclaration.swift
+++ b/Sources/Rules/unusedPrivateDeclaration.swift
@@ -1,5 +1,5 @@
 //
-//  unusedPrivateDeclaration.swift
+//  UnusedPrivateDeclaration.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/void.swift
+++ b/Sources/Rules/void.swift
@@ -1,5 +1,5 @@
 //
-//  void.swift
+//  Void.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrap.swift
+++ b/Sources/Rules/wrap.swift
@@ -1,5 +1,5 @@
 //
-//  wrap.swift
+//  Wrap.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapArguments.swift
+++ b/Sources/Rules/wrapArguments.swift
@@ -1,5 +1,5 @@
 //
-//  wrapArguments.swift
+//  WrapArguments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapAttributes.swift
+++ b/Sources/Rules/wrapAttributes.swift
@@ -1,5 +1,5 @@
 //
-//  wrapAttributes.swift
+//  WrapAttributes.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapConditionalBodies.swift
+++ b/Sources/Rules/wrapConditionalBodies.swift
@@ -1,5 +1,5 @@
 //
-//  wrapConditionalBodies.swift
+//  WrapConditionalBodies.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapEnumCases.swift
+++ b/Sources/Rules/wrapEnumCases.swift
@@ -1,5 +1,5 @@
 //
-//  wrapEnumCases.swift
+//  WrapEnumCases.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapLoopBodies.swift
+++ b/Sources/Rules/wrapLoopBodies.swift
@@ -1,5 +1,5 @@
 //
-//  wrapLoopBodies.swift
+//  WrapLoopBodies.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapMultilineConditionalAssignment.swift
+++ b/Sources/Rules/wrapMultilineConditionalAssignment.swift
@@ -1,5 +1,5 @@
 //
-//  wrapMultilineConditionalAssignment.swift
+//  WrapMultilineConditionalAssignment.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapMultilineStatementBraces.swift
+++ b/Sources/Rules/wrapMultilineStatementBraces.swift
@@ -1,5 +1,5 @@
 //
-//  wrapMultilineStatementBraces.swift
+//  WrapMultilineStatementBraces.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapSingleLineComments.swift
+++ b/Sources/Rules/wrapSingleLineComments.swift
@@ -1,5 +1,5 @@
 //
-//  wrapSingleLineComments.swift
+//  WrapSingleLineComments.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/wrapSwitchCases.swift
+++ b/Sources/Rules/wrapSwitchCases.swift
@@ -1,5 +1,5 @@
 //
-//  wrapSwitchCases.swift
+//  WrapSwitchCases.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/Sources/Rules/yodaConditions.swift
+++ b/Sources/Rules/yodaConditions.swift
@@ -1,5 +1,5 @@
 //
-//  yodaConditions.swift
+//  YodaConditions.swift
 //  SwiftFormat
 //
 //  Created by Cal Stephens on 7/28/24.

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -84,450 +84,340 @@
 		08180DD02C4EB67F00FD60FF /* DeclarationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E230CA12C4C1C0700A16E2E /* DeclarationHelpers.swift */; };
 		08180DD12C4EB68000FD60FF /* DeclarationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E230CA12C4C1C0700A16E2E /* DeclarationHelpers.swift */; };
 		2E230CA22C4C1C0700A16E2E /* DeclarationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E230CA12C4C1C0700A16E2E /* DeclarationHelpers.swift */; };
-		2E2BF34B2C554E6400AB08D2 /* preferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */; };
-		2E2BF34C2C554E6400AB08D2 /* preferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */; };
-		2E2BF34D2C554E6400AB08D2 /* preferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */; };
-		2E2BF34E2C554E6400AB08D2 /* preferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */; };
+		2E2BA6682C57D2D500590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */; };
+		2E2BA6692C57D2D500590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */; };
+		2E2BA66A2C57D2D500590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */; };
+		2E2BA66B2C57D2D500590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */; };
+		2E2BA66C2C57D2D500590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */; };
+		2E2BA66D2C57D2D500590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */; };
+		2E2BA66E2C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */; };
+		2E2BA66F2C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */; };
+		2E2BA6702C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */; };
+		2E2BA6712C57D2D500590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FD2C57D2D500590239 /* Indent.swift */; };
+		2E2BA6722C57D2D500590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FD2C57D2D500590239 /* Indent.swift */; };
+		2E2BA6732C57D2D500590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FD2C57D2D500590239 /* Indent.swift */; };
+		2E2BA6742C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */; };
+		2E2BA6752C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */; };
+		2E2BA6762C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */; };
+		2E2BA6772C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */; };
+		2E2BA6782C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */; };
+		2E2BA6792C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */; };
+		2E2BA67A2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */; };
+		2E2BA67B2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */; };
+		2E2BA67C2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */; };
+		2E2BA67D2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */; };
+		2E2BA67E2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */; };
+		2E2BA67F2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */; };
+		2E2BA6802C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */; };
+		2E2BA6812C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */; };
+		2E2BA6822C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */; };
+		2E2BA6832C57D2D500590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6032C57D2D500590239 /* RedundantInternal.swift */; };
+		2E2BA6842C57D2D500590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6032C57D2D500590239 /* RedundantInternal.swift */; };
+		2E2BA6852C57D2D500590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6032C57D2D500590239 /* RedundantInternal.swift */; };
+		2E2BA6862C57D2D500590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */; };
+		2E2BA6872C57D2D500590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */; };
+		2E2BA6882C57D2D500590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */; };
+		2E2BA6892C57D2D500590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6052C57D2D500590239 /* Todos.swift */; };
+		2E2BA68A2C57D2D500590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6052C57D2D500590239 /* Todos.swift */; };
+		2E2BA68B2C57D2D500590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6052C57D2D500590239 /* Todos.swift */; };
+		2E2BA68C2C57D2D500590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */; };
+		2E2BA68D2C57D2D500590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */; };
+		2E2BA68E2C57D2D500590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */; };
+		2E2BA68F2C57D2D500590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6072C57D2D500590239 /* Semicolons.swift */; };
+		2E2BA6902C57D2D500590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6072C57D2D500590239 /* Semicolons.swift */; };
+		2E2BA6912C57D2D500590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6072C57D2D500590239 /* Semicolons.swift */; };
+		2E2BA6922C57D2D500590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */; };
+		2E2BA6932C57D2D500590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */; };
+		2E2BA6942C57D2D500590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */; };
+		2E2BA6952C57D2D500590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */; };
+		2E2BA6962C57D2D500590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */; };
+		2E2BA6972C57D2D500590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */; };
+		2E2BA6982C57D2D500590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */; };
+		2E2BA6992C57D2D500590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */; };
+		2E2BA69A2C57D2D500590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */; };
+		2E2BA69B2C57D2D500590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60B2C57D2D500590239 /* RedundantGet.swift */; };
+		2E2BA69C2C57D2D500590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60B2C57D2D500590239 /* RedundantGet.swift */; };
+		2E2BA69D2C57D2D500590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60B2C57D2D500590239 /* RedundantGet.swift */; };
+		2E2BA69E2C57D2D500590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */; };
+		2E2BA69F2C57D2D500590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */; };
+		2E2BA6A02C57D2D500590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */; };
+		2E2BA6A12C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */; };
+		2E2BA6A22C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */; };
+		2E2BA6A32C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */; };
+		2E2BA6A42C57D2D500590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60E2C57D2D500590239 /* SortImports.swift */; };
+		2E2BA6A52C57D2D500590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60E2C57D2D500590239 /* SortImports.swift */; };
+		2E2BA6A62C57D2D500590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60E2C57D2D500590239 /* SortImports.swift */; };
+		2E2BA6A72C57D2D500590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60F2C57D2D500590239 /* SortedImports.swift */; };
+		2E2BA6A82C57D2D500590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60F2C57D2D500590239 /* SortedImports.swift */; };
+		2E2BA6A92C57D2D500590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60F2C57D2D500590239 /* SortedImports.swift */; };
+		2E2BA6AA2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */; };
+		2E2BA6AB2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */; };
+		2E2BA6AC2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */; };
+		2E2BA6AD2C57D2D500590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */; };
+		2E2BA6AE2C57D2D500590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */; };
+		2E2BA6AF2C57D2D500590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */; };
+		2E2BA6B02C57D2D500590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6122C57D2D500590239 /* BlockComments.swift */; };
+		2E2BA6B12C57D2D500590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6122C57D2D500590239 /* BlockComments.swift */; };
+		2E2BA6B22C57D2D500590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6122C57D2D500590239 /* BlockComments.swift */; };
+		2E2BA6B32C57D2D500590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6132C57D2D500590239 /* StrongOutlets.swift */; };
+		2E2BA6B42C57D2D500590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6132C57D2D500590239 /* StrongOutlets.swift */; };
+		2E2BA6B52C57D2D500590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6132C57D2D500590239 /* StrongOutlets.swift */; };
+		2E2BA6B62C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */; };
+		2E2BA6B72C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */; };
+		2E2BA6B82C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */; };
+		2E2BA6B92C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */; };
+		2E2BA6BA2C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */; };
+		2E2BA6BB2C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */; };
+		2E2BA6BC2C57D2D500590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6162C57D2D500590239 /* AssertionFailures.swift */; };
+		2E2BA6BD2C57D2D500590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6162C57D2D500590239 /* AssertionFailures.swift */; };
+		2E2BA6BE2C57D2D500590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6162C57D2D500590239 /* AssertionFailures.swift */; };
+		2E2BA6BF2C57D2D500590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6172C57D2D500590239 /* EmptyBraces.swift */; };
+		2E2BA6C02C57D2D500590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6172C57D2D500590239 /* EmptyBraces.swift */; };
+		2E2BA6C12C57D2D500590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6172C57D2D500590239 /* EmptyBraces.swift */; };
+		2E2BA6C22C57D2D500590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */; };
+		2E2BA6C32C57D2D500590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */; };
+		2E2BA6C42C57D2D500590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */; };
+		2E2BA6C52C57D2D500590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6192C57D2D500590239 /* RedundantParens.swift */; };
+		2E2BA6C62C57D2D500590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6192C57D2D500590239 /* RedundantParens.swift */; };
+		2E2BA6C72C57D2D500590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6192C57D2D500590239 /* RedundantParens.swift */; };
+		2E2BA6C82C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */; };
+		2E2BA6C92C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */; };
+		2E2BA6CA2C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */; };
+		2E2BA6CB2C57D2D500590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61B2C57D2D500590239 /* Linebreaks.swift */; };
+		2E2BA6CC2C57D2D500590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61B2C57D2D500590239 /* Linebreaks.swift */; };
+		2E2BA6CD2C57D2D500590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61B2C57D2D500590239 /* Linebreaks.swift */; };
+		2E2BA6CE2C57D2D500590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */; };
+		2E2BA6CF2C57D2D500590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */; };
+		2E2BA6D02C57D2D500590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */; };
+		2E2BA6D12C57D2D500590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */; };
+		2E2BA6D22C57D2D500590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */; };
+		2E2BA6D32C57D2D500590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */; };
+		2E2BA6D42C57D2D500590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61E2C57D2D500590239 /* RedundantLet.swift */; };
+		2E2BA6D52C57D2D500590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61E2C57D2D500590239 /* RedundantLet.swift */; };
+		2E2BA6D62C57D2D500590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61E2C57D2D500590239 /* RedundantLet.swift */; };
+		2E2BA6D72C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */; };
+		2E2BA6D82C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */; };
+		2E2BA6D92C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */; };
+		2E2BA6DA2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */; };
+		2E2BA6DB2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */; };
+		2E2BA6DC2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */; };
+		2E2BA6DD2C57D2D500590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6212C57D2D500590239 /* RedundantInit.swift */; };
+		2E2BA6DE2C57D2D500590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6212C57D2D500590239 /* RedundantInit.swift */; };
+		2E2BA6DF2C57D2D500590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6212C57D2D500590239 /* RedundantInit.swift */; };
+		2E2BA6E02C57D2D500590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */; };
+		2E2BA6E12C57D2D500590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */; };
+		2E2BA6E22C57D2D500590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */; };
+		2E2BA6E32C57D2D500590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6232C57D2D500590239 /* Void.swift */; };
+		2E2BA6E42C57D2D500590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6232C57D2D500590239 /* Void.swift */; };
+		2E2BA6E52C57D2D500590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6232C57D2D500590239 /* Void.swift */; };
+		2E2BA6E62C57D2D500590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */; };
+		2E2BA6E72C57D2D500590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */; };
+		2E2BA6E82C57D2D500590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */; };
+		2E2BA6E92C57D2D500590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6252C57D2D500590239 /* RedundantLetError.swift */; };
+		2E2BA6EA2C57D2D500590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6252C57D2D500590239 /* RedundantLetError.swift */; };
+		2E2BA6EB2C57D2D500590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6252C57D2D500590239 /* RedundantLetError.swift */; };
+		2E2BA6EC2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */; };
+		2E2BA6ED2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */; };
+		2E2BA6EE2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */; };
+		2E2BA6EF2C57D2D500590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6272C57D2D500590239 /* RedundantClosure.swift */; };
+		2E2BA6F02C57D2D500590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6272C57D2D500590239 /* RedundantClosure.swift */; };
+		2E2BA6F12C57D2D500590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6272C57D2D500590239 /* RedundantClosure.swift */; };
+		2E2BA6F22C57D2D500590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */; };
+		2E2BA6F32C57D2D500590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */; };
+		2E2BA6F42C57D2D500590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */; };
+		2E2BA6F52C57D2D500590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6292C57D2D500590239 /* FileHeader.swift */; };
+		2E2BA6F62C57D2D500590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6292C57D2D500590239 /* FileHeader.swift */; };
+		2E2BA6F72C57D2D500590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6292C57D2D500590239 /* FileHeader.swift */; };
+		2E2BA6F82C57D2D500590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62A2C57D2D500590239 /* TypeSugar.swift */; };
+		2E2BA6F92C57D2D500590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62A2C57D2D500590239 /* TypeSugar.swift */; };
+		2E2BA6FA2C57D2D500590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62A2C57D2D500590239 /* TypeSugar.swift */; };
+		2E2BA6FB2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */; };
+		2E2BA6FC2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */; };
+		2E2BA6FD2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */; };
+		2E2BA6FE2C57D2D500590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */; };
+		2E2BA6FF2C57D2D500590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */; };
+		2E2BA7002C57D2D500590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */; };
+		2E2BA7012C57D2D500590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62D2C57D2D500590239 /* IsEmpty.swift */; };
+		2E2BA7022C57D2D500590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62D2C57D2D500590239 /* IsEmpty.swift */; };
+		2E2BA7032C57D2D500590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62D2C57D2D500590239 /* IsEmpty.swift */; };
+		2E2BA7042C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */; };
+		2E2BA7052C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */; };
+		2E2BA7062C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */; };
+		2E2BA7072C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */; };
+		2E2BA7082C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */; };
+		2E2BA7092C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */; };
+		2E2BA70A2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */; };
+		2E2BA70B2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */; };
+		2E2BA70C2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */; };
+		2E2BA70D2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */; };
+		2E2BA70E2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */; };
+		2E2BA70F2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */; };
+		2E2BA7102C57D2D500590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6322C57D2D500590239 /* RedundantReturn.swift */; };
+		2E2BA7112C57D2D500590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6322C57D2D500590239 /* RedundantReturn.swift */; };
+		2E2BA7122C57D2D500590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6322C57D2D500590239 /* RedundantReturn.swift */; };
+		2E2BA7132C57D2D500590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6332C57D2D500590239 /* GenericExtensions.swift */; };
+		2E2BA7142C57D2D500590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6332C57D2D500590239 /* GenericExtensions.swift */; };
+		2E2BA7152C57D2D500590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6332C57D2D500590239 /* GenericExtensions.swift */; };
+		2E2BA7162C57D2D500590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6342C57D2D500590239 /* TrailingSpace.swift */; };
+		2E2BA7172C57D2D500590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6342C57D2D500590239 /* TrailingSpace.swift */; };
+		2E2BA7182C57D2D500590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6342C57D2D500590239 /* TrailingSpace.swift */; };
+		2E2BA7192C57D2D500590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6352C57D2D500590239 /* RedundantObjc.swift */; };
+		2E2BA71A2C57D2D500590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6352C57D2D500590239 /* RedundantObjc.swift */; };
+		2E2BA71B2C57D2D500590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6352C57D2D500590239 /* RedundantObjc.swift */; };
+		2E2BA71C2C57D2D500590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */; };
+		2E2BA71D2C57D2D500590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */; };
+		2E2BA71E2C57D2D500590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */; };
+		2E2BA71F2C57D2D500590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6372C57D2D500590239 /* PreferForLoop.swift */; };
+		2E2BA7202C57D2D500590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6372C57D2D500590239 /* PreferForLoop.swift */; };
+		2E2BA7212C57D2D500590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6372C57D2D500590239 /* PreferForLoop.swift */; };
+		2E2BA7222C57D2D500590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */; };
+		2E2BA7232C57D2D500590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */; };
+		2E2BA7242C57D2D500590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */; };
+		2E2BA7252C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */; };
+		2E2BA7262C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */; };
+		2E2BA7272C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */; };
+		2E2BA7282C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */; };
+		2E2BA7292C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */; };
+		2E2BA72A2C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */; };
+		2E2BA72B2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */; };
+		2E2BA72C2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */; };
+		2E2BA72D2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */; };
+		2E2BA72E2C57D2D500590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */; };
+		2E2BA72F2C57D2D500590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */; };
+		2E2BA7302C57D2D500590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */; };
+		2E2BA7312C57D2D500590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */; };
+		2E2BA7322C57D2D500590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */; };
+		2E2BA7332C57D2D500590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */; };
+		2E2BA7342C57D2D500590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */; };
+		2E2BA7352C57D2D500590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */; };
+		2E2BA7362C57D2D500590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */; };
+		2E2BA7372C57D2D500590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63F2C57D2D500590239 /* Wrap.swift */; };
+		2E2BA7382C57D2D500590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63F2C57D2D500590239 /* Wrap.swift */; };
+		2E2BA7392C57D2D500590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63F2C57D2D500590239 /* Wrap.swift */; };
+		2E2BA73A2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */; };
+		2E2BA73B2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */; };
+		2E2BA73C2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */; };
+		2E2BA73D2C57D2D500590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6412C57D2D500590239 /* ModifierOrder.swift */; };
+		2E2BA73E2C57D2D500590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6412C57D2D500590239 /* ModifierOrder.swift */; };
+		2E2BA73F2C57D2D500590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6412C57D2D500590239 /* ModifierOrder.swift */; };
+		2E2BA7402C57D2D500590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */; };
+		2E2BA7412C57D2D500590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */; };
+		2E2BA7422C57D2D500590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */; };
+		2E2BA7432C57D2D500590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6432C57D2D500590239 /* RedundantSelf.swift */; };
+		2E2BA7442C57D2D500590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6432C57D2D500590239 /* RedundantSelf.swift */; };
+		2E2BA7452C57D2D500590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6432C57D2D500590239 /* RedundantSelf.swift */; };
+		2E2BA7462C57D2D500590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */; };
+		2E2BA7472C57D2D500590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */; };
+		2E2BA7482C57D2D500590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */; };
+		2E2BA7492C57D2D500590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */; };
+		2E2BA74A2C57D2D500590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */; };
+		2E2BA74B2C57D2D500590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */; };
+		2E2BA74C2C57D2D500590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6462C57D2D500590239 /* WrapAttributes.swift */; };
+		2E2BA74D2C57D2D500590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6462C57D2D500590239 /* WrapAttributes.swift */; };
+		2E2BA74E2C57D2D500590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6462C57D2D500590239 /* WrapAttributes.swift */; };
+		2E2BA74F2C57D2D500590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */; };
+		2E2BA7502C57D2D500590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */; };
+		2E2BA7512C57D2D500590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */; };
+		2E2BA7522C57D2D500590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */; };
+		2E2BA7532C57D2D500590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */; };
+		2E2BA7542C57D2D500590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */; };
+		2E2BA7552C57D2D500590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6492C57D2D500590239 /* Braces.swift */; };
+		2E2BA7562C57D2D500590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6492C57D2D500590239 /* Braces.swift */; };
+		2E2BA7572C57D2D500590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6492C57D2D500590239 /* Braces.swift */; };
+		2E2BA7582C57D2D500590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64A2C57D2D500590239 /* MarkTypes.swift */; };
+		2E2BA7592C57D2D500590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64A2C57D2D500590239 /* MarkTypes.swift */; };
+		2E2BA75A2C57D2D500590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64A2C57D2D500590239 /* MarkTypes.swift */; };
+		2E2BA75B2C57D2D500590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64B2C57D2D500590239 /* AndOperator.swift */; };
+		2E2BA75C2C57D2D500590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64B2C57D2D500590239 /* AndOperator.swift */; };
+		2E2BA75D2C57D2D500590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64B2C57D2D500590239 /* AndOperator.swift */; };
+		2E2BA75E2C57D2D500590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */; };
+		2E2BA75F2C57D2D500590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */; };
+		2E2BA7602C57D2D500590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */; };
+		2E2BA7612C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */; };
+		2E2BA7622C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */; };
+		2E2BA7632C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */; };
+		2E2BA7642C57D2D500590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */; };
+		2E2BA7652C57D2D500590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */; };
+		2E2BA7662C57D2D500590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */; };
+		2E2BA7672C57D2D500590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */; };
+		2E2BA7682C57D2D500590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */; };
+		2E2BA7692C57D2D500590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */; };
+		2E2BA76A2C57D2D500590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */; };
+		2E2BA76B2C57D2D500590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */; };
+		2E2BA76C2C57D2D500590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */; };
+		2E2BA76D2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */; };
+		2E2BA76E2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */; };
+		2E2BA76F2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */; };
+		2E2BA7702C57D2D500590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */; };
+		2E2BA7712C57D2D500590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */; };
+		2E2BA7722C57D2D500590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */; };
+		2E2BA7732C57D2D500590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */; };
+		2E2BA7742C57D2D500590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */; };
+		2E2BA7752C57D2D500590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */; };
+		2E2BA7762C57D2D500590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6542C57D2D500590239 /* HoistAwait.swift */; };
+		2E2BA7772C57D2D500590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6542C57D2D500590239 /* HoistAwait.swift */; };
+		2E2BA7782C57D2D500590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6542C57D2D500590239 /* HoistAwait.swift */; };
+		2E2BA7792C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */; };
+		2E2BA77A2C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */; };
+		2E2BA77B2C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */; };
+		2E2BA77C2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */; };
+		2E2BA77D2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */; };
+		2E2BA77E2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */; };
+		2E2BA77F2C57D2D500590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6572C57D2D500590239 /* TrailingClosures.swift */; };
+		2E2BA7802C57D2D500590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6572C57D2D500590239 /* TrailingClosures.swift */; };
+		2E2BA7812C57D2D500590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6572C57D2D500590239 /* TrailingClosures.swift */; };
+		2E2BA7822C57D2D500590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */; };
+		2E2BA7832C57D2D500590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */; };
+		2E2BA7842C57D2D500590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */; };
+		2E2BA7852C57D2D500590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6592C57D2D500590239 /* Acronyms.swift */; };
+		2E2BA7862C57D2D500590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6592C57D2D500590239 /* Acronyms.swift */; };
+		2E2BA7872C57D2D500590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6592C57D2D500590239 /* Acronyms.swift */; };
+		2E2BA7882C57D2D500590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */; };
+		2E2BA7892C57D2D500590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */; };
+		2E2BA78A2C57D2D500590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */; };
+		2E2BA78B2C57D2D500590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65B2C57D2D500590239 /* DocComments.swift */; };
+		2E2BA78C2C57D2D500590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65B2C57D2D500590239 /* DocComments.swift */; };
+		2E2BA78D2C57D2D500590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65B2C57D2D500590239 /* DocComments.swift */; };
+		2E2BA78E2C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */; };
+		2E2BA78F2C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */; };
+		2E2BA7902C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */; };
+		2E2BA7912C57D2D500590239 /* PropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65D2C57D2D500590239 /* PropertyType.swift */; };
+		2E2BA7922C57D2D500590239 /* PropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65D2C57D2D500590239 /* PropertyType.swift */; };
+		2E2BA7932C57D2D500590239 /* PropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65D2C57D2D500590239 /* PropertyType.swift */; };
+		2E2BA7942C57D2D500590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65E2C57D2D500590239 /* HoistTry.swift */; };
+		2E2BA7952C57D2D500590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65E2C57D2D500590239 /* HoistTry.swift */; };
+		2E2BA7962C57D2D500590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65E2C57D2D500590239 /* HoistTry.swift */; };
+		2E2BA7972C57D2D500590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */; };
+		2E2BA7982C57D2D500590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */; };
+		2E2BA7992C57D2D500590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */; };
+		2E2BA79A2C57D2D500590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6602C57D2D500590239 /* WrapArguments.swift */; };
+		2E2BA79B2C57D2D500590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6602C57D2D500590239 /* WrapArguments.swift */; };
+		2E2BA79C2C57D2D500590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6602C57D2D500590239 /* WrapArguments.swift */; };
+		2E2BA79D2C57D2D500590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6612C57D2D500590239 /* Specifiers.swift */; };
+		2E2BA79E2C57D2D500590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6612C57D2D500590239 /* Specifiers.swift */; };
+		2E2BA79F2C57D2D500590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6612C57D2D500590239 /* Specifiers.swift */; };
+		2E2BA7A02C57D2D500590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6622C57D2D500590239 /* YodaConditions.swift */; };
+		2E2BA7A12C57D2D500590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6622C57D2D500590239 /* YodaConditions.swift */; };
+		2E2BA7A22C57D2D500590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6622C57D2D500590239 /* YodaConditions.swift */; };
+		2E2BA7A32C57D2D500590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */; };
+		2E2BA7A42C57D2D500590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */; };
+		2E2BA7A52C57D2D500590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */; };
+		2E2BA7A62C57D2D500590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6642C57D2D500590239 /* UnusedArguments.swift */; };
+		2E2BA7A72C57D2D500590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6642C57D2D500590239 /* UnusedArguments.swift */; };
+		2E2BA7A82C57D2D500590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6642C57D2D500590239 /* UnusedArguments.swift */; };
+		2E2BA7A92C57D2D500590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */; };
+		2E2BA7AA2C57D2D500590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */; };
+		2E2BA7AB2C57D2D500590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */; };
+		2E2BA7AC2C57D2D500590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6662C57D2D500590239 /* RedundantType.swift */; };
+		2E2BA7AD2C57D2D500590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6662C57D2D500590239 /* RedundantType.swift */; };
+		2E2BA7AE2C57D2D500590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6662C57D2D500590239 /* RedundantType.swift */; };
+		2E2BA7AF2C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
+		2E2BA7B02C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
+		2E2BA7B12C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
 		2E2BF3552C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
 		2E2BF3562C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
 		2E2BF3572C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
 		2E2BF3582C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
-		2E2BF35B2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */; };
-		2E2BF35C2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */; };
-		2E2BF35D2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */; };
-		2E2BF35E2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */; };
-		2E2BF3602C555CE500AB08D2 /* indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35F2C555CE500AB08D2 /* indent.swift */; };
-		2E2BF3612C555CE500AB08D2 /* indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35F2C555CE500AB08D2 /* indent.swift */; };
-		2E2BF3622C555CE500AB08D2 /* indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35F2C555CE500AB08D2 /* indent.swift */; };
-		2E2BF3632C555CE500AB08D2 /* indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF35F2C555CE500AB08D2 /* indent.swift */; };
-		2E2CCE992C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */; };
-		2E2CCE9A2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */; };
-		2E2CCE9B2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */; };
-		2E2CCE9C2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */; };
-		2E2CCE9E2C56ACFA00D70FB0 /* applicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */; };
-		2E2CCE9F2C56ACFA00D70FB0 /* applicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */; };
-		2E2CCEA02C56ACFA00D70FB0 /* applicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */; };
-		2E2CCEA12C56ACFA00D70FB0 /* applicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */; };
-		2E2CCEA32C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */; };
-		2E2CCEA42C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */; };
-		2E2CCEA52C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */; };
-		2E2CCEA62C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */; };
-		2E2CCEA82C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */; };
-		2E2CCEA92C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */; };
-		2E2CCEAA2C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */; };
-		2E2CCEAB2C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */; };
-		2E2CCEAD2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */; };
-		2E2CCEAE2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */; };
-		2E2CCEAF2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */; };
-		2E2CCEB02C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */; };
-		2E2CCEB22C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */; };
-		2E2CCEB32C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */; };
-		2E2CCEB42C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */; };
-		2E2CCEB52C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */; };
-		2E2CCEB72C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */; };
-		2E2CCEB82C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */; };
-		2E2CCEB92C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */; };
-		2E2CCEBA2C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */; };
-		2E2CCEBC2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */; };
-		2E2CCEBD2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */; };
-		2E2CCEBE2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */; };
-		2E2CCEBF2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */; };
-		2E2CCEC12C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */; };
-		2E2CCEC22C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */; };
-		2E2CCEC32C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */; };
-		2E2CCEC42C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */; };
-		2E2CCEC62C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */; };
-		2E2CCEC72C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */; };
-		2E2CCEC82C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */; };
-		2E2CCEC92C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */; };
-		2E2CCECB2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */; };
-		2E2CCECC2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */; };
-		2E2CCECD2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */; };
-		2E2CCECE2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */; };
-		2E2CCED02C56AE2500D70FB0 /* redundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */; };
-		2E2CCED12C56AE2500D70FB0 /* redundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */; };
-		2E2CCED22C56AE2500D70FB0 /* redundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */; };
-		2E2CCED32C56AE2500D70FB0 /* redundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */; };
-		2E2CCED52C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */; };
-		2E2CCED62C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */; };
-		2E2CCED72C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */; };
-		2E2CCED82C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */; };
-		2E2CCEDA2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */; };
-		2E2CCEDB2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */; };
-		2E2CCEDC2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */; };
-		2E2CCEDD2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */; };
-		2E2CCEDF2C56AEB000D70FB0 /* trailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */; };
-		2E2CCEE02C56AEB000D70FB0 /* trailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */; };
-		2E2CCEE12C56AEB000D70FB0 /* trailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */; };
-		2E2CCEE22C56AEB000D70FB0 /* trailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */; };
-		2E2CCEE42C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */; };
-		2E2CCEE52C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */; };
-		2E2CCEE62C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */; };
-		2E2CCEE72C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */; };
-		2E2CCEE92C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */; };
-		2E2CCEEA2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */; };
-		2E2CCEEB2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */; };
-		2E2CCEEC2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */; };
-		2E2CCEEE2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */; };
-		2E2CCEEF2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */; };
-		2E2CCEF02C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */; };
-		2E2CCEF12C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */; };
-		2E2CCEF32C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */; };
-		2E2CCEF42C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */; };
-		2E2CCEF52C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */; };
-		2E2CCEF62C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */; };
-		2E2CCEF82C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */; };
-		2E2CCEF92C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */; };
-		2E2CCEFA2C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */; };
-		2E2CCEFB2C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */; };
-		2E2CCEFD2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */; };
-		2E2CCEFE2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */; };
-		2E2CCEFF2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */; };
-		2E2CCF002C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */; };
-		2E2CCF022C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */; };
-		2E2CCF032C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */; };
-		2E2CCF042C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */; };
-		2E2CCF052C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */; };
-		2E2CCF072C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */; };
-		2E2CCF082C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */; };
-		2E2CCF092C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */; };
-		2E2CCF0A2C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */; };
-		2E2CCF0C2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */; };
-		2E2CCF0D2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */; };
-		2E2CCF0E2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */; };
-		2E2CCF0F2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */; };
-		2E2CCF112C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */; };
-		2E2CCF122C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */; };
-		2E2CCF132C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */; };
-		2E2CCF142C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */; };
-		2E2CCF162C56B00E00D70FB0 /* braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF152C56B00E00D70FB0 /* braces.swift */; };
-		2E2CCF172C56B00E00D70FB0 /* braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF152C56B00E00D70FB0 /* braces.swift */; };
-		2E2CCF182C56B00E00D70FB0 /* braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF152C56B00E00D70FB0 /* braces.swift */; };
-		2E2CCF192C56B00E00D70FB0 /* braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF152C56B00E00D70FB0 /* braces.swift */; };
-		2E2CCF1B2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */; };
-		2E2CCF1C2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */; };
-		2E2CCF1D2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */; };
-		2E2CCF1E2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */; };
-		2E2CCF202C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */; };
-		2E2CCF212C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */; };
-		2E2CCF222C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */; };
-		2E2CCF232C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */; };
-		2E2CCF252C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */; };
-		2E2CCF262C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */; };
-		2E2CCF272C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */; };
-		2E2CCF282C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */; };
-		2E2CCF2A2C56B07200D70FB0 /* trailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */; };
-		2E2CCF2B2C56B07200D70FB0 /* trailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */; };
-		2E2CCF2C2C56B07200D70FB0 /* trailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */; };
-		2E2CCF2D2C56B07200D70FB0 /* trailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */; };
-		2E2CCF2F2C56B09700D70FB0 /* todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF2E2C56B09700D70FB0 /* todos.swift */; };
-		2E2CCF302C56B09700D70FB0 /* todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF2E2C56B09700D70FB0 /* todos.swift */; };
-		2E2CCF312C56B09700D70FB0 /* todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF2E2C56B09700D70FB0 /* todos.swift */; };
-		2E2CCF322C56B09700D70FB0 /* todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF2E2C56B09700D70FB0 /* todos.swift */; };
-		2E2CCF342C56B0AC00D70FB0 /* semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */; };
-		2E2CCF352C56B0AC00D70FB0 /* semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */; };
-		2E2CCF362C56B0AC00D70FB0 /* semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */; };
-		2E2CCF372C56B0AC00D70FB0 /* semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */; };
-		2E2CCF392C56B0C300D70FB0 /* linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */; };
-		2E2CCF3A2C56B0C300D70FB0 /* linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */; };
-		2E2CCF3B2C56B0C300D70FB0 /* linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */; };
-		2E2CCF3C2C56B0C300D70FB0 /* linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */; };
-		2E2CCF3E2C56B0DC00D70FB0 /* specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */; };
-		2E2CCF3F2C56B0DC00D70FB0 /* specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */; };
-		2E2CCF402C56B0DC00D70FB0 /* specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */; };
-		2E2CCF412C56B0DC00D70FB0 /* specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */; };
-		2E2CCF432C56B0F300D70FB0 /* modifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */; };
-		2E2CCF442C56B0F300D70FB0 /* modifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */; };
-		2E2CCF452C56B0F300D70FB0 /* modifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */; };
-		2E2CCF462C56B0F300D70FB0 /* modifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */; };
-		2E2CCF482C56B10E00D70FB0 /* trailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */; };
-		2E2CCF492C56B10E00D70FB0 /* trailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */; };
-		2E2CCF4A2C56B10E00D70FB0 /* trailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */; };
-		2E2CCF4B2C56B10E00D70FB0 /* trailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */; };
-		2E2CCF4D2C56B12F00D70FB0 /* redundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */; };
-		2E2CCF4E2C56B12F00D70FB0 /* redundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */; };
-		2E2CCF4F2C56B12F00D70FB0 /* redundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */; };
-		2E2CCF502C56B12F00D70FB0 /* redundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */; };
-		2E2CCF522C56B14400D70FB0 /* redundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF512C56B14400D70FB0 /* redundantGet.swift */; };
-		2E2CCF532C56B14400D70FB0 /* redundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF512C56B14400D70FB0 /* redundantGet.swift */; };
-		2E2CCF542C56B14400D70FB0 /* redundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF512C56B14400D70FB0 /* redundantGet.swift */; };
-		2E2CCF552C56B14400D70FB0 /* redundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF512C56B14400D70FB0 /* redundantGet.swift */; };
-		2E2CCF572C56B18100D70FB0 /* redundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */; };
-		2E2CCF582C56B18100D70FB0 /* redundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */; };
-		2E2CCF592C56B18100D70FB0 /* redundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */; };
-		2E2CCF5A2C56B18100D70FB0 /* redundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */; };
-		2E2CCF5C2C56B19B00D70FB0 /* redundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */; };
-		2E2CCF5D2C56B19B00D70FB0 /* redundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */; };
-		2E2CCF5E2C56B19B00D70FB0 /* redundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */; };
-		2E2CCF5F2C56B19B00D70FB0 /* redundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */; };
-		2E2CCF612C56B1B500D70FB0 /* redundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */; };
-		2E2CCF622C56B1B500D70FB0 /* redundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */; };
-		2E2CCF632C56B1B500D70FB0 /* redundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */; };
-		2E2CCF642C56B1B500D70FB0 /* redundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */; };
-		2E2CCF662C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */; };
-		2E2CCF672C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */; };
-		2E2CCF682C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */; };
-		2E2CCF692C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */; };
-		2E2CCF6B2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */; };
-		2E2CCF6C2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */; };
-		2E2CCF6D2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */; };
-		2E2CCF6E2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */; };
-		2E2CCF702C56B20900D70FB0 /* redundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */; };
-		2E2CCF712C56B20900D70FB0 /* redundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */; };
-		2E2CCF722C56B20900D70FB0 /* redundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */; };
-		2E2CCF732C56B20900D70FB0 /* redundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */; };
-		2E2CCF752C56B22000D70FB0 /* redundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */; };
-		2E2CCF762C56B22000D70FB0 /* redundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */; };
-		2E2CCF772C56B22000D70FB0 /* redundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */; };
-		2E2CCF782C56B22000D70FB0 /* redundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */; };
-		2E2CCF7A2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */; };
-		2E2CCF7B2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */; };
-		2E2CCF7C2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */; };
-		2E2CCF7D2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */; };
-		2E2CCF7F2C56B24F00D70FB0 /* redundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */; };
-		2E2CCF802C56B24F00D70FB0 /* redundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */; };
-		2E2CCF812C56B24F00D70FB0 /* redundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */; };
-		2E2CCF822C56B24F00D70FB0 /* redundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */; };
-		2E2CCF842C56B26E00D70FB0 /* unusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */; };
-		2E2CCF852C56B26E00D70FB0 /* unusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */; };
-		2E2CCF862C56B26F00D70FB0 /* unusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */; };
-		2E2CCF872C56B26F00D70FB0 /* unusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */; };
-		2E2CCF892C56B28C00D70FB0 /* hoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */; };
-		2E2CCF8A2C56B28C00D70FB0 /* hoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */; };
-		2E2CCF8B2C56B28C00D70FB0 /* hoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */; };
-		2E2CCF8C2C56B28C00D70FB0 /* hoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */; };
-		2E2CCF8E2C56B2A400D70FB0 /* hoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */; };
-		2E2CCF8F2C56B2A400D70FB0 /* hoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */; };
-		2E2CCF902C56B2A400D70FB0 /* hoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */; };
-		2E2CCF912C56B2A400D70FB0 /* hoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */; };
-		2E2CCF932C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */; };
-		2E2CCF942C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */; };
-		2E2CCF952C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */; };
-		2E2CCF962C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */; };
-		2E2CCF982C56B2FA00D70FB0 /* wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF972C56B2FA00D70FB0 /* wrap.swift */; };
-		2E2CCF992C56B2FA00D70FB0 /* wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF972C56B2FA00D70FB0 /* wrap.swift */; };
-		2E2CCF9A2C56B2FA00D70FB0 /* wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF972C56B2FA00D70FB0 /* wrap.swift */; };
-		2E2CCF9B2C56B2FA00D70FB0 /* wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF972C56B2FA00D70FB0 /* wrap.swift */; };
-		2E2CCF9D2C56B31000D70FB0 /* wrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */; };
-		2E2CCF9E2C56B31000D70FB0 /* wrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */; };
-		2E2CCF9F2C56B31000D70FB0 /* wrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */; };
-		2E2CCFA02C56B31000D70FB0 /* wrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */; };
-		2E2CCFA22C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */; };
-		2E2CCFA32C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */; };
-		2E2CCFA42C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */; };
-		2E2CCFA52C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */; };
-		2E2CCFA72C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */; };
-		2E2CCFA82C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */; };
-		2E2CCFA92C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */; };
-		2E2CCFAA2C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */; };
-		2E2CCFAC2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */; };
-		2E2CCFAD2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */; };
-		2E2CCFAE2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */; };
-		2E2CCFAF2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */; };
-		2E2CCFB12C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */; };
-		2E2CCFB22C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */; };
-		2E2CCFB32C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */; };
-		2E2CCFB42C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */; };
-		2E2CCFB62C56B38500D70FB0 /* void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB52C56B38500D70FB0 /* void.swift */; };
-		2E2CCFB72C56B38500D70FB0 /* void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB52C56B38500D70FB0 /* void.swift */; };
-		2E2CCFB82C56B38500D70FB0 /* void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB52C56B38500D70FB0 /* void.swift */; };
-		2E2CCFB92C56B38500D70FB0 /* void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFB52C56B38500D70FB0 /* void.swift */; };
-		2E2CCFBB2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */; };
-		2E2CCFBC2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */; };
-		2E2CCFBD2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */; };
-		2E2CCFBE2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */; };
-		2E2CCFC02C56B41600D70FB0 /* fileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */; };
-		2E2CCFC12C56B41600D70FB0 /* fileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */; };
-		2E2CCFC22C56B41600D70FB0 /* fileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */; };
-		2E2CCFC32C56B41600D70FB0 /* fileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */; };
-		2E2CCFC52C56B42A00D70FB0 /* headerFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */; };
-		2E2CCFC62C56B42A00D70FB0 /* headerFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */; };
-		2E2CCFC72C56B42A00D70FB0 /* headerFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */; };
-		2E2CCFC82C56B42A00D70FB0 /* headerFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */; };
-		2E2CCFCA2C56B44100D70FB0 /* redundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */; };
-		2E2CCFCB2C56B44100D70FB0 /* redundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */; };
-		2E2CCFCC2C56B44100D70FB0 /* redundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */; };
-		2E2CCFCD2C56B44100D70FB0 /* redundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */; };
-		2E2CCFCF2C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */; };
-		2E2CCFD02C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */; };
-		2E2CCFD12C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */; };
-		2E2CCFD22C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */; };
-		2E2CCFD42C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */; };
-		2E2CCFD52C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */; };
-		2E2CCFD62C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */; };
-		2E2CCFD72C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */; };
-		2E2CCFD92C56B48400D70FB0 /* sortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */; };
-		2E2CCFDA2C56B48400D70FB0 /* sortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */; };
-		2E2CCFDB2C56B48400D70FB0 /* sortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */; };
-		2E2CCFDC2C56B48400D70FB0 /* sortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */; };
-		2E2CCFDE2C56B4A000D70FB0 /* sortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */; };
-		2E2CCFDF2C56B4A000D70FB0 /* sortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */; };
-		2E2CCFE02C56B4A000D70FB0 /* sortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */; };
-		2E2CCFE12C56B4A000D70FB0 /* sortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */; };
-		2E2CCFE32C56B4B700D70FB0 /* duplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */; };
-		2E2CCFE42C56B4B700D70FB0 /* duplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */; };
-		2E2CCFE52C56B4B700D70FB0 /* duplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */; };
-		2E2CCFE62C56B4B700D70FB0 /* duplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */; };
-		2E2CCFE82C56B4CC00D70FB0 /* strongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */; };
-		2E2CCFE92C56B4CC00D70FB0 /* strongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */; };
-		2E2CCFEA2C56B4CC00D70FB0 /* strongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */; };
-		2E2CCFEB2C56B4CC00D70FB0 /* strongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */; };
-		2E2CCFED2C56B4E000D70FB0 /* emptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */; };
-		2E2CCFEE2C56B4E000D70FB0 /* emptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */; };
-		2E2CCFEF2C56B4E000D70FB0 /* emptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */; };
-		2E2CCFF02C56B4E000D70FB0 /* emptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */; };
-		2E2CCFF22C56B4F900D70FB0 /* andOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */; };
-		2E2CCFF32C56B4F900D70FB0 /* andOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */; };
-		2E2CCFF42C56B4F900D70FB0 /* andOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */; };
-		2E2CCFF52C56B4F900D70FB0 /* andOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */; };
-		2E2CCFF72C56B51100D70FB0 /* isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */; };
-		2E2CCFF82C56B51100D70FB0 /* isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */; };
-		2E2CCFF92C56B51100D70FB0 /* isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */; };
-		2E2CCFFA2C56B51100D70FB0 /* isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */; };
-		2E2CCFFC2C56B52900D70FB0 /* redundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */; };
-		2E2CCFFD2C56B52900D70FB0 /* redundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */; };
-		2E2CCFFE2C56B52900D70FB0 /* redundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */; };
-		2E2CCFFF2C56B52900D70FB0 /* redundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */; };
-		2E2CD0012C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */; };
-		2E2CD0022C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */; };
-		2E2CD0032C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */; };
-		2E2CD0042C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */; };
-		2E2CD0062C56B55200D70FB0 /* redundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */; };
-		2E2CD0072C56B55200D70FB0 /* redundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */; };
-		2E2CD0082C56B55200D70FB0 /* redundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */; };
-		2E2CD0092C56B55200D70FB0 /* redundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */; };
-		2E2CD00B2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */; };
-		2E2CD00C2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */; };
-		2E2CD00D2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */; };
-		2E2CD00E2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */; };
-		2E2CD0102C56B58300D70FB0 /* redundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */; };
-		2E2CD0112C56B58300D70FB0 /* redundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */; };
-		2E2CD0122C56B58300D70FB0 /* redundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */; };
-		2E2CD0132C56B58300D70FB0 /* redundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */; };
-		2E2CD0152C56B59C00D70FB0 /* typeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */; };
-		2E2CD0162C56B59C00D70FB0 /* typeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */; };
-		2E2CD0172C56B59C00D70FB0 /* typeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */; };
-		2E2CD0182C56B59C00D70FB0 /* typeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */; };
-		2E2CD01A2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */; };
-		2E2CD01B2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */; };
-		2E2CD01C2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */; };
-		2E2CD01D2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */; };
-		2E2CD01F2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */; };
-		2E2CD0202C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */; };
-		2E2CD0212C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */; };
-		2E2CD0222C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */; };
-		2E2CD0242C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */; };
-		2E2CD0252C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */; };
-		2E2CD0262C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */; };
-		2E2CD0272C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */; };
-		2E2CD0292C56B5FE00D70FB0 /* yodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */; };
-		2E2CD02A2C56B5FE00D70FB0 /* yodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */; };
-		2E2CD02B2C56B5FE00D70FB0 /* yodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */; };
-		2E2CD02C2C56B5FF00D70FB0 /* yodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */; };
-		2E2CD02E2C56B61500D70FB0 /* leadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */; };
-		2E2CD02F2C56B61500D70FB0 /* leadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */; };
-		2E2CD0302C56B61500D70FB0 /* leadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */; };
-		2E2CD0312C56B61500D70FB0 /* leadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */; };
-		2E2CD0332C56B62C00D70FB0 /* wrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */; };
-		2E2CD0342C56B62C00D70FB0 /* wrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */; };
-		2E2CD0352C56B62C00D70FB0 /* wrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */; };
-		2E2CD0362C56B62C00D70FB0 /* wrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */; };
-		2E2CD0382C56B64300D70FB0 /* preferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */; };
-		2E2CD0392C56B64300D70FB0 /* preferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */; };
-		2E2CD03A2C56B64300D70FB0 /* preferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */; };
-		2E2CD03B2C56B64300D70FB0 /* preferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */; };
-		2E2CD03D2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */; };
-		2E2CD03E2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */; };
-		2E2CD03F2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */; };
-		2E2CD0402C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */; };
-		2E2CD0422C56B67400D70FB0 /* extensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */; };
-		2E2CD0432C56B67400D70FB0 /* extensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */; };
-		2E2CD0442C56B67400D70FB0 /* extensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */; };
-		2E2CD0452C56B67400D70FB0 /* extensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */; };
-		2E2CD0472C56B69800D70FB0 /* markTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0462C56B69800D70FB0 /* markTypes.swift */; };
-		2E2CD0482C56B69800D70FB0 /* markTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0462C56B69800D70FB0 /* markTypes.swift */; };
-		2E2CD0492C56B69800D70FB0 /* markTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0462C56B69800D70FB0 /* markTypes.swift */; };
-		2E2CD04A2C56B69800D70FB0 /* markTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0462C56B69800D70FB0 /* markTypes.swift */; };
-		2E2CD04C2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */; };
-		2E2CD04D2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */; };
-		2E2CD04E2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */; };
-		2E2CD04F2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */; };
-		2E2CD0512C56B6C800D70FB0 /* assertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */; };
-		2E2CD0522C56B6C900D70FB0 /* assertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */; };
-		2E2CD0532C56B6C900D70FB0 /* assertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */; };
-		2E2CD0542C56B6C900D70FB0 /* assertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */; };
-		2E2CD0562C56B6E000D70FB0 /* acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0552C56B6E000D70FB0 /* acronyms.swift */; };
-		2E2CD0572C56B6E000D70FB0 /* acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0552C56B6E000D70FB0 /* acronyms.swift */; };
-		2E2CD0582C56B6E000D70FB0 /* acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0552C56B6E000D70FB0 /* acronyms.swift */; };
-		2E2CD0592C56B6E000D70FB0 /* acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0552C56B6E000D70FB0 /* acronyms.swift */; };
-		2E2CD05B2C56B6F900D70FB0 /* blockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */; };
-		2E2CD05C2C56B6F900D70FB0 /* blockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */; };
-		2E2CD05D2C56B6F900D70FB0 /* blockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */; };
-		2E2CD05E2C56B6F900D70FB0 /* blockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */; };
-		2E2CD0602C56B71A00D70FB0 /* redundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */; };
-		2E2CD0612C56B71A00D70FB0 /* redundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */; };
-		2E2CD0622C56B71A00D70FB0 /* redundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */; };
-		2E2CD0632C56B71A00D70FB0 /* redundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */; };
-		2E2CD0652C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */; };
-		2E2CD0662C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */; };
-		2E2CD0672C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */; };
-		2E2CD0682C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */; };
-		2E2CD06A2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */; };
-		2E2CD06B2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */; };
-		2E2CD06C2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */; };
-		2E2CD06D2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */; };
-		2E2CD06F2C56B8F100D70FB0 /* genericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */; };
-		2E2CD0702C56B8F100D70FB0 /* genericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */; };
-		2E2CD0712C56B8F100D70FB0 /* genericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */; };
-		2E2CD0722C56B8F100D70FB0 /* genericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */; };
-		2E2CD0742C56B90900D70FB0 /* docComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0732C56B90900D70FB0 /* docComments.swift */; };
-		2E2CD0752C56B90900D70FB0 /* docComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0732C56B90900D70FB0 /* docComments.swift */; };
-		2E2CD0762C56B90900D70FB0 /* docComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0732C56B90900D70FB0 /* docComments.swift */; };
-		2E2CD0772C56B90900D70FB0 /* docComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0732C56B90900D70FB0 /* docComments.swift */; };
-		2E2CD0792C56B92100D70FB0 /* conditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */; };
-		2E2CD07A2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */; };
-		2E2CD07B2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */; };
-		2E2CD07C2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */; };
-		2E2CD07E2C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */; };
-		2E2CD07F2C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */; };
-		2E2CD0802C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */; };
-		2E2CD0812C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */; };
-		2E2CD0832C56B9D100D70FB0 /* redundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */; };
-		2E2CD0842C56B9D100D70FB0 /* redundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */; };
-		2E2CD0852C56B9D100D70FB0 /* redundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */; };
-		2E2CD0862C56B9D100D70FB0 /* redundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */; };
-		2E2CD0882C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */; };
-		2E2CD0892C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */; };
-		2E2CD08A2C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */; };
-		2E2CD08B2C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */; };
-		2E2CD08D2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */; };
-		2E2CD08E2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */; };
-		2E2CD08F2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */; };
-		2E2CD0902C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */; };
-		2E2CD0922C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */; };
-		2E2CD0932C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */; };
-		2E2CD0942C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */; };
-		2E2CD0952C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */; };
-		2E2CD0972C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */; };
-		2E2CD0982C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */; };
-		2E2CD0992C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */; };
-		2E2CD09A2C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */; };
-		2E2CD09C2C56BA3900D70FB0 /* redundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */; };
-		2E2CD09D2C56BA3900D70FB0 /* redundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */; };
-		2E2CD09E2C56BA3900D70FB0 /* redundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */; };
-		2E2CD09F2C56BA3900D70FB0 /* redundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */; };
-		2E2CD0A12C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */; };
-		2E2CD0A22C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */; };
-		2E2CD0A32C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */; };
-		2E2CD0A42C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */; };
-		2E2CD0A62C56BA6A00D70FB0 /* propertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */; };
-		2E2CD0A72C56BA6A00D70FB0 /* propertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */; };
-		2E2CD0A82C56BA6A00D70FB0 /* propertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */; };
-		2E2CD0A92C56BA6A00D70FB0 /* propertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */; };
-		2E2CD0AB2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */; };
-		2E2CD0AC2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */; };
-		2E2CD0AD2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */; };
-		2E2CD0AE2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */; };
 		2E4A8AE92C56DF14005A22B1 /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A8AE52C56DF14005A22B1 /* GithubActionsLogReporter.swift */; };
 		2E4A8AEA2C56DF14005A22B1 /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A8AE52C56DF14005A22B1 /* GithubActionsLogReporter.swift */; };
 		2E4A8AEB2C56DF14005A22B1 /* XMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A8AE62C56DF14005A22B1 /* XMLReporter.swift */; };
@@ -683,117 +573,117 @@
 		01F3DF8B1DB9FD3F00454944 /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		01F3DF8F1DBA003E00454944 /* InferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InferenceTests.swift; sourceTree = "<group>"; };
 		2E230CA12C4C1C0700A16E2E /* DeclarationHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationHelpers.swift; sourceTree = "<group>"; };
-		2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = preferForLoop.swift; sourceTree = "<group>"; };
+		2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitCoderUnavailable.swift; sourceTree = "<group>"; };
+		2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBreak.swift; sourceTree = "<group>"; };
+		2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterSwitchCase.swift; sourceTree = "<group>"; };
+		2E2BA5FD2C57D2D500590239 /* Indent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Indent.swift; sourceTree = "<group>"; };
+		2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineConditionalAssignment.swift; sourceTree = "<group>"; };
+		2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveSpaces.swift; sourceTree = "<group>"; };
+		2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsistentSwitchCaseSpacing.swift; sourceTree = "<group>"; };
+		2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantExtensionACL.swift; sourceTree = "<group>"; };
+		2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalBinding.swift; sourceTree = "<group>"; };
+		2E2BA6032C57D2D500590239 /* RedundantInternal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInternal.swift; sourceTree = "<group>"; };
+		2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilInit.swift; sourceTree = "<group>"; };
+		2E2BA6052C57D2D500590239 /* Todos.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todos.swift; sourceTree = "<group>"; };
+		2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideParens.swift; sourceTree = "<group>"; };
+		2E2BA6072C57D2D500590239 /* Semicolons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semicolons.swift; sourceTree = "<group>"; };
+		2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistPatternLet.swift; sourceTree = "<group>"; };
+		2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElseOnSameLine.swift; sourceTree = "<group>"; };
+		2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImports.swift; sourceTree = "<group>"; };
+		2E2BA60B2C57D2D500590239 /* RedundantGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantGet.swift; sourceTree = "<group>"; };
+		2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundOperators.swift; sourceTree = "<group>"; };
+		2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAroundMark.swift; sourceTree = "<group>"; };
+		2E2BA60E2C57D2D500590239 /* SortImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortImports.swift; sourceTree = "<group>"; };
+		2E2BA60F2C57D2D500590239 /* SortedImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImports.swift; sourceTree = "<group>"; };
+		2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenChainedFunctions.swift; sourceTree = "<group>"; };
+		2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantFileprivate.swift; sourceTree = "<group>"; };
+		2E2BA6122C57D2D500590239 /* BlockComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockComments.swift; sourceTree = "<group>"; };
+		2E2BA6132C57D2D500590239 /* StrongOutlets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongOutlets.swift; sourceTree = "<group>"; };
+		2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinebreakAtEndOfFile.swift; sourceTree = "<group>"; };
+		2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideGenerics.swift; sourceTree = "<group>"; };
+		2E2BA6162C57D2D500590239 /* AssertionFailures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionFailures.swift; sourceTree = "<group>"; };
+		2E2BA6172C57D2D500590239 /* EmptyBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyBraces.swift; sourceTree = "<group>"; };
+		2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundComments.swift; sourceTree = "<group>"; };
+		2E2BA6192C57D2D500590239 /* RedundantParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantParens.swift; sourceTree = "<group>"; };
+		2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundGenerics.swift; sourceTree = "<group>"; };
+		2E2BA61B2C57D2D500590239 /* Linebreaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linebreaks.swift; sourceTree = "<group>"; };
+		2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeadingDelimiters.swift; sourceTree = "<group>"; };
+		2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideComments.swift; sourceTree = "<group>"; };
+		2E2BA61E2C57D2D500590239 /* RedundantLet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLet.swift; sourceTree = "<group>"; };
+		2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocCommentsBeforeAttributes.swift; sourceTree = "<group>"; };
+		2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveBlankLines.swift; sourceTree = "<group>"; };
+		2E2BA6212C57D2D500590239 /* RedundantInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInit.swift; sourceTree = "<group>"; };
+		2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExplicitOwnership.swift; sourceTree = "<group>"; };
+		2E2BA6232C57D2D500590239 /* Void.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Void.swift; sourceTree = "<group>"; };
+		2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSingleLineComments.swift; sourceTree = "<group>"; };
+		2E2BA6252C57D2D500590239 /* RedundantLetError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLetError.swift; sourceTree = "<group>"; };
+		2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenScopes.swift; sourceTree = "<group>"; };
+		2E2BA6272C57D2D500590239 /* RedundantClosure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantClosure.swift; sourceTree = "<group>"; };
+		2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizeDeclarations.swift; sourceTree = "<group>"; };
+		2E2BA6292C57D2D500590239 /* FileHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeader.swift; sourceTree = "<group>"; };
+		2E2BA62A2C57D2D500590239 /* TypeSugar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeSugar.swift; sourceTree = "<group>"; };
+		2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBrackets.swift; sourceTree = "<group>"; };
+		2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFileName.swift; sourceTree = "<group>"; };
+		2E2BA62D2C57D2D500590239 /* IsEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsEmpty.swift; sourceTree = "<group>"; };
+		2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBrackets.swift; sourceTree = "<group>"; };
+		2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtEndOfScope.swift; sourceTree = "<group>"; };
+		2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionAccessControl.swift; sourceTree = "<group>"; };
+		2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBraces.swift; sourceTree = "<group>"; };
+		2E2BA6322C57D2D500590239 /* RedundantReturn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantReturn.swift; sourceTree = "<group>"; };
+		2E2BA6332C57D2D500590239 /* GenericExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericExtensions.swift; sourceTree = "<group>"; };
+		2E2BA6342C57D2D500590239 /* TrailingSpace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingSpace.swift; sourceTree = "<group>"; };
+		2E2BA6352C57D2D500590239 /* RedundantObjc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjc.swift; sourceTree = "<group>"; };
+		2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalAssignment.swift; sourceTree = "<group>"; };
+		2E2BA6372C57D2D500590239 /* PreferForLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferForLoop.swift; sourceTree = "<group>"; };
+		2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStaticSelf.swift; sourceTree = "<group>"; };
+		2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenImports.swift; sourceTree = "<group>"; };
+		2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineStatementBraces.swift; sourceTree = "<group>"; };
+		2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBraces.swift; sourceTree = "<group>"; };
+		2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantPattern.swift; sourceTree = "<group>"; };
+		2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationMain.swift; sourceTree = "<group>"; };
+		2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantProperty.swift; sourceTree = "<group>"; };
+		2E2BA63F2C57D2D500590239 /* Wrap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrap.swift; sourceTree = "<group>"; };
+		2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterImports.swift; sourceTree = "<group>"; };
+		2E2BA6412C57D2D500590239 /* ModifierOrder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrder.swift; sourceTree = "<group>"; };
+		2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumNamespaces.swift; sourceTree = "<group>"; };
+		2E2BA6432C57D2D500590239 /* RedundantSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantSelf.swift; sourceTree = "<group>"; };
+		2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferKeyPath.swift; sourceTree = "<group>"; };
+		2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapEnumCases.swift; sourceTree = "<group>"; };
+		2E2BA6462C57D2D500590239 /* WrapAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapAttributes.swift; sourceTree = "<group>"; };
+		2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapConditionalBodies.swift; sourceTree = "<group>"; };
+		2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSwitchCases.swift; sourceTree = "<group>"; };
+		2E2BA6492C57D2D500590239 /* Braces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Braces.swift; sourceTree = "<group>"; };
+		2E2BA64A2C57D2D500590239 /* MarkTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkTypes.swift; sourceTree = "<group>"; };
+		2E2BA64B2C57D2D500590239 /* AndOperator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AndOperator.swift; sourceTree = "<group>"; };
+		2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapLoopBodies.swift; sourceTree = "<group>"; };
+		2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnType.swift; sourceTree = "<group>"; };
+		2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantRawValues.swift; sourceTree = "<group>"; };
+		2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommas.swift; sourceTree = "<group>"; };
+		2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongifiedSelf.swift; sourceTree = "<group>"; };
+		2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyObjectProtocol.swift; sourceTree = "<group>"; };
+		2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBackticks.swift; sourceTree = "<group>"; };
+		2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundParens.swift; sourceTree = "<group>"; };
+		2E2BA6542C57D2D500590239 /* HoistAwait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistAwait.swift; sourceTree = "<group>"; };
+		2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtStartOfScope.swift; sourceTree = "<group>"; };
+		2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpaqueGenericParameters.swift; sourceTree = "<group>"; };
+		2E2BA6572C57D2D500590239 /* TrailingClosures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingClosures.swift; sourceTree = "<group>"; };
+		2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedSwitchCases.swift; sourceTree = "<group>"; };
+		2E2BA6592C57D2D500590239 /* Acronyms.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Acronyms.swift; sourceTree = "<group>"; };
+		2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortTypealiases.swift; sourceTree = "<group>"; };
+		2E2BA65B2C57D2D500590239 /* DocComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocComments.swift; sourceTree = "<group>"; };
+		2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedPrivateDeclaration.swift; sourceTree = "<group>"; };
+		2E2BA65D2C57D2D500590239 /* PropertyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyType.swift; sourceTree = "<group>"; };
+		2E2BA65E2C57D2D500590239 /* HoistTry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistTry.swift; sourceTree = "<group>"; };
+		2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatting.swift; sourceTree = "<group>"; };
+		2E2BA6602C57D2D500590239 /* WrapArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapArguments.swift; sourceTree = "<group>"; };
+		2E2BA6612C57D2D500590239 /* Specifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Specifiers.swift; sourceTree = "<group>"; };
+		2E2BA6622C57D2D500590239 /* YodaConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YodaConditions.swift; sourceTree = "<group>"; };
+		2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantTypedThrows.swift; sourceTree = "<group>"; };
+		2E2BA6642C57D2D500590239 /* UnusedArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedArguments.swift; sourceTree = "<group>"; };
+		2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortSwitchCases.swift; sourceTree = "<group>"; };
+		2E2BA6662C57D2D500590239 /* RedundantType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantType.swift; sourceTree = "<group>"; };
+		2E2BA6672C57D2D500590239 /* SortDeclarations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDeclarations.swift; sourceTree = "<group>"; };
 		2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleRegistry.swift; sourceTree = "<group>"; };
-		2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundComments.swift; sourceTree = "<group>"; };
-		2E2BF35F2C555CE500AB08D2 /* indent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = indent.swift; sourceTree = "<group>"; };
-		2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundParens.swift; sourceTree = "<group>"; };
-		2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = applicationMain.swift; sourceTree = "<group>"; };
-		2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceInsideParens.swift; sourceTree = "<group>"; };
-		2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundBrackets.swift; sourceTree = "<group>"; };
-		2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceInsideBrackets.swift; sourceTree = "<group>"; };
-		2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundBraces.swift; sourceTree = "<group>"; };
-		2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceInsideBraces.swift; sourceTree = "<group>"; };
-		2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundGenerics.swift; sourceTree = "<group>"; };
-		2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceInsideGenerics.swift; sourceTree = "<group>"; };
-		2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceAroundOperators.swift; sourceTree = "<group>"; };
-		2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = spaceInsideComments.swift; sourceTree = "<group>"; };
-		2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantType.swift; sourceTree = "<group>"; };
-		2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = consecutiveSpaces.swift; sourceTree = "<group>"; };
-		2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = enumNamespaces.swift; sourceTree = "<group>"; };
-		2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = trailingSpace.swift; sourceTree = "<group>"; };
-		2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = consecutiveBlankLines.swift; sourceTree = "<group>"; };
-		2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesAtStartOfScope.swift; sourceTree = "<group>"; };
-		2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesAtEndOfScope.swift; sourceTree = "<group>"; };
-		2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesBetweenImports.swift; sourceTree = "<group>"; };
-		2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesBetweenChainedFunctions.swift; sourceTree = "<group>"; };
-		2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLineAfterImports.swift; sourceTree = "<group>"; };
-		2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesBetweenScopes.swift; sourceTree = "<group>"; };
-		2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLinesAroundMark.swift; sourceTree = "<group>"; };
-		2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = linebreakAtEndOfFile.swift; sourceTree = "<group>"; };
-		2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = initCoderUnavailable.swift; sourceTree = "<group>"; };
-		2E2CCF152C56B00E00D70FB0 /* braces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = braces.swift; sourceTree = "<group>"; };
-		2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = elseOnSameLine.swift; sourceTree = "<group>"; };
-		2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapConditionalBodies.swift; sourceTree = "<group>"; };
-		2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapLoopBodies.swift; sourceTree = "<group>"; };
-		2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = trailingCommas.swift; sourceTree = "<group>"; };
-		2E2CCF2E2C56B09700D70FB0 /* todos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = todos.swift; sourceTree = "<group>"; };
-		2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = semicolons.swift; sourceTree = "<group>"; };
-		2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = linebreaks.swift; sourceTree = "<group>"; };
-		2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = specifiers.swift; sourceTree = "<group>"; };
-		2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = modifierOrder.swift; sourceTree = "<group>"; };
-		2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = trailingClosures.swift; sourceTree = "<group>"; };
-		2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantParens.swift; sourceTree = "<group>"; };
-		2E2CCF512C56B14400D70FB0 /* redundantGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantGet.swift; sourceTree = "<group>"; };
-		2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantNilInit.swift; sourceTree = "<group>"; };
-		2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantLet.swift; sourceTree = "<group>"; };
-		2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantPattern.swift; sourceTree = "<group>"; };
-		2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantRawValues.swift; sourceTree = "<group>"; };
-		2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantVoidReturnType.swift; sourceTree = "<group>"; };
-		2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantReturn.swift; sourceTree = "<group>"; };
-		2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantBackticks.swift; sourceTree = "<group>"; };
-		2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantStaticSelf.swift; sourceTree = "<group>"; };
-		2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantSelf.swift; sourceTree = "<group>"; };
-		2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unusedArguments.swift; sourceTree = "<group>"; };
-		2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hoistTry.swift; sourceTree = "<group>"; };
-		2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hoistAwait.swift; sourceTree = "<group>"; };
-		2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hoistPatternLet.swift; sourceTree = "<group>"; };
-		2E2CCF972C56B2FA00D70FB0 /* wrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrap.swift; sourceTree = "<group>"; };
-		2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapArguments.swift; sourceTree = "<group>"; };
-		2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapMultilineStatementBraces.swift; sourceTree = "<group>"; };
-		2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapEnumCases.swift; sourceTree = "<group>"; };
-		2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapSingleLineComments.swift; sourceTree = "<group>"; };
-		2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapSwitchCases.swift; sourceTree = "<group>"; };
-		2E2CCFB52C56B38500D70FB0 /* void.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = void.swift; sourceTree = "<group>"; };
-		2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = numberFormatting.swift; sourceTree = "<group>"; };
-		2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fileHeader.swift; sourceTree = "<group>"; };
-		2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = headerFileName.swift; sourceTree = "<group>"; };
-		2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantInit.swift; sourceTree = "<group>"; };
-		2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortedSwitchCases.swift; sourceTree = "<group>"; };
-		2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortSwitchCases.swift; sourceTree = "<group>"; };
-		2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortedImports.swift; sourceTree = "<group>"; };
-		2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortImports.swift; sourceTree = "<group>"; };
-		2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = duplicateImports.swift; sourceTree = "<group>"; };
-		2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = strongOutlets.swift; sourceTree = "<group>"; };
-		2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = emptyBraces.swift; sourceTree = "<group>"; };
-		2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = andOperator.swift; sourceTree = "<group>"; };
-		2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = isEmpty.swift; sourceTree = "<group>"; };
-		2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantLetError.swift; sourceTree = "<group>"; };
-		2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = anyObjectProtocol.swift; sourceTree = "<group>"; };
-		2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantBreak.swift; sourceTree = "<group>"; };
-		2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = strongifiedSelf.swift; sourceTree = "<group>"; };
-		2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantObjc.swift; sourceTree = "<group>"; };
-		2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = typeSugar.swift; sourceTree = "<group>"; };
-		2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantExtensionACL.swift; sourceTree = "<group>"; };
-		2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unusedPrivateDeclaration.swift; sourceTree = "<group>"; };
-		2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantFileprivate.swift; sourceTree = "<group>"; };
-		2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = yodaConditions.swift; sourceTree = "<group>"; };
-		2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = leadingDelimiters.swift; sourceTree = "<group>"; };
-		2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapAttributes.swift; sourceTree = "<group>"; };
-		2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = preferKeyPath.swift; sourceTree = "<group>"; };
-		2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = organizeDeclarations.swift; sourceTree = "<group>"; };
-		2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = extensionAccessControl.swift; sourceTree = "<group>"; };
-		2E2CD0462C56B69800D70FB0 /* markTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = markTypes.swift; sourceTree = "<group>"; };
-		2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortDeclarations.swift; sourceTree = "<group>"; };
-		2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = assertionFailures.swift; sourceTree = "<group>"; };
-		2E2CD0552C56B6E000D70FB0 /* acronyms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = acronyms.swift; sourceTree = "<group>"; };
-		2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blockComments.swift; sourceTree = "<group>"; };
-		2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantClosure.swift; sourceTree = "<group>"; };
-		2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantOptionalBinding.swift; sourceTree = "<group>"; };
-		2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = opaqueGenericParameters.swift; sourceTree = "<group>"; };
-		2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = genericExtensions.swift; sourceTree = "<group>"; };
-		2E2CD0732C56B90900D70FB0 /* docComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = docComments.swift; sourceTree = "<group>"; };
-		2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = conditionalAssignment.swift; sourceTree = "<group>"; };
-		2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sortTypealiases.swift; sourceTree = "<group>"; };
-		2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantInternal.swift; sourceTree = "<group>"; };
-		2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = noExplicitOwnership.swift; sourceTree = "<group>"; };
-		2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrapMultilineConditionalAssignment.swift; sourceTree = "<group>"; };
-		2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = blankLineAfterSwitchCase.swift; sourceTree = "<group>"; };
-		2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = consistentSwitchCaseSpacing.swift; sourceTree = "<group>"; };
-		2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantProperty.swift; sourceTree = "<group>"; };
-		2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = redundantTypedThrows.swift; sourceTree = "<group>"; };
-		2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = propertyType.swift; sourceTree = "<group>"; };
-		2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = docCommentsBeforeAttributes.swift; sourceTree = "<group>"; };
 		2E4A8AE52C56DF14005A22B1 /* GithubActionsLogReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubActionsLogReporter.swift; sourceTree = "<group>"; };
 		2E4A8AE62C56DF14005A22B1 /* XMLReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLReporter.swift; sourceTree = "<group>"; };
 		2E4A8AE72C56DF14005A22B1 /* JSONReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
@@ -918,7 +808,7 @@
 		01A0EAA61D5DB4CF00A0A8E3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				2E2BF3492C554E2E00AB08D2 /* Rules */,
+				2E2BA5F92C57D2D500590239 /* Rules */,
 				01F17E811E25870700DCD359 /* CommandLine.swift */,
 				E4E4D3C82033F17C000D7CB1 /* EnumAssociable.swift */,
 				01B3987C1D763493009ADE61 /* Formatter.swift */,
@@ -996,119 +886,119 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
-		2E2BF3492C554E2E00AB08D2 /* Rules */ = {
+		2E2BA5F92C57D2D500590239 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
-				2E2BF34A2C554E6400AB08D2 /* preferForLoop.swift */,
-				2E2BF35F2C555CE500AB08D2 /* indent.swift */,
-				2E2CCE982C56ACE500D70FB0 /* spaceAroundParens.swift */,
-				2E2CCE9D2C56ACFA00D70FB0 /* applicationMain.swift */,
-				2E2CCEA22C56AD0E00D70FB0 /* spaceInsideParens.swift */,
-				2E2CCEA72C56AD2700D70FB0 /* spaceAroundBrackets.swift */,
-				2E2CCEAC2C56AD3900D70FB0 /* spaceInsideBrackets.swift */,
-				2E2CCEB12C56AD5100D70FB0 /* spaceAroundBraces.swift */,
-				2E2CCEB62C56AD9700D70FB0 /* spaceInsideBraces.swift */,
-				2E2CCEBB2C56ADB000D70FB0 /* spaceAroundGenerics.swift */,
-				2E2CCEC02C56ADC000D70FB0 /* spaceInsideGenerics.swift */,
-				2E2CCEC52C56ADE600D70FB0 /* spaceAroundOperators.swift */,
-				2E2CCECA2C56AE0800D70FB0 /* spaceInsideComments.swift */,
-				2E2BF35A2C555CB700AB08D2 /* spaceAroundComments.swift */,
-				2E2CCECF2C56AE2500D70FB0 /* redundantType.swift */,
-				2E2CCED42C56AE3C00D70FB0 /* consecutiveSpaces.swift */,
-				2E2CCED92C56AE5500D70FB0 /* enumNamespaces.swift */,
-				2E2CCEDE2C56AEB000D70FB0 /* trailingSpace.swift */,
-				2E2CCEE32C56AECB00D70FB0 /* consecutiveBlankLines.swift */,
-				2E2CCEE82C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift */,
-				2E2CCEED2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift */,
-				2E2CCEF22C56AF1A00D70FB0 /* blankLinesBetweenImports.swift */,
-				2E2CCEF72C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift */,
-				2E2CCEFC2C56AF5A00D70FB0 /* blankLineAfterImports.swift */,
-				2E2CCF012C56AF8300D70FB0 /* blankLinesBetweenScopes.swift */,
-				2E2CCF062C56AF9F00D70FB0 /* blankLinesAroundMark.swift */,
-				2E2CCF0B2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift */,
-				2E2CCF102C56AFE900D70FB0 /* initCoderUnavailable.swift */,
-				2E2CCF152C56B00E00D70FB0 /* braces.swift */,
-				2E2CCF1A2C56B02A00D70FB0 /* elseOnSameLine.swift */,
-				2E2CCF1F2C56B04200D70FB0 /* wrapConditionalBodies.swift */,
-				2E2CCF242C56B05A00D70FB0 /* wrapLoopBodies.swift */,
-				2E2CCF292C56B07200D70FB0 /* trailingCommas.swift */,
-				2E2CCF2E2C56B09700D70FB0 /* todos.swift */,
-				2E2CCF332C56B0AC00D70FB0 /* semicolons.swift */,
-				2E2CCF382C56B0C300D70FB0 /* linebreaks.swift */,
-				2E2CCF3D2C56B0DC00D70FB0 /* specifiers.swift */,
-				2E2CCF422C56B0F300D70FB0 /* modifierOrder.swift */,
-				2E2CCF472C56B10E00D70FB0 /* trailingClosures.swift */,
-				2E2CCF4C2C56B12F00D70FB0 /* redundantParens.swift */,
-				2E2CCF512C56B14400D70FB0 /* redundantGet.swift */,
-				2E2CCF562C56B18100D70FB0 /* redundantNilInit.swift */,
-				2E2CCF5B2C56B19B00D70FB0 /* redundantLet.swift */,
-				2E2CCF602C56B1B500D70FB0 /* redundantPattern.swift */,
-				2E2CCF652C56B1CE00D70FB0 /* redundantRawValues.swift */,
-				2E2CCF6A2C56B1E600D70FB0 /* redundantVoidReturnType.swift */,
-				2E2CCF6F2C56B20900D70FB0 /* redundantReturn.swift */,
-				2E2CCF742C56B22000D70FB0 /* redundantBackticks.swift */,
-				2E2CCF792C56B23B00D70FB0 /* redundantStaticSelf.swift */,
-				2E2CCF7E2C56B24F00D70FB0 /* redundantSelf.swift */,
-				2E2CCF832C56B26E00D70FB0 /* unusedArguments.swift */,
-				2E2CCF882C56B28C00D70FB0 /* hoistTry.swift */,
-				2E2CCF8D2C56B2A400D70FB0 /* hoistAwait.swift */,
-				2E2CCF922C56B2E100D70FB0 /* hoistPatternLet.swift */,
-				2E2CCF972C56B2FA00D70FB0 /* wrap.swift */,
-				2E2CCF9C2C56B31000D70FB0 /* wrapArguments.swift */,
-				2E2CCFA12C56B32700D70FB0 /* wrapMultilineStatementBraces.swift */,
-				2E2CCFA62C56B33E00D70FB0 /* wrapEnumCases.swift */,
-				2E2CCFAB2C56B35800D70FB0 /* wrapSingleLineComments.swift */,
-				2E2CCFB02C56B36B00D70FB0 /* wrapSwitchCases.swift */,
-				2E2CCFB52C56B38500D70FB0 /* void.swift */,
-				2E2CCFBA2C56B3FA00D70FB0 /* numberFormatting.swift */,
-				2E2CCFBF2C56B41600D70FB0 /* fileHeader.swift */,
-				2E2CCFC42C56B42A00D70FB0 /* headerFileName.swift */,
-				2E2CCFC92C56B44100D70FB0 /* redundantInit.swift */,
-				2E2CCFCE2C56B45500D70FB0 /* sortedSwitchCases.swift */,
-				2E2CCFD32C56B46E00D70FB0 /* sortSwitchCases.swift */,
-				2E2CCFD82C56B48400D70FB0 /* sortedImports.swift */,
-				2E2CCFDD2C56B4A000D70FB0 /* sortImports.swift */,
-				2E2CCFE22C56B4B700D70FB0 /* duplicateImports.swift */,
-				2E2CCFE72C56B4CC00D70FB0 /* strongOutlets.swift */,
-				2E2CCFEC2C56B4E000D70FB0 /* emptyBraces.swift */,
-				2E2CCFF12C56B4F900D70FB0 /* andOperator.swift */,
-				2E2CCFF62C56B51100D70FB0 /* isEmpty.swift */,
-				2E2CCFFB2C56B52900D70FB0 /* redundantLetError.swift */,
-				2E2CD0002C56B53F00D70FB0 /* anyObjectProtocol.swift */,
-				2E2CD0052C56B55200D70FB0 /* redundantBreak.swift */,
-				2E2CD00A2C56B56B00D70FB0 /* strongifiedSelf.swift */,
-				2E2CD00F2C56B58300D70FB0 /* redundantObjc.swift */,
-				2E2CD0142C56B59C00D70FB0 /* typeSugar.swift */,
-				2E2CD0192C56B5B500D70FB0 /* redundantExtensionACL.swift */,
-				2E2CD01E2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift */,
-				2E2CD0232C56B5E800D70FB0 /* redundantFileprivate.swift */,
-				2E2CD0282C56B5FE00D70FB0 /* yodaConditions.swift */,
-				2E2CD02D2C56B61500D70FB0 /* leadingDelimiters.swift */,
-				2E2CD0322C56B62C00D70FB0 /* wrapAttributes.swift */,
-				2E2CD0372C56B64300D70FB0 /* preferKeyPath.swift */,
-				2E2CD03C2C56B65A00D70FB0 /* organizeDeclarations.swift */,
-				2E2CD0412C56B67400D70FB0 /* extensionAccessControl.swift */,
-				2E2CD0462C56B69800D70FB0 /* markTypes.swift */,
-				2E2CD04B2C56B6B000D70FB0 /* sortDeclarations.swift */,
-				2E2CD0502C56B6C800D70FB0 /* assertionFailures.swift */,
-				2E2CD0552C56B6E000D70FB0 /* acronyms.swift */,
-				2E2CD05A2C56B6F900D70FB0 /* blockComments.swift */,
-				2E2CD05F2C56B71A00D70FB0 /* redundantClosure.swift */,
-				2E2CD0642C56B8A600D70FB0 /* redundantOptionalBinding.swift */,
-				2E2CD0692C56B8C700D70FB0 /* opaqueGenericParameters.swift */,
-				2E2CD06E2C56B8F100D70FB0 /* genericExtensions.swift */,
-				2E2CD0732C56B90900D70FB0 /* docComments.swift */,
-				2E2CD0782C56B92100D70FB0 /* conditionalAssignment.swift */,
-				2E2CD07D2C56B9BD00D70FB0 /* sortTypealiases.swift */,
-				2E2CD0822C56B9D100D70FB0 /* redundantInternal.swift */,
-				2E2CD0872C56B9E400D70FB0 /* noExplicitOwnership.swift */,
-				2E2CD08C2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift */,
-				2E2CD0912C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift */,
-				2E2CD0962C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift */,
-				2E2CD09B2C56BA3900D70FB0 /* redundantProperty.swift */,
-				2E2CD0A02C56BA4D00D70FB0 /* redundantTypedThrows.swift */,
-				2E2CD0A52C56BA6A00D70FB0 /* propertyType.swift */,
-				2E2CD0AA2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift */,
+				2E2BA6592C57D2D500590239 /* Acronyms.swift */,
+				2E2BA64B2C57D2D500590239 /* AndOperator.swift */,
+				2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */,
+				2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */,
+				2E2BA6162C57D2D500590239 /* AssertionFailures.swift */,
+				2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */,
+				2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */,
+				2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */,
+				2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */,
+				2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */,
+				2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */,
+				2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */,
+				2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */,
+				2E2BA6122C57D2D500590239 /* BlockComments.swift */,
+				2E2BA6492C57D2D500590239 /* Braces.swift */,
+				2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */,
+				2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */,
+				2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */,
+				2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */,
+				2E2BA65B2C57D2D500590239 /* DocComments.swift */,
+				2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */,
+				2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */,
+				2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */,
+				2E2BA6172C57D2D500590239 /* EmptyBraces.swift */,
+				2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */,
+				2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */,
+				2E2BA6292C57D2D500590239 /* FileHeader.swift */,
+				2E2BA6332C57D2D500590239 /* GenericExtensions.swift */,
+				2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */,
+				2E2BA6542C57D2D500590239 /* HoistAwait.swift */,
+				2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */,
+				2E2BA65E2C57D2D500590239 /* HoistTry.swift */,
+				2E2BA5FD2C57D2D500590239 /* Indent.swift */,
+				2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */,
+				2E2BA62D2C57D2D500590239 /* IsEmpty.swift */,
+				2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */,
+				2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */,
+				2E2BA61B2C57D2D500590239 /* Linebreaks.swift */,
+				2E2BA64A2C57D2D500590239 /* MarkTypes.swift */,
+				2E2BA6412C57D2D500590239 /* ModifierOrder.swift */,
+				2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */,
+				2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */,
+				2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */,
+				2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */,
+				2E2BA6372C57D2D500590239 /* PreferForLoop.swift */,
+				2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */,
+				2E2BA65D2C57D2D500590239 /* PropertyType.swift */,
+				2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */,
+				2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */,
+				2E2BA6272C57D2D500590239 /* RedundantClosure.swift */,
+				2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */,
+				2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */,
+				2E2BA60B2C57D2D500590239 /* RedundantGet.swift */,
+				2E2BA6212C57D2D500590239 /* RedundantInit.swift */,
+				2E2BA6032C57D2D500590239 /* RedundantInternal.swift */,
+				2E2BA61E2C57D2D500590239 /* RedundantLet.swift */,
+				2E2BA6252C57D2D500590239 /* RedundantLetError.swift */,
+				2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */,
+				2E2BA6352C57D2D500590239 /* RedundantObjc.swift */,
+				2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */,
+				2E2BA6192C57D2D500590239 /* RedundantParens.swift */,
+				2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */,
+				2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */,
+				2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */,
+				2E2BA6322C57D2D500590239 /* RedundantReturn.swift */,
+				2E2BA6432C57D2D500590239 /* RedundantSelf.swift */,
+				2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */,
+				2E2BA6662C57D2D500590239 /* RedundantType.swift */,
+				2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */,
+				2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */,
+				2E2BA6072C57D2D500590239 /* Semicolons.swift */,
+				2E2BA6672C57D2D500590239 /* SortDeclarations.swift */,
+				2E2BA60F2C57D2D500590239 /* SortedImports.swift */,
+				2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */,
+				2E2BA60E2C57D2D500590239 /* SortImports.swift */,
+				2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */,
+				2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */,
+				2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */,
+				2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */,
+				2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */,
+				2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */,
+				2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */,
+				2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */,
+				2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */,
+				2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */,
+				2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */,
+				2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */,
+				2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */,
+				2E2BA6612C57D2D500590239 /* Specifiers.swift */,
+				2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */,
+				2E2BA6132C57D2D500590239 /* StrongOutlets.swift */,
+				2E2BA6052C57D2D500590239 /* Todos.swift */,
+				2E2BA6572C57D2D500590239 /* TrailingClosures.swift */,
+				2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */,
+				2E2BA6342C57D2D500590239 /* TrailingSpace.swift */,
+				2E2BA62A2C57D2D500590239 /* TypeSugar.swift */,
+				2E2BA6642C57D2D500590239 /* UnusedArguments.swift */,
+				2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */,
+				2E2BA6232C57D2D500590239 /* Void.swift */,
+				2E2BA63F2C57D2D500590239 /* Wrap.swift */,
+				2E2BA6602C57D2D500590239 /* WrapArguments.swift */,
+				2E2BA6462C57D2D500590239 /* WrapAttributes.swift */,
+				2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */,
+				2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */,
+				2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */,
+				2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */,
+				2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */,
+				2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */,
+				2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */,
+				2E2BA6622C57D2D500590239 /* YodaConditions.swift */,
 			);
 			path = Rules;
 			sourceTree = "<group>";
@@ -1480,138 +1370,138 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E2CCFD42C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */,
-				2E2CCF072C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */,
-				2E2CD01F2C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */,
-				2E2CCF842C56B26E00D70FB0 /* unusedArguments.swift in Sources */,
+				2E2BA79D2C57D2D500590239 /* Specifiers.swift in Sources */,
 				D52F6A642A82E04600FE1448 /* GitFileInfo.swift in Sources */,
+				2E2BA7192C57D2D500590239 /* RedundantObjc.swift in Sources */,
+				2E2BA6AA2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
+				2E2BA6E92C57D2D500590239 /* RedundantLetError.swift in Sources */,
+				2E2BA7A62C57D2D500590239 /* UnusedArguments.swift in Sources */,
+				2E2BA7012C57D2D500590239 /* IsEmpty.swift in Sources */,
+				2E2BA7312C57D2D500590239 /* ApplicationMain.swift in Sources */,
+				2E2BA76A2C57D2D500590239 /* StrongifiedSelf.swift in Sources */,
+				2E2BA66B2C57D2D500590239 /* RedundantBreak.swift in Sources */,
+				2E2BA69B2C57D2D500590239 /* RedundantGet.swift in Sources */,
 				2E4A8AE92C56DF14005A22B1 /* GithubActionsLogReporter.swift in Sources */,
-				2E2CCFFC2C56B52900D70FB0 /* redundantLetError.swift in Sources */,
-				2E2CD09C2C56BA3900D70FB0 /* redundantProperty.swift in Sources */,
-				2E2CCF4D2C56B12F00D70FB0 /* redundantParens.swift in Sources */,
-				2E2CD03D2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */,
-				2E2CCFCA2C56B44100D70FB0 /* redundantInit.swift in Sources */,
-				2E2CCFDE2C56B4A000D70FB0 /* sortImports.swift in Sources */,
 				01045A992119979400D2BE3D /* Arguments.swift in Sources */,
-				2E2CCECB2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */,
-				2E2CCF2A2C56B07200D70FB0 /* trailingCommas.swift in Sources */,
-				2E2CCEE42C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */,
+				2E2BA6EF2C57D2D500590239 /* RedundantClosure.swift in Sources */,
+				2E2BA72B2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */,
+				2E2BA6C52C57D2D500590239 /* RedundantParens.swift in Sources */,
+				2E2BA67D2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */,
 				01567D2F225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
-				2E2CD0382C56B64300D70FB0 /* preferKeyPath.swift in Sources */,
-				2E2CCFC02C56B41600D70FB0 /* fileHeader.swift in Sources */,
-				2E2CCF5C2C56B19B00D70FB0 /* redundantLet.swift in Sources */,
-				2E2CCF662C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */,
-				2E2CCFAC2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */,
-				2E2CD06A2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */,
-				2E2CCEDF2C56AEB000D70FB0 /* trailingSpace.swift in Sources */,
-				2E2CCF6B2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */,
-				2E2CCF7F2C56B24F00D70FB0 /* redundantSelf.swift in Sources */,
-				2E2CCED02C56AE2500D70FB0 /* redundantType.swift in Sources */,
-				2E2CD0882C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */,
-				2E2CCEBC2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */,
-				2E2CD0602C56B71A00D70FB0 /* redundantClosure.swift in Sources */,
-				2E2CCE992C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */,
-				2E2CCF342C56B0AC00D70FB0 /* semicolons.swift in Sources */,
-				2E2CCFE82C56B4CC00D70FB0 /* strongOutlets.swift in Sources */,
+				2E2BA6B02C57D2D500590239 /* BlockComments.swift in Sources */,
 				01045A91211988F100D2BE3D /* Inference.swift in Sources */,
-				2E2CD04C2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */,
-				2E2CCFBB2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */,
-				2E2CCF612C56B1B500D70FB0 /* redundantPattern.swift in Sources */,
-				2E2CCEC12C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */,
-				2E2CCEB22C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */,
-				2E2CD0652C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */,
-				2E2CD0A12C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */,
-				2E2CD0422C56B67400D70FB0 /* extensionAccessControl.swift in Sources */,
-				2E2CD0152C56B59C00D70FB0 /* typeSugar.swift in Sources */,
-				2E2CCEA82C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */,
+				2E2BA6A42C57D2D500590239 /* SortImports.swift in Sources */,
+				2E2BA6B32C57D2D500590239 /* StrongOutlets.swift in Sources */,
+				2E2BA6A72C57D2D500590239 /* SortedImports.swift in Sources */,
+				2E2BA7AC2C57D2D500590239 /* RedundantType.swift in Sources */,
+				2E2BA7852C57D2D500590239 /* Acronyms.swift in Sources */,
 				E4FABAD5202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2CCFB12C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */,
+				2E2BA6D42C57D2D500590239 /* RedundantLet.swift in Sources */,
 				01BBD85921DAA2A000457380 /* Globs.swift in Sources */,
+				2E2BA7942C57D2D500590239 /* HoistTry.swift in Sources */,
+				2E2BA6BF2C57D2D500590239 /* EmptyBraces.swift in Sources */,
+				2E2BA77C2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */,
+				2E2BA7072C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */,
+				2E2BA7222C57D2D500590239 /* RedundantStaticSelf.swift in Sources */,
+				2E2BA6A12C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */,
+				2E2BA6922C57D2D500590239 /* HoistPatternLet.swift in Sources */,
+				2E2BA7762C57D2D500590239 /* HoistAwait.swift in Sources */,
+				2E2BA78B2C57D2D500590239 /* DocComments.swift in Sources */,
+				2E2BA6892C57D2D500590239 /* Todos.swift in Sources */,
+				2E2BA6BC2C57D2D500590239 /* AssertionFailures.swift in Sources */,
+				2E2BA76D2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */,
+				2E2BA66E2C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E2BA7A32C57D2D500590239 /* RedundantTypedThrows.swift in Sources */,
+				2E2BA7612C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */,
+				2E2BA68F2C57D2D500590239 /* Semicolons.swift in Sources */,
+				2E2BA6712C57D2D500590239 /* Indent.swift in Sources */,
+				2E2BA6FB2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */,
+				2E2BA71F2C57D2D500590239 /* PreferForLoop.swift in Sources */,
+				2E2BA67A2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
+				2E2BA7132C57D2D500590239 /* GenericExtensions.swift in Sources */,
 				01ACAE05220CD90F003F3CCF /* Examples.swift in Sources */,
-				2E2CD0062C56B55200D70FB0 /* redundantBreak.swift in Sources */,
-				2E2CCF702C56B20900D70FB0 /* redundantReturn.swift in Sources */,
-				2E2CCFED2C56B4E000D70FB0 /* emptyBraces.swift in Sources */,
-				2E2CCEEE2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */,
-				2E2CCF0C2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */,
 				01D3B28624E9C9C700888DE0 /* FormattingHelpers.swift in Sources */,
 				E4E4D3C92033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2CCF432C56B0F300D70FB0 /* modifierOrder.swift in Sources */,
-				2E2CCF932C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */,
+				2E2BA7672C57D2D500590239 /* TrailingCommas.swift in Sources */,
+				2E2BA7702C57D2D500590239 /* RedundantBackticks.swift in Sources */,
+				2E2BA6862C57D2D500590239 /* RedundantNilInit.swift in Sources */,
+				2E2BA70D2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */,
+				2E2BA6C22C57D2D500590239 /* SpaceAroundComments.swift in Sources */,
+				2E2BA7912C57D2D500590239 /* PropertyType.swift in Sources */,
+				2E2BA7582C57D2D500590239 /* MarkTypes.swift in Sources */,
+				2E2BA6DA2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */,
+				2E2BA6772C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */,
+				2E2BA7342C57D2D500590239 /* RedundantProperty.swift in Sources */,
+				2E2BA7282C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */,
 				2E4A8AED2C56DF14005A22B1 /* JSONReporter.swift in Sources */,
-				2E2CCF392C56B0C300D70FB0 /* linebreaks.swift in Sources */,
-				2E2CCF9D2C56B31000D70FB0 /* wrapArguments.swift in Sources */,
-				2E2CD00B2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */,
-				2E2CD0742C56B90900D70FB0 /* docComments.swift in Sources */,
-				2E2CD05B2C56B6F900D70FB0 /* blockComments.swift in Sources */,
-				2E2CCF892C56B28C00D70FB0 /* hoistTry.swift in Sources */,
+				2E2BA69E2C57D2D500590239 /* SpaceAroundOperators.swift in Sources */,
+				2E2BA74C2C57D2D500590239 /* WrapAttributes.swift in Sources */,
+				2E2BA6D72C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */,
 				2E4A8AEF2C56DF14005A22B1 /* Reporter.swift in Sources */,
-				2E2CD01A2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */,
 				2E4A8AEB2C56DF14005A22B1 /* XMLReporter.swift in Sources */,
-				2E2CCEC62C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */,
-				2E2CD0832C56B9D100D70FB0 /* redundantInternal.swift in Sources */,
-				2E2CD06F2C56B8F100D70FB0 /* genericExtensions.swift in Sources */,
-				2E2CCFA22C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */,
-				2E2CD0012C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */,
-				2E2CCF3E2C56B0DC00D70FB0 /* specifiers.swift in Sources */,
-				2E2CCFF72C56B51100D70FB0 /* isEmpty.swift in Sources */,
-				2E2CD02E2C56B61500D70FB0 /* leadingDelimiters.swift in Sources */,
-				2E2CCF522C56B14400D70FB0 /* redundantGet.swift in Sources */,
-				2E2CCFE32C56B4B700D70FB0 /* duplicateImports.swift in Sources */,
+				2E2BA6E02C57D2D500590239 /* NoExplicitOwnership.swift in Sources */,
+				2E2BA6E62C57D2D500590239 /* WrapSingleLineComments.swift in Sources */,
+				2E2BA6FE2C57D2D500590239 /* HeaderFileName.swift in Sources */,
+				2E2BA70A2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */,
+				2E2BA6C82C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */,
+				2E2BA6AD2C57D2D500590239 /* RedundantFileprivate.swift in Sources */,
+				2E2BA6F52C57D2D500590239 /* FileHeader.swift in Sources */,
+				2E2BA79A2C57D2D500590239 /* WrapArguments.swift in Sources */,
+				2E2BA7462C57D2D500590239 /* PreferKeyPath.swift in Sources */,
+				2E2BA6B92C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */,
+				2E2BA7042C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */,
+				2E2BA6DD2C57D2D500590239 /* RedundantInit.swift in Sources */,
+				2E2BA6952C57D2D500590239 /* ElseOnSameLine.swift in Sources */,
 				01A0EAC11D5DB4F700A0A8E3 /* FormatRule.swift in Sources */,
+				2E2BA6832C57D2D500590239 /* RedundantInternal.swift in Sources */,
+				2E2BA6CE2C57D2D500590239 /* LeadingDelimiters.swift in Sources */,
+				2E2BA6D12C57D2D500590239 /* SpaceInsideComments.swift in Sources */,
+				2E2BA6B62C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */,
+				2E2BA7252C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */,
+				2E2BA7492C57D2D500590239 /* WrapEnumCases.swift in Sources */,
+				2E2BA78E2C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */,
+				2E2BA73D2C57D2D500590239 /* ModifierOrder.swift in Sources */,
 				01A0EAC51D5DB54A00A0A8E3 /* SwiftFormat.swift in Sources */,
-				2E2CCF162C56B00E00D70FB0 /* braces.swift in Sources */,
-				2E2CD0562C56B6E000D70FB0 /* acronyms.swift in Sources */,
-				2E2CCFCF2C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */,
-				2E2CCEFD2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */,
-				2E2CCEAD2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */,
-				2E2CD0512C56B6C800D70FB0 /* assertionFailures.swift in Sources */,
-				2E2BF35B2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */,
+				2E2BA7732C57D2D500590239 /* SpaceAroundParens.swift in Sources */,
 				2E7D30A42A7940C500C32174 /* Singularize.swift in Sources */,
-				2E2CD0472C56B69800D70FB0 /* markTypes.swift in Sources */,
-				2E2CCFB62C56B38500D70FB0 /* void.swift in Sources */,
-				2E2CD08D2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */,
-				2E2CD0AB2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */,
-				2E2CD0A62C56BA6A00D70FB0 /* propertyType.swift in Sources */,
-				2E2CD0102C56B58300D70FB0 /* redundantObjc.swift in Sources */,
-				2E2CCF7A2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */,
-				2E2CCF252C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */,
-				2E2CCF8E2C56B2A400D70FB0 /* hoistAwait.swift in Sources */,
-				2E2CD07E2C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */,
-				2E2CD0332C56B62C00D70FB0 /* wrapAttributes.swift in Sources */,
+				2E2BA7AF2C57D2D500590239 /* SortDeclarations.swift in Sources */,
+				2E2BA6EC2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */,
 				01B3987D1D763493009ADE61 /* Formatter.swift in Sources */,
 				2E230CA22C4C1C0700A16E2E /* DeclarationHelpers.swift in Sources */,
-				2E2CCFC52C56B42A00D70FB0 /* headerFileName.swift in Sources */,
-				2E2CCEE92C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */,
-				2E2CCEF32C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */,
-				2E2CCF572C56B18100D70FB0 /* redundantNilInit.swift in Sources */,
-				2E2CCF2F2C56B09700D70FB0 /* todos.swift in Sources */,
-				2E2CCFA72C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */,
 				01F17E821E25870700DCD359 /* CommandLine.swift in Sources */,
-				2E2CCF752C56B22000D70FB0 /* redundantBackticks.swift in Sources */,
-				2E2CCF482C56B10E00D70FB0 /* trailingClosures.swift in Sources */,
+				2E2BA7972C57D2D500590239 /* NumberFormatting.swift in Sources */,
 				01F3DF8C1DB9FD3F00454944 /* Options.swift in Sources */,
-				2E2CCEB72C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */,
-				2E2CD0972C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */,
-				2E2CCEDA2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */,
+				2E2BA7882C57D2D500590239 /* SortTypealiases.swift in Sources */,
+				2E2BA7822C57D2D500590239 /* SortedSwitchCases.swift in Sources */,
+				2E2BA6E32C57D2D500590239 /* Void.swift in Sources */,
+				2E2BA7A02C57D2D500590239 /* YodaConditions.swift in Sources */,
+				2E2BA7552C57D2D500590239 /* Braces.swift in Sources */,
+				2E2BA6682C57D2D500590239 /* InitCoderUnavailable.swift in Sources */,
+				2E2BA6F22C57D2D500590239 /* OrganizeDeclarations.swift in Sources */,
+				2E2BA7372C57D2D500590239 /* Wrap.swift in Sources */,
+				2E2BA7102C57D2D500590239 /* RedundantReturn.swift in Sources */,
+				2E2BA6742C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
+				2E2BA72E2C57D2D500590239 /* RedundantPattern.swift in Sources */,
+				2E2BA7162C57D2D500590239 /* TrailingSpace.swift in Sources */,
+				2E2BA71C2C57D2D500590239 /* ConditionalAssignment.swift in Sources */,
+				2E2BA73A2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */,
+				2E2BA74F2C57D2D500590239 /* WrapConditionalBodies.swift in Sources */,
+				2E2BA68C2C57D2D500590239 /* SpaceInsideParens.swift in Sources */,
+				2E2BA7A92C57D2D500590239 /* SortSwitchCases.swift in Sources */,
+				2E2BA6CB2C57D2D500590239 /* Linebreaks.swift in Sources */,
+				2E2BA6982C57D2D500590239 /* DuplicateImports.swift in Sources */,
+				2E2BA6802C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */,
+				2E2BA6F82C57D2D500590239 /* TypeSugar.swift in Sources */,
+				2E2BA7522C57D2D500590239 /* WrapSwitchCases.swift in Sources */,
+				2E2BA75E2C57D2D500590239 /* WrapLoopBodies.swift in Sources */,
+				2E2BA75B2C57D2D500590239 /* AndOperator.swift in Sources */,
+				2E2BA7642C57D2D500590239 /* RedundantRawValues.swift in Sources */,
+				2E2BA7402C57D2D500590239 /* EnumNamespaces.swift in Sources */,
+				2E2BA7432C57D2D500590239 /* RedundantSelf.swift in Sources */,
 				2E2BF3552C554FDA00AB08D2 /* RuleRegistry.swift in Sources */,
-				2E2CCF982C56B2FA00D70FB0 /* wrap.swift in Sources */,
-				2E2CCF202C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */,
-				2E2CD0292C56B5FE00D70FB0 /* yodaConditions.swift in Sources */,
-				2E2CCEF82C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2CCF1B2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */,
-				2E2CCFF22C56B4F900D70FB0 /* andOperator.swift in Sources */,
-				2E2CD0792C56B92100D70FB0 /* conditionalAssignment.swift in Sources */,
-				2E2CD0242C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */,
+				2E2BA7792C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */,
 				01A0EAC21D5DB4F700A0A8E3 /* Tokenizer.swift in Sources */,
-				2E2BF34B2C554E6400AB08D2 /* preferForLoop.swift in Sources */,
-				2E2CD0922C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */,
-				2E2CCFD92C56B48400D70FB0 /* sortedImports.swift in Sources */,
-				2E2CCE9E2C56ACFA00D70FB0 /* applicationMain.swift in Sources */,
-				2E2CCF022C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */,
-				2E2CCF112C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */,
-				2E2CCED52C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */,
-				2E2BF3602C555CE500AB08D2 /* indent.swift in Sources */,
-				2E2CCEA32C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */,
+				2E2BA77F2C57D2D500590239 /* TrailingClosures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1653,138 +1543,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E2CCEA92C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */,
-				2E2CCEEA2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */,
-				2E2CCED12C56AE2500D70FB0 /* redundantType.swift in Sources */,
 				01A0EAD51D5DC08A00A0A8E3 /* FormatRule.swift in Sources */,
-				2E2CCE9F2C56ACFA00D70FB0 /* applicationMain.swift in Sources */,
 				01A0EAD61D5DC08A00A0A8E3 /* Tokenizer.swift in Sources */,
-				2E2CCEB82C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */,
-				2E2CCFA82C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */,
-				2E2CD0702C56B8F100D70FB0 /* genericExtensions.swift in Sources */,
-				2E2CCF6C2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */,
-				2E2CD0892C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */,
-				2E2CCFC62C56B42A00D70FB0 /* headerFileName.swift in Sources */,
 				01567D30225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
-				2E2CCFF32C56B4F900D70FB0 /* andOperator.swift in Sources */,
-				2E2CCFE92C56B4CC00D70FB0 /* strongOutlets.swift in Sources */,
-				2E2CCF3F2C56B0DC00D70FB0 /* specifiers.swift in Sources */,
-				2E2CCF582C56B18100D70FB0 /* redundantNilInit.swift in Sources */,
 				01B3987F1D7634A0009ADE61 /* Formatter.swift in Sources */,
-				2E2CD09D2C56BA3900D70FB0 /* redundantProperty.swift in Sources */,
-				2E2CCF2B2C56B07200D70FB0 /* trailingCommas.swift in Sources */,
-				2E2CCEBD2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */,
-				2E2CCF442C56B0F300D70FB0 /* modifierOrder.swift in Sources */,
-				2E2CCEC22C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */,
 				01A0EAD41D5DC08A00A0A8E3 /* SwiftFormat.swift in Sources */,
-				2E2CD0752C56B90900D70FB0 /* docComments.swift in Sources */,
 				E4E4D3CA2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2CCFE42C56B4B700D70FB0 /* duplicateImports.swift in Sources */,
-				2E2CD07A2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */,
-				2E2CCF802C56B24F00D70FB0 /* redundantSelf.swift in Sources */,
-				2E2CCF262C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */,
 				2E4A8AEA2C56DF14005A22B1 /* GithubActionsLogReporter.swift in Sources */,
-				2E2CCFD02C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */,
-				2E2CCF532C56B14400D70FB0 /* redundantGet.swift in Sources */,
-				2E2CCFEE2C56B4E000D70FB0 /* emptyBraces.swift in Sources */,
 				01BBD85A21DAA2A600457380 /* Globs.swift in Sources */,
-				2E2CCFC12C56B41600D70FB0 /* fileHeader.swift in Sources */,
-				2E2CD0AC2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */,
-				2E2CCEC72C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */,
-				2E2CD01B2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */,
-				2E2CD0252C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */,
-				2E2CCF8A2C56B28C00D70FB0 /* hoistTry.swift in Sources */,
-				2E2CCEE02C56AEB000D70FB0 /* trailingSpace.swift in Sources */,
-				2E2CCF352C56B0AC00D70FB0 /* semicolons.swift in Sources */,
-				2E2CD0612C56B71A00D70FB0 /* redundantClosure.swift in Sources */,
-				2E2CCFA32C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */,
-				2E2CCF942C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */,
-				2E2CD0982C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */,
-				2E2CCF3A2C56B0C300D70FB0 /* linebreaks.swift in Sources */,
-				2E2CCF622C56B1B500D70FB0 /* redundantPattern.swift in Sources */,
-				2E2CD0162C56B59C00D70FB0 /* typeSugar.swift in Sources */,
-				2E2CCF672C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */,
-				2E2CCF9E2C56B31000D70FB0 /* wrapArguments.swift in Sources */,
-				2E2CD02A2C56B5FE00D70FB0 /* yodaConditions.swift in Sources */,
-				2E2CD0112C56B58300D70FB0 /* redundantObjc.swift in Sources */,
-				2E2CCF0D2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */,
-				2E2CCEEF2C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */,
-				2E2CD02F2C56B61500D70FB0 /* leadingDelimiters.swift in Sources */,
-				2E2CCF8F2C56B2A400D70FB0 /* hoistAwait.swift in Sources */,
-				2E2CD04D2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */,
-				2E2CD08E2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */,
-				2E2CD06B2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */,
 				08180DCF2C4EB67F00FD60FF /* DeclarationHelpers.swift in Sources */,
-				2E2CCFBC2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */,
-				2E2BF3612C555CE500AB08D2 /* indent.swift in Sources */,
-				2E2CCF5D2C56B19B00D70FB0 /* redundantLet.swift in Sources */,
-				2E2CCF082C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */,
 				01045A92211988F100D2BE3D /* Inference.swift in Sources */,
-				2E2CD05C2C56B6F900D70FB0 /* blockComments.swift in Sources */,
-				2E2BF34C2C554E6400AB08D2 /* preferForLoop.swift in Sources */,
 				01F3DF8D1DB9FD3F00454944 /* Options.swift in Sources */,
-				2E2CCECC2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */,
 				E4FABAD6202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2CD03E2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */,
-				2E2CD07F2C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */,
-				2E2CCF1C2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */,
 				D52F6A652A82E04600FE1448 /* GitFileInfo.swift in Sources */,
-				2E2CD0842C56B9D100D70FB0 /* redundantInternal.swift in Sources */,
-				2E2CD0482C56B69800D70FB0 /* markTypes.swift in Sources */,
-				2E2CCF212C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */,
-				2E2CCFDF2C56B4A000D70FB0 /* sortImports.swift in Sources */,
-				2E2CCF992C56B2FA00D70FB0 /* wrap.swift in Sources */,
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
-				2E2CCFB22C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */,
-				2E2CD0A72C56BA6A00D70FB0 /* propertyType.swift in Sources */,
-				2E2CCFAD2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */,
-				2E2CCEAE2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */,
-				2E2CCF302C56B09700D70FB0 /* todos.swift in Sources */,
-				2E2CCF712C56B20900D70FB0 /* redundantReturn.swift in Sources */,
 				015243E22B04B0A600F65221 /* Singularize.swift in Sources */,
-				2E2CCFD52C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */,
-				2E2CCFB72C56B38500D70FB0 /* void.swift in Sources */,
-				2E2CD0342C56B62C00D70FB0 /* wrapAttributes.swift in Sources */,
-				2E2BF35C2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */,
-				2E2CD0392C56B64300D70FB0 /* preferKeyPath.swift in Sources */,
 				2E4A8AEC2C56DF14005A22B1 /* XMLReporter.swift in Sources */,
-				2E2CCEB32C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */,
 				01ACAE06220CD914003F3CCF /* Examples.swift in Sources */,
-				2E2CD0522C56B6C900D70FB0 /* assertionFailures.swift in Sources */,
-				2E2CCF492C56B10E00D70FB0 /* trailingClosures.swift in Sources */,
-				2E2CCEF92C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2CCE9A2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */,
-				2E2CCEA42C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */,
-				2E2CD0072C56B55200D70FB0 /* redundantBreak.swift in Sources */,
-				2E2CD0432C56B67400D70FB0 /* extensionAccessControl.swift in Sources */,
-				2E2CCEFE2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */,
-				2E2CD0572C56B6E000D70FB0 /* acronyms.swift in Sources */,
-				2E2CCEE52C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */,
-				2E2CD0932C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */,
 				2E4A8AF02C56DF14005A22B1 /* Reporter.swift in Sources */,
-				2E2CCED62C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */,
 				2E4A8AEE2C56DF14005A22B1 /* JSONReporter.swift in Sources */,
-				2E2CCF172C56B00E00D70FB0 /* braces.swift in Sources */,
-				2E2CD0022C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */,
 				01A0EACD1D5DB5F500A0A8E3 /* main.swift in Sources */,
-				2E2CCF762C56B22000D70FB0 /* redundantBackticks.swift in Sources */,
-				2E2CD0202C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */,
-				2E2CCFF82C56B51100D70FB0 /* isEmpty.swift in Sources */,
-				2E2CCEF42C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */,
-				2E2CCEDB2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */,
-				2E2CD0A22C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */,
-				2E2CCFCB2C56B44100D70FB0 /* redundantInit.swift in Sources */,
-				2E2CD00C2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */,
-				2E2CCFFD2C56B52900D70FB0 /* redundantLetError.swift in Sources */,
 				2E2BF3562C554FDA00AB08D2 /* RuleRegistry.swift in Sources */,
-				2E2CCF7B2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */,
-				2E2CCF122C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */,
-				2E2CCFDA2C56B48400D70FB0 /* sortedImports.swift in Sources */,
-				2E2CCF4E2C56B12F00D70FB0 /* redundantParens.swift in Sources */,
-				2E2CD0662C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */,
-				2E2CCF032C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */,
-				2E2CCF852C56B26E00D70FB0 /* unusedArguments.swift in Sources */,
 				01045A9A2119979400D2BE3D /* Arguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1793,142 +1573,142 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E2BA77A2C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */,
+				2E2BA6842C57D2D500590239 /* RedundantInternal.swift in Sources */,
+				2E2BA7B02C57D2D500590239 /* SortDeclarations.swift in Sources */,
+				2E2BA6F32C57D2D500590239 /* OrganizeDeclarations.swift in Sources */,
+				2E2BA7862C57D2D500590239 /* Acronyms.swift in Sources */,
+				2E2BA7802C57D2D500590239 /* TrailingClosures.swift in Sources */,
+				2E2BA7AA2C57D2D500590239 /* SortSwitchCases.swift in Sources */,
 				E4083191202C049200CAF11D /* SwiftFormat.swift in Sources */,
-				2E2CCEB92C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */,
 				E4FABAD7202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2CCF312C56B09700D70FB0 /* todos.swift in Sources */,
-				2E2CCF1D2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */,
-				2E2CCFB82C56B38500D70FB0 /* void.swift in Sources */,
-				2E2CCFD62C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */,
-				2E2CCF542C56B14400D70FB0 /* redundantGet.swift in Sources */,
+				2E2BA7832C57D2D500590239 /* SortedSwitchCases.swift in Sources */,
+				2E2BA7592C57D2D500590239 /* MarkTypes.swift in Sources */,
+				2E2BA66F2C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E2BA6722C57D2D500590239 /* Indent.swift in Sources */,
 				015D3A562995A0340065B2D9 /* AboutViewController.swift in Sources */,
-				2E2CCF4A2C56B10E00D70FB0 /* trailingClosures.swift in Sources */,
-				2E2CCEF52C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */,
-				2E2CD0262C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */,
-				2E2CCEA52C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */,
-				2E2CD08F2C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */,
-				2E2CD06C2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */,
+				2E2BA6EA2C57D2D500590239 /* RedundantLetError.swift in Sources */,
+				2E2BA6ED2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */,
+				2E2BA72F2C57D2D500590239 /* RedundantPattern.swift in Sources */,
 				E41CB5C52027700100C1BEDE /* FreeTextTableCellView.swift in Sources */,
+				2E2BA79B2C57D2D500590239 /* WrapArguments.swift in Sources */,
+				2E2BA6CC2C57D2D500590239 /* Linebreaks.swift in Sources */,
+				2E2BA7142C57D2D500590239 /* GenericExtensions.swift in Sources */,
+				2E2BA6B42C57D2D500590239 /* StrongOutlets.swift in Sources */,
 				E4872125201D980D0014845E /* BinarySelectionTableCellView.swift in Sources */,
-				2E2CCF222C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */,
-				2E2CCFB32C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */,
-				2E2CCFC72C56B42A00D70FB0 /* headerFileName.swift in Sources */,
-				2E2CD0492C56B69800D70FB0 /* markTypes.swift in Sources */,
-				2E2CCF182C56B00E00D70FB0 /* braces.swift in Sources */,
-				2E2CCEBE2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */,
-				2E2CCEB42C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */,
-				2E2CCF862C56B26F00D70FB0 /* unusedArguments.swift in Sources */,
-				2E2CCFEF2C56B4E000D70FB0 /* emptyBraces.swift in Sources */,
-				2E2CCF2C2C56B07200D70FB0 /* trailingCommas.swift in Sources */,
-				2E2CCF5E2C56B19B00D70FB0 /* redundantLet.swift in Sources */,
+				2E2BA7532C57D2D500590239 /* WrapSwitchCases.swift in Sources */,
+				2E2BA6932C57D2D500590239 /* HoistPatternLet.swift in Sources */,
+				2E2BA7A42C57D2D500590239 /* RedundantTypedThrows.swift in Sources */,
+				2E2BA6F92C57D2D500590239 /* TypeSugar.swift in Sources */,
+				2E2BA6E12C57D2D500590239 /* NoExplicitOwnership.swift in Sources */,
+				2E2BA70B2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */,
+				2E2BA6C32C57D2D500590239 /* SpaceAroundComments.swift in Sources */,
+				2E2BA6962C57D2D500590239 /* ElseOnSameLine.swift in Sources */,
+				2E2BA6B12C57D2D500590239 /* BlockComments.swift in Sources */,
+				2E2BA6FC2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */,
+				2E2BA6D22C57D2D500590239 /* SpaceInsideComments.swift in Sources */,
+				2E2BA6E72C57D2D500590239 /* WrapSingleLineComments.swift in Sources */,
+				2E2BA69C2C57D2D500590239 /* RedundantGet.swift in Sources */,
+				2E2BA7412C57D2D500590239 /* EnumNamespaces.swift in Sources */,
+				2E2BA71A2C57D2D500590239 /* RedundantObjc.swift in Sources */,
+				2E2BA6B72C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				E487211D201D885A0014845E /* RulesViewController.swift in Sources */,
-				2E2CD0032C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */,
-				2E2CD0212C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */,
-				2E2CD0582C56B6E000D70FB0 /* acronyms.swift in Sources */,
-				2E2CCEDC2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */,
-				2E2CCF132C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */,
-				2E2CCECD2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */,
+				2E2BA6812C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */,
 				01045A9B2119979400D2BE3D /* Arguments.swift in Sources */,
-				2E2CCF402C56B0DC00D70FB0 /* specifiers.swift in Sources */,
-				2E2BF35D2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */,
-				2E2CD0AD2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */,
-				2E2CCFF92C56B51100D70FB0 /* isEmpty.swift in Sources */,
-				2E2CCF952C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */,
-				2E2CCFC22C56B41600D70FB0 /* fileHeader.swift in Sources */,
-				2E2CCEC32C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */,
-				2E2CD0082C56B55200D70FB0 /* redundantBreak.swift in Sources */,
-				2E2CCFA92C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */,
-				2E2CCF902C56B2A400D70FB0 /* hoistAwait.swift in Sources */,
-				2E2CCF0E2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */,
-				2E2CCEA02C56ACFA00D70FB0 /* applicationMain.swift in Sources */,
-				2E2BF3622C555CE500AB08D2 /* indent.swift in Sources */,
-				2E2CCF272C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */,
-				2E2CD0302C56B61500D70FB0 /* leadingDelimiters.swift in Sources */,
+				2E2BA6BD2C57D2D500590239 /* AssertionFailures.swift in Sources */,
 				E4872114201D3B8C0014845E /* Tokenizer.swift in Sources */,
-				2E2CCED22C56AE2500D70FB0 /* redundantType.swift in Sources */,
-				2E2CD0352C56B62C00D70FB0 /* wrapAttributes.swift in Sources */,
+				2E2BA7712C57D2D500590239 /* RedundantBackticks.swift in Sources */,
+				2E2BA6C02C57D2D500590239 /* EmptyBraces.swift in Sources */,
+				2E2BA7232C57D2D500590239 /* RedundantStaticSelf.swift in Sources */,
+				2E2BA6A52C57D2D500590239 /* SortImports.swift in Sources */,
+				2E2BA6752C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				015243E32B04B0A600F65221 /* Singularize.swift in Sources */,
+				2E2BA7682C57D2D500590239 /* TrailingCommas.swift in Sources */,
+				2E2BA7292C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */,
+				2E2BA7742C57D2D500590239 /* SpaceAroundParens.swift in Sources */,
+				2E2BA6992C57D2D500590239 /* DuplicateImports.swift in Sources */,
+				2E2BA7A12C57D2D500590239 /* YodaConditions.swift in Sources */,
+				2E2BA7922C57D2D500590239 /* PropertyType.swift in Sources */,
 				E4872112201D3B860014845E /* FormatRule.swift in Sources */,
-				2E2CCE9B2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */,
-				2E2CCEAA2C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */,
-				2E2CCF092C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */,
-				2E2CCF772C56B22000D70FB0 /* redundantBackticks.swift in Sources */,
-				2E2CD0442C56B67400D70FB0 /* extensionAccessControl.swift in Sources */,
 				E4962DE0203F3CD500A02013 /* OptionsStore.swift in Sources */,
-				2E2CD0672C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */,
-				2E2CCF632C56B1B500D70FB0 /* redundantPattern.swift in Sources */,
-				2E2CCEE12C56AEB000D70FB0 /* trailingSpace.swift in Sources */,
-				2E2CCF6D2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */,
+				2E2BA6CF2C57D2D500590239 /* LeadingDelimiters.swift in Sources */,
+				2E2BA7082C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */,
+				2E2BA6E42C57D2D500590239 /* Void.swift in Sources */,
+				2E2BA69F2C57D2D500590239 /* SpaceAroundOperators.swift in Sources */,
+				2E2BA6C92C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */,
+				2E2BA72C2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */,
+				2E2BA78F2C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */,
 				01ACAE07220CD915003F3CCF /* Examples.swift in Sources */,
-				2E2CD0172C56B59C00D70FB0 /* typeSugar.swift in Sources */,
-				2E2CCEC82C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */,
-				2E2CCF042C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */,
-				2E2CCF9F2C56B31000D70FB0 /* wrapArguments.swift in Sources */,
-				2E2CD0122C56B58300D70FB0 /* redundantObjc.swift in Sources */,
-				2E2CCF682C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */,
-				2E2CCED72C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */,
-				2E2CCF362C56B0AC00D70FB0 /* semicolons.swift in Sources */,
+				2E2BA74A2C57D2D500590239 /* WrapEnumCases.swift in Sources */,
+				2E2BA70E2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */,
 				E4872113201D3B890014845E /* Formatter.swift in Sources */,
-				2E2CD03A2C56B64300D70FB0 /* preferKeyPath.swift in Sources */,
-				2E2CCFEA2C56B4CC00D70FB0 /* strongOutlets.swift in Sources */,
-				2E2CD00D2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */,
-				2E2CCF812C56B24F00D70FB0 /* redundantSelf.swift in Sources */,
-				2E2CCF9A2C56B2FA00D70FB0 /* wrap.swift in Sources */,
-				2E2CD08A2C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */,
-				2E2CD0712C56B8F100D70FB0 /* genericExtensions.swift in Sources */,
-				2E2CCF7C2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */,
-				2E2CD0622C56B71A00D70FB0 /* redundantClosure.swift in Sources */,
-				2E2CD0762C56B90900D70FB0 /* docComments.swift in Sources */,
-				2E2CCFCC2C56B44100D70FB0 /* redundantInit.swift in Sources */,
-				2E2CCFF42C56B4F900D70FB0 /* andOperator.swift in Sources */,
-				2E2CCFAE2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */,
-				2E2CCFA42C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */,
-				2E2CCEF02C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */,
-				2E2CD0A82C56BA6A00D70FB0 /* propertyType.swift in Sources */,
-				2E2CD0802C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */,
+				2E2BA7772C57D2D500590239 /* HoistAwait.swift in Sources */,
+				2E2BA73B2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */,
+				2E2BA66C2C57D2D500590239 /* RedundantBreak.swift in Sources */,
+				2E2BA67B2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
+				2E2BA6C62C57D2D500590239 /* RedundantParens.swift in Sources */,
+				2E2BA6AB2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
 				08180DD02C4EB67F00FD60FF /* DeclarationHelpers.swift in Sources */,
 				E4E4D3CB2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2CD0A32C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */,
-				2E2CD01C2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */,
-				2E2CD02B2C56B5FE00D70FB0 /* yodaConditions.swift in Sources */,
-				2E2CD0942C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */,
-				2E2CCFE02C56B4A000D70FB0 /* sortImports.swift in Sources */,
-				2E2CCF722C56B20900D70FB0 /* redundantReturn.swift in Sources */,
 				01BBD85B21DAA2A700457380 /* Globs.swift in Sources */,
-				2E2CD07B2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */,
-				2E2CD04E2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */,
-				2E2CD03F2C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */,
-				2E2CCF8B2C56B28C00D70FB0 /* hoistTry.swift in Sources */,
-				2E2CCFFE2C56B52900D70FB0 /* redundantLetError.swift in Sources */,
-				2E2CD09E2C56BA3900D70FB0 /* redundantProperty.swift in Sources */,
+				2E2BA6DB2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */,
+				2E2BA7172C57D2D500590239 /* TrailingSpace.swift in Sources */,
+				2E2BA6A22C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */,
+				2E2BA6BA2C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */,
+				2E2BA76B2C57D2D500590239 /* StrongifiedSelf.swift in Sources */,
+				2E2BA7952C57D2D500590239 /* HoistTry.swift in Sources */,
+				2E2BA7A72C57D2D500590239 /* UnusedArguments.swift in Sources */,
+				2E2BA75C2C57D2D500590239 /* AndOperator.swift in Sources */,
+				2E2BA68D2C57D2D500590239 /* SpaceInsideParens.swift in Sources */,
+				2E2BA76E2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */,
+				2E2BA75F2C57D2D500590239 /* WrapLoopBodies.swift in Sources */,
+				2E2BA7202C57D2D500590239 /* PreferForLoop.swift in Sources */,
+				2E2BA7022C57D2D500590239 /* IsEmpty.swift in Sources */,
+				2E2BA7562C57D2D500590239 /* Braces.swift in Sources */,
+				2E2BA77D2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */,
+				2E2BA6DE2C57D2D500590239 /* RedundantInit.swift in Sources */,
+				2E2BA6F02C57D2D500590239 /* RedundantClosure.swift in Sources */,
+				2E2BA7322C57D2D500590239 /* ApplicationMain.swift in Sources */,
+				2E2BA68A2C57D2D500590239 /* Todos.swift in Sources */,
+				2E2BA78C2C57D2D500590239 /* DocComments.swift in Sources */,
+				2E2BA6872C57D2D500590239 /* RedundantNilInit.swift in Sources */,
+				2E2BA7AD2C57D2D500590239 /* RedundantType.swift in Sources */,
 				01A8320824EC7F7700A9D0EB /* FormattingHelpers.swift in Sources */,
-				2E2CCF4F2C56B12F00D70FB0 /* redundantParens.swift in Sources */,
-				2E2CCFDB2C56B48400D70FB0 /* sortedImports.swift in Sources */,
-				2E2BF34D2C554E6400AB08D2 /* preferForLoop.swift in Sources */,
-				2E2CCEFA2C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2CCEEB2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */,
-				2E2CCF592C56B18100D70FB0 /* redundantNilInit.swift in Sources */,
-				2E2CCEFF2C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */,
+				2E2BA7352C57D2D500590239 /* RedundantProperty.swift in Sources */,
 				01045A93211988F100D2BE3D /* Inference.swift in Sources */,
-				2E2CCEAF2C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */,
+				2E2BA7262C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */,
+				2E2BA71D2C57D2D500590239 /* ConditionalAssignment.swift in Sources */,
+				2E2BA7622C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */,
 				2E2BF3572C554FDA00AB08D2 /* RuleRegistry.swift in Sources */,
-				2E2CCFD12C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */,
 				E41CB5C32026CACD00C1BEDE /* ListSelectionTableCellView.swift in Sources */,
-				2E2CCEE62C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */,
+				2E2BA6D52C57D2D500590239 /* RedundantLet.swift in Sources */,
+				2E2BA7472C57D2D500590239 /* PreferKeyPath.swift in Sources */,
 				E4872129201E3DD50014845E /* RulesStore.swift in Sources */,
-				2E2CD0992C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */,
-				2E2CD0852C56B9D100D70FB0 /* redundantInternal.swift in Sources */,
-				2E2CCF452C56B0F300D70FB0 /* modifierOrder.swift in Sources */,
+				2E2BA6782C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */,
+				2E2BA6F62C57D2D500590239 /* FileHeader.swift in Sources */,
 				E41CB5BF2025761D00C1BEDE /* UserSelection.swift in Sources */,
-				2E2CD05D2C56B6F900D70FB0 /* blockComments.swift in Sources */,
+				2E2BA6D82C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */,
+				2E2BA67E2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */,
+				2E2BA7052C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */,
+				2E2BA74D2C57D2D500590239 /* WrapAttributes.swift in Sources */,
+				2E2BA79E2C57D2D500590239 /* Specifiers.swift in Sources */,
 				E4872111201D3B830014845E /* Options.swift in Sources */,
-				2E2CCFE52C56B4B700D70FB0 /* duplicateImports.swift in Sources */,
+				2E2BA6FF2C57D2D500590239 /* HeaderFileName.swift in Sources */,
+				2E2BA7442C57D2D500590239 /* RedundantSelf.swift in Sources */,
 				01A95BD3225BEDE400744931 /* ParsingHelpers.swift in Sources */,
-				2E2CCF3B2C56B0C300D70FB0 /* linebreaks.swift in Sources */,
-				2E2CCFBD2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */,
-				2E2CD0532C56B6C900D70FB0 /* assertionFailures.swift in Sources */,
+				2E2BA7112C57D2D500590239 /* RedundantReturn.swift in Sources */,
 				D52F6A662A82E04600FE1448 /* GitFileInfo.swift in Sources */,
+				2E2BA7982C57D2D500590239 /* NumberFormatting.swift in Sources */,
+				2E2BA7892C57D2D500590239 /* SortTypealiases.swift in Sources */,
 				90C4B6CD1DA4B04A009EB000 /* AppDelegate.swift in Sources */,
+				2E2BA6A82C57D2D500590239 /* SortedImports.swift in Sources */,
+				2E2BA7502C57D2D500590239 /* WrapConditionalBodies.swift in Sources */,
+				2E2BA6692C57D2D500590239 /* InitCoderUnavailable.swift in Sources */,
+				2E2BA6902C57D2D500590239 /* Semicolons.swift in Sources */,
+				2E2BA7652C57D2D500590239 /* RedundantRawValues.swift in Sources */,
+				2E2BA6AE2C57D2D500590239 /* RedundantFileprivate.swift in Sources */,
+				2E2BA7382C57D2D500590239 /* Wrap.swift in Sources */,
+				2E2BA73E2C57D2D500590239 /* ModifierOrder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1936,142 +1716,142 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E2BA77B2C57D2D500590239 /* BlankLinesAtStartOfScope.swift in Sources */,
+				2E2BA6852C57D2D500590239 /* RedundantInternal.swift in Sources */,
+				2E2BA7B12C57D2D500590239 /* SortDeclarations.swift in Sources */,
+				2E2BA6F42C57D2D500590239 /* OrganizeDeclarations.swift in Sources */,
+				2E2BA7872C57D2D500590239 /* Acronyms.swift in Sources */,
+				2E2BA7812C57D2D500590239 /* TrailingClosures.swift in Sources */,
+				2E2BA7AB2C57D2D500590239 /* SortSwitchCases.swift in Sources */,
 				01045AA0211A1EE300D2BE3D /* Arguments.swift in Sources */,
-				2E2CCEBA2C56AD9700D70FB0 /* spaceInsideBraces.swift in Sources */,
 				01BBD85C21DAA2A700457380 /* Globs.swift in Sources */,
-				2E2CCF322C56B09700D70FB0 /* todos.swift in Sources */,
-				2E2CCF1E2C56B02A00D70FB0 /* elseOnSameLine.swift in Sources */,
-				2E2CCFB92C56B38500D70FB0 /* void.swift in Sources */,
-				2E2CCFD72C56B46E00D70FB0 /* sortSwitchCases.swift in Sources */,
-				2E2CCF552C56B14400D70FB0 /* redundantGet.swift in Sources */,
+				2E2BA7842C57D2D500590239 /* SortedSwitchCases.swift in Sources */,
+				2E2BA75A2C57D2D500590239 /* MarkTypes.swift in Sources */,
+				2E2BA6702C57D2D500590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E2BA6732C57D2D500590239 /* Indent.swift in Sources */,
 				01045A9F2119D30D00D2BE3D /* Inference.swift in Sources */,
-				2E2CCF4B2C56B10E00D70FB0 /* trailingClosures.swift in Sources */,
-				2E2CCEF62C56AF1A00D70FB0 /* blankLinesBetweenImports.swift in Sources */,
-				2E2CD0272C56B5E800D70FB0 /* redundantFileprivate.swift in Sources */,
-				2E2CCEA62C56AD0E00D70FB0 /* spaceInsideParens.swift in Sources */,
-				2E2CD0902C56B9F900D70FB0 /* wrapMultilineConditionalAssignment.swift in Sources */,
-				2E2CD06D2C56B8C700D70FB0 /* opaqueGenericParameters.swift in Sources */,
+				2E2BA6EB2C57D2D500590239 /* RedundantLetError.swift in Sources */,
+				2E2BA6EE2C57D2D500590239 /* BlankLinesBetweenScopes.swift in Sources */,
+				2E2BA7302C57D2D500590239 /* RedundantPattern.swift in Sources */,
 				01A95BD2225BEDE300744931 /* ParsingHelpers.swift in Sources */,
+				2E2BA79C2C57D2D500590239 /* WrapArguments.swift in Sources */,
+				2E2BA6CD2C57D2D500590239 /* Linebreaks.swift in Sources */,
+				2E2BA7152C57D2D500590239 /* GenericExtensions.swift in Sources */,
+				2E2BA6B52C57D2D500590239 /* StrongOutlets.swift in Sources */,
 				90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */,
-				2E2CCF232C56B04200D70FB0 /* wrapConditionalBodies.swift in Sources */,
-				2E2CCFB42C56B36B00D70FB0 /* wrapSwitchCases.swift in Sources */,
-				2E2CCFC82C56B42A00D70FB0 /* headerFileName.swift in Sources */,
-				2E2CD04A2C56B69800D70FB0 /* markTypes.swift in Sources */,
-				2E2CCF192C56B00E00D70FB0 /* braces.swift in Sources */,
-				2E2CCEBF2C56ADB000D70FB0 /* spaceAroundGenerics.swift in Sources */,
-				2E2CCEB52C56AD5100D70FB0 /* spaceAroundBraces.swift in Sources */,
-				2E2CCF872C56B26F00D70FB0 /* unusedArguments.swift in Sources */,
-				2E2CCFF02C56B4E000D70FB0 /* emptyBraces.swift in Sources */,
-				2E2CCF2D2C56B07200D70FB0 /* trailingCommas.swift in Sources */,
-				2E2CCF5F2C56B19B00D70FB0 /* redundantLet.swift in Sources */,
+				2E2BA7542C57D2D500590239 /* WrapSwitchCases.swift in Sources */,
+				2E2BA6942C57D2D500590239 /* HoistPatternLet.swift in Sources */,
+				2E2BA7A52C57D2D500590239 /* RedundantTypedThrows.swift in Sources */,
+				2E2BA6FA2C57D2D500590239 /* TypeSugar.swift in Sources */,
+				2E2BA6E22C57D2D500590239 /* NoExplicitOwnership.swift in Sources */,
+				2E2BA70C2C57D2D500590239 /* ExtensionAccessControl.swift in Sources */,
+				2E2BA6C42C57D2D500590239 /* SpaceAroundComments.swift in Sources */,
+				2E2BA6972C57D2D500590239 /* ElseOnSameLine.swift in Sources */,
+				2E2BA6B22C57D2D500590239 /* BlockComments.swift in Sources */,
+				2E2BA6FD2C57D2D500590239 /* SpaceInsideBrackets.swift in Sources */,
+				2E2BA6D32C57D2D500590239 /* SpaceInsideComments.swift in Sources */,
+				2E2BA6E82C57D2D500590239 /* WrapSingleLineComments.swift in Sources */,
+				2E2BA69D2C57D2D500590239 /* RedundantGet.swift in Sources */,
+				2E2BA7422C57D2D500590239 /* EnumNamespaces.swift in Sources */,
+				2E2BA71B2C57D2D500590239 /* RedundantObjc.swift in Sources */,
+				2E2BA6B82C57D2D500590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */,
-				2E2CD0042C56B53F00D70FB0 /* anyObjectProtocol.swift in Sources */,
-				2E2CD0222C56B5CC00D70FB0 /* unusedPrivateDeclaration.swift in Sources */,
-				2E2CD0592C56B6E000D70FB0 /* acronyms.swift in Sources */,
-				2E2CCEDD2C56AE5500D70FB0 /* enumNamespaces.swift in Sources */,
-				2E2CCF142C56AFE900D70FB0 /* initCoderUnavailable.swift in Sources */,
-				2E2CCECE2C56AE0800D70FB0 /* spaceInsideComments.swift in Sources */,
+				2E2BA6822C57D2D500590239 /* RedundantOptionalBinding.swift in Sources */,
 				E4E4D3CC2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2CCF412C56B0DC00D70FB0 /* specifiers.swift in Sources */,
-				2E2BF35E2C555CB700AB08D2 /* spaceAroundComments.swift in Sources */,
-				2E2CD0AE2C56BA8700D70FB0 /* docCommentsBeforeAttributes.swift in Sources */,
-				2E2CCFFA2C56B51100D70FB0 /* isEmpty.swift in Sources */,
-				2E2CCF962C56B2E100D70FB0 /* hoistPatternLet.swift in Sources */,
-				2E2CCFC32C56B41600D70FB0 /* fileHeader.swift in Sources */,
-				2E2CCEC42C56ADC000D70FB0 /* spaceInsideGenerics.swift in Sources */,
-				2E2CD0092C56B55200D70FB0 /* redundantBreak.swift in Sources */,
-				2E2CCFAA2C56B33E00D70FB0 /* wrapEnumCases.swift in Sources */,
-				2E2CCF912C56B2A400D70FB0 /* hoistAwait.swift in Sources */,
-				2E2CCF0F2C56AFC000D70FB0 /* linebreakAtEndOfFile.swift in Sources */,
-				2E2CCEA12C56ACFA00D70FB0 /* applicationMain.swift in Sources */,
-				2E2BF3632C555CE500AB08D2 /* indent.swift in Sources */,
-				2E2CCF282C56B05A00D70FB0 /* wrapLoopBodies.swift in Sources */,
-				2E2CD0312C56B61500D70FB0 /* leadingDelimiters.swift in Sources */,
+				2E2BA6BE2C57D2D500590239 /* AssertionFailures.swift in Sources */,
 				E4FABAD8202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2CCED32C56AE2500D70FB0 /* redundantType.swift in Sources */,
-				2E2CD0362C56B62C00D70FB0 /* wrapAttributes.swift in Sources */,
+				2E2BA7722C57D2D500590239 /* RedundantBackticks.swift in Sources */,
+				2E2BA6C12C57D2D500590239 /* EmptyBraces.swift in Sources */,
+				2E2BA7242C57D2D500590239 /* RedundantStaticSelf.swift in Sources */,
+				2E2BA6A62C57D2D500590239 /* SortImports.swift in Sources */,
+				2E2BA6762C57D2D500590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				015243E42B04B0A700F65221 /* Singularize.swift in Sources */,
+				2E2BA7692C57D2D500590239 /* TrailingCommas.swift in Sources */,
+				2E2BA72A2C57D2D500590239 /* WrapMultilineStatementBraces.swift in Sources */,
+				2E2BA7752C57D2D500590239 /* SpaceAroundParens.swift in Sources */,
+				2E2BA69A2C57D2D500590239 /* DuplicateImports.swift in Sources */,
+				2E2BA7A22C57D2D500590239 /* YodaConditions.swift in Sources */,
+				2E2BA7932C57D2D500590239 /* PropertyType.swift in Sources */,
 				9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */,
-				2E2CCE9C2C56ACE500D70FB0 /* spaceAroundParens.swift in Sources */,
-				2E2CCEAB2C56AD2700D70FB0 /* spaceAroundBrackets.swift in Sources */,
-				2E2CCF0A2C56AF9F00D70FB0 /* blankLinesAroundMark.swift in Sources */,
-				2E2CCF782C56B22000D70FB0 /* redundantBackticks.swift in Sources */,
-				2E2CD0452C56B67400D70FB0 /* extensionAccessControl.swift in Sources */,
 				90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */,
-				2E2CD0682C56B8A600D70FB0 /* redundantOptionalBinding.swift in Sources */,
-				2E2CCF642C56B1B500D70FB0 /* redundantPattern.swift in Sources */,
-				2E2CCEE22C56AEB000D70FB0 /* trailingSpace.swift in Sources */,
-				2E2CCF6E2C56B1E600D70FB0 /* redundantVoidReturnType.swift in Sources */,
+				2E2BA6D02C57D2D500590239 /* LeadingDelimiters.swift in Sources */,
+				2E2BA7092C57D2D500590239 /* BlankLinesAtEndOfScope.swift in Sources */,
+				2E2BA6E52C57D2D500590239 /* Void.swift in Sources */,
+				2E2BA6A02C57D2D500590239 /* SpaceAroundOperators.swift in Sources */,
+				2E2BA6CA2C57D2D500590239 /* SpaceAroundGenerics.swift in Sources */,
+				2E2BA72D2C57D2D500590239 /* SpaceInsideBraces.swift in Sources */,
+				2E2BA7902C57D2D500590239 /* UnusedPrivateDeclaration.swift in Sources */,
 				01A8320924EC7F7800A9D0EB /* FormattingHelpers.swift in Sources */,
-				2E2CD0182C56B59C00D70FB0 /* typeSugar.swift in Sources */,
-				2E2CCEC92C56ADE600D70FB0 /* spaceAroundOperators.swift in Sources */,
-				2E2CCF052C56AF8300D70FB0 /* blankLinesBetweenScopes.swift in Sources */,
-				2E2CCFA02C56B31000D70FB0 /* wrapArguments.swift in Sources */,
-				2E2CD0132C56B58300D70FB0 /* redundantObjc.swift in Sources */,
-				2E2CCF692C56B1CE00D70FB0 /* redundantRawValues.swift in Sources */,
-				2E2CCED82C56AE3C00D70FB0 /* consecutiveSpaces.swift in Sources */,
-				2E2CCF372C56B0AC00D70FB0 /* semicolons.swift in Sources */,
+				2E2BA74B2C57D2D500590239 /* WrapEnumCases.swift in Sources */,
+				2E2BA70F2C57D2D500590239 /* SpaceAroundBraces.swift in Sources */,
 				018541CF1DBA0F17000F82E3 /* XCSourceTextBuffer+SwiftFormat.swift in Sources */,
-				2E2CD03B2C56B64300D70FB0 /* preferKeyPath.swift in Sources */,
-				2E2CCFEB2C56B4CC00D70FB0 /* strongOutlets.swift in Sources */,
-				2E2CD00E2C56B56B00D70FB0 /* strongifiedSelf.swift in Sources */,
-				2E2CCF822C56B24F00D70FB0 /* redundantSelf.swift in Sources */,
-				2E2CCF9B2C56B2FA00D70FB0 /* wrap.swift in Sources */,
-				2E2CD08B2C56B9E400D70FB0 /* noExplicitOwnership.swift in Sources */,
-				2E2CD0722C56B8F100D70FB0 /* genericExtensions.swift in Sources */,
-				2E2CCF7D2C56B23B00D70FB0 /* redundantStaticSelf.swift in Sources */,
-				2E2CD0632C56B71A00D70FB0 /* redundantClosure.swift in Sources */,
-				2E2CD0772C56B90900D70FB0 /* docComments.swift in Sources */,
-				2E2CCFCD2C56B44100D70FB0 /* redundantInit.swift in Sources */,
-				2E2CCFF52C56B4F900D70FB0 /* andOperator.swift in Sources */,
-				2E2CCFAF2C56B35800D70FB0 /* wrapSingleLineComments.swift in Sources */,
-				2E2CCFA52C56B32700D70FB0 /* wrapMultilineStatementBraces.swift in Sources */,
-				2E2CCEF12C56AF0200D70FB0 /* blankLinesAtEndOfScope.swift in Sources */,
-				2E2CD0A92C56BA6A00D70FB0 /* propertyType.swift in Sources */,
-				2E2CD0812C56B9BD00D70FB0 /* sortTypealiases.swift in Sources */,
+				2E2BA7782C57D2D500590239 /* HoistAwait.swift in Sources */,
+				2E2BA73C2C57D2D500590239 /* BlankLineAfterImports.swift in Sources */,
+				2E2BA66D2C57D2D500590239 /* RedundantBreak.swift in Sources */,
+				2E2BA67C2C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
+				2E2BA6C72C57D2D500590239 /* RedundantParens.swift in Sources */,
+				2E2BA6AC2C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
 				08180DD12C4EB68000FD60FF /* DeclarationHelpers.swift in Sources */,
 				E4962DE1203F3CD500A02013 /* OptionsStore.swift in Sources */,
-				2E2CD0A42C56BA4D00D70FB0 /* redundantTypedThrows.swift in Sources */,
-				2E2CD01D2C56B5B500D70FB0 /* redundantExtensionACL.swift in Sources */,
-				2E2CD02C2C56B5FF00D70FB0 /* yodaConditions.swift in Sources */,
-				2E2CD0952C56BA0D00D70FB0 /* blankLineAfterSwitchCase.swift in Sources */,
-				2E2CCFE12C56B4A000D70FB0 /* sortImports.swift in Sources */,
-				2E2CCF732C56B20900D70FB0 /* redundantReturn.swift in Sources */,
 				9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */,
-				2E2CD07C2C56B92100D70FB0 /* conditionalAssignment.swift in Sources */,
-				2E2CD04F2C56B6B000D70FB0 /* sortDeclarations.swift in Sources */,
-				2E2CD0402C56B65A00D70FB0 /* organizeDeclarations.swift in Sources */,
-				2E2CCF8C2C56B28C00D70FB0 /* hoistTry.swift in Sources */,
-				2E2CCFFF2C56B52900D70FB0 /* redundantLetError.swift in Sources */,
-				2E2CD09F2C56BA3900D70FB0 /* redundantProperty.swift in Sources */,
+				2E2BA6DC2C57D2D500590239 /* ConsecutiveBlankLines.swift in Sources */,
+				2E2BA7182C57D2D500590239 /* TrailingSpace.swift in Sources */,
+				2E2BA6A32C57D2D500590239 /* BlankLinesAroundMark.swift in Sources */,
+				2E2BA6BB2C57D2D500590239 /* SpaceInsideGenerics.swift in Sources */,
+				2E2BA76C2C57D2D500590239 /* StrongifiedSelf.swift in Sources */,
+				2E2BA7962C57D2D500590239 /* HoistTry.swift in Sources */,
+				2E2BA7A82C57D2D500590239 /* UnusedArguments.swift in Sources */,
+				2E2BA75D2C57D2D500590239 /* AndOperator.swift in Sources */,
+				2E2BA68E2C57D2D500590239 /* SpaceInsideParens.swift in Sources */,
+				2E2BA76F2C57D2D500590239 /* AnyObjectProtocol.swift in Sources */,
+				2E2BA7602C57D2D500590239 /* WrapLoopBodies.swift in Sources */,
+				2E2BA7212C57D2D500590239 /* PreferForLoop.swift in Sources */,
+				2E2BA7032C57D2D500590239 /* IsEmpty.swift in Sources */,
+				2E2BA7572C57D2D500590239 /* Braces.swift in Sources */,
+				2E2BA77E2C57D2D500590239 /* OpaqueGenericParameters.swift in Sources */,
+				2E2BA6DF2C57D2D500590239 /* RedundantInit.swift in Sources */,
+				2E2BA6F12C57D2D500590239 /* RedundantClosure.swift in Sources */,
+				2E2BA7332C57D2D500590239 /* ApplicationMain.swift in Sources */,
+				2E2BA68B2C57D2D500590239 /* Todos.swift in Sources */,
+				2E2BA78D2C57D2D500590239 /* DocComments.swift in Sources */,
+				2E2BA6882C57D2D500590239 /* RedundantNilInit.swift in Sources */,
+				2E2BA7AE2C57D2D500590239 /* RedundantType.swift in Sources */,
 				E487212A201E3DD50014845E /* RulesStore.swift in Sources */,
-				2E2CCF502C56B12F00D70FB0 /* redundantParens.swift in Sources */,
-				2E2CCFDC2C56B48400D70FB0 /* sortedImports.swift in Sources */,
-				2E2BF34E2C554E6400AB08D2 /* preferForLoop.swift in Sources */,
-				2E2CCEFB2C56AF3600D70FB0 /* blankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2CCEEC2C56AEEA00D70FB0 /* blankLinesAtStartOfScope.swift in Sources */,
-				2E2CCF5A2C56B18100D70FB0 /* redundantNilInit.swift in Sources */,
-				2E2CCF002C56AF5A00D70FB0 /* blankLineAfterImports.swift in Sources */,
+				2E2BA7362C57D2D500590239 /* RedundantProperty.swift in Sources */,
 				01F3DF8E1DB9FD3F00454944 /* Options.swift in Sources */,
-				2E2CCEB02C56AD3900D70FB0 /* spaceInsideBrackets.swift in Sources */,
+				2E2BA7272C57D2D500590239 /* BlankLinesBetweenImports.swift in Sources */,
+				2E2BA71E2C57D2D500590239 /* ConditionalAssignment.swift in Sources */,
+				2E2BA7632C57D2D500590239 /* RedundantVoidReturnType.swift in Sources */,
 				2E2BF3582C554FDA00AB08D2 /* RuleRegistry.swift in Sources */,
-				2E2CCFD22C56B45500D70FB0 /* sortedSwitchCases.swift in Sources */,
 				9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */,
-				2E2CCEE72C56AECB00D70FB0 /* consecutiveBlankLines.swift in Sources */,
+				2E2BA6D62C57D2D500590239 /* RedundantLet.swift in Sources */,
+				2E2BA7482C57D2D500590239 /* PreferKeyPath.swift in Sources */,
 				B9C4F55C2387FA3E0088DBEE /* SupportedContentUTIs.swift in Sources */,
-				2E2CD09A2C56BA2100D70FB0 /* consistentSwitchCaseSpacing.swift in Sources */,
-				2E2CD0862C56B9D100D70FB0 /* redundantInternal.swift in Sources */,
-				2E2CCF462C56B0F300D70FB0 /* modifierOrder.swift in Sources */,
+				2E2BA6792C57D2D500590239 /* ConsecutiveSpaces.swift in Sources */,
+				2E2BA6F72C57D2D500590239 /* FileHeader.swift in Sources */,
 				90C4B6E71DA4B059009EB000 /* FormatSelectionCommand.swift in Sources */,
-				2E2CD05E2C56B6F900D70FB0 /* blockComments.swift in Sources */,
+				2E2BA6D92C57D2D500590239 /* DocCommentsBeforeAttributes.swift in Sources */,
+				2E2BA67F2C57D2D500590239 /* RedundantExtensionACL.swift in Sources */,
+				2E2BA7062C57D2D500590239 /* SpaceAroundBrackets.swift in Sources */,
+				2E2BA74E2C57D2D500590239 /* WrapAttributes.swift in Sources */,
+				2E2BA79F2C57D2D500590239 /* Specifiers.swift in Sources */,
 				90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */,
-				2E2CCFE62C56B4B700D70FB0 /* duplicateImports.swift in Sources */,
+				2E2BA7002C57D2D500590239 /* HeaderFileName.swift in Sources */,
+				2E2BA7452C57D2D500590239 /* RedundantSelf.swift in Sources */,
 				01ACAE08220CD916003F3CCF /* Examples.swift in Sources */,
-				2E2CCF3C2C56B0C300D70FB0 /* linebreaks.swift in Sources */,
-				2E2CCFBE2C56B3FA00D70FB0 /* numberFormatting.swift in Sources */,
-				2E2CD0542C56B6C900D70FB0 /* assertionFailures.swift in Sources */,
+				2E2BA7122C57D2D500590239 /* RedundantReturn.swift in Sources */,
 				D52F6A672A82E04600FE1448 /* GitFileInfo.swift in Sources */,
+				2E2BA7992C57D2D500590239 /* NumberFormatting.swift in Sources */,
+				2E2BA78A2C57D2D500590239 /* SortTypealiases.swift in Sources */,
 				9028F7861DA4B435009FE5B4 /* FormatRule.swift in Sources */,
+				2E2BA6A92C57D2D500590239 /* SortedImports.swift in Sources */,
+				2E2BA7512C57D2D500590239 /* WrapConditionalBodies.swift in Sources */,
+				2E2BA66A2C57D2D500590239 /* InitCoderUnavailable.swift in Sources */,
+				2E2BA6912C57D2D500590239 /* Semicolons.swift in Sources */,
+				2E2BA7662C57D2D500590239 /* RedundantRawValues.swift in Sources */,
+				2E2BA6AF2C57D2D500590239 /* RedundantFileprivate.swift in Sources */,
+				2E2BA7392C57D2D500590239 /* Wrap.swift in Sources */,
+				2E2BA73F2C57D2D500590239 /* ModifierOrder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -414,6 +414,116 @@
 		2E2BA7AF2C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
 		2E2BA7B02C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
 		2E2BA7B12C57D2D500590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
+		2E2BA8F72C57F0D800590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6382C57D2D500590239 /* RedundantStaticSelf.swift */; };
+		2E2BA8F82C57F0D800590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65B2C57D2D500590239 /* DocComments.swift */; };
+		2E2BA8F92C57F0D800590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6312C57D2D500590239 /* SpaceAroundBraces.swift */; };
+		2E2BA8FA2C57F0D800590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6462C57D2D500590239 /* WrapAttributes.swift */; };
+		2E2BA8FB2C57F0D800590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62F2C57D2D500590239 /* BlankLinesAtEndOfScope.swift */; };
+		2E2BA8FC2C57F0D800590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6552C57D2D500590239 /* BlankLinesAtStartOfScope.swift */; };
+		2E2BA8FD2C57F0D800590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FD2C57D2D500590239 /* Indent.swift */; };
+		2E2BA8FE2C57F0D800590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6642C57D2D500590239 /* UnusedArguments.swift */; };
+		2E2BA8FF2C57F0D800590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6282C57D2D500590239 /* OrganizeDeclarations.swift */; };
+		2E2BA9002C57F0D800590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62E2C57D2D500590239 /* SpaceAroundBrackets.swift */; };
+		2E2BA9012C57F0D800590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6362C57D2D500590239 /* ConditionalAssignment.swift */; };
+		2E2BA9022C57F0D800590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64A2C57D2D500590239 /* MarkTypes.swift */; };
+		2E2BA9032C57F0D800590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6592C57D2D500590239 /* Acronyms.swift */; };
+		2E2BA9042C57F0D800590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6532C57D2D500590239 /* SpaceAroundParens.swift */; };
+		2E2BA9052C57F0D800590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62A2C57D2D500590239 /* TypeSugar.swift */; };
+		2E2BA9062C57F0D800590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6672C57D2D500590239 /* SortDeclarations.swift */; };
+		2E2BA9072C57F0D800590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60F2C57D2D500590239 /* SortedImports.swift */; };
+		2E2BA9082C57F0D800590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6522C57D2D500590239 /* RedundantBackticks.swift */; };
+		2E2BA9092C57F0D800590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6162C57D2D500590239 /* AssertionFailures.swift */; };
+		2E2BA90A2C57F0D800590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6092C57D2D500590239 /* ElseOnSameLine.swift */; };
+		2E2BA90B2C57F0D800590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6122C57D2D500590239 /* BlockComments.swift */; };
+		2E2BA90C2C57F0D800590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6342C57D2D500590239 /* TrailingSpace.swift */; };
+		2E2BA90D2C57F0D800590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6202C57D2D500590239 /* ConsecutiveBlankLines.swift */; };
+		2E2BA90E2C57F0D800590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6012C57D2D500590239 /* RedundantExtensionACL.swift */; };
+		2E2BA90F2C57F0D800590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6302C57D2D500590239 /* ExtensionAccessControl.swift */; };
+		2E2BA9102C57F0D800590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6492C57D2D500590239 /* Braces.swift */; };
+		2E2BA9112C57F0D800590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63E2C57D2D500590239 /* RedundantProperty.swift */; };
+		2E2BA9122C57F0D800590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6442C57D2D500590239 /* PreferKeyPath.swift */; };
+		2E2BA9132C57F0D800590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64C2C57D2D500590239 /* WrapLoopBodies.swift */; };
+		2E2BA9142C57F0D800590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65F2C57D2D500590239 /* NumberFormatting.swift */; };
+		2E2BA9152C57F0D800590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6652C57D2D500590239 /* SortSwitchCases.swift */; };
+		2E2BA9162C57F0D800590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6322C57D2D500590239 /* RedundantReturn.swift */; };
+		2E2BA9172C57F0D800590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6062C57D2D500590239 /* SpaceInsideParens.swift */; };
+		2E2BA9182C57F0D800590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6052C57D2D500590239 /* Todos.swift */; };
+		2E2BA9192C57F0D800590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6022C57D2D500590239 /* RedundantOptionalBinding.swift */; };
+		2E2BA91A2C57F0D800590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6252C57D2D500590239 /* RedundantLetError.swift */; };
+		2E2BA91B2C57F0D800590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6412C57D2D500590239 /* ModifierOrder.swift */; };
+		2E2BA91C2C57F0D800590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62B2C57D2D500590239 /* SpaceInsideBrackets.swift */; };
+		2E2BA91D2C57F0D800590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6482C57D2D500590239 /* WrapSwitchCases.swift */; };
+		2E2BA91E2C57F0D800590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6002C57D2D500590239 /* ConsistentSwitchCaseSpacing.swift */; };
+		2E2BA91F2C57F0D800590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6212C57D2D500590239 /* RedundantInit.swift */; };
+		2E2BA9202C57F0D800590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6262C57D2D500590239 /* BlankLinesBetweenScopes.swift */; };
+		2E2BA9212C57F0D800590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60E2C57D2D500590239 /* SortImports.swift */; };
+		2E2BA9222C57F0D800590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6372C57D2D500590239 /* PreferForLoop.swift */; };
+		2E2BA9232C57F0D800590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6602C57D2D500590239 /* WrapArguments.swift */; };
+		2E2BA9242C57F0D800590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61D2C57D2D500590239 /* SpaceInsideComments.swift */; };
+		2E2BA9252C57F0D800590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65E2C57D2D500590239 /* HoistTry.swift */; };
+		2E2BA9262C57F0D800590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6472C57D2D500590239 /* WrapConditionalBodies.swift */; };
+		2E2BA9272C57F0D800590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63B2C57D2D500590239 /* SpaceInsideBraces.swift */; };
+		2E2BA9282C57F0D800590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6172C57D2D500590239 /* EmptyBraces.swift */; };
+		2E2BA9292C57F0D800590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6192C57D2D500590239 /* RedundantParens.swift */; };
+		2E2BA92A2C57F0D800590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61A2C57D2D500590239 /* SpaceAroundGenerics.swift */; };
+		2E2BA92B2C57F0D800590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6152C57D2D500590239 /* SpaceInsideGenerics.swift */; };
+		2E2BA92C2C57F0D800590239 /* PropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65D2C57D2D500590239 /* PropertyType.swift */; };
+		2E2BA92D2C57F0D800590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64D2C57D2D500590239 /* RedundantVoidReturnType.swift */; };
+		2E2BA92E2C57F0D800590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64F2C57D2D500590239 /* TrailingCommas.swift */; };
+		2E2BA92F2C57F0D800590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6242C57D2D500590239 /* WrapSingleLineComments.swift */; };
+		2E2BA9302C57F0D800590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6142C57D2D500590239 /* LinebreakAtEndOfFile.swift */; };
+		2E2BA9312C57F0D800590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FF2C57D2D500590239 /* ConsecutiveSpaces.swift */; };
+		2E2BA9322C57F0D800590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60A2C57D2D500590239 /* DuplicateImports.swift */; };
+		2E2BA9332C57F0D800590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6132C57D2D500590239 /* StrongOutlets.swift */; };
+		2E2BA9342C57F0D800590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6572C57D2D500590239 /* TrailingClosures.swift */; };
+		2E2BA9352C57F0D800590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6332C57D2D500590239 /* GenericExtensions.swift */; };
+		2E2BA9362C57F0D800590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62D2C57D2D500590239 /* IsEmpty.swift */; };
+		2E2BA9372C57F0D800590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63C2C57D2D500590239 /* RedundantPattern.swift */; };
+		2E2BA9382C57F0D800590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6542C57D2D500590239 /* HoistAwait.swift */; };
+		2E2BA9392C57F0D800590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6432C57D2D500590239 /* RedundantSelf.swift */; };
+		2E2BA93A2C57F0D800590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FB2C57D2D500590239 /* RedundantBreak.swift */; };
+		2E2BA93B2C57F0D800590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6582C57D2D500590239 /* SortedSwitchCases.swift */; };
+		2E2BA93C2C57F0D800590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6402C57D2D500590239 /* BlankLineAfterImports.swift */; };
+		2E2BA93D2C57F0D800590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61E2C57D2D500590239 /* RedundantLet.swift */; };
+		2E2BA93E2C57F0D800590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61B2C57D2D500590239 /* Linebreaks.swift */; };
+		2E2BA93F2C57F0D800590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60D2C57D2D500590239 /* BlankLinesAroundMark.swift */; };
+		2E2BA9402C57F0D800590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6352C57D2D500590239 /* RedundantObjc.swift */; };
+		2E2BA9412C57F0D800590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6512C57D2D500590239 /* AnyObjectProtocol.swift */; };
+		2E2BA9422C57F0D800590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65A2C57D2D500590239 /* SortTypealiases.swift */; };
+		2E2BA9432C57F0D800590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60C2C57D2D500590239 /* SpaceAroundOperators.swift */; };
+		2E2BA9442C57F0D800590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6112C57D2D500590239 /* RedundantFileprivate.swift */; };
+		2E2BA9452C57F0D800590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6502C57D2D500590239 /* StrongifiedSelf.swift */; };
+		2E2BA9462C57F0D800590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FC2C57D2D500590239 /* BlankLineAfterSwitchCase.swift */; };
+		2E2BA9472C57F0D800590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FA2C57D2D500590239 /* InitCoderUnavailable.swift */; };
+		2E2BA9482C57F0D800590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA5FE2C57D2D500590239 /* WrapMultilineConditionalAssignment.swift */; };
+		2E2BA9492C57F0D800590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6102C57D2D500590239 /* BlankLinesBetweenChainedFunctions.swift */; };
+		2E2BA94A2C57F0D800590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6622C57D2D500590239 /* YodaConditions.swift */; };
+		2E2BA94B2C57F0D800590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6452C57D2D500590239 /* WrapEnumCases.swift */; };
+		2E2BA94C2C57F0D800590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63A2C57D2D500590239 /* WrapMultilineStatementBraces.swift */; };
+		2E2BA94D2C57F0D800590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA60B2C57D2D500590239 /* RedundantGet.swift */; };
+		2E2BA94E2C57F0D800590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6422C57D2D500590239 /* EnumNamespaces.swift */; };
+		2E2BA94F2C57F0D800590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6182C57D2D500590239 /* SpaceAroundComments.swift */; };
+		2E2BA9502C57F0D800590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6222C57D2D500590239 /* NoExplicitOwnership.swift */; };
+		2E2BA9512C57F0D800590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6292C57D2D500590239 /* FileHeader.swift */; };
+		2E2BA9522C57F0D800590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6072C57D2D500590239 /* Semicolons.swift */; };
+		2E2BA9532C57F0D800590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6232C57D2D500590239 /* Void.swift */; };
+		2E2BA9542C57F0D800590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63F2C57D2D500590239 /* Wrap.swift */; };
+		2E2BA9552C57F0D800590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA63D2C57D2D500590239 /* ApplicationMain.swift */; };
+		2E2BA9562C57F0D800590239 /* DocCommentsBeforeAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61F2C57D2D500590239 /* DocCommentsBeforeAttributes.swift */; };
+		2E2BA9572C57F0D800590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6032C57D2D500590239 /* RedundantInternal.swift */; };
+		2E2BA9582C57F0D800590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA61C2C57D2D500590239 /* LeadingDelimiters.swift */; };
+		2E2BA9592C57F0D800590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64B2C57D2D500590239 /* AndOperator.swift */; };
+		2E2BA95A2C57F0D800590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA64E2C57D2D500590239 /* RedundantRawValues.swift */; };
+		2E2BA95B2C57F0D800590239 /* UnusedPrivateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA65C2C57D2D500590239 /* UnusedPrivateDeclaration.swift */; };
+		2E2BA95C2C57F0D800590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6632C57D2D500590239 /* RedundantTypedThrows.swift */; };
+		2E2BA95D2C57F0D800590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6612C57D2D500590239 /* Specifiers.swift */; };
+		2E2BA95E2C57F0D800590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6042C57D2D500590239 /* RedundantNilInit.swift */; };
+		2E2BA95F2C57F0D800590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6392C57D2D500590239 /* BlankLinesBetweenImports.swift */; };
+		2E2BA9602C57F0D800590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6662C57D2D500590239 /* RedundantType.swift */; };
+		2E2BA9612C57F0D800590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6562C57D2D500590239 /* OpaqueGenericParameters.swift */; };
+		2E2BA9622C57F0D800590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA62C2C57D2D500590239 /* HeaderFileName.swift */; };
+		2E2BA9632C57F0D800590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6082C57D2D500590239 /* HoistPatternLet.swift */; };
+		2E2BA9642C57F0D800590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BA6272C57D2D500590239 /* RedundantClosure.swift */; };
 		2E2BF3552C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
 		2E2BF3562C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
 		2E2BF3572C554FDA00AB08D2 /* RuleRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BF3542C554FDA00AB08D2 /* RuleRegistry.swift */; };
@@ -1543,29 +1653,139 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E2BA95D2C57F0D800590239 /* Specifiers.swift in Sources */,
 				01A0EAD51D5DC08A00A0A8E3 /* FormatRule.swift in Sources */,
+				2E2BA9552C57F0D800590239 /* ApplicationMain.swift in Sources */,
+				2E2BA92C2C57F0D800590239 /* PropertyType.swift in Sources */,
 				01A0EAD61D5DC08A00A0A8E3 /* Tokenizer.swift in Sources */,
+				2E2BA9262C57F0D800590239 /* WrapConditionalBodies.swift in Sources */,
+				2E2BA9372C57F0D800590239 /* RedundantPattern.swift in Sources */,
+				2E2BA8F82C57F0D800590239 /* DocComments.swift in Sources */,
+				2E2BA93A2C57F0D800590239 /* RedundantBreak.swift in Sources */,
+				2E2BA9172C57F0D800590239 /* SpaceInsideParens.swift in Sources */,
+				2E2BA9642C57F0D800590239 /* RedundantClosure.swift in Sources */,
+				2E2BA9542C57F0D800590239 /* Wrap.swift in Sources */,
+				2E2BA9562C57F0D800590239 /* DocCommentsBeforeAttributes.swift in Sources */,
+				2E2BA9092C57F0D800590239 /* AssertionFailures.swift in Sources */,
+				2E2BA9312C57F0D800590239 /* ConsecutiveSpaces.swift in Sources */,
+				2E2BA9162C57F0D800590239 /* RedundantReturn.swift in Sources */,
+				2E2BA8FD2C57F0D800590239 /* Indent.swift in Sources */,
 				01567D30225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
+				2E2BA91E2C57F0D800590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
+				2E2BA9422C57F0D800590239 /* SortTypealiases.swift in Sources */,
+				2E2BA9032C57F0D800590239 /* Acronyms.swift in Sources */,
+				2E2BA95F2C57F0D800590239 /* BlankLinesBetweenImports.swift in Sources */,
+				2E2BA91C2C57F0D800590239 /* SpaceInsideBrackets.swift in Sources */,
+				2E2BA90F2C57F0D800590239 /* ExtensionAccessControl.swift in Sources */,
+				2E2BA9042C57F0D800590239 /* SpaceAroundParens.swift in Sources */,
+				2E2BA8FA2C57F0D800590239 /* WrapAttributes.swift in Sources */,
 				01B3987F1D7634A0009ADE61 /* Formatter.swift in Sources */,
 				01A0EAD41D5DC08A00A0A8E3 /* SwiftFormat.swift in Sources */,
+				2E2BA91A2C57F0D800590239 /* RedundantLetError.swift in Sources */,
+				2E2BA9292C57F0D800590239 /* RedundantParens.swift in Sources */,
+				2E2BA90A2C57F0D800590239 /* ElseOnSameLine.swift in Sources */,
+				2E2BA9432C57F0D800590239 /* SpaceAroundOperators.swift in Sources */,
 				E4E4D3CA2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
+				2E2BA93D2C57F0D800590239 /* RedundantLet.swift in Sources */,
 				2E4A8AEA2C56DF14005A22B1 /* GithubActionsLogReporter.swift in Sources */,
+				2E2BA9442C57F0D800590239 /* RedundantFileprivate.swift in Sources */,
+				2E2BA9492C57F0D800590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
 				01BBD85A21DAA2A600457380 /* Globs.swift in Sources */,
+				2E2BA94D2C57F0D800590239 /* RedundantGet.swift in Sources */,
+				2E2BA8F92C57F0D800590239 /* SpaceAroundBraces.swift in Sources */,
+				2E2BA8FE2C57F0D800590239 /* UnusedArguments.swift in Sources */,
+				2E2BA9202C57F0D800590239 /* BlankLinesBetweenScopes.swift in Sources */,
+				2E2BA9342C57F0D800590239 /* TrailingClosures.swift in Sources */,
+				2E2BA9402C57F0D800590239 /* RedundantObjc.swift in Sources */,
+				2E2BA9592C57F0D800590239 /* AndOperator.swift in Sources */,
+				2E2BA9512C57F0D800590239 /* FileHeader.swift in Sources */,
+				2E2BA9212C57F0D800590239 /* SortImports.swift in Sources */,
+				2E2BA9002C57F0D800590239 /* SpaceAroundBrackets.swift in Sources */,
+				2E2BA9052C57F0D800590239 /* TypeSugar.swift in Sources */,
+				2E2BA90C2C57F0D800590239 /* TrailingSpace.swift in Sources */,
+				2E2BA9222C57F0D800590239 /* PreferForLoop.swift in Sources */,
+				2E2BA9182C57F0D800590239 /* Todos.swift in Sources */,
+				2E2BA9472C57F0D800590239 /* InitCoderUnavailable.swift in Sources */,
+				2E2BA9242C57F0D800590239 /* SpaceInsideComments.swift in Sources */,
+				2E2BA95E2C57F0D800590239 /* RedundantNilInit.swift in Sources */,
+				2E2BA8FF2C57F0D800590239 /* OrganizeDeclarations.swift in Sources */,
 				08180DCF2C4EB67F00FD60FF /* DeclarationHelpers.swift in Sources */,
+				2E2BA92A2C57F0D800590239 /* SpaceAroundGenerics.swift in Sources */,
+				2E2BA92D2C57F0D800590239 /* RedundantVoidReturnType.swift in Sources */,
 				01045A92211988F100D2BE3D /* Inference.swift in Sources */,
+				2E2BA9022C57F0D800590239 /* MarkTypes.swift in Sources */,
+				2E2BA8FC2C57F0D800590239 /* BlankLinesAtStartOfScope.swift in Sources */,
+				2E2BA9352C57F0D800590239 /* GenericExtensions.swift in Sources */,
+				2E2BA93E2C57F0D800590239 /* Linebreaks.swift in Sources */,
+				2E2BA90D2C57F0D800590239 /* ConsecutiveBlankLines.swift in Sources */,
+				2E2BA9572C57F0D800590239 /* RedundantInternal.swift in Sources */,
+				2E2BA9152C57F0D800590239 /* SortSwitchCases.swift in Sources */,
+				2E2BA94B2C57F0D800590239 /* WrapEnumCases.swift in Sources */,
+				2E2BA9062C57F0D800590239 /* SortDeclarations.swift in Sources */,
 				01F3DF8D1DB9FD3F00454944 /* Options.swift in Sources */,
+				2E2BA9382C57F0D800590239 /* HoistAwait.swift in Sources */,
+				2E2BA9612C57F0D800590239 /* OpaqueGenericParameters.swift in Sources */,
+				2E2BA9582C57F0D800590239 /* LeadingDelimiters.swift in Sources */,
+				2E2BA8F72C57F0D800590239 /* RedundantStaticSelf.swift in Sources */,
+				2E2BA9502C57F0D800590239 /* NoExplicitOwnership.swift in Sources */,
+				2E2BA9272C57F0D800590239 /* SpaceInsideBraces.swift in Sources */,
+				2E2BA94F2C57F0D800590239 /* SpaceAroundComments.swift in Sources */,
 				E4FABAD6202FEF060065716E /* OptionDescriptor.swift in Sources */,
+				2E2BA9282C57F0D800590239 /* EmptyBraces.swift in Sources */,
+				2E2BA94E2C57F0D800590239 /* EnumNamespaces.swift in Sources */,
+				2E2BA94C2C57F0D800590239 /* WrapMultilineStatementBraces.swift in Sources */,
+				2E2BA92F2C57F0D800590239 /* WrapSingleLineComments.swift in Sources */,
+				2E2BA9362C57F0D800590239 /* IsEmpty.swift in Sources */,
+				2E2BA91D2C57F0D800590239 /* WrapSwitchCases.swift in Sources */,
+				2E2BA9322C57F0D800590239 /* DuplicateImports.swift in Sources */,
+				2E2BA9602C57F0D800590239 /* RedundantType.swift in Sources */,
+				2E2BA9232C57F0D800590239 /* WrapArguments.swift in Sources */,
+				2E2BA91F2C57F0D800590239 /* RedundantInit.swift in Sources */,
+				2E2BA9622C57F0D800590239 /* HeaderFileName.swift in Sources */,
+				2E2BA9012C57F0D800590239 /* ConditionalAssignment.swift in Sources */,
 				D52F6A652A82E04600FE1448 /* GitFileInfo.swift in Sources */,
+				2E2BA8FB2C57F0D800590239 /* BlankLinesAtEndOfScope.swift in Sources */,
+				2E2BA90B2C57F0D800590239 /* BlockComments.swift in Sources */,
+				2E2BA9302C57F0D800590239 /* LinebreakAtEndOfFile.swift in Sources */,
+				2E2BA9082C57F0D800590239 /* RedundantBackticks.swift in Sources */,
+				2E2BA9112C57F0D800590239 /* RedundantProperty.swift in Sources */,
+				2E2BA9452C57F0D800590239 /* StrongifiedSelf.swift in Sources */,
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
+				2E2BA9392C57F0D800590239 /* RedundantSelf.swift in Sources */,
+				2E2BA9462C57F0D800590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E2BA9192C57F0D800590239 /* RedundantOptionalBinding.swift in Sources */,
+				2E2BA9522C57F0D800590239 /* Semicolons.swift in Sources */,
+				2E2BA9482C57F0D800590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
+				2E2BA91B2C57F0D800590239 /* ModifierOrder.swift in Sources */,
+				2E2BA92B2C57F0D800590239 /* SpaceInsideGenerics.swift in Sources */,
+				2E2BA94A2C57F0D800590239 /* YodaConditions.swift in Sources */,
+				2E2BA95C2C57F0D800590239 /* RedundantTypedThrows.swift in Sources */,
+				2E2BA93F2C57F0D800590239 /* BlankLinesAroundMark.swift in Sources */,
+				2E2BA9532C57F0D800590239 /* Void.swift in Sources */,
 				015243E22B04B0A600F65221 /* Singularize.swift in Sources */,
 				2E4A8AEC2C56DF14005A22B1 /* XMLReporter.swift in Sources */,
 				01ACAE06220CD914003F3CCF /* Examples.swift in Sources */,
+				2E2BA9412C57F0D800590239 /* AnyObjectProtocol.swift in Sources */,
+				2E2BA95B2C57F0D800590239 /* UnusedPrivateDeclaration.swift in Sources */,
+				2E2BA92E2C57F0D800590239 /* TrailingCommas.swift in Sources */,
 				2E4A8AF02C56DF14005A22B1 /* Reporter.swift in Sources */,
 				2E4A8AEE2C56DF14005A22B1 /* JSONReporter.swift in Sources */,
 				01A0EACD1D5DB5F500A0A8E3 /* main.swift in Sources */,
+				2E2BA9072C57F0D800590239 /* SortedImports.swift in Sources */,
+				2E2BA9122C57F0D800590239 /* PreferKeyPath.swift in Sources */,
+				2E2BA9102C57F0D800590239 /* Braces.swift in Sources */,
 				2E2BF3562C554FDA00AB08D2 /* RuleRegistry.swift in Sources */,
+				2E2BA93C2C57F0D800590239 /* BlankLineAfterImports.swift in Sources */,
+				2E2BA9132C57F0D800590239 /* WrapLoopBodies.swift in Sources */,
 				01045A9A2119979400D2BE3D /* Arguments.swift in Sources */,
+				2E2BA90E2C57F0D800590239 /* RedundantExtensionACL.swift in Sources */,
+				2E2BA9632C57F0D800590239 /* HoistPatternLet.swift in Sources */,
+				2E2BA93B2C57F0D800590239 /* SortedSwitchCases.swift in Sources */,
+				2E2BA9142C57F0D800590239 /* NumberFormatting.swift in Sources */,
+				2E2BA9252C57F0D800590239 /* HoistTry.swift in Sources */,
+				2E2BA9332C57F0D800590239 /* StrongOutlets.swift in Sources */,
+				2E2BA95A2C57F0D800590239 /* RedundantRawValues.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
In https://github.com/nicklockwood/SwiftFormat/pull/1789#issuecomment-2255061098 you mentioned that you'd probably prefer TitleCase for the name of rule files. I'm starting to agree, because I find `class ruleNameTests: XCTestCase` a bit too unsightly compared to `class RuleNameTests: XCTestCase`.

This PR updates all of the rule code files to use TitleCase. I automated this with a short script:

<details>

```swift
    func testUpdateRuleFiles() {
        for ruleFile in allRuleFiles {
            let ruleName = ruleFile.lastPathComponent.replacingOccurrences(of: ".swift", with: "")
            let capitalizedRuleName = ruleName.first!.uppercased() + ruleName.dropFirst()
            print(capitalizedRuleName)

            let fileContents = try! String(contentsOf: ruleFile)
            let formatter = Formatter(tokenize(fileContents))
            guard formatter.tokens[4].string.contains(".swift") else { fatalError() }
            formatter.replaceToken(at: 4, with: .stringBody("\(capitalizedRuleName).swift"))

            let updatedFileContents = formatter.tokens.string
            let updatedFilePath = projectDirectory.appendingPathComponent("Sources/UpdatedRules/\(capitalizedRuleName).swift")
            try! updatedFileContents.write(to: updatedFilePath, atomically: true, encoding: .utf8)
        }
    }
```

</details>

If we're worried about git case sensitivity, we could squash this commit with [778ade4](https://github.com/nicklockwood/SwiftFormat/commit/778ade43b4eef1bd9498be176560e3d480d625ef) in the git history.