### PR TITLE
Add EmptyExtension rule+ tests

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -808,6 +808,18 @@ Option | Description
 
 Remove empty, non-conforming, extensions.
 
+<details>
+<summary>Examples</summary>
+
+```diff
+-- extension String {}
+--
+extension String: Equatable {}
+```
+
+</details>
+<br/>
+
 ## enumNamespaces
 
 Convert types used for hosting only static members into enums (an empty enum is

--- a/Rules.md
+++ b/Rules.md
@@ -815,6 +815,7 @@ Remove empty, non-conforming, extensions.
 - extension String {}
 -
   extension String: Equatable {}
+```
 
 </details>
 <br/>

--- a/Rules.md
+++ b/Rules.md
@@ -812,10 +812,9 @@ Remove empty, non-conforming, extensions.
 <summary>Examples</summary>
 
 ```diff
--- extension String {}
---
-extension String: Equatable {}
-```
+- extension String {}
+-
+  extension String: Equatable {}
 
 </details>
 <br/>

--- a/Rules.md
+++ b/Rules.md
@@ -19,6 +19,7 @@
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
+* [emptyExtension](#emptyExtension)
 * [enumNamespaces](#enumNamespaces)
 * [extensionAccessControl](#extensionAccessControl)
 * [fileHeader](#fileHeader)
@@ -802,6 +803,10 @@ Option | Description
 
 </details>
 <br/>
+
+## emptyExtension
+
+Remove empty, non-conforming, extensions.
 
 ## enumNamespaces
 

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -2011,9 +2011,9 @@ private struct Examples {
 
     let emptyExtension = """
     ```diff
-    -- extension String {}
-    --
-    extension String: Equatable {}
+    - extension String {}
+    -
+      extension String: Equatable {}
     ```
     """
 }

--- a/Sources/Examples.swift
+++ b/Sources/Examples.swift
@@ -2008,4 +2008,12 @@ private struct Examples {
       func foo() {}
     ```
     """
+
+    let emptyExtension = """
+    ```diff
+    -- extension String {}
+    --
+    extension String: Equatable {}
+    ```
+    """
 }

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -33,6 +33,7 @@ let ruleRegistry: [String: FormatRule] = [
     "duplicateImports": .duplicateImports,
     "elseOnSameLine": .elseOnSameLine,
     "emptyBraces": .emptyBraces,
+    "emptyExtension": .emptyExtension,
     "enumNamespaces": .enumNamespaces,
     "extensionAccessControl": .extensionAccessControl,
     "fileHeader": .fileHeader,

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -22,7 +22,7 @@ public extension FormatRule {
                   let declarationBody = declaration.body,
                   declarationBody.isEmpty,
                   // Ensure that it is not a macro
-                  !(declarationModifiers.contains { $0.first == "@" })
+                  !declarationModifiers.contains { $0.first == "@" }
             else { return }
 
             // Ensure that the extension does not conform to any protocols
@@ -31,7 +31,7 @@ public extension FormatRule {
                   let typeNameIndex = parser.index(of: .nonSpaceOrLinebreak, after: extensionIndex),
                   let type = parser.parseType(at: typeNameIndex),
                   let indexAfterType = parser.index(of: .nonSpaceOrCommentOrLinebreak, after: type.range.upperBound),
-                  !(parser.tokens[indexAfterType] == .delimiter(":"))
+                  parser.tokens[indexAfterType] != .delimiter(":")
             else { return }
 
             emptyExtensions.append(declaration)

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -10,26 +10,34 @@ import Foundation
 
 public extension FormatRule {
     /// Remove empty, non-conforming, extensions.
-    static let emptyExtension = FormatRule(help: "Remove empty, non-conforming, extensions.") { formatter in
-
+    static let emptyExtension = FormatRule(
+        help: "Remove empty, non-conforming, extensions.",
+        orderAfter: [.unusedPrivateDeclaration]
+    ) { formatter in
         var emptyExtensions = [Declaration]()
 
         formatter.forEachRecursiveDeclaration { declaration in
             let declarationModifiers = Set(declaration.modifiers)
-            guard let declarationBody = declaration.body,
-                  declaration.keyword == "extension",
+            guard declaration.keyword == "extension",
+                  let declarationBody = declaration.body,
                   declarationBody.isEmpty,
-                  // Ensure that the extension does not conform to any protocols
-                  !declaration.openTokens.contains(where: { $0 == .delimiter(":") }),
                   // Ensure that it is not a macro
                   !(declarationModifiers.contains { $0.first == "@" })
+            else { return }
+
+            // Ensure that the extension does not conform to any protocols
+            let parser = Formatter(declaration.openTokens)
+            guard let extensionIndex = parser.index(of: .keyword("extension"), after: -1),
+                  let typeNameIndex = parser.index(of: .nonSpaceOrLinebreak, after: extensionIndex),
+                  let type = parser.parseType(at: typeNameIndex),
+                  let indexAfterType = parser.index(of: .nonSpaceOrCommentOrLinebreak, after: type.range.upperBound),
+                  !(parser.tokens[indexAfterType] == .delimiter(":"))
             else { return }
 
             emptyExtensions.append(declaration)
         }
 
         for declaration in emptyExtensions.reversed() {
-            print(declaration.originalRange)
             formatter.removeTokens(in: declaration.originalRange)
         }
     }

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -22,7 +22,7 @@ public extension FormatRule {
                   let declarationBody = declaration.body,
                   declarationBody.isEmpty,
                   // Ensure that it is not a macro
-                  !declarationModifiers.contains { $0.first == "@" }
+                  !declarationModifiers.contains(where: { $0.first == "@" })
             else { return }
 
             // Ensure that the extension does not conform to any protocols

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -9,14 +9,20 @@
 import Foundation
 
 public extension FormatRule {
-    /// Remove empty, non-conforming, extensions
-    static let emptyExtension = FormatRule(help: "Remove empty, non-conforming, extensions") { formatter in
+    /// Remove empty, non-conforming, extensions.
+    static let emptyExtension = FormatRule(help: "Remove empty, non-conforming, extensions.") { formatter in
+
         var emptyExtensions = [Declaration]()
+
         formatter.forEachRecursiveDeclaration { declaration in
-            guard case let .type(_, open, body, _, _) = declaration,
+            let declarationModifiers = Set(declaration.modifiers)
+            guard let declarationBody = declaration.body,
                   declaration.keyword == "extension",
-                  body.isEmpty,
-                  !open.contains(where: { $0 == .delimiter(":") })
+                  declarationBody.isEmpty,
+                  // Ensure that the extension does not conform to any protocols
+                  !declaration.openTokens.contains(where: { $0 == .delimiter(":") }),
+                  // Ensure that it is not a macro
+                  !(declarationModifiers.contains { $0.first == "@" })
             else { return }
 
             emptyExtensions.append(declaration)

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -1,0 +1,30 @@
+//
+//  EmptyExtension.swift
+//  SwiftFormat
+//
+// Created by manny_lopez on 7/29/24.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Remove empty, non-conforming, extensions
+    static let emptyExtension = FormatRule(help: "Remove empty, non-conforming, extensions") { formatter in
+        var emptyExtensions = [Declaration]()
+        formatter.forEachRecursiveDeclaration { declaration in
+            guard case let .type(_, open, body, _, _) = declaration,
+                  declaration.keyword == "extension",
+                  body.isEmpty,
+                  !open.contains(where: { $0 == .delimiter(":") })
+            else { return }
+
+            emptyExtensions.append(declaration)
+        }
+
+        for declaration in emptyExtensions.reversed() {
+            print(declaration.originalRange)
+            formatter.removeTokens(in: declaration.originalRange)
+        }
+    }
+}

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -627,6 +627,11 @@
 		2E8DE7622C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */; };
 		37D828AB24BF77DA0012FC0A /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; };
 		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		580496D52C584E8F004B7DBF /* EmptyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtension.swift */; };
+		580496D62C584E8F004B7DBF /* EmptyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtension.swift */; };
+		580496D72C584E8F004B7DBF /* EmptyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtension.swift */; };
+		580496D82C584E8F004B7DBF /* EmptyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtension.swift */; };
+		580496DE2C584F8C004B7DBF /* EmptyExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D92C584F24004B7DBF /* EmptyExtensionTests.swift */; };
 		9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EAC41D5DB54A00A0A8E3 /* SwiftFormat.swift */; };
 		9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EABF1D5DB4F700A0A8E3 /* Tokenizer.swift */; };
 		9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
@@ -988,6 +993,8 @@
 		2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantFileprivateTests.swift; sourceTree = "<group>"; };
 		2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSingleLineCommentsTests.swift; sourceTree = "<group>"; };
 		37D828AA24BF77DA0012FC0A /* XcodeKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XcodeKit.framework; path = Library/Frameworks/XcodeKit.framework; sourceTree = DEVELOPER_DIR; };
+		580496D42C584E8F004B7DBF /* EmptyExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyExtension.swift; sourceTree = "<group>"; };
+		580496D92C584F24004B7DBF /* EmptyExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmptyExtensionTests.swift; path = Tests/Rules/EmptyExtensionTests.swift; sourceTree = "<group>"; };
 		90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftFormat for Xcode.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		90C4B6D01DA4B04A009EB000 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1093,6 +1100,7 @@
 		01A0EA9A1D5DB4CF00A0A8E3 = {
 			isa = PBXGroup;
 			children = (
+				580496D92C584F24004B7DBF /* EmptyExtensionTests.swift */,
 				01A0EACB1D5DB5F500A0A8E3 /* CommandLineTool */,
 				90C4B6F01DA4B0BF009EB000 /* EditorExtension */,
 				01A0EAA61D5DB4CF00A0A8E3 /* Sources */,
@@ -1201,6 +1209,7 @@
 				2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */,
 				2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */,
 				2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */,
+				580496D42C584E8F004B7DBF /* EmptyExtension.swift */,
 				2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */,
 				2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */,
 				2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */,
@@ -1813,6 +1822,7 @@
 				2E2BAC2B2C57F6DD00590239 /* Todos.swift in Sources */,
 				2E2BAC6F2C57F6DD00590239 /* AssertionFailures.swift in Sources */,
 				2E2BAD5B2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */,
+				580496D52C584E8F004B7DBF /* EmptyExtension.swift in Sources */,
 				2E2BAC072C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
 				2E2BADA32C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */,
 				2E2BAD4B2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */,
@@ -2035,6 +2045,7 @@
 				2E8DE6FF2C57FEB30032BF25 /* DuplicateImportsTests.swift in Sources */,
 				2E8DE7112C57FEB30032BF25 /* RedundantStaticSelfTests.swift in Sources */,
 				2E8DE72C2C57FEB30032BF25 /* RedundantLetTests.swift in Sources */,
+				580496DE2C584F8C004B7DBF /* EmptyExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2165,6 +2176,7 @@
 				2E2BAD502C57F6DD00590239 /* RedundantRawValues.swift in Sources */,
 				2E2BACAC2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
 				01045A9A2119979400D2BE3D /* Arguments.swift in Sources */,
+				580496D62C584E8F004B7DBF /* EmptyExtension.swift in Sources */,
 				2E2BAD482C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
 				2E2BAD082C57F6DD00590239 /* RedundantPattern.swift in Sources */,
 				2E2BAD042C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
@@ -2300,6 +2312,7 @@
 				2E2BAC1D2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
 				2E2BACD12C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
 				2E2BAD312C57F6DD00590239 /* WrapAttributes.swift in Sources */,
+				580496D72C584E8F004B7DBF /* EmptyExtension.swift in Sources */,
 				2E2BAD9D2C57F6DD00590239 /* Specifiers.swift in Sources */,
 				E4872111201D3B830014845E /* Options.swift in Sources */,
 				2E2BACC92C57F6DD00590239 /* HeaderFileName.swift in Sources */,
@@ -2443,6 +2456,7 @@
 				2E2BAC1E2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
 				2E2BACD22C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
 				2E2BAD322C57F6DD00590239 /* WrapAttributes.swift in Sources */,
+				580496D82C584E8F004B7DBF /* EmptyExtension.swift in Sources */,
 				2E2BAD9E2C57F6DD00590239 /* Specifiers.swift in Sources */,
 				90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */,
 				2E2BACCA2C57F6DD00590239 /* HeaderFileName.swift in Sources */,

--- a/Tests/Rules/EmptyExtensionTests.swift
+++ b/Tests/Rules/EmptyExtensionTests.swift
@@ -1,0 +1,33 @@
+//
+//  EmptyExtensionTests.swift
+//  SwiftFormatTests
+//
+//  Created by manny_lopez on 7/28/2024.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class EmptyExtensionTests: XCTestCase {
+    // MARK: - emptyExtension
+
+    func testRemoveEmptyExtension() {
+        let input = """
+        extension String {}
+
+        extension String: Equatable {}
+        """
+        let output = """
+        extension String: Equatable {}
+        """
+        testFormatting(for: input, output, rule: .emptyExtension)
+    }
+
+    func testDoNotRemoveEmptyConformingExtension() {
+        let input = """
+        extension String: Equatable {}
+        """
+        testFormatting(for: input, rule: .emptyExtension)
+    }
+}

--- a/Tests/Rules/EmptyExtensionTests.swift
+++ b/Tests/Rules/EmptyExtensionTests.swift
@@ -10,8 +10,6 @@ import XCTest
 @testable import SwiftFormat
 
 class EmptyExtensionTests: XCTestCase {
-    // MARK: - emptyExtension
-
     func testRemoveEmptyExtension() {
         let input = """
         extension String {}
@@ -29,5 +27,25 @@ class EmptyExtensionTests: XCTestCase {
         extension String: Equatable {}
         """
         testFormatting(for: input, rule: .emptyExtension)
+    }
+
+    func testDoNotRemoveAtModifierEmptyExtension() {
+        let input = """
+        @GenerateBoilerPlate
+        extension Foo {}
+        """
+        testFormatting(for: input, rule: .emptyExtension)
+    }
+
+    func testRemoveEmptyExtensionWithEmptyBody() {
+        let input = """
+        extension Foo { }
+
+        extension Foo {
+
+        }
+        """
+        let output = ""
+        testFormatting(for: input, output, rule: .emptyExtension)
     }
 }

--- a/Tests/Rules/EmptyExtensionTests.swift
+++ b/Tests/Rules/EmptyExtensionTests.swift
@@ -22,6 +22,16 @@ class EmptyExtensionTests: XCTestCase {
         testFormatting(for: input, output, rule: .emptyExtension)
     }
 
+    func testRemoveNonConformingEmptyExtension() {
+        let input = """
+        extension [Foo: Bar] {}
+
+        extension Array where Element: Foo {}
+        """
+        let output = ""
+        testFormatting(for: input, output, rule: .emptyExtension)
+    }
+
     func testDoNotRemoveEmptyConformingExtension() {
         let input = """
         extension String: Equatable {}
@@ -47,5 +57,24 @@ class EmptyExtensionTests: XCTestCase {
         """
         let output = ""
         testFormatting(for: input, output, rule: .emptyExtension)
+    }
+
+    func testRemoveUnusedPrivateDeclarationThenEmptyExtension() {
+        let input = """
+        class Foo {
+            init() {}
+        }
+        extension Foo {
+            private var bar: Bar { "bar" }
+        }
+        """
+
+        let output = """
+        class Foo {
+            init() {}
+        }
+
+        """
+        testFormatting(for: input, [output], rules: [.unusedPrivateDeclaration, .emptyExtension])
     }
 }

--- a/Tests/Rules/GenericExtensionsTests.swift
+++ b/Tests/Rules/GenericExtensionsTests.swift
@@ -15,7 +15,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Array<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testUpdatesOptionalGenericExtensionToAngleBracketSyntax() {
@@ -23,7 +23,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Optional<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testUpdatesArrayGenericExtensionToAngleBracketSyntaxWithSelf() {
@@ -31,7 +31,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Array<Foo> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testUpdatesArrayWithGenericElement() {
@@ -39,7 +39,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Array<Foo<Bar>> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testUpdatesDictionaryGenericExtensionToAngleBracketSyntax() {
@@ -47,7 +47,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Dictionary<Foo, Bar> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testRequiresAllGenericTypesToBeProvided() {
@@ -55,7 +55,7 @@ class GenericExtensionsTests: XCTestCase {
         let input = "extension Dictionary where Key == Foo {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, rule: .genericExtensions, options: options)
+        testFormatting(for: input, rule: .genericExtensions, options: options, exclude: [.emptyExtension])
     }
 
     func testHandlesNestedCollectionTypes() {
@@ -63,7 +63,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Array<[[Foo: Bar]]> {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar])
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtension])
     }
 
     func testDoesntUpdateIneligibleConstraints() {
@@ -80,7 +80,7 @@ class GenericExtensionsTests: XCTestCase {
         let output = "extension Collection<String> where Index == Int {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, output, rule: .genericExtensions, options: options)
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.emptyExtension])
     }
 
     func testSupportsUserProvidedGenericTypes() {
@@ -97,7 +97,7 @@ class GenericExtensionsTests: XCTestCase {
             genericTypes: "LinkedList<Element>;StateStore<State, Action>",
             swiftVersion: "5.7"
         )
-        testFormatting(for: input, output, rule: .genericExtensions, options: options)
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.emptyExtension])
     }
 
     func testSupportsMultilineUserProvidedGenericTypes() {
@@ -116,6 +116,6 @@ class GenericExtensionsTests: XCTestCase {
             genericTypes: "Reducer<State, Action, Environment>",
             swiftVersion: "5.7"
         )
-        testFormatting(for: input, output, rule: .genericExtensions, options: options)
+        testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.emptyExtension])
     }
 }

--- a/Tests/Rules/GenericExtensionsTests.swift
+++ b/Tests/Rules/GenericExtensionsTests.swift
@@ -72,7 +72,7 @@ class GenericExtensionsTests: XCTestCase {
         let input = "extension Optional where Wrapped: Fooable {}"
 
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, rule: .genericExtensions, options: options)
+        testFormatting(for: input, rule: .genericExtensions, options: options, exclude: [.emptyExtension])
     }
 
     func testPreservesOtherConstraintsInWhereClause() {

--- a/Tests/Rules/MarkTypesTests.swift
+++ b/Tests/Rules/MarkTypesTests.swift
@@ -36,7 +36,7 @@ class MarkTypesTests: XCTestCase {
         protocol Quux {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testDoesntAddMarkBeforeStructWithExistingMark() {
@@ -47,7 +47,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, rule: .markTypes)
+        testFormatting(for: input, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testCorrectsTypoInTypeMark() {
@@ -65,7 +65,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testUpdatesMarkAfterTypeIsRenamed() {
@@ -83,7 +83,7 @@ class MarkTypesTests: XCTestCase {
         extension FooBarControllerBuilder {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testAddsMarkBeforeTypeWithDocComment() {
@@ -107,7 +107,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testCustomTypeMark() {
@@ -125,7 +125,8 @@ class MarkTypesTests: XCTestCase {
 
         testFormatting(
             for: input, output, rule: .markTypes,
-            options: FormatOptions(typeMarkComment: "TYPE DEFINITION: %t")
+            options: FormatOptions(typeMarkComment: "TYPE DEFINITION: %t"),
+            exclude: [.emptyExtension]
         )
     }
 
@@ -135,7 +136,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, rule: .markTypes)
+        testFormatting(for: input, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func preservesExistingCommentForExtensionWithNoConformances() {
@@ -162,7 +163,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testUpdatesExtensionMarkToCorrectMark() {
@@ -180,7 +181,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testAddsMarkCommentForExtensionWithMultipleConformances() {
@@ -196,7 +197,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testUpdatesMarkCommentWithCorrectConformances() {
@@ -214,7 +215,7 @@ class MarkTypesTests: XCTestCase {
         extension Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testCustomExtensionMarkComment() {
@@ -284,7 +285,7 @@ class MarkTypesTests: XCTestCase {
         extension MyModule.Foo {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testWhereClauseConformanceWithExactConstraint() {
@@ -300,7 +301,7 @@ class MarkTypesTests: XCTestCase {
         extension Array {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testWhereClauseConformanceWithConformanceConstraint() {
@@ -316,7 +317,7 @@ class MarkTypesTests: XCTestCase {
         extension Array {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testWhereClauseWithExactConstraint() {
@@ -325,7 +326,7 @@ class MarkTypesTests: XCTestCase {
         extension Array {}
         """
 
-        testFormatting(for: input, rule: .markTypes)
+        testFormatting(for: input, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testWhereClauseWithConformanceConstraint() {
@@ -336,7 +337,7 @@ class MarkTypesTests: XCTestCase {
         extension Rules {}
         """
 
-        testFormatting(for: input, rule: .markTypes)
+        testFormatting(for: input, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testPlacesMarkAfterImports() {
@@ -360,7 +361,7 @@ class MarkTypesTests: XCTestCase {
         extension Rules {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testPlacesMarkAfterFileHeader() {
@@ -384,7 +385,7 @@ class MarkTypesTests: XCTestCase {
         extension Rules {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testPlacesMarkAfterFileHeaderAndImports() {
@@ -414,7 +415,7 @@ class MarkTypesTests: XCTestCase {
         extension Rules {}
         """
 
-        testFormatting(for: input, output, rule: .markTypes)
+        testFormatting(for: input, output, rule: .markTypes, exclude: [.emptyExtension])
     }
 
     func testDoesNothingIfOnlyOneDeclaration() {

--- a/Tests/Rules/OpaqueGenericParametersTests.swift
+++ b/Tests/Rules/OpaqueGenericParametersTests.swift
@@ -513,7 +513,7 @@ class OpaqueGenericParametersTests: XCTestCase {
         let input = "extension Array where Element == Foo {}"
 
         let options = FormatOptions(swiftVersion: "5.6")
-        testFormatting(for: input, rule: .opaqueGenericParameters, options: options)
+        testFormatting(for: input, rule: .opaqueGenericParameters, options: options, exclude: [.emptyExtension])
     }
 
     func testOpaqueGenericParametersRuleSuccessfullyTerminatesInSampleCode() {

--- a/Tests/Rules/TypeSugarTests.swift
+++ b/Tests/Rules/TypeSugarTests.swift
@@ -72,7 +72,7 @@ class TypeSugarTests: XCTestCase {
         extension [Foo: Bar] {}
         extension [[Foo: [Bar]]]? {}
         """
-        testFormatting(for: input, output, rule: .typeSugar)
+        testFormatting(for: input, output, rule: .typeSugar, exclude: [.emptyExtension])
     }
 
     // dictionaries


### PR DESCRIPTION
Removes empty, non-conforming, extensions

```diff
-- extension String {}
--
extension String: Equatable {}
```