### PR TITLE
Add SwiftUI properties subcategory alphabetical sort

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1410,6 +1410,7 @@ Option | Description
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
+`--sortswiftuiprops` | Sorts SwiftUI properties alphabetically, defaults to "false"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -149,6 +149,10 @@ enum Declaration: Hashable {
         })
         return allModifiers
     }
+
+    var swiftUIPropertyWrapper: String? {
+        modifiers.first(where: Declaration.swiftUIPropertyWrappers.contains)
+    }
 }
 
 extension Formatter {
@@ -530,7 +534,7 @@ extension Declaration {
 
             let isSwiftUIPropertyWrapper = declarationParser
                 .modifiersForDeclaration(at: declarationTypeTokenIndex) { _, modifier in
-                    swiftUIPropertyWrappers.contains(modifier)
+                    Declaration.swiftUIPropertyWrappers.contains(modifier)
                 }
 
             switch declarationTypeToken {
@@ -608,7 +612,7 @@ extension Declaration {
 
     /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.
     /// Most of these are listed here: https://developer.apple.com/documentation/swiftui/dynamicproperty
-    private var swiftUIPropertyWrappers: Set<String> {
+    fileprivate static var swiftUIPropertyWrappers: Set<String> {
         [
             "@AccessibilityFocusState",
             "@AppStorage",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1200,6 +1200,15 @@ struct _Descriptors {
         keyPath: \.preservedPrivateDeclarations
     )
 
+    let alphabetizeSwiftUIPropertyTypes = OptionDescriptor(
+        argumentName: "sortswiftuiprops",
+        displayName: "Alphabetize SwiftUI Properties",
+        help: "Sorts SwiftUI properties alphabetically, defaults to \"false\"",
+        keyPath: \.alphabetizeSwiftUIPropertyTypes,
+        trueValues: ["enabled", "true"],
+        falseValues: ["disabled", "false"]
+    )
+
     // MARK: - Internal
 
     let fragment = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -673,6 +673,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var customTypeMarks: Set<String>
     public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
+    public var alphabetizeSwiftUIPropertyTypes: Bool
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var redundantType: RedundantType
@@ -798,6 +799,7 @@ public struct FormatOptions: CustomStringConvertible {
                 customTypeMarks: Set<String> = [],
                 blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
+                alphabetizeSwiftUIPropertyTypes: Bool = false,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 redundantType: RedundantType = .inferLocalsOnly,
@@ -913,6 +915,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.customTypeMarks = customTypeMarks
         self.blankLineAfterSubgroups = blankLineAfterSubgroups
         self.alphabeticallySortedDeclarationPatterns = alphabeticallySortedDeclarationPatterns
+        self.alphabetizeSwiftUIPropertyTypes = alphabetizeSwiftUIPropertyTypes
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
         self.redundantType = redundantType

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -19,7 +19,7 @@ public extension FormatRule {
             "lifecycle", "organizetypes", "structthreshold", "classthreshold",
             "enumthreshold", "extensionlength", "organizationmode",
             "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
-            "groupblanklines",
+            "groupblanklines", "sortswiftuiprops",
         ],
         sharedOptions: ["sortedpatterns", "lineaftermarks"]
     ) { formatter in

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -217,6 +217,14 @@ extension Formatter {
                     return lhsName.localizedCompare(rhsName) == .orderedAscending
                 }
 
+                if options.alphabetizeSwiftUIPropertyTypes,
+                   lhs.category.type == rhs.category.type,
+                   let lhsSwiftUIProperty = lhs.declaration.swiftUIPropertyWrapper,
+                   let rhsSwiftUIProperty = rhs.declaration.swiftUIPropertyWrapper
+                {
+                    return lhsSwiftUIProperty.localizedCompare(rhsSwiftUIProperty) == .orderedAscending
+                }
+
                 // Respect the original declaration ordering when the categories and types are the same
                 return lhsOriginalIndex < rhsOriginalIndex
             })

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -254,6 +254,7 @@ class MetadataTests: XCTestCase {
                             Descriptors.customVisibilityMarks,
                             Descriptors.customTypeMarks,
                             Descriptors.blankLineAfterSubgroups,
+                            Descriptors.alphabetizeSwiftUIPropertyTypes,
                         ]
                     case .identifier("removeSelf"):
                         referencedOptions += [

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3005,6 +3005,114 @@ class OrganizeDeclarationsTests: XCTestCase {
         )
     }
 
+    func testSortSwiftUIPropertyWrappersSubCategory() {
+        let input = """
+        struct ContentView: View {
+            init() {}
+
+            @Environment(\\.colorScheme) var colorScheme
+            @State var foo: Foo
+            @Binding var isOn: Bool
+            @Environment(\\.quux) var quux: Quux
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            @Binding var isOn: Bool
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+            @State var foo: Foo
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(
+                organizeTypes: ["struct"],
+                organizationMode: .visibility,
+                blankLineAfterSubgroups: false,
+                alphabetizeSwiftUIPropertyTypes: true
+            ),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testSortSwiftUIWrappersByTypeAndMaintainGroupSpacing() {
+        let input = """
+        struct ContentView: View {
+            init() {}
+
+            @State var foo: Foo
+            @State var bar: Bar
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+
+            @Binding var isOn: Bool
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            @Binding var isOn: Bool
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+
+            @State var foo: Foo
+            @State var bar: Bar
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(
+                organizeTypes: ["struct"],
+                organizationMode: .visibility,
+                blankLineAfterSubgroups: false,
+                alphabetizeSwiftUIPropertyTypes: true
+            ),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
     func testPreservesBlockOfConsecutivePropertiesWithoutBlankLinesBetweenSubgroups1() {
         let input = """
         class Foo {


### PR DESCRIPTION
This PR enables the alphabetical sorting of SwiftUI property wrappers. This PR continues the implementation of https://github.com/nicklockwood/SwiftFormat/pull/1784 but I opened a new PR to prevent spending too much time fixing conflicts from `develop`.

 ```swift
        // WRONG
        struct ContentView: View {

            @Environment(\\.colorScheme) var colorScheme
            @State var foo: Foo
            @Binding var isOn: Bool
            @Environment(\\.quux) var quux: Quux

            var body: some View {
                Toggle(label, isOn: $isOn)
            }
        }
        // RIGHT
        struct ContentView: View {

            @Binding var isOn: Bool
            @Environment(\\.colorScheme) var colorScheme
            @Environment(\\.quux) var quux: Quux
            @State var foo: Foo

            var body: some View {
                Toggle(label, isOn: $isOn)
            }
        }
```

cc: @calda 