### PR TITLE
Update organizeDeclarations to avoid inserting blank lines inside consecutive groups of properties

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1392,6 +1392,7 @@ Option | Description
 `--typeorder` | Order for declaration type groups inside declaration
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
+`--groupblanklines` | Require a blank line after each subgroup. Default: true
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -999,6 +999,14 @@ struct _Descriptors {
             }
         }
     )
+    let blankLineAfterSubgroups = OptionDescriptor(
+        argumentName: "groupblanklines",
+        displayName: "Blank Line After Subgroups",
+        help: "Require a blank line after each subgroup. Default: true",
+        keyPath: \.blankLineAfterSubgroups,
+        trueValues: ["true"],
+        falseValues: ["false"]
+    )
     let alphabeticallySortedDeclarationPatterns = OptionDescriptor(
         argumentName: "sortedpatterns",
         displayName: "Declaration Name Patterns To Sort Alphabetically",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -671,6 +671,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var typeOrder: [String]?
     public var customVisibilityMarks: Set<String>
     public var customTypeMarks: Set<String>
+    public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
@@ -795,6 +796,7 @@ public struct FormatOptions: CustomStringConvertible {
                 typeOrder: [String]? = nil,
                 customVisibilityMarks: Set<String> = [],
                 customTypeMarks: Set<String> = [],
+                blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
@@ -909,6 +911,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.typeOrder = typeOrder
         self.customVisibilityMarks = customVisibilityMarks
         self.customTypeMarks = customTypeMarks
+        self.blankLineAfterSubgroups = blankLineAfterSubgroups
         self.alphabeticallySortedDeclarationPatterns = alphabeticallySortedDeclarationPatterns
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement

--- a/Sources/Rules/MarkTypes.swift
+++ b/Sources/Rules/MarkTypes.swift
@@ -92,7 +92,7 @@ public extension FormatRule {
                 }
             }
 
-            declarations[index] = formatter.mapOpeningTokens(in: declarations[index]) { openingTokens -> [Token] in
+            declarations[index] = declarations[index].mapOpeningTokens { openingTokens -> [Token] in
                 var openingFormatter = Formatter(openingTokens)
 
                 guard let keywordIndex = openingFormatter.index(after: -1, where: {
@@ -239,9 +239,7 @@ public extension FormatRule {
                 // If the previous declaration doesn't end in a blank line,
                 // add an additional linebreak to balance the mark.
                 if index != 0 {
-                    declarations[index - 1] = formatter.mapClosingTokens(in: declarations[index - 1]) {
-                        formatter.endingWithBlankLine($0)
-                    }
+                    declarations[index - 1] = declarations[index - 1].endingWithBlankLine()
                 }
 
                 return openingFormatter.tokens

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -19,6 +19,7 @@ public extension FormatRule {
             "lifecycle", "organizetypes", "structthreshold", "classthreshold",
             "enumthreshold", "extensionlength", "organizationmode",
             "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
+            "groupblanklines",
         ],
         sharedOptions: ["sortedpatterns", "lineaftermarks"]
     ) { formatter in

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -109,7 +109,7 @@ public extension FormatRule {
                 if declaration.tokens.last?.isLinebreak == false,
                    nextDeclaration.tokens.first?.isLinebreak == false
                 {
-                    declarations[i + 1] = formatter.mapOpeningTokens(in: nextDeclaration) { openTokens in
+                    declarations[i + 1] = nextDeclaration.mapOpeningTokens { openTokens in
                         let openFormatter = Formatter(openTokens)
                         openFormatter.insertLinebreak(at: 0)
                         return openFormatter.tokens

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -253,6 +253,7 @@ class MetadataTests: XCTestCase {
                             Descriptors.typeOrder,
                             Descriptors.customVisibilityMarks,
                             Descriptors.customTypeMarks,
+                            Descriptors.blankLineAfterSubgroups,
                         ]
                     case .identifier("removeSelf"):
                         referencedOptions += [

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -2927,4 +2927,164 @@ class OrganizeDeclarationsTests: XCTestCase {
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
+
+    func testPreservesBlockOfConsecutivePropertiesWithoutBlankLinesBetweenSubgroups1() {
+        let input = """
+        class Foo {
+            init() {}
+
+            let foo: Foo
+            let baaz: Baaz
+            static let bar: Bar
+
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            static let bar: Bar
+            let foo: Foo
+            let baaz: Baaz
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(blankLineAfterSubgroups: false),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testPreservesBlockOfConsecutivePropertiesWithoutBlankLinesBetweenSubgroups2() {
+        let input = """
+        class Foo {
+            init() {}
+
+            let foo: Foo
+            let baaz: Baaz
+            static let bar: Bar
+
+            static let quux: Quux
+            let fooBar: FooBar
+            let baazQuux: BaazQuux
+
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            static let bar: Bar
+            static let quux: Quux
+            let foo: Foo
+            let baaz: Baaz
+
+            let fooBar: FooBar
+            let baazQuux: BaazQuux
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(blankLineAfterSubgroups: false),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testPreservesBlockOfConsecutiveProperties() {
+        let input = """
+        class Foo {
+            init() {}
+
+            let foo: Foo
+            let baaz: Baaz
+            static let bar: Bar
+
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            static let bar: Bar
+
+            let foo: Foo
+            let baaz: Baaz
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testPreservesBlockOfConsecutiveProperties2() {
+        let input = """
+        class Foo {
+            init() {}
+
+            let foo: Foo
+            let baaz: Baaz
+            static let bar: Bar
+
+            static let quux: Quux
+            let fooBar: FooBar
+            let baazQuux: BaazQuux
+
+        }
+        """
+
+        let output = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            static let bar: Bar
+            static let quux: Quux
+
+            let foo: Foo
+            let baaz: Baaz
+
+            let fooBar: FooBar
+            let baazQuux: BaazQuux
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
 }


### PR DESCRIPTION
This PR updates the `organizeDeclarations` rule to avoid inserting blank lines inside consecutive groups of single-line properties.

For example, take this input:

```swift
class Foo {
    init() {}

    let foo: Foo
    let baaz: Baaz
    static let bar: Bar

}
```

Today, the reformatted output has a blank line that seems unnecessary:

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    // MARK: Internal

    static let bar: Bar

    let foo: Foo
    let baaz: Baaz

}
```

Now, we try to preserve the groupings in the original declaration. The output now feels more reasonable:

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    // MARK: Internal

    static let bar: Bar
    let foo: Foo
    let baaz: Baaz

}
```

-------

@miguel-jimenez-0529, I'm thinking this will fix the issue in #1794 where this input:

```swift
@Environment(\\.colorScheme) var colorScheme
@State var foo: Foo
@Binding var isOn: Bool
@Environment(\\.quux) var quux: Quux

@ViewBuilder
var body: some View { ... }
```

was being reformatted to:

```swift
@Binding var isOn: Bool
@Environment(\\.colorScheme) var colorScheme
@Environment(\\.quux) var quux: Quux

@State var foo: Foo

@ViewBuilder
var body: some View { ... }
```

instead of:

```swift
@Binding var isOn: Bool
@Environment(\\.colorScheme) var colorScheme
@Environment(\\.quux) var quux: Quux
@State var foo: Foo

@ViewBuilder
var body: some View { ... }
```