### PR TITLE
Fix issue where closing brace could turn into a comment unexpectedly

### DIFF
--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3164,4 +3164,29 @@ class OrganizeDeclarationsTests: XCTestCase {
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
+
+    func testPreservesCommentAtEndOfTypeBody() {
+        let input = """
+        class Foo {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            let bar: Bar
+            let baaz: Baaz
+
+            // Comment at end of file
+
+        }
+        """
+
+        testFormatting(
+            for: input,
+            rule: .organizeDeclarations,
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
 }


### PR DESCRIPTION
This PR fixes an issue introduced by #1795 where a type's closing brace could unexpectedly turn into a comment if the type body ended with a comment.

For example, this sample code:

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    // MARK: Internal

    let bar: Bar
    let baaz: Baaz

    // Comment at end of file

}
```

was being unexpectedly changed to:

```swift
class Foo {

    // MARK: Lifecycle

    init() {}

    // MARK: Internal

    let bar: Bar
    let baaz: Baaz

    // }
```