### PR TITLE
Add test case to unusedPrivateDeclaration

### DIFF
--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -2,7 +2,7 @@
 //  EmptyExtension.swift
 //  SwiftFormat
 //
-// Created by manny_lopez on 7/29/24.
+//  Created by manny_lopez on 7/29/24.
 //  Copyright © 2024 Nick Lockwood. All rights reserved.
 //
 

--- a/Tests/Rules/UnusedPrivateDeclarationTests.swift
+++ b/Tests/Rules/UnusedPrivateDeclarationTests.swift
@@ -352,4 +352,29 @@ class UnusedPrivateDeclarationTests: XCTestCase {
         """
         testFormatting(for: input, rule: .unusedPrivateDeclaration)
     }
+
+    func testRemoveUnusedRecursivePrivateDeclaration() {
+        let input = """
+        struct Planet {
+            private typealias Dependencies = UniverseBuilderProviding // unused
+            private var mass: Double // unused
+            private func distance(to: Planet) { } // unused
+            private func gravitationalForce(between other: Planet) -> Double {
+                (G * mass * other.mass) / distance(to: other).squared()
+            } // unused
+
+            var ageInBillionYears: Double {
+                ageInMillionYears / 1000
+            }
+        }
+        """
+        let output = """
+        struct Planet {
+            var ageInBillionYears: Double {
+                ageInMillionYears / 1000
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .unusedPrivateDeclaration)
+    }
 }


### PR DESCRIPTION
1. Adds `testRemoveUnusedRecursivePrivateDeclaration` test case to rule `unusedPrivateDeclaration` 
2. Fixes a small typo in EmptyExtension.swift

@calda 