### PR TITLE
Fix issue where organizeDeclarations would add extra blank lines due to spaces on blank lines

### DIFF
--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -344,10 +344,19 @@ extension Formatter {
         }
 
         // Prefer keeping linebreaks at the end of a declaration's tokens,
-        // instead of the start of the next delaration's tokens
+        // instead of the start of the next delaration's tokens.
+        //  - This inclues any spaces on blank lines, but doesn't include the
+        //    indentation associated with the next declaration.
         while let linebreakSearchIndex = endOfDeclaration,
-              token(at: linebreakSearchIndex + 1)?.isLinebreak == true
+              token(at: linebreakSearchIndex + 1)?.isSpaceOrLinebreak == true
         {
+            // Only spaces between linebreaks (e.g. spaces on blank lines) are included
+            if token(at: linebreakSearchIndex + 1)?.isSpace == true {
+                guard token(at: linebreakSearchIndex)?.isLinebreak == true,
+                      token(at: linebreakSearchIndex + 2)?.isLinebreak == true
+                else { break }
+            }
+
             endOfDeclaration = linebreakSearchIndex + 1
         }
 

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -353,9 +353,7 @@ extension Formatter {
     func addCategorySeparators(
         to typeDeclaration: TypeDeclaration,
         sortedDeclarations: [CategorizedDeclaration]
-    )
-        -> TypeDeclaration
-    {
+    ) -> TypeDeclaration {
         let numberOfCategories: Int = {
             switch options.organizationMode {
             case .visibility:

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Command Line Tool).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Command Line Tool).xcscheme
@@ -59,6 +59,12 @@
             ReferencedContainer = "container:SwiftFormat.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "/Users/cal/Downloads/Test.swift --classthreshold 1 --rules organizeDeclarations --lint"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3297,4 +3297,54 @@ class OrganizeDeclarationsTests: XCTestCase {
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
+
+    func testDoesntAddUnexpectedBlankLinesDueToBlankLinesWithSpaces() {
+        // The blank lines in this input code are indented with four spaces.
+        // Done using string interpolation in the input code to make this
+        // more clear, and to prevent the spaces from being removed automatically.
+        let input = """
+        public class TestClass {
+            var variable01 = 1
+            var variable02 = 2
+            var variable03 = 3
+            var variable04 = 4
+            var variable05 = 5
+        \("    ")
+            public func foo() {}
+        \("    ")
+            func bar() {}
+        \("    ")
+            private func baz() {}
+        }
+        """
+
+        let output = """
+        public class TestClass {
+
+            // MARK: Public
+
+            public func foo() {}
+        \("    ")
+            // MARK: Internal
+
+            var variable01 = 1
+            var variable02 = 2
+            var variable03 = 3
+            var variable04 = 4
+            var variable05 = 5
+        \("    ")
+            func bar() {}
+        \("    ")
+            // MARK: Private
+
+            private func baz() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .consecutiveBlankLines, .trailingSpace, .consecutiveSpaces, .indent]
+        )
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the `organizeDeclarations` rule would unexpectedly add extra blank lines due to spaces on blank lines in the file (e.g. `\n    \n` instead of `\n\n`).

This PR fixes #1809.