### PR TITLE
Add --outputtokens option to print output tokens instead of source code

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -675,6 +675,7 @@ let commandLineArguments = [
     "ruleinfo",
     "dateformat",
     "timezone",
+    "outputtokens",
 ] + optionsArguments
 
 let deprecatedArguments = Descriptors.all.compactMap {

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -716,11 +716,7 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
                         // Write to stdout
                         if printTokens {
                             let tokensToPrint = dryrun ? tokenize(input) : outputTokens
-                            let encoder = JSONEncoder()
-                            encoder.outputFormatting = .sortedKeys
-                            let encodedTokens = try encoder.encode(tokensToPrint)
-                            let tokensJsonString = String(data: encodedTokens, encoding: .utf8)!
-                            print(tokensJsonString, as: .raw)
+                            try print(OutputTokensData.encodedString(for: tokensToPrint), as: .raw)
                         } else {
                             print(dryrun ? input : output, as: .raw)
                         }
@@ -1185,4 +1181,28 @@ func processInput(_ inputURLs: [URL],
         }
     }
     return (outputFlags, errors)
+}
+
+/// The data format used with `--outputtokens`
+private struct OutputTokensData: Encodable {
+    init(tokens: [Token]) {
+        self.tokens = tokens
+        version = swiftFormatVersion
+    }
+
+    /// The SwiftFormat version that this data originated from
+    let version: String
+    /// A representation of the output in `Tokens`
+    let tokens: [Token]
+
+    /// Creates the `OutputTokensData` and encodes it to a JSON string
+    static func encodedString(for tokens: [Token]) throws -> String {
+        let outputData = OutputTokensData(tokens: tokens)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        let encodedData = try encoder.encode(outputData)
+        return String(data: encodedData, encoding: .utf8)!
+    }
 }

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -204,6 +204,7 @@ func printHelp(as type: CLI.OutputType) {
     --strict           Emit errors for unformatted code when formatting
     --verbose          Display detailed formatting output and warnings/errors
     --quiet            Disables non-critical output messages and warnings
+    --outputtokens     Outputs an array of tokens instead of text when using stdin
 
     SwiftFormat has a number of rules that can be enabled or disabled. By default
     most rules are enabled. Use --rules to display all enabled/disabled rules.
@@ -341,6 +342,9 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
 
         // Dry run
         let dryrun = lint || (args["dryrun"] != nil)
+
+        // Whether or not to output tokens instead of source code
+        let printTokens = args["outputtokens"] != nil
 
         // Warnings
         for warning in warningsForArguments(args) {
@@ -699,17 +703,27 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
                             return
                         }
                     }
-                    let output = try applyRules(
+                    let outputTokens = try applyRules(
                         input, options: options, lineRange: lineRange,
                         verbose: verbose, lint: lint, reporter: reporter
                     )
+                    let output = sourceCode(for: outputTokens)
                     if let outputURL = outputURL, !useStdout {
                         if !dryrun, (try? String(contentsOf: outputURL)) != output {
                             try write(output, to: outputURL)
                         }
                     } else if !lint {
                         // Write to stdout
-                        print(dryrun ? input : output, as: .raw)
+                        if printTokens {
+                            let tokensToPrint = dryrun ? tokenize(input) : outputTokens
+                            let encoder = JSONEncoder()
+                            encoder.outputFormatting = .sortedKeys
+                            let encodedTokens = try encoder.encode(tokensToPrint)
+                            let tokensJsonString = String(data: encodedTokens, encoding: .utf8)!
+                            print(tokensJsonString, as: .raw)
+                        } else {
+                            print(dryrun ? input : output, as: .raw)
+                        }
                     } else if let reporterOutput = try reporter.write() {
                         if let reportURL = reportURL {
                             print("Writing report file to \(reportURL.path)", as: .info)
@@ -911,7 +925,7 @@ func computeHash(_ source: String) -> String {
 }
 
 func applyRules(_ source: String, options: Options, lineRange: ClosedRange<Int>?,
-                verbose: Bool, lint: Bool, reporter: Reporter?) throws -> String
+                verbose: Bool, lint: Bool, reporter: Reporter?) throws -> [Token]
 {
     // Parse source
     var tokens = tokenize(source)
@@ -953,7 +967,7 @@ func applyRules(_ source: String, options: Options, lineRange: ClosedRange<Int>?
     }
 
     // Output
-    return updatedSource
+    return tokens
 }
 
 func processInput(_ inputURLs: [URL],
@@ -1054,8 +1068,9 @@ func processInput(_ inputURLs: [URL],
                         print("-- no changes (cached)", as: .success)
                     }
                 } else {
-                    output = try applyRules(input, options: options, lineRange: lineRange,
-                                            verbose: verbose, lint: lint, reporter: reporter)
+                    let outputTokens = try applyRules(input, options: options, lineRange: lineRange,
+                                                      verbose: verbose, lint: lint, reporter: reporter)
+                    output = sourceCode(for: outputTokens)
                     if output != input {
                         sourceHash = nil
                     }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -114,7 +114,7 @@ public enum TokenType {
 }
 
 /// Numeric literal types
-public enum NumberType {
+public enum NumberType: String {
     case integer
     case decimal
     case binary
@@ -123,7 +123,7 @@ public enum NumberType {
 }
 
 /// Operator/operator types
-public enum OperatorType {
+public enum OperatorType: String {
     case none
     case infix
     case prefix
@@ -1990,4 +1990,50 @@ public func tokenize(_ source: String) -> [Token] {
     }
 
     return tokens
+}
+
+extension Token: Encodable {
+    private enum CodingKeys: CodingKey {
+        // Properties shared by all tokens
+        case type
+        case string
+        // Properties unique to individual tokens
+        case originalLine
+        case numberType
+        case operatorType
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(typeName, forKey: .type)
+        try container.encode(string, forKey: .string)
+
+        switch self {
+        case let .linebreak(_, originalLine):
+            try container.encode(originalLine, forKey: .originalLine)
+        case let .number(_, numberType):
+            try container.encode(numberType.rawValue, forKey: .numberType)
+        case let .operator(_, operatorType):
+            try container.encode(operatorType.rawValue, forKey: .operatorType)
+        default:
+            break
+        }
+    }
+
+    private var typeName: String {
+        switch self {
+        case .number: return "number"
+        case .linebreak: return "linebreak"
+        case .startOfScope: return "startOfScope"
+        case .endOfScope: return "endOfScope"
+        case .delimiter: return "delimiter"
+        case .operator: return "operator"
+        case .stringBody: return "stringBody"
+        case .keyword: return "keyword"
+        case .identifier: return "identifier"
+        case .space: return "space"
+        case .commentBody: return "commentBody"
+        case .error: return "error"
+        }
+    }
 }

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -112,7 +112,8 @@ class CommandLineTests: XCTestCase {
             switch type {
             case .raw, .content:
                 XCTAssertEqual(message, """
-                [{"string":"func","type":"keyword"},\
+                {"tokens":[\
+                {"string":"func","type":"keyword"},\
                 {"string":" ","type":"space"},\
                 {"string":"foo","type":"identifier"},\
                 {"string":"(","type":"startOfScope"},\
@@ -136,7 +137,8 @@ class CommandLineTests: XCTestCase {
                 {"numberType":"integer","string":"25","type":"number"},\
                 {"originalLine":3,"string":"\\n","type":"linebreak"},\
                 {"string":"}","type":"endOfScope"},\
-                {"originalLine":4,"string":"\\n","type":"linebreak"}]
+                {"originalLine":4,"string":"\\n","type":"linebreak"}\
+                ],"version":"\(swiftFormatVersion)"}
                 """)
             case .error, .warning:
                 XCTFail()


### PR DESCRIPTION
This PR adds a new `--outputtokens` CLI option that prints the output tokens, encoded as JSON, rather than printing the output source code. This only works when using stdin and stdout.

----

There's a specific use case I have in mind for this: at Airbnb we have an Xcode editor extension with a Format Swift command similar to [`FormatFileCommand.swift`](https://github.com/nicklockwood/SwiftFormat/blob/076525b91983bcd91f59367ed500b23d2a46c2e3/EditorExtension/Extension/FormatFileCommand.swift#L79). Instead of embedding the SwiftFormat framework in the app, we invoke the command line tool using stdin / stdout. This lets us use the same SwiftFormat version as whatever internal repo commit is checked out, rather than coupling the SwiftFormat version to the build of the app that contains the extension. This is important for our workflow since we update SwiftFormat frequently but don't want to have to update the extension app all of the time.

We want to implement the same selection preservation behavior as implemented [here](https://github.com/nicklockwood/SwiftFormat/blob/076525b91983bcd91f59367ed500b23d2a46c2e3/Sources/SwiftFormat.swift#L395) in the SwiftFormat extension. This requires having access to the full `case linebreak(String, OriginalLine)` token with the `OriginalLine` context. Having access to the raw token output via the command line will let us implement this selection preservation functionality pretty easily.

I could imagine this `--outputtokens` option being useful in other circumstances. It's at least not coupled to any specific use case, so seems general purpose enough to include as an option. Any other approach for exposing the `OriginalLine` context would be much more coupled to this specific use case.

What do you think @nicklockwood?