### PR TITLE
Fix issue where unusedArguments didn't handle conditional assignment shadowing

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -700,6 +700,16 @@ extension Formatter {
         startOfConditionalStatement(at: i, excluding: excluding) != nil
     }
 
+    /// Returns true if the token at the specified index is part of a conditional assignment
+    /// (e.g. an if or switch expression following an `=` token)
+    func isConditionalAssignment(at i: Int) -> Bool {
+        guard let startOfConditional = startOfConditionalStatement(at: i),
+              let previousToken = lastToken(before: startOfConditional, where: { !$0.isSpaceOrCommentOrLinebreak })
+        else { return false }
+
+        return previousToken.isOperator("=")
+    }
+
     /// If the token at the specified index is part of a conditional statement, returns the index of the first
     /// token in the statement (e.g. `if`, `guard`, `while`, etc.), otherwise returns nil
     func startOfConditionalStatement(at i: Int, excluding: Set<String> = []) -> Int? {

--- a/Sources/Rules/UnusedArguments.swift
+++ b/Sources/Rules/UnusedArguments.swift
@@ -245,6 +245,14 @@ extension Formatter {
                         return
                     }
                 }
+            case .keyword("if"), .keyword("switch"):
+                guard isConditionalAssignment(at: i),
+                      let conditinalBranches = conditionalBranches(at: i),
+                      let endIndex = conditinalBranches.last?.endOfBranch
+                else { fallthrough }
+
+                removeUsed(from: &argNames, with: &associatedData,
+                           locals: locals, in: i + 1 ..< endIndex)
             case .startOfScope("{"):
                 guard let endIndex = endOfScope(at: i) else {
                     return fatalError("Expected }", at: i)

--- a/Tests/Rules/UnusedArgumentsTests.swift
+++ b/Tests/Rules/UnusedArgumentsTests.swift
@@ -1092,6 +1092,32 @@ class UnusedArgumentsTests: XCTestCase {
         testFormatting(for: input, rule: .unusedArguments)
     }
 
+    func testIssue1688_1() {
+        let input = #"""
+        func urlTestContains(path: String, strict _: Bool = true) -> Bool {
+            let path = if path.hasSuffix("/") { path } else { "\(path)/" }
+
+            return false
+        }
+        """#
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.wrapConditionalBodies])
+    }
+
+    func testIssue1688_2() {
+        let input = """
+        enum Sample {
+            func invite(lang: String, randomValue: Int) -> String {
+                let flag: String? = if randomValue > 0 { "hello" } else { nil }
+
+                let lang = if let flag { flag } else { lang }
+
+                return lang
+            }
+        }
+        """
+        testFormatting(for: input, rule: .unusedArguments, exclude: [.wrapConditionalBodies, .redundantProperty])
+    }
+
     func testIssue1694() {
         let input = """
         listenForUpdates() { [weak self] update, error in


### PR DESCRIPTION
This PR fixes https://github.com/nicklockwood/SwiftFormat/issues/1688#issuecomment-2282208032.

In this example, `lang` was incorrectly being marked as unused:

```swift
enum Sample {
    func invite(lang _: String, randomValue: Int) -> String {
        let flag: String? = if randomValue > 0 { "hello" } else { nil }

        let lang = if let flag { flag } else { lang }

        return lang
    }
}
```

This was because `lang` was being added as a local from `let lang =` before we handled the `else { lang }` (which refers to the `lang: String` argument, not the `let lang =` local).