### PR TITLE
Add `preserve` option to `spaceAroundRangeOperators` and `spaceAroundOperatorDeclarations`

### DIFF
--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -96,8 +96,8 @@ class PerformanceTests: XCTestCase {
         let tokens = files.map { tokenize($0) }
         let options = FormatOptions(
             linebreak: "\r\n",
-            spaceAroundRangeOperators: false,
-            spaceAroundOperatorDeclarations: false,
+            spaceAroundRangeOperators: .remove,
+            spaceAroundOperatorDeclarations: .remove,
             useVoid: false,
             indentCase: true,
             trailingCommas: false,

--- a/Rules.md
+++ b/Rules.md
@@ -2460,9 +2460,9 @@ Add or remove space around operators or delimiters.
 
 Option | Description
 --- | ---
-`--operatorfunc` | Spacing for operator funcs: "spaced" (default) or "no-space"
+`--operatorfunc` | Operator funcs: "spaced" (default), "no-space", or "preserve"
 `--nospaceoperators` | Comma-delimited list of operators without surrounding space
-`--ranges` | Spacing for ranges: "spaced" (default) or "no-space"
+`--ranges` | Range spaces: "spaced" (default) or "no-space", or "preserve"
 `--typedelimiter` | "space-after" (default), "spaced" or "no-space"
 
 <details>

--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -1273,7 +1273,11 @@ private struct Inference {
                 nospace += 1
             }
         }
-        options.spaceAroundOperatorDeclarations = (nospace <= space)
+        if nospace <= space {
+            options.spaceAroundOperatorDeclarations = .insert
+        } else {
+            options.spaceAroundOperatorDeclarations = .remove
+        }
     }
 
     let elseOnNextLine = OptionInferrer { formatter, options in

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -466,10 +466,23 @@ struct _Descriptors {
     let spaceAroundOperatorDeclarations = OptionDescriptor(
         argumentName: "operatorfunc",
         displayName: "Operator Functions",
-        help: "Spacing for operator funcs: \"spaced\" (default) or \"no-space\"",
+        help: "Operator funcs: \"spaced\" (default), \"no-space\", or \"preserve\"",
         keyPath: \.spaceAroundOperatorDeclarations,
-        trueValues: ["spaced", "space", "spaces"],
-        falseValues: ["no-space", "nospace"]
+        fromArgument: { argument in
+            switch argument {
+            case "spaced", "space", "spaces":
+                return .insert
+            case "no-space", "nospace":
+                return .remove
+            case "preserve", "preserve-spaces", "preservespaces":
+                return .preserve
+            default:
+                return nil
+            }
+        },
+        toArgument: { value in
+            value.rawValue
+        }
     )
     let useVoid = OptionDescriptor(
         argumentName: "voidtype",
@@ -793,10 +806,23 @@ struct _Descriptors {
     let spaceAroundRangeOperators = OptionDescriptor(
         argumentName: "ranges",
         displayName: "Ranges",
-        help: "Spacing for ranges: \"spaced\" (default) or \"no-space\"",
+        help: "Range spaces: \"spaced\" (default) or \"no-space\", or \"preserve\"",
         keyPath: \.spaceAroundRangeOperators,
-        trueValues: ["spaced", "space", "spaces"],
-        falseValues: ["no-space", "nospace"]
+        fromArgument: { argument in
+            switch argument {
+            case "spaced", "space", "spaces":
+                return .insert
+            case "no-space", "nospace":
+                return .remove
+            case "preserve", "preserve-spaces", "preservespaces":
+                return .preserve
+            default:
+                return nil
+            }
+        },
+        toArgument: { value in
+            value.rawValue
+        }
     )
     let noWrapOperators = OptionDescriptor(
         argumentName: "nowrapoperators",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -172,6 +172,13 @@ public enum ClosureVoidReturn: String, CaseIterable {
     case preserve
 }
 
+/// Whether to insert, remove, or preserve spaces around operators
+public enum OperatorSpacingMode: String, CaseIterable {
+    case insert = "spaced"
+    case remove = "no-space"
+    case preserve
+}
+
 /// Version number wrapper
 public struct Version: RawRepresentable, Comparable, ExpressibleByStringLiteral, CustomStringConvertible {
     public let rawValue: String
@@ -594,8 +601,8 @@ public struct FormatOptions: CustomStringConvertible {
     public var indent: String
     public var linebreak: String
     public var allowInlineSemicolons: Bool
-    public var spaceAroundRangeOperators: Bool
-    public var spaceAroundOperatorDeclarations: Bool
+    public var spaceAroundRangeOperators: OperatorSpacingMode
+    public var spaceAroundOperatorDeclarations: OperatorSpacingMode
     public var useVoid: Bool
     public var indentCase: Bool
     public var trailingCommas: Bool
@@ -719,8 +726,8 @@ public struct FormatOptions: CustomStringConvertible {
                 indent: String = "    ",
                 linebreak: String = "\n",
                 allowInlineSemicolons: Bool = true,
-                spaceAroundRangeOperators: Bool = true,
-                spaceAroundOperatorDeclarations: Bool = true,
+                spaceAroundRangeOperators: OperatorSpacingMode = .insert,
+                spaceAroundOperatorDeclarations: OperatorSpacingMode = .insert,
                 useVoid: Bool = true,
                 indentCase: Bool = false,
                 trailingCommas: Bool = true,

--- a/Sources/Rules/SpaceAroundOperators.swift
+++ b/Sources/Rules/SpaceAroundOperators.swift
@@ -24,12 +24,12 @@ public extension FormatRule {
             case .operator(_, .none):
                 switch formatter.token(at: i + 1) {
                 case nil, .linebreak?, .endOfScope?, .operator?, .delimiter?,
-                     .startOfScope("(")? where !formatter.options.spaceAroundOperatorDeclarations:
+                     .startOfScope("(")? where formatter.options.spaceAroundOperatorDeclarations != .insert:
                     break
                 case .space?:
                     switch formatter.next(.nonSpaceOrLinebreak, after: i) {
                     case nil, .linebreak?, .endOfScope?, .delimiter?,
-                         .startOfScope("(")? where !formatter.options.spaceAroundOperatorDeclarations:
+                         .startOfScope("(")? where formatter.options.spaceAroundOperatorDeclarations == .remove:
                         formatter.removeToken(at: i + 1)
                     default:
                         break
@@ -79,7 +79,7 @@ public extension FormatRule {
             case .operator("?", .infix):
                 break // Spacing around ternary ? is not optional
             case let .operator(name, .infix) where formatter.options.noSpaceOperators.contains(name) ||
-                (!formatter.options.spaceAroundRangeOperators && token.isRangeOperator):
+                (formatter.options.spaceAroundRangeOperators == .remove && token.isRangeOperator):
                 if formatter.token(at: i + 1)?.isSpace == true,
                    formatter.token(at: i - 1)?.isSpace == true,
                    let nextToken = formatter.next(.nonSpace, after: i),
@@ -91,6 +91,9 @@ public extension FormatRule {
                     formatter.removeToken(at: i - 1)
                 }
             case .operator(_, .infix):
+                if token.isRangeOperator, formatter.options.spaceAroundRangeOperators != .insert {
+                    break
+                }
                 if formatter.token(at: i + 1)?.isSpaceOrLinebreak == false {
                     formatter.insert(.space(" "), at: i + 1)
                 }

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -702,7 +702,7 @@ class ArgumentsTests: XCTestCase {
 
     func testParseDeprecatedOption() throws {
         let options = try Options(["ranges": "nospace"], in: "")
-        XCTAssertEqual(options.formatOptions?.spaceAroundRangeOperators, false)
+        XCTAssertEqual(options.formatOptions?.spaceAroundRangeOperators, .remove)
     }
 
     func testParseNoSpaceOperatorsOption() throws {

--- a/Tests/InferenceTests.swift
+++ b/Tests/InferenceTests.swift
@@ -567,13 +567,13 @@ class InferenceTests: XCTestCase {
     func testInferSpaceAfterOperatorFunc() {
         let input = "func == (lhs: Int, rhs: Int) -> Bool {}"
         let options = inferFormatOptions(from: tokenize(input))
-        XCTAssertTrue(options.spaceAroundOperatorDeclarations)
+        XCTAssertEqual(options.spaceAroundOperatorDeclarations, .insert)
     }
 
     func testInferNoSpaceAfterOperatorFunc() {
         let input = "func ==(lhs: Int, rhs: Int) -> Bool {}"
         let options = inferFormatOptions(from: tokenize(input))
-        XCTAssertFalse(options.spaceAroundOperatorDeclarations)
+        XCTAssertEqual(options.spaceAroundOperatorDeclarations, .remove)
     }
 
     // MARK: elseOnNextLine

--- a/Tests/Rules/SpaceAroundOperatorsTests.swift
+++ b/Tests/Rules/SpaceAroundOperatorsTests.swift
@@ -372,8 +372,17 @@ class SpaceAroundOperatorsTests: XCTestCase {
     func testRemoveSpaceAfterFuncEquals() {
         let input = "func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
         let output = "func ==(lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
-        let options = FormatOptions(spaceAroundOperatorDeclarations: false)
+        let options = FormatOptions(spaceAroundOperatorDeclarations: .remove)
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
+    }
+
+    func testPreserveSpaceAfterFuncEquals() {
+        let input = """
+        func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }
+        func !=(lhs: Int, rhs: Int) -> Bool { return lhs !== rhs }
+        """
+        let options = FormatOptions(spaceAroundOperatorDeclarations: .preserve)
+        testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testAddSpaceAfterOperatorEquals() {
@@ -384,7 +393,7 @@ class SpaceAroundOperatorsTests: XCTestCase {
 
     func testNoRemoveSpaceAfterOperatorEqualsWhenSpaceAroundOperatorDeclarationsFalse() {
         let input = "operator == {}"
-        let options = FormatOptions(spaceAroundOperatorDeclarations: false)
+        let options = FormatOptions(spaceAroundOperatorDeclarations: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
@@ -612,86 +621,99 @@ class SpaceAroundOperatorsTests: XCTestCase {
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
-    // spaceAroundRangeOperators = false
+    // spaceAroundRangeOperators: .remove
 
     func testNoSpaceAroundRangeOperatorsWithCustomOptions() {
         let input = "foo ..< bar"
         let output = "foo..<bar"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceNotRemovedBeforeLeadingRangeOperatorWithSpaceAroundRangeOperatorsFalse() {
         let input = "let range = ..<foo.endIndex"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceOnOneSideOfRangeMatchedByCommentNotRemoved() {
         let input = "let range = 0 .../* foo */4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByCommentNotRemoved2() {
         let input = "let range = 0/* foo */... 4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved() {
         let input = "let range = 0 ... /* foo */4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved2() {
         let input = "let range = 0/* foo */ ... 4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved() {
         let input = "let range = 0 ...\n4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved2() {
         let input = "let range = 0\n... 4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved() {
         let input = "let range = 0 ... \n4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent, .trailingSpace])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved2() {
         let input = "let range = 0\n ... 4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceNotRemovedAroundRangeFollowedByPrefixOperator() {
         let input = "let range = 0 ... -4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceNotRemovedAroundRangePreceededByPostfixOperator() {
         let input = "let range = 0>> ... 4"
-        let options = FormatOptions(spaceAroundRangeOperators: false)
+        let options = FormatOptions(spaceAroundRangeOperators: .remove)
+        testFormatting(for: input, rule: .spaceAroundOperators, options: options)
+    }
+
+    // spaceAroundRangeOperators: .preserve
+
+    func testPreserveSpaceAroundRangeOperators() {
+        let input = """
+        let a = foo ..< bar
+        let b = foo..<bar
+        let c = foo ... bar
+        let d = foo...bar
+        """
+        let options = FormatOptions(spaceAroundRangeOperators: .preserve)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 


### PR DESCRIPTION
This PR adds support for `--ranges preserve` and `--operatorfunc preserve` options.

This lets us adopt the SwiftFormat `spaceAroundRangeOperators` rule in Airbnb's Swift Style Guide. Previously we were using a set of four SwiftLint rules, but don't currently state a rule for spacing around range operators or in operator declarations.