### PR TITLE
Add option to sort SwiftUI properties by the first property appearance

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1411,7 +1411,7 @@ Option | Description
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
-`--sortswiftuiprops` | Sorts SwiftUI dynamic properties using different strategies, doesn't sorts by default
+`--sortswiftuiprops` | Sorts SwiftUI dynamic properties, doesn't sorts by default
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -1411,7 +1411,7 @@ Option | Description
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
-`--sortswiftuiprops` | Sorts SwiftUI dynamic properties, doesn't sorts by default
+`--sortswiftuiprops` | Sort SwiftUI props: none, alphabetize, or firstAppearanceSort
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -1411,7 +1411,7 @@ Option | Description
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
-`--sortswiftuiprops` | Sorts SwiftUI properties alphabetically, defaults to "false"
+`--sortswiftuiprops` | Sorts SwiftUI dynamic properties using different strategies, doesn't sorts by default
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -1411,7 +1411,7 @@ Option | Description
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
-`--sortswiftuiprops` | Sort SwiftUI props: none, alphabetize, or firstAppearanceSort
+`--sortswiftuiprops` | Sort SwiftUI props: none, alphabetize, first-appearance-sort
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1229,7 +1229,7 @@ struct _Descriptors {
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
         displayName: "Sort SwiftUI Dynamic Properties",
-        help: "Sorts SwiftUI dynamic properties, doesn't sorts by default",
+        help: "Sorts SwiftUI dynamic properties, doesn't sort by default",
         keyPath: \.swiftUIPropertiesSortMode
     )
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1229,7 +1229,7 @@ struct _Descriptors {
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
         displayName: "Sort SwiftUI Dynamic Properties",
-        help: "Sorts SwiftUI dynamic properties using different strategies, doesn't sorts by default",
+        help: "Sorts SwiftUI dynamic properties, doesn't sorts by default",
         keyPath: \.swiftUIPropertiesSortMode
     )
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1229,7 +1229,7 @@ struct _Descriptors {
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
         displayName: "Sort SwiftUI Dynamic Properties",
-        help: "Sort SwiftUI props: none, alphabetize, or firstAppearanceSort",
+        help: "Sort SwiftUI props: none, alphabetize, first-appearance-sort",
         keyPath: \.swiftUIPropertiesSortMode
     )
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1226,13 +1226,11 @@ struct _Descriptors {
         keyPath: \.preservedPrivateDeclarations
     )
 
-    let alphabetizeSwiftUIPropertyTypes = OptionDescriptor(
+    let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
-        displayName: "Alphabetize SwiftUI Properties",
-        help: "Sorts SwiftUI properties alphabetically, defaults to \"false\"",
-        keyPath: \.alphabetizeSwiftUIPropertyTypes,
-        trueValues: ["enabled", "true"],
-        falseValues: ["disabled", "false"]
+        displayName: "Sort SwiftUI Dynamic Properties",
+        help: "Sorts SwiftUI dynamic properties using different strategies, doesn't sorts by default",
+        keyPath: \.swiftUIPropertiesSortMode
     )
 
     // MARK: - Internal

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1229,7 +1229,7 @@ struct _Descriptors {
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
         displayName: "Sort SwiftUI Dynamic Properties",
-        help: "Sorts SwiftUI dynamic properties, doesn't sort by default",
+        help: "Sort SwiftUI props: none, alphabetize, or firstAppearanceSort",
         keyPath: \.swiftUIPropertiesSortMode
     )
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -600,8 +600,6 @@ public enum SwiftUIPropertiesSortMode: String, CaseIterable {
     /// Sorts SwiftUI dynamic properties by grouping all dynamic properties of the same type by using the first time each property appears
     /// as the sort order.
     case firstAppearanceSort = "first-appearance-sort"
-    /// No sort
-    case none
 }
 
 /// Configuration options for formatting. These aren't actually used by the
@@ -690,7 +688,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var customTypeMarks: Set<String>
     public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
-    public var swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode
+    public var swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode?
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var redundantType: RedundantType
@@ -816,7 +814,7 @@ public struct FormatOptions: CustomStringConvertible {
                 customTypeMarks: Set<String> = [],
                 blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
-                swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode = .none,
+                swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode? = nil,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 redundantType: RedundantType = .inferLocalsOnly,
@@ -1071,5 +1069,16 @@ public struct Options {
 
     public func shouldSkipFile(_ inputURL: URL) -> Bool {
         fileOptions?.shouldSkipFile(inputURL) ?? false
+    }
+}
+
+extension Optional: RawRepresentable where Wrapped: RawRepresentable, Wrapped.RawValue == String {
+    public init?(rawValue: String) {
+        self = Wrapped(rawValue: rawValue)
+    }
+
+    public var rawValue: String {
+        guard let wrapped = self else { return "none" }
+        return wrapped.rawValue
     }
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -594,6 +594,16 @@ public enum ClosingParenPosition: String, CaseIterable {
     case `default`
 }
 
+public enum SwiftUIPropertiesSortMode: String, CaseIterable {
+    /// Sorts all SwiftUI dynamic properties alphabetically
+    case alphabetize
+    /// Sorts SwiftUI dynamic properties by grouping all dynamic properties of the same type by using the first time each property appears
+    /// as the sort order.
+    case firstAppearanceSort
+    /// No sort
+    case none
+}
+
 /// Configuration options for formatting. These aren't actually used by the
 /// Formatter class itself, but it makes them available to the format rules.
 public struct FormatOptions: CustomStringConvertible {
@@ -680,7 +690,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var customTypeMarks: Set<String>
     public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
-    public var alphabetizeSwiftUIPropertyTypes: Bool
+    public var swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var redundantType: RedundantType
@@ -806,7 +816,7 @@ public struct FormatOptions: CustomStringConvertible {
                 customTypeMarks: Set<String> = [],
                 blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
-                alphabetizeSwiftUIPropertyTypes: Bool = false,
+                swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode = .none,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 redundantType: RedundantType = .inferLocalsOnly,
@@ -922,7 +932,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.customTypeMarks = customTypeMarks
         self.blankLineAfterSubgroups = blankLineAfterSubgroups
         self.alphabeticallySortedDeclarationPatterns = alphabeticallySortedDeclarationPatterns
-        self.alphabetizeSwiftUIPropertyTypes = alphabetizeSwiftUIPropertyTypes
+        self.swiftUIPropertiesSortMode = swiftUIPropertiesSortMode
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
         self.redundantType = redundantType

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -599,7 +599,7 @@ public enum SwiftUIPropertiesSortMode: String, CaseIterable {
     case alphabetize
     /// Sorts SwiftUI dynamic properties by grouping all dynamic properties of the same type by using the first time each property appears
     /// as the sort order.
-    case firstAppearanceSort
+    case firstAppearanceSort = "first-appearance-sort"
     /// No sort
     case none
 }

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -756,7 +756,7 @@ extension Formatter {
     }
 }
 
-extension Array where Element: Equatable {
+extension Array where Element: Equatable & Hashable {
     /// Sort function to sort an array based on the order of the elements on Self
     /// - Parameters:
     ///   - lhs: Sort closure left hand side element
@@ -770,7 +770,7 @@ extension Array where Element: Equatable {
 
     /// Creates a list without duplicates and ordered by the first time the element appeared in Self
     /// For example, this function would transform [1,2,3,1,2] into [1,2,3]
-    func firstElementAppearanceOrder() -> [Element] where Element: Hashable {
+    func firstElementAppearanceOrder() -> [Element] {
         var appeared: Set<Element> = []
         var appearedList: [Element] = []
 

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -239,13 +239,10 @@ extension Formatter {
     }
 
     func customDeclarationSortOrderList(from categorizedDeclarations: [CategorizedDeclaration]) -> [String] {
-        if options.swiftUIPropertiesSortMode == .firstAppearanceSort {
-            categorizedDeclarations
-                .compactMap(\.declaration.swiftUIPropertyWrapper)
-                .firstElementAppearanceOrder()
-        } else {
-            []
-        }
+        guard options.swiftUIPropertiesSortMode == .firstAppearanceSort else { return [] }
+        return categorizedDeclarations
+            .compactMap(\.declaration.swiftUIPropertyWrapper)
+            .firstElementAppearanceOrder()
     }
 
     /// Whether or not type members should additionally be sorted alphabetically

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -198,14 +198,7 @@ extension Formatter {
         _ categorizedDeclarations: [CategorizedDeclaration],
         sortAlphabeticallyWithinSubcategories: Bool
     ) -> [CategorizedDeclaration] {
-        let customSwiftUIPropertyOrder: [String] = if options.swiftUIPropertiesSortMode == .firstAppearanceSort {
-            categorizedDeclarations
-                .compactMap(\.declaration.swiftUIPropertyWrapper)
-                .firstElementAppearanceOrder()
-        } else {
-            []
-        }
-
+        let customDeclarationSortOrder = customDeclarationSortOrderList(from: categorizedDeclarations)
         return categorizedDeclarations.enumerated()
             .sorted(by: { lhs, rhs in
                 let (lhsOriginalIndex, lhs) = lhs
@@ -234,7 +227,7 @@ extension Formatter {
                     case .alphabetize:
                         return lhsSwiftUIProperty.localizedCompare(rhsSwiftUIProperty) == .orderedAscending
                     case .firstAppearanceSort:
-                        return customSwiftUIPropertyOrder.areInRelativeOrder(lhs: lhsSwiftUIProperty, rhs: rhsSwiftUIProperty)
+                        return customDeclarationSortOrder.areInRelativeOrder(lhs: lhsSwiftUIProperty, rhs: rhsSwiftUIProperty)
                     case .none:
                         Swift.fatalError("None case should be handled in the else branch")
                     }
@@ -245,6 +238,16 @@ extension Formatter {
 
             })
             .map { $0.element }
+    }
+
+    func customDeclarationSortOrderList(from categorizedDeclarations: [CategorizedDeclaration]) -> [String] {
+        if options.swiftUIPropertiesSortMode == .firstAppearanceSort {
+            categorizedDeclarations
+                .compactMap(\.declaration.swiftUIPropertyWrapper)
+                .firstElementAppearanceOrder()
+        } else {
+            []
+        }
     }
 
     /// Whether or not type members should additionally be sorted alphabetically

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -218,18 +218,16 @@ extension Formatter {
                     return lhsName.localizedCompare(rhsName) == .orderedAscending
                 }
 
-                if options.swiftUIPropertiesSortMode != .none,
+                if let swiftUIPropertiesSortMode = options.swiftUIPropertiesSortMode,
                    lhs.category.type == rhs.category.type,
                    let lhsSwiftUIProperty = lhs.declaration.swiftUIPropertyWrapper,
                    let rhsSwiftUIProperty = rhs.declaration.swiftUIPropertyWrapper
                 {
-                    switch options.swiftUIPropertiesSortMode {
+                    switch swiftUIPropertiesSortMode {
                     case .alphabetize:
                         return lhsSwiftUIProperty.localizedCompare(rhsSwiftUIProperty) == .orderedAscending
                     case .firstAppearanceSort:
                         return customDeclarationSortOrder.areInRelativeOrder(lhs: lhsSwiftUIProperty, rhs: rhsSwiftUIProperty)
-                    case .none:
-                        Swift.fatalError("None case should be handled in the else branch")
                     }
                 } else {
                     // Respect the original declaration ordering when the categories and types are the same

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -239,6 +239,7 @@ extension Formatter {
                         Swift.fatalError("None case should be handled in the else branch")
                     }
                 } else {
+                    // Respect the original declaration ordering when the categories and types are the same
                     return lhsOriginalIndex < rhsOriginalIndex
                 }
 

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -234,7 +234,7 @@ extension Formatter {
                     case .alphabetize:
                         return lhsSwiftUIProperty.localizedCompare(rhsSwiftUIProperty) == .orderedAscending
                     case .firstAppearanceSort:
-                        return customSwiftUIPropertyOrder.sortOrder(lhs: lhsSwiftUIProperty, rhs: rhsSwiftUIProperty)
+                        return customSwiftUIPropertyOrder.areInRelativeOrder(lhs: lhsSwiftUIProperty, rhs: rhsSwiftUIProperty)
                     case .none:
                         Swift.fatalError("None case should be handled in the else branch")
                     }
@@ -763,7 +763,7 @@ extension Array where Element: Equatable {
     ///   - lhs: Sort closure left hand side element
     ///   - rhs: Sort closure right hand side element
     /// - Returns: Whether the elements are sorted or not.
-    func sortOrder(lhs: Element, rhs: Element) -> Bool {
+    func areInRelativeOrder(lhs: Element, rhs: Element) -> Bool {
         guard let lhsIndex = firstIndex(of: lhs) else { return false }
         guard let rhsIndex = firstIndex(of: rhs) else { return true }
         return lhsIndex < rhsIndex

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3005,7 +3005,7 @@ class OrganizeDeclarationsTests: XCTestCase {
         )
     }
 
-    func testSortSwiftUIPropertyWrappersSubCategory() {
+    func testSortSwiftUIPropertyWrappersSubCategoryAlphabetically() {
         let input = """
         struct ContentView: View {
             init() {}
@@ -3050,13 +3050,13 @@ class OrganizeDeclarationsTests: XCTestCase {
                 organizeTypes: ["struct"],
                 organizationMode: .visibility,
                 blankLineAfterSubgroups: false,
-                alphabetizeSwiftUIPropertyTypes: true
+                swiftUIPropertiesSortMode: .alphabetize
             ),
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
 
-    func testSortSwiftUIWrappersByTypeAndMaintainGroupSpacing() {
+    func testSortSwiftUIWrappersByTypeAndMaintainGroupSpacingAlphabetically() {
         let input = """
         struct ContentView: View {
             init() {}
@@ -3107,7 +3107,115 @@ class OrganizeDeclarationsTests: XCTestCase {
                 organizeTypes: ["struct"],
                 organizationMode: .visibility,
                 blankLineAfterSubgroups: false,
-                alphabetizeSwiftUIPropertyTypes: true
+                swiftUIPropertiesSortMode: .alphabetize
+            ),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testSortSwiftUIPropertyWrappersSubCategoryPreservingGroupPosition() {
+        let input = """
+        struct ContentView: View {
+            init() {}
+
+            @Environment(\\.colorScheme) var colorScheme
+            @State var foo: Foo
+            @Binding var isOn: Bool
+            @Environment(\\.quux) var quux: Quux
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+            @State var foo: Foo
+            @Binding var isOn: Bool
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(
+                organizeTypes: ["struct"],
+                organizationMode: .visibility,
+                blankLineAfterSubgroups: false,
+                swiftUIPropertiesSortMode: .firstAppearanceSort
+            ),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testSortSwiftUIWrappersByTypeAndMaintainGroupSpacingAndPosition() {
+        let input = """
+        struct ContentView: View {
+            init() {}
+
+            @State var foo: Foo
+            @State var bar: Bar
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+
+            @Binding var isOn: Bool
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        let output = """
+        struct ContentView: View {
+
+            // MARK: Lifecycle
+
+            init() {}
+
+            // MARK: Internal
+
+            @State var foo: Foo
+            @State var bar: Bar
+
+            @Environment(\\.colorScheme) var colorScheme
+            @Environment(\\.quux) var quux: Quux
+
+            @Binding var isOn: Bool
+
+            @ViewBuilder
+            var body: some View {
+                Toggle(label, isOn: $isOn)
+            }
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(
+                organizeTypes: ["struct"],
+                organizationMode: .visibility,
+                blankLineAfterSubgroups: false,
+                swiftUIPropertiesSortMode: .firstAppearanceSort
             ),
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )


### PR DESCRIPTION
Adds a new way to sort SwiftUI properties, sorting them by the first time a property appears. This feature allow to still have custom sorting but requires that all SwiftUI properties of the same type are together.

```
/// WRONG
struct ContentView: View {

    @Environment(\\.colorScheme) var colorScheme
    @State var foo: Foo
    @Binding var isOn: Bool
    @Environment(\\.quux) var quux: Quux

    var body: some View {
        Toggle(label, isOn: $isOn)
    }
}

/// RIGHT
struct ContentView: View {

    @Environment(\\.colorScheme) var colorScheme
    @Environment(\\.quux) var quux: Quux
    @State var foo: Foo
    @Binding var isOn: Bool

    var body: some View {
        Toggle(label, isOn: $isOn)
    }
}
```

cc: @calda 