### PR TITLE
 Remove redundant Void from protocol definitions

### DIFF
--- a/Sources/Rules/RedundantVoidReturnType.swift
+++ b/Sources/Rules/RedundantVoidReturnType.swift
@@ -35,7 +35,7 @@ public extension FormatRule {
             let isInProtocol = nextToken == .endOfScope("}") || (nextToken.isKeywordOrAttribute && nextToken != .keyword("in"))
 
             // After a `Void` we could see the start of a function's body, or if the function is inside a protocol declaration
-            // we can find an identifier related to another func, var, etc declared in the protocol or the end of the protocol definition.
+            // we can find a keyword related to other declarations or the end scope of the protocol definition.
             guard nextToken == .startOfScope("{") || isInProtocol else { return }
 
             guard let prevIndex = formatter.index(of: .endOfScope(")"), before: i),

--- a/Tests/Rules/BlankLinesBetweenScopesTests.swift
+++ b/Tests/Rules/BlankLinesBetweenScopesTests.swift
@@ -49,7 +49,7 @@ class BlankLinesBetweenScopesTests: XCTestCase {
     }
 
     func testNoBlankLineBetweenFunctionsInProtocol() {
-        let input = "protocol Foo {\n    func bar() -> Void\n    func baz() -> Int\n}"
+        let input = "protocol Foo {\n    func bar()\n    func baz() -> Int\n}"
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 

--- a/Tests/Rules/RedundantVoidReturnTypeTests.swift
+++ b/Tests/Rules/RedundantVoidReturnTypeTests.swift
@@ -91,4 +91,25 @@ class RedundantVoidReturnTypeTests: XCTestCase {
         let options = FormatOptions(closureVoidReturn: .preserve)
         testFormatting(for: input, rule: .redundantVoidReturnType, options: options)
     }
+
+    func testRemoveRedundantVoidInProtocolDeclaration() {
+        let input = """
+        protocol Foo {
+            func foo() -> Void
+            func bar() -> ()
+            var baz: Int { get }
+            func bazz() -> ( )
+        }
+        """
+
+        let output = """
+        protocol Foo {
+            func foo()
+            func bar()
+            var baz: Int { get }
+            func bazz()
+        }
+        """
+        testFormatting(for: input, [output], rules: [.void, .redundantVoidReturnType])
+    }
 }


### PR DESCRIPTION
The existing rule doesn't remove redundant `Void` if the function is inside a protocol

```swift
// WRONG
protocol Foo {
    func foo() -> Void
    func bar() -> ()
    var baz: Int { get }
    func bazz() -> ( )
}
// RIGHT
protocol Foo {
    func foo()
    func bar()
    var baz: Int { get }
    func bazz()
}
```

cc: @calda 