### PR TITLE
GitHub Actions build on macOS v14 on AMD 64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
         macos:
           - 12
           - 13
+          - latest
         xcode:
           - latest-stable
     runs-on: macos-${{ matrix.macos }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c5037fd1-1b47-4382-8b12-2b4ebb2fbb05)
https://github.com/nicklockwood/SwiftFormat/actions/runs/10539051276/job/29202226289?pr=1828

Apple Silicon delivers faster build times:
macOS | GHA Build
--- | ---
v12 | 9m44
v13 | 9m45
v14 | ___4m50___

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
