### PR TITLE
Package Swift runtime with installer on Windows

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -22,11 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: swift-5.9.2-release
-            tag: 5.9.2-RELEASE
-
-          - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2023-06-05-a
+          - branch: swift-5.10.1-release
+            tag: 5.10.1-RELEASE
 
     steps:
       - uses: compnerd/gha-setup-swift@main
@@ -42,7 +39,28 @@ jobs:
 
       - uses: microsoft/setup-msbuild@v2.0.0
 
-      - run: msbuild -nologo -restore Platforms\Windows\SwiftFormat.wixproj -p:Configuration=Release -p:ProductVersion=${{ github.event.inputs.version }} -p:SWIFTFORMAT_BUILD=${{ github.workspace }}\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+      - shell: pwsh
+        run: |
+          # Bundle the Swift runtime if the version we're using ships with a redistributable
+          $SwiftExePath = (& where.exe swift.exe)
+          if (-not ($SwiftExePath -match "(.+)\\Toolchains\\(\d+\.\d+\.\d+)[^\\]*\\.*")) {
+            throw "Unexpected Swift installation path format"
+          }
+
+          $SwiftInstallRoot = $Matches[1]
+          $SwiftRuntimeVersion = $Matches[2]
+          $SwiftRedistDir = "$SwiftInstallRoot\Redistributables\$SwiftRuntimeVersion"
+          if (-not (Test-Path $SwiftRedistDir)) {
+            throw "Swift redistributable not found at $SwiftRedistDir"
+          }
+
+          & msbuild -nologo -restore Platforms\Windows\SwiftFormat.wixproj `
+            -p:Configuration=Release `
+            -p:ProductVersion=${{ github.event.inputs.version }} `
+            -p:SwiftFormatBuildDir=${{ github.workspace }}\.build\release `
+            -p:SwiftRedistDir=$SwiftRedistDir `
+            -p:OutputPath=${{ github.workspace }}\artifacts `
+            -p:RunWixToolsOutOfProc=true
 
       - run: |
           $MSI_PATH = cygpath -m ${{ github.workspace }}\artifacts\SwiftFormat.msi

--- a/Platforms/Windows/SwiftFormat.wixproj
+++ b/Platforms/Windows/SwiftFormat.wixproj
@@ -5,10 +5,7 @@
 
   <PropertyGroup>
     <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
-    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
-
     <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
-    <ProductVersion>$(ProductVersion)</ProductVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +16,12 @@
   <Import Project="WiXCodeSigning.targets" />
 
   <PropertyGroup>
-    <DefineConstants>ProductArchitecture=$(ProductArchitecture);ProductVersion=$(ProductVersion);SWIFTFORMAT_BUILD=$(SWIFTFORMAT_BUILD)</DefineConstants>
+    <DefineConstants>
+      ProductArchitecture=$(ProductArchitecture);
+      ProductVersion=$(ProductVersion);
+      SwiftFormatBuildDir=$(SwiftFormatBuildDir);
+      SwiftRedistDir=$(SwiftRedistDir)
+      </DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">

--- a/Platforms/Windows/SwiftFormat.wxs
+++ b/Platforms/Windows/SwiftFormat.wxs
@@ -1,6 +1,13 @@
 <Wix
     xmlns="http://wixtoolset.org/schemas/v4/wxs"
     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+
+  <?if $(sys.BUILDARCH) == x64 ?>
+    <?define MergeModuleFileName = "rtl.amd64.msm" ?>
+  <?else?>
+    <?define MergeModuleFileName = "rtl.$(sys.BUILDARCH).msm" ?>
+  <?endif?>
+
   <Package
       Language="1033"
       Manufacturer="nicklockwood"
@@ -16,14 +23,16 @@
       <Directory Id="ManufacturerFolder" Name="nicklockwood">
         <Directory Id="INSTALLDIR" Name="SwiftFormat">
           <Directory Id="_usr" Name="usr">
-            <Directory Id="_usr_bin" Name="bin" />
+            <Directory Id="_usr_bin" Name="bin">
+              <Merge Id="SwiftRuntime" DiskId="1" Language="0" SourceFile="$(SwiftRedistDir)\$(MergeModuleFileName)" />
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
     </StandardDirectory>
 
     <Component Directory="_usr_bin" Id="swiftformat.exe">
-      <File Id="swiftformat.exe" Source="$(var.SWIFTFORMAT_BUILD)\swiftformat.exe" Checksum="yes" KeyPath="yes" />
+      <File Id="swiftformat.exe" Source="$(var.SwiftFormatBuildDir)\swiftformat.exe" Checksum="yes" KeyPath="yes" />
     </Component>
 
     <ComponentGroup Id="EnvironmentVariables">
@@ -36,6 +45,7 @@
     </ComponentGroup>
 
     <Feature Id="SwiftFormat" Level="1">
+      <MergeRef Id="SwiftRuntime" />
       <ComponentRef Id="swiftformat.exe" />
       <ComponentGroupRef Id="EnvironmentVariables" />
     </Feature>


### PR DESCRIPTION
We can't assume that SwiftFormat.exe will work with the Swift runtime installed on the user's machine (if there even is one), so the installer should package the runtime.

Also updates the github workflow to build with Swift 5.10.1 whose installer includes a redistributable.

Verified with a local build + installer build invocation.