### PR TITLE
Move rule examples below rule implementation

### DIFF
--- a/Sources/FormatRule.swift
+++ b/Sources/FormatRule.swift
@@ -56,14 +56,14 @@ public final class FormatRule: Equatable, Comparable, CustomStringConvertible {
     }
 
     init(help: String,
-         examples: String? = nil,
          deprecationMessage: String? = nil,
          runOnceOnly: Bool = false,
          disabledByDefault: Bool = false,
          orderAfter: [FormatRule] = [],
          options: [String] = [],
          sharedOptions: [String] = [],
-         _ fn: @escaping (Formatter) -> Void)
+         _ fn: @escaping (Formatter) -> Void,
+         examples: (() -> String)? = nil)
     {
         self.fn = fn
         self.help = help
@@ -73,7 +73,7 @@ public final class FormatRule: Equatable, Comparable, CustomStringConvertible {
         self.options = options
         self.sharedOptions = sharedOptions
         self.deprecationMessage = deprecationMessage
-        self.examples = examples
+        self.examples = examples?()
     }
 
     public func apply(with formatter: Formatter) {

--- a/Sources/Rules/Acronyms.swift
+++ b/Sources/Rules/Acronyms.swift
@@ -11,19 +11,6 @@ import Foundation
 public extension FormatRule {
     static let acronyms = FormatRule(
         help: "Capitalize acronyms when the first character is capitalized.",
-        examples: """
-        ```diff
-        - let destinationUrl: URL
-        - let urlRouter: UrlRouter
-        - let screenId: String
-        - let entityUuid: UUID
-
-        + let destinationURL: URL
-        + let urlRouter: URLRouter
-        + let screenID: String
-        + let entityUUID: UUID
-        ```
-        """,
         disabledByDefault: true,
         options: ["acronyms"]
     ) { formatter in
@@ -85,5 +72,19 @@ public extension FormatRule {
                 formatter.replaceToken(at: index, with: updatedToken)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let destinationUrl: URL
+        - let urlRouter: UrlRouter
+        - let screenId: String
+        - let entityUuid: UUID
+
+        + let destinationURL: URL
+        + let urlRouter: URLRouter
+        + let screenID: String
+        + let entityUUID: UUID
+        ```
+        """
     }
 }

--- a/Sources/Rules/AndOperator.swift
+++ b/Sources/Rules/AndOperator.swift
@@ -11,28 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Replace the `&&` operator with `,` where applicable
     static let andOperator = FormatRule(
-        help: "Prefer comma over `&&` in `if`, `guard` or `while` conditions.",
-        examples: """
-        ```diff
-        - if true && true {
-        + if true, true {
-        ```
-
-        ```diff
-        - guard true && true else {
-        + guard true, true else {
-        ```
-
-        ```diff
-        - if functionReturnsBool() && true {
-        + if functionReturnsBool(), true {
-        ```
-
-        ```diff
-        - if functionReturnsBool() && variable {
-        + if functionReturnsBool(), variable {
-        ```
-        """
+        help: "Prefer comma over `&&` in `if`, `guard` or `while` conditions."
     ) { formatter in
         formatter.forEachToken { i, token in
             switch token {
@@ -102,5 +81,27 @@ public extension FormatRule {
                 index += 1
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if true && true {
+        + if true, true {
+        ```
+
+        ```diff
+        - guard true && true else {
+        + guard true, true else {
+        ```
+
+        ```diff
+        - if functionReturnsBool() && true {
+        + if functionReturnsBool(), true {
+        ```
+
+        ```diff
+        - if functionReturnsBool() && variable {
+        + if functionReturnsBool(), variable {
+        ```
+        """
     }
 }

--- a/Sources/Rules/AnyObjectProtocol.swift
+++ b/Sources/Rules/AnyObjectProtocol.swift
@@ -11,17 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Prefer `AnyObject` over `class` for class-based protocols
     static let anyObjectProtocol = FormatRule(
-        help: "Prefer `AnyObject` over `class` in protocol definitions.",
-        examples: """
-        ```diff
-        - protocol Foo: class {}
-        + protocol Foo: AnyObject {}
-        ```
-
-        **NOTE:** The guideline to use `AnyObject` instead of `class` was only
-        introduced in Swift 4.1, so the `anyObjectProtocol` rule is disabled unless the
-        swift version is set to 4.1 or above.
-        """
+        help: "Prefer `AnyObject` over `class` in protocol definitions."
     ) { formatter in
         formatter.forEach(.keyword("protocol")) { i, _ in
             guard formatter.options.swiftVersion >= "4.1",
@@ -37,5 +27,16 @@ public extension FormatRule {
             }
             formatter.replaceToken(at: classIndex, with: .identifier("AnyObject"))
         }
+    } examples: {
+        """
+        ```diff
+        - protocol Foo: class {}
+        + protocol Foo: AnyObject {}
+        ```
+
+        **NOTE:** The guideline to use `AnyObject` instead of `class` was only
+        introduced in Swift 4.1, so the `anyObjectProtocol` rule is disabled unless the
+        swift version is set to 4.1 or above.
+        """
     }
 }

--- a/Sources/Rules/AssertionFailures.swift
+++ b/Sources/Rules/AssertionFailures.swift
@@ -13,22 +13,6 @@ public extension FormatRule {
         help: """
         Changes all instances of assert(false, ...) to assertionFailure(...)
         and precondition(false, ...) to preconditionFailure(...).
-        """,
-        examples: """
-        ```diff
-        - assert(false)
-        + assertionFailure()
-        ```
-
-        ```diff
-        - assert(false, "message", 2, 1)
-        + assertionFailure("message", 2, 1)
-        ```
-
-        ```diff
-        - precondition(false, "message", 2, 1)
-        + preconditionFailure("message", 2, 1)
-        ```
         """
     ) { formatter in
         formatter.forEachToken { i, token in
@@ -55,5 +39,22 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - assert(false)
+        + assertionFailure()
+        ```
+
+        ```diff
+        - assert(false, "message", 2, 1)
+        + assertionFailure("message", 2, 1)
+        ```
+
+        ```diff
+        - precondition(false, "message", 2, 1)
+        + preconditionFailure("message", 2, 1)
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLineAfterImports.swift
+++ b/Sources/Rules/BlankLineAfterImports.swift
@@ -12,17 +12,6 @@ public extension FormatRule {
     /// Insert blank line after import statements
     static let blankLineAfterImports = FormatRule(
         help: "Insert blank line after import statements.",
-        examples: """
-        ```diff
-          import A
-          import B
-          @testable import D
-        +
-          class Foo {
-            // foo
-          }
-        ```
-        """,
         sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.keyword("import")) { currentImportIndex, _ in
@@ -45,5 +34,17 @@ public extension FormatRule {
                 formatter.insertLinebreak(at: endOfLine)
             }
         }
+    } examples: {
+        """
+        ```diff
+          import A
+          import B
+          @testable import D
+        +
+          class Foo {
+            // foo
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLineAfterSwitchCase.swift
+++ b/Sources/Rules/BlankLineAfterSwitchCase.swift
@@ -14,28 +14,6 @@ public extension FormatRule {
         Insert a blank line after multiline switch cases (excluding the last case,
         which is followed by a closing brace).
         """,
-        examples: #"""
-        ```diff
-          func handle(_ action: SpaceshipAction) {
-              switch action {
-              case .engageWarpDrive:
-                  navigationComputer.destination = targetedDestination
-                  await warpDrive.spinUp()
-                  warpDrive.activate()
-        +
-              case let .scanPlanet(planet):
-                  scanner.target = planet
-                  scanner.scanAtmosphere()
-                  scanner.scanBiosphere()
-                  scanner.scanForArticialLife()
-        +
-              case .handleIncomingEnergyBlast:
-                  await energyShields.prepare()
-                  energyShields.engage()
-              }
-          }
-        ```
-        """#,
         disabledByDefault: true,
         orderAfter: [.redundantBreak]
     ) { formatter in
@@ -61,5 +39,28 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        #"""
+        ```diff
+          func handle(_ action: SpaceshipAction) {
+              switch action {
+              case .engageWarpDrive:
+                  navigationComputer.destination = targetedDestination
+                  await warpDrive.spinUp()
+                  warpDrive.activate()
+        +
+              case let .scanPlanet(planet):
+                  scanner.target = planet
+                  scanner.scanAtmosphere()
+                  scanner.scanBiosphere()
+                  scanner.scanForArticialLife()
+        +
+              case .handleIncomingEnergyBlast:
+                  await energyShields.prepare()
+                  energyShields.engage()
+              }
+          }
+        ```
+        """#
     }
 }

--- a/Sources/Rules/BlankLinesAroundMark.swift
+++ b/Sources/Rules/BlankLinesAroundMark.swift
@@ -12,27 +12,6 @@ public extension FormatRule {
     /// Adds a blank line around MARK: comments
     static let blankLinesAroundMark = FormatRule(
         help: "Insert blank line before and after `MARK:` comments.",
-        examples: """
-        ```diff
-          func foo() {
-            // foo
-          }
-          // MARK: bar
-          func bar() {
-            // bar
-          }
-
-          func foo() {
-            // foo
-          }
-        +
-          // MARK: bar
-        +
-          func bar() {
-            // bar
-          }
-        ```
-        """,
         options: ["lineaftermarks"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -55,5 +34,27 @@ public extension FormatRule {
                 formatter.insertLinebreak(at: lastIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+          func foo() {
+            // foo
+          }
+          // MARK: bar
+          func bar() {
+            // bar
+          }
+
+          func foo() {
+            // foo
+          }
+        +
+          // MARK: bar
+        +
+          func bar() {
+            // bar
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLinesAtEndOfScope.swift
+++ b/Sources/Rules/BlankLinesAtEndOfScope.swift
@@ -13,33 +13,6 @@ public extension FormatRule {
     /// unless it's followed by more code on the same line (e.g. } else { )
     static let blankLinesAtEndOfScope = FormatRule(
         help: "Remove trailing blank line at the end of a scope.",
-        examples: """
-        ```diff
-          func foo() {
-            // foo
-        -
-          }
-
-          func foo() {
-            // foo
-          }
-        ```
-
-        ```diff
-          array = [
-            foo,
-            bar,
-            baz,
-        -
-          ]
-
-          array = [
-            foo,
-            bar,
-            baz,
-          ]
-        ```
-        """,
         orderAfter: [.organizeDeclarations],
         sharedOptions: ["typeblanklines"]
     ) { formatter in
@@ -86,5 +59,33 @@ public extension FormatRule {
                 return
             }
         }
+    } examples: {
+        """
+        ```diff
+          func foo() {
+            // foo
+        -
+          }
+
+          func foo() {
+            // foo
+          }
+        ```
+
+        ```diff
+          array = [
+            foo,
+            bar,
+            baz,
+        -
+          ]
+
+          array = [
+            foo,
+            bar,
+            baz,
+          ]
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLinesAtStartOfScope.swift
+++ b/Sources/Rules/BlankLinesAtStartOfScope.swift
@@ -12,33 +12,6 @@ public extension FormatRule {
     /// Remove blank lines immediately after an opening brace, bracket, paren or chevron
     static let blankLinesAtStartOfScope = FormatRule(
         help: "Remove leading blank line at the start of a scope.",
-        examples: """
-        ```diff
-          func foo() {
-        -
-            // foo
-          }
-
-          func foo() {
-            // foo
-          }
-        ```
-
-        ```diff
-          array = [
-        -
-            foo,
-            bar,
-            baz,
-          ]
-
-          array = [
-            foo,
-            bar,
-            baz,
-          ]
-        ```
-        """,
         orderAfter: [.organizeDeclarations],
         options: ["typeblanklines"]
     ) { formatter in
@@ -76,5 +49,33 @@ public extension FormatRule {
                 return
             }
         }
+    } examples: {
+        """
+        ```diff
+          func foo() {
+        -
+            // foo
+          }
+
+          func foo() {
+            // foo
+          }
+        ```
+
+        ```diff
+          array = [
+        -
+            foo,
+            bar,
+            baz,
+          ]
+
+          array = [
+            foo,
+            bar,
+            baz,
+          ]
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLinesBetweenImports.swift
+++ b/Sources/Rules/BlankLinesBetweenImports.swift
@@ -14,18 +14,6 @@ public extension FormatRule {
         help: """
         Remove blank lines between import statements.
         """,
-        examples: """
-        ```diff
-          import A
-        -
-          import B
-          import C
-        -
-        -
-          @testable import D
-          import E
-        ```
-        """,
         disabledByDefault: true,
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -40,5 +28,18 @@ public extension FormatRule {
 
             formatter.replaceTokens(in: endOfLine ..< nextImportIndex, with: formatter.linebreakToken(for: currentImportIndex + 1))
         }
+    } examples: {
+        """
+        ```diff
+          import A
+        -
+          import B
+          import C
+        -
+        -
+          @testable import D
+          import E
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLinesBetweenScopes.swift
+++ b/Sources/Rules/BlankLinesBetweenScopes.swift
@@ -15,29 +15,6 @@ public extension FormatRule {
         Insert blank line before class, struct, enum, extension, protocol or function
         declarations.
         """,
-        examples: """
-        ```diff
-          func foo() {
-            // foo
-          }
-          func bar() {
-            // bar
-          }
-          var baz: Bool
-          var quux: Int
-
-          func foo() {
-            // foo
-          }
-        +
-          func bar() {
-            // bar
-          }
-        +
-          var baz: Bool
-          var quux: Int
-        ```
-        """,
         sharedOptions: ["linebreaks"]
     ) { formatter in
         var spaceableScopeStack = [true]
@@ -128,5 +105,29 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+          func foo() {
+            // foo
+          }
+          func bar() {
+            // bar
+          }
+          var baz: Bool
+          var quux: Int
+
+          func foo() {
+            // foo
+          }
+        +
+          func bar() {
+            // bar
+          }
+        +
+          var baz: Bool
+          var quux: Int
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlockComments.swift
+++ b/Sources/Rules/BlockComments.swift
@@ -11,27 +11,6 @@ import Foundation
 public extension FormatRule {
     static let blockComments = FormatRule(
         help: "Convert block comments to consecutive single line comments.",
-        examples: """
-        ```diff
-        - /*
-        -  * foo
-        -  * bar
-        -  */
-
-        + // foo
-        + // bar
-        ```
-
-        ```diff
-        - /**
-        -  * foo
-        -  * bar
-        -  */
-
-        + /// foo
-        + /// bar
-        ```
-        """,
         disabledByDefault: true
     ) { formatter in
         formatter.forEachToken { i, token in
@@ -124,6 +103,28 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - /*
+        -  * foo
+        -  * bar
+        -  */
+
+        + // foo
+        + // bar
+        ```
+
+        ```diff
+        - /**
+        -  * foo
+        -  * bar
+        -  */
+
+        + /// foo
+        + /// bar
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/Braces.swift
+++ b/Sources/Rules/Braces.swift
@@ -12,25 +12,6 @@ public extension FormatRule {
     /// Implement brace-wrapping rules
     static let braces = FormatRule(
         help: "Wrap braces in accordance with selected style (K&R or Allman).",
-        examples: """
-        ```diff
-        - if x
-        - {
-            // foo
-          }
-        - else
-        - {
-            // bar
-          }
-
-        + if x {
-            // foo
-          }
-        + else {
-            // bar
-          }
-        ```
-        """,
         options: ["allman"],
         sharedOptions: ["linebreaks", "maxwidth", "indent", "tabwidth", "assetliterals"]
     ) { formatter in
@@ -104,5 +85,25 @@ public extension FormatRule {
                 formatter.replaceTokens(in: prevIndex + 1 ..< i, with: .space(" "))
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if x
+        - {
+            // foo
+          }
+        - else
+        - {
+            // bar
+          }
+
+        + if x {
+            // foo
+          }
+        + else {
+            // bar
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/ConditionalAssignment.swift
+++ b/Sources/Rules/ConditionalAssignment.swift
@@ -11,41 +11,6 @@ import Foundation
 public extension FormatRule {
     static let conditionalAssignment = FormatRule(
         help: "Assign properties using if / switch expressions.",
-        examples: """
-        ```diff
-        - let foo: String
-        - if condition {
-        + let foo = if condition {
-        -     foo = "foo"
-        +     "foo"
-          } else {
-        -     foo = "bar"
-        +     "bar"
-          }
-
-        - let foo: String
-        - switch condition {
-        + let foo = switch condition {
-          case true:
-        -     foo = "foo"
-        +     "foo"
-          case false:
-        -     foo = "bar"
-        +     "bar"
-          }
-
-        // With --condassignment always (disabled by default)
-        - switch condition {
-        + foo.bar = switch condition {
-          case true:
-        -     foo.bar = "baaz"
-        +     "baaz"
-          case false:
-        -     foo.bar = "quux"
-        +     "quux"
-          }
-        ```
-        """,
         orderAfter: [.redundantReturn],
         options: ["condassignment"]
     ) { formatter in
@@ -167,6 +132,42 @@ public extension FormatRule {
                 formatter.insert(identifierEqualsTokens, at: startOfConditional)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let foo: String
+        - if condition {
+        + let foo = if condition {
+        -     foo = "foo"
+        +     "foo"
+          } else {
+        -     foo = "bar"
+        +     "bar"
+          }
+
+        - let foo: String
+        - switch condition {
+        + let foo = switch condition {
+          case true:
+        -     foo = "foo"
+        +     "foo"
+          case false:
+        -     foo = "bar"
+        +     "bar"
+          }
+
+        // With --condassignment always (disabled by default)
+        - switch condition {
+        + foo.bar = switch condition {
+          case true:
+        -     foo.bar = "baaz"
+        +     "baaz"
+          case false:
+        -     foo.bar = "quux"
+        +     "quux"
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/ConsecutiveBlankLines.swift
+++ b/Sources/Rules/ConsecutiveBlankLines.swift
@@ -11,23 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Collapse all consecutive blank lines into a single blank line
     static let consecutiveBlankLines = FormatRule(
-        help: "Replace consecutive blank lines with a single blank line.",
-        examples: """
-        ```diff
-          func foo() {
-            let x = "bar"
-        -
-
-            print(x)
-          }
-
-          func foo() {
-            let x = "bar"
-
-            print(x)
-          }
-        ```
-        """
+        help: "Replace consecutive blank lines with a single blank line."
     ) { formatter in
         formatter.forEach(.linebreak) { i, _ in
             guard let prevIndex = formatter.index(of: .nonSpace, before: i, if: { $0.isLinebreak }) else {
@@ -44,5 +28,22 @@ public extension FormatRule {
                 formatter.removeTokens(in: i ..< formatter.tokens.count)
             }
         }
+    } examples: {
+        """
+        ```diff
+          func foo() {
+            let x = "bar"
+        -
+
+            print(x)
+          }
+
+          func foo() {
+            let x = "bar"
+
+            print(x)
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/ConsecutiveSpaces.swift
+++ b/Sources/Rules/ConsecutiveSpaces.swift
@@ -13,13 +13,7 @@ public extension FormatRule {
     /// the start of a line or inside a comment or string, as these have no semantic
     /// meaning and lead to noise in commits.
     static let consecutiveSpaces = FormatRule(
-        help: "Replace consecutive spaces with a single space.",
-        examples: """
-        ```diff
-        - let     foo = 5
-        + let foo = 5
-        ```
-        """
+        help: "Replace consecutive spaces with a single space."
     ) { formatter in
         formatter.forEach(.space) { i, token in
             switch token {
@@ -50,5 +44,12 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let     foo = 5
+        + let foo = 5
+        ```
+        """
     }
 }

--- a/Sources/Rules/ConsistentSwitchCaseSpacing.swift
+++ b/Sources/Rules/ConsistentSwitchCaseSpacing.swift
@@ -11,7 +11,40 @@ import Foundation
 public extension FormatRule {
     static let consistentSwitchCaseSpacing = FormatRule(
         help: "Ensures consistent spacing among all of the cases in a switch statement.",
-        examples: #"""
+        orderAfter: [.blankLineAfterSwitchCase]
+    ) { formatter in
+        formatter.forEach(.keyword("switch")) { switchIndex, _ in
+            guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }
+
+            // When counting the switch cases, exclude the last case (which should never have a trailing blank line).
+            let countWithTrailingBlankLine = switchCases.filter { $0.isFollowedByBlankLine && !$0.isLastCase }.count
+            let countWithoutTrailingBlankLine = switchCases.filter { !$0.isFollowedByBlankLine && !$0.isLastCase }.count
+
+            // We want the spacing to be consistent for all switch cases,
+            // so use whichever formatting is used for the majority of cases.
+            var allCasesShouldHaveBlankLine = countWithTrailingBlankLine >= countWithoutTrailingBlankLine
+
+            // When the `blankLinesBetweenChainedFunctions` rule is enabled, and there is a switch case
+            // that is required to span multiple lines, then all cases must span multiple lines.
+            // (Since if this rule removed the blank line from that case, it would contradict the other rule)
+            if formatter.options.enabledRules.contains(FormatRule.blankLineAfterSwitchCase.name),
+               switchCases.contains(where: { $0.spansMultipleLines && !$0.isLastCase })
+            {
+                allCasesShouldHaveBlankLine = true
+            }
+
+            for switchCase in switchCases.reversed() {
+                if !switchCase.isFollowedByBlankLine, allCasesShouldHaveBlankLine, !switchCase.isLastCase {
+                    switchCase.insertTrailingBlankLine(using: formatter)
+                }
+
+                if switchCase.isFollowedByBlankLine, !allCasesShouldHaveBlankLine || switchCase.isLastCase {
+                    switchCase.removeTrailingBlankLine(using: formatter)
+                }
+            }
+        }
+    } examples: {
+        #"""
         ```diff
           func handle(_ action: SpaceshipAction) {
               switch action {
@@ -58,38 +91,6 @@ public extension FormatRule {
               "Neptune"
           }
         ```
-        """#,
-        orderAfter: [.blankLineAfterSwitchCase]
-    ) { formatter in
-        formatter.forEach(.keyword("switch")) { switchIndex, _ in
-            guard let switchCases = formatter.switchStatementBranchesWithSpacingInfo(at: switchIndex) else { return }
-
-            // When counting the switch cases, exclude the last case (which should never have a trailing blank line).
-            let countWithTrailingBlankLine = switchCases.filter { $0.isFollowedByBlankLine && !$0.isLastCase }.count
-            let countWithoutTrailingBlankLine = switchCases.filter { !$0.isFollowedByBlankLine && !$0.isLastCase }.count
-
-            // We want the spacing to be consistent for all switch cases,
-            // so use whichever formatting is used for the majority of cases.
-            var allCasesShouldHaveBlankLine = countWithTrailingBlankLine >= countWithoutTrailingBlankLine
-
-            // When the `blankLinesBetweenChainedFunctions` rule is enabled, and there is a switch case
-            // that is required to span multiple lines, then all cases must span multiple lines.
-            // (Since if this rule removed the blank line from that case, it would contradict the other rule)
-            if formatter.options.enabledRules.contains(FormatRule.blankLineAfterSwitchCase.name),
-               switchCases.contains(where: { $0.spansMultipleLines && !$0.isLastCase })
-            {
-                allCasesShouldHaveBlankLine = true
-            }
-
-            for switchCase in switchCases.reversed() {
-                if !switchCase.isFollowedByBlankLine, allCasesShouldHaveBlankLine, !switchCase.isLastCase {
-                    switchCase.insertTrailingBlankLine(using: formatter)
-                }
-
-                if switchCase.isFollowedByBlankLine, !allCasesShouldHaveBlankLine || switchCase.isLastCase {
-                    switchCase.removeTrailingBlankLine(using: formatter)
-                }
-            }
-        }
+        """#
     }
 }

--- a/Sources/Rules/DocComments.swift
+++ b/Sources/Rules/DocComments.swift
@@ -11,20 +11,6 @@ import Foundation
 public extension FormatRule {
     static let docComments = FormatRule(
         help: "Use doc comments for API declarations, otherwise use regular comments.",
-        examples: """
-        ```diff
-        - // A placeholder type used to demonstrate syntax rules
-        + /// A placeholder type used to demonstrate syntax rules
-          class Foo {
-        -     // This function doesn't really do anything
-        +     /// This function doesn't really do anything
-              func bar() {
-        -         /// TODO: implement Foo.bar() algorithm
-        +         // TODO: implement Foo.bar() algorithm
-              }
-          }
-        ```
-        """,
         disabledByDefault: true,
         orderAfter: [.fileHeader],
         options: ["doccomments"]
@@ -130,6 +116,21 @@ public extension FormatRule {
                 formatter.insert(.commentBody(startOfDocCommentBody), at: index + 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - // A placeholder type used to demonstrate syntax rules
+        + /// A placeholder type used to demonstrate syntax rules
+          class Foo {
+        -     // This function doesn't really do anything
+        +     /// This function doesn't really do anything
+              func bar() {
+        -         /// TODO: implement Foo.bar() algorithm
+        +         // TODO: implement Foo.bar() algorithm
+              }
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/DocCommentsBeforeAttributes.swift
+++ b/Sources/Rules/DocCommentsBeforeAttributes.swift
@@ -11,14 +11,6 @@ import Foundation
 public extension FormatRule {
     static let docCommentsBeforeAttributes = FormatRule(
         help: "Place doc comments on declarations before any attributes.",
-        examples: """
-        ```diff
-        + /// Doc comment on this function declaration
-          @MainActor
-        - /// Doc comment on this function declaration
-          func foo() {}
-        ```
-        """,
         orderAfter: [.docComments]
     ) { formatter in
         formatter.forEachToken(where: \.isDeclarationTypeKeyword) { keywordIndex, _ in
@@ -48,5 +40,14 @@ public extension FormatRule {
                 to: startOfAttributes
             )
         }
+    } examples: {
+        """
+        ```diff
+        + /// Doc comment on this function declaration
+          @MainActor
+        - /// Doc comment on this function declaration
+          func foo() {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/DuplicateImports.swift
+++ b/Sources/Rules/DuplicateImports.swift
@@ -11,22 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove duplicate import statements
     static let duplicateImports = FormatRule(
-        help: "Remove duplicate import statements.",
-        examples: """
-        ```diff
-          import Foo
-          import Bar
-        - import Foo
-        ```
-
-        ```diff
-          import B
-          #if os(iOS)
-            import A
-        -   import B
-          #endif
-        ```
-        """
+        help: "Remove duplicate import statements."
     ) { formatter in
         for var importRanges in formatter.parseImports().reversed() {
             for i in importRanges.indices.reversed() {
@@ -46,5 +31,21 @@ public extension FormatRule {
                 importRanges.append(range)
             }
         }
+    } examples: {
+        """
+        ```diff
+          import Foo
+          import Bar
+        - import Foo
+        ```
+
+        ```diff
+          import B
+          #if os(iOS)
+            import A
+        -   import B
+          #endif
+        ```
+        """
     }
 }

--- a/Sources/Rules/ElseOnSameLine.swift
+++ b/Sources/Rules/ElseOnSameLine.swift
@@ -17,52 +17,6 @@ public extension FormatRule {
         Place `else`, `catch` or `while` keyword in accordance with current style (same or
         next line).
         """,
-        examples: """
-        ```diff
-          if x {
-            // foo
-        - }
-        - else {
-            // bar
-          }
-
-          if x {
-            // foo
-        + } else {
-            // bar
-          }
-        ```
-
-        ```diff
-          do {
-            // try foo
-        - }
-        - catch {
-            // bar
-          }
-
-          do {
-            // try foo
-        + } catch {
-            // bar
-          }
-        ```
-
-        ```diff
-          repeat {
-            // foo
-        - }
-        - while {
-            // bar
-          }
-
-          repeat {
-            // foo
-        + } while {
-            // bar
-          }
-        ```
-        """,
         orderAfter: [.wrapMultilineStatementBraces],
         options: ["elseposition", "guardelse"],
         sharedOptions: ["allman", "linebreaks"]
@@ -154,6 +108,53 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+          if x {
+            // foo
+        - }
+        - else {
+            // bar
+          }
+
+          if x {
+            // foo
+        + } else {
+            // bar
+          }
+        ```
+
+        ```diff
+          do {
+            // try foo
+        - }
+        - catch {
+            // bar
+          }
+
+          do {
+            // try foo
+        + } catch {
+            // bar
+          }
+        ```
+
+        ```diff
+          repeat {
+            // foo
+        - }
+        - while {
+            // bar
+          }
+
+          repeat {
+            // foo
+        + } while {
+            // bar
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/EmptyBraces.swift
+++ b/Sources/Rules/EmptyBraces.swift
@@ -12,15 +12,6 @@ public extension FormatRule {
     /// Remove white-space between empty braces
     static let emptyBraces = FormatRule(
         help: "Remove whitespace inside empty braces.",
-        examples: """
-        ```diff
-        - func foo() {
-        -
-        - }
-
-        + func foo() {}
-        ```
-        """,
         options: ["emptybraces"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -46,5 +37,15 @@ public extension FormatRule {
                 formatter.replaceTokens(in: range, with: formatter.linebreakToken(for: i + 1))
             }
         }
+    } examples: {
+        """
+        ```diff
+        - func foo() {
+        -
+        - }
+
+        + func foo() {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/EmptyExtension.swift
+++ b/Sources/Rules/EmptyExtension.swift
@@ -12,13 +12,6 @@ public extension FormatRule {
     /// Remove empty, non-conforming, extensions.
     static let emptyExtension = FormatRule(
         help: "Remove empty, non-conforming, extensions.",
-        examples: """
-        ```diff
-        - extension String {}
-        -
-          extension String: Equatable {}
-        ```
-        """,
         orderAfter: [.unusedPrivateDeclaration]
     ) { formatter in
         var emptyExtensions = [Declaration]()
@@ -47,5 +40,13 @@ public extension FormatRule {
         for declaration in emptyExtensions.reversed() {
             formatter.removeTokens(in: declaration.originalRange)
         }
+    } examples: {
+        """
+        ```diff
+        - extension String {}
+        -
+          extension String: Equatable {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/ExtensionAccessControl.swift
+++ b/Sources/Rules/ExtensionAccessControl.swift
@@ -11,37 +11,6 @@ import Foundation
 public extension FormatRule {
     static let extensionAccessControl = FormatRule(
         help: "Configure the placement of an extension's access control keyword.",
-        examples: """
-        `--extensionacl on-extension` (default)
-
-        ```diff
-        - extension Foo {
-        -     public func bar() {}
-        -     public func baz() {}
-          }
-
-        + public extension Foo {
-        +     func bar() {}
-        +     func baz() {}
-          }
-        ```
-
-        `--extensionacl on-declarations`
-
-        ```diff
-        - public extension Foo {
-        -     func bar() {}
-        -     func baz() {}
-        -     internal func quux() {}
-          }
-
-        + extension Foo {
-        +     public func bar() {}
-        +     public func baz() {}
-        +     func quux() {}
-          }
-        ```
-        """,
         options: ["extensionacl"]
     ) { formatter in
         guard !formatter.options.fragment else { return }
@@ -148,6 +117,38 @@ public extension FormatRule {
 
         let updatedTokens = updatedDeclarations.flatMap(\.tokens)
         formatter.replaceTokens(in: formatter.tokens.indices, with: updatedTokens)
+    } examples: {
+        """
+        `--extensionacl on-extension` (default)
+
+        ```diff
+        - extension Foo {
+        -     public func bar() {}
+        -     public func baz() {}
+          }
+
+        + public extension Foo {
+        +     func bar() {}
+        +     func baz() {}
+          }
+        ```
+
+        `--extensionacl on-declarations`
+
+        ```diff
+        - public extension Foo {
+        -     func bar() {}
+        -     func baz() {}
+        -     internal func quux() {}
+          }
+
+        + extension Foo {
+        +     public func bar() {}
+        +     public func baz() {}
+        +     func quux() {}
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/FileHeader.swift
+++ b/Sources/Rules/FileHeader.swift
@@ -12,7 +12,73 @@ public extension FormatRule {
     /// Strip header comments from the file
     static let fileHeader = FormatRule(
         help: "Use specified source file header template for all files.",
-        examples: """
+        runOnceOnly: true,
+        options: ["header", "dateformat", "timezone"],
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        var headerTokens = [Token]()
+        var directives = [String]()
+        switch formatter.options.fileHeader {
+        case .ignore:
+            return
+        case var .replace(string):
+            let file = formatter.options.fileInfo
+            let options = ReplacementOptions(
+                dateFormat: formatter.options.dateFormat,
+                timeZone: formatter.options.timeZone
+            )
+
+            for (key, replacement) in formatter.options.fileInfo.replacements {
+                if let replacementStr = replacement.resolve(file, options) {
+                    while let range = string.range(of: "{\(key.rawValue)}") {
+                        string.replaceSubrange(range, with: replacementStr)
+                    }
+                }
+            }
+            headerTokens = tokenize(string)
+            directives = headerTokens.compactMap {
+                guard case let .commentBody(body) = $0 else {
+                    return nil
+                }
+                return body.commentDirective
+            }
+        }
+
+        guard let headerRange = formatter.headerCommentTokenRange(includingDirectives: directives) else {
+            return
+        }
+
+        if headerTokens.isEmpty {
+            formatter.removeTokens(in: headerRange)
+            return
+        }
+
+        var lastHeaderTokenIndex = headerRange.endIndex - 1
+        let endIndex = lastHeaderTokenIndex + headerTokens.count
+        if formatter.tokens.endIndex > endIndex, headerTokens == Array(formatter.tokens[
+            lastHeaderTokenIndex + 1 ... endIndex
+        ]) {
+            lastHeaderTokenIndex += headerTokens.count
+        }
+        let headerLinebreaks = headerTokens.reduce(0) { result, token -> Int in
+            result + (token.isLinebreak ? 1 : 0)
+        }
+        if lastHeaderTokenIndex < formatter.tokens.count - 1 {
+            headerTokens.append(.linebreak(formatter.options.linebreak, headerLinebreaks + 1))
+            if lastHeaderTokenIndex < formatter.tokens.count - 2,
+               !formatter.tokens[lastHeaderTokenIndex + 1 ... lastHeaderTokenIndex + 2].allSatisfy(\.isLinebreak)
+            {
+                headerTokens.append(.linebreak(formatter.options.linebreak, headerLinebreaks + 2))
+            }
+        }
+        if let index = formatter.index(of: .nonSpace, after: lastHeaderTokenIndex, if: {
+            $0.isLinebreak
+        }) {
+            lastHeaderTokenIndex = index
+        }
+        formatter.replaceTokens(in: headerRange.startIndex ..< lastHeaderTokenIndex + 1, with: headerTokens)
+    } examples: {
+        """
         You can use the following tokens in the text:
 
         Token | Description
@@ -97,71 +163,6 @@ public extension FormatRule {
         - // Created 2023-08-10 11:00 GMT
         + // Created 2023-08-10 23:00 GMT+12:00
         ```
-        """,
-        runOnceOnly: true,
-        options: ["header", "dateformat", "timezone"],
-        sharedOptions: ["linebreaks"]
-    ) { formatter in
-        var headerTokens = [Token]()
-        var directives = [String]()
-        switch formatter.options.fileHeader {
-        case .ignore:
-            return
-        case var .replace(string):
-            let file = formatter.options.fileInfo
-            let options = ReplacementOptions(
-                dateFormat: formatter.options.dateFormat,
-                timeZone: formatter.options.timeZone
-            )
-
-            for (key, replacement) in formatter.options.fileInfo.replacements {
-                if let replacementStr = replacement.resolve(file, options) {
-                    while let range = string.range(of: "{\(key.rawValue)}") {
-                        string.replaceSubrange(range, with: replacementStr)
-                    }
-                }
-            }
-            headerTokens = tokenize(string)
-            directives = headerTokens.compactMap {
-                guard case let .commentBody(body) = $0 else {
-                    return nil
-                }
-                return body.commentDirective
-            }
-        }
-
-        guard let headerRange = formatter.headerCommentTokenRange(includingDirectives: directives) else {
-            return
-        }
-
-        if headerTokens.isEmpty {
-            formatter.removeTokens(in: headerRange)
-            return
-        }
-
-        var lastHeaderTokenIndex = headerRange.endIndex - 1
-        let endIndex = lastHeaderTokenIndex + headerTokens.count
-        if formatter.tokens.endIndex > endIndex, headerTokens == Array(formatter.tokens[
-            lastHeaderTokenIndex + 1 ... endIndex
-        ]) {
-            lastHeaderTokenIndex += headerTokens.count
-        }
-        let headerLinebreaks = headerTokens.reduce(0) { result, token -> Int in
-            result + (token.isLinebreak ? 1 : 0)
-        }
-        if lastHeaderTokenIndex < formatter.tokens.count - 1 {
-            headerTokens.append(.linebreak(formatter.options.linebreak, headerLinebreaks + 1))
-            if lastHeaderTokenIndex < formatter.tokens.count - 2,
-               !formatter.tokens[lastHeaderTokenIndex + 1 ... lastHeaderTokenIndex + 2].allSatisfy(\.isLinebreak)
-            {
-                headerTokens.append(.linebreak(formatter.options.linebreak, headerLinebreaks + 2))
-            }
-        }
-        if let index = formatter.index(of: .nonSpace, after: lastHeaderTokenIndex, if: {
-            $0.isLinebreak
-        }) {
-            lastHeaderTokenIndex = index
-        }
-        formatter.replaceTokens(in: headerRange.startIndex ..< lastHeaderTokenIndex + 1, with: headerTokens)
+        """
     }
 }

--- a/Sources/Rules/GenericExtensions.swift
+++ b/Sources/Rules/GenericExtensions.swift
@@ -14,35 +14,6 @@ public extension FormatRule {
         Use angle brackets (`extension Array<Foo>`) for generic type extensions
         instead of type constraints (`extension Array where Element == Foo`).
         """,
-        examples: """
-        ```diff
-        - extension Array where Element == Foo {}
-        - extension Optional where Wrapped == Foo {}
-        - extension Dictionary where Key == Foo, Value == Bar {}
-        - extension Collection where Element == Foo {}
-        + extension Array<Foo> {}
-        + extension Optional<Foo> {}
-        + extension Dictionary<Key, Value> {}
-        + extension Collection<Foo> {}
-
-        // With `typeSugar` also enabled:
-        - extension Array where Element == Foo {}
-        - extension Optional where Wrapped == Foo {}
-        - extension Dictionary where Key == Foo, Value == Bar {}
-        + extension [Foo] {}
-        + extension Foo? {}
-        + extension [Key: Value] {}
-
-        // Also supports user-defined types!
-        - extension LinkedList where Element == Foo {}
-        - extension Reducer where
-        -     State == FooState,
-        -     Action == FooAction,
-        -     Environment == FooEnvironment {}
-        + extension LinkedList<Foo> {}
-        + extension Reducer<FooState, FooAction, FooEnvironment> {}
-        ```
-        """,
         options: ["generictypes"]
     ) { formatter in
         formatter.forEach(.keyword("extension")) { extensionIndex, _ in
@@ -152,5 +123,35 @@ public extension FormatRule {
             let fullGenericType = "\(extendedType)<\(genericSubtypes)>"
             formatter.replaceToken(at: typeNameIndex, with: tokenize(fullGenericType))
         }
+    } examples: {
+        """
+        ```diff
+        - extension Array where Element == Foo {}
+        - extension Optional where Wrapped == Foo {}
+        - extension Dictionary where Key == Foo, Value == Bar {}
+        - extension Collection where Element == Foo {}
+        + extension Array<Foo> {}
+        + extension Optional<Foo> {}
+        + extension Dictionary<Key, Value> {}
+        + extension Collection<Foo> {}
+
+        // With `typeSugar` also enabled:
+        - extension Array where Element == Foo {}
+        - extension Optional where Wrapped == Foo {}
+        - extension Dictionary where Key == Foo, Value == Bar {}
+        + extension [Foo] {}
+        + extension Foo? {}
+        + extension [Key: Value] {}
+
+        // Also supports user-defined types!
+        - extension LinkedList where Element == Foo {}
+        - extension Reducer where
+        -     State == FooState,
+        -     Action == FooAction,
+        -     Environment == FooEnvironment {}
+        + extension LinkedList<Foo> {}
+        + extension Reducer<FooState, FooAction, FooEnvironment> {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/HoistAwait.swift
+++ b/Sources/Rules/HoistAwait.swift
@@ -12,17 +12,6 @@ public extension FormatRule {
     /// Reposition `await` keyword outside of the current scope.
     static let hoistAwait = FormatRule(
         help: "Move inline `await` keyword(s) to start of expression.",
-        examples: """
-        ```diff
-        - greet(await forename, await surname)
-        + await greet(forename, surname)
-        ```
-
-        ```diff
-        - let foo = String(try await getFoo())
-        + let foo = await String(try getFoo())
-        ```
-        """,
         options: ["asynccapturing"]
     ) { formatter in
         guard formatter.options.swiftVersion >= "5.5" else { return }
@@ -34,5 +23,17 @@ public extension FormatRule {
                 formatter.isSymbol(at: prevIndex, in: formatter.options.asyncCapturing)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - greet(await forename, await surname)
+        + await greet(forename, surname)
+        ```
+
+        ```diff
+        - let foo = String(try await getFoo())
+        + let foo = await String(try getFoo())
+        ```
+        """
     }
 }

--- a/Sources/Rules/HoistPatternLet.swift
+++ b/Sources/Rules/HoistPatternLet.swift
@@ -12,22 +12,6 @@ public extension FormatRule {
     /// Move `let` and `var` inside patterns to the beginning
     static let hoistPatternLet = FormatRule(
         help: "Reposition `let` or `var` bindings within pattern.",
-        examples: """
-        ```diff
-        - (let foo, let bar) = baz()
-        + let (foo, bar) = baz()
-        ```
-
-        ```diff
-        - if case .foo(let bar, let baz) = quux {
-            // inner foo
-          }
-
-        + if case let .foo(bar, baz) = quux {
-            // inner foo
-          }
-        ```
-        """,
         options: ["patternlet"]
     ) { formatter in
         formatter.forEach(.startOfScope("(")) { i, _ in
@@ -145,6 +129,23 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - (let foo, let bar) = baz()
+        + let (foo, bar) = baz()
+        ```
+
+        ```diff
+        - if case .foo(let bar, let baz) = quux {
+            // inner foo
+          }
+
+        + if case let .foo(bar, baz) = quux {
+            // inner foo
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/HoistTry.swift
+++ b/Sources/Rules/HoistTry.swift
@@ -11,17 +11,6 @@ import Foundation
 public extension FormatRule {
     static let hoistTry = FormatRule(
         help: "Move inline `try` keyword(s) to start of expression.",
-        examples: """
-        ```diff
-        - foo(try bar(), try baz())
-        + try foo(bar(), baz())
-        ```
-
-        ```diff
-        - let foo = String(try await getFoo())
-        + let foo = try String(await getFoo())
-        ```
-        """,
         options: ["throwcapturing"]
     ) { formatter in
         let names = formatter.options.throwCapturing.union(["expect"])
@@ -35,5 +24,17 @@ public extension FormatRule {
                 return name.hasPrefix("XCTAssert") || formatter.isSymbol(at: prevIndex, in: names)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - foo(try bar(), try baz())
+        + try foo(bar(), baz())
+        ```
+
+        ```diff
+        - let foo = String(try await getFoo())
+        + let foo = try String(await getFoo())
+        ```
+        """
     }
 }

--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -14,47 +14,6 @@ public extension FormatRule {
     /// indenting can be configured with the `options` parameter of the formatter.
     static let indent = FormatRule(
         help: "Indent code in accordance with the scope level.",
-        examples: """
-        ```diff
-          if x {
-        -     // foo
-          } else {
-        -     // bar
-        -       }
-
-          if x {
-        +   // foo
-          } else {
-        +   // bar
-        + }
-        ```
-
-        ```diff
-          let array = [
-            foo,
-        -     bar,
-        -       baz
-        -   ]
-
-          let array = [
-            foo,
-        +   bar,
-        +   baz
-        + ]
-        ```
-
-        ```diff
-          switch foo {
-        -   case bar: break
-        -   case baz: break
-          }
-
-          switch foo {
-        + case bar: break
-        + case baz: break
-          }
-        ```
-        """,
         orderAfter: [.trailingSpace, .wrap, .wrapArguments],
         options: ["indent", "tabwidth", "smarttabs", "indentcase", "ifdef", "xcodeindentation", "indentstrings"],
         sharedOptions: ["trimwhitespace", "allman", "wrapconditions", "wrapternary"]
@@ -732,6 +691,48 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+          if x {
+        -     // foo
+          } else {
+        -     // bar
+        -       }
+
+          if x {
+        +   // foo
+          } else {
+        +   // bar
+        + }
+        ```
+
+        ```diff
+          let array = [
+            foo,
+        -     bar,
+        -       baz
+        -   ]
+
+          let array = [
+            foo,
+        +   bar,
+        +   baz
+        + ]
+        ```
+
+        ```diff
+          switch foo {
+        -   case bar: break
+        -   case baz: break
+          }
+
+          switch foo {
+        + case bar: break
+        + case baz: break
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/InitCoderUnavailable.swift
+++ b/Sources/Rules/InitCoderUnavailable.swift
@@ -15,14 +15,6 @@ public extension FormatRule {
         Add `@available(*, unavailable)` attribute to required `init(coder:)` when
         it hasn't been implemented.
         """,
-        examples: """
-        ```diff
-        + @available(*, unavailable)
-          required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-          }
-        ```
-        """,
         options: ["initcodernil"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -64,5 +56,14 @@ public extension FormatRule {
             formatter.insertLinebreak(at: startIndex)
             formatter.insert(unavailableTokens, at: startIndex)
         }
+    } examples: {
+        """
+        ```diff
+        + @available(*, unavailable)
+          required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/IsEmpty.swift
+++ b/Sources/Rules/IsEmpty.swift
@@ -12,23 +12,6 @@ public extension FormatRule {
     /// Replace count == 0 with isEmpty
     static let isEmpty = FormatRule(
         help: "Prefer `isEmpty` over comparing `count` against zero.",
-        examples: """
-        ```diff
-        - if foo.count == 0 {
-        + if foo.isEmpty {
-
-        - if foo.count > 0 {
-        + if !foo.isEmpty {
-
-        - if foo?.count == 0 {
-        + if foo?.isEmpty == true {
-        ```
-
-        ***NOTE:*** In rare cases, the `isEmpty` rule may insert an `isEmpty` call for
-        a type that doesn't implement that property, breaking the program. For this
-        reason, the rule is disabled by default, and must be manually enabled via the
-        `--enable isEmpty` option.
-        """,
         disabledByDefault: true
     ) { formatter in
         formatter.forEach(.identifier("count")) { i, _ in
@@ -108,5 +91,23 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if foo.count == 0 {
+        + if foo.isEmpty {
+
+        - if foo.count > 0 {
+        + if !foo.isEmpty {
+
+        - if foo?.count == 0 {
+        + if foo?.isEmpty == true {
+        ```
+
+        ***NOTE:*** In rare cases, the `isEmpty` rule may insert an `isEmpty` call for
+        a type that doesn't implement that property, breaking the program. For this
+        reason, the rule is disabled by default, and must be manually enabled via the
+        `--enable isEmpty` option.
+        """
     }
 }

--- a/Sources/Rules/LeadingDelimiters.swift
+++ b/Sources/Rules/LeadingDelimiters.swift
@@ -11,15 +11,6 @@ import Foundation
 public extension FormatRule {
     static let leadingDelimiters = FormatRule(
         help: "Move leading delimiters to the end of the previous line.",
-        examples: """
-        ```diff
-        - guard let foo = maybeFoo // first
-        -     , let bar = maybeBar else { ... }
-
-        + guard let foo = maybeFoo, // first
-        +      let bar = maybeBar else { ... }
-        ```
-        """,
         sharedOptions: ["linebreaks"]
     ) { formatter in
         formatter.forEach(.delimiter) { i, _ in
@@ -42,5 +33,15 @@ public extension FormatRule {
             formatter.insert(comment, at: endOfLine + 1)
             formatter.removeTokens(in: startIndex + 1 ..< endOfLine)
         }
+    } examples: {
+        """
+        ```diff
+        - guard let foo = maybeFoo // first
+        -     , let bar = maybeBar else { ... }
+
+        + guard let foo = maybeFoo, // first
+        +      let bar = maybeBar else { ... }
+        ```
+        """
     }
 }

--- a/Sources/Rules/MarkTypes.swift
+++ b/Sources/Rules/MarkTypes.swift
@@ -11,21 +11,6 @@ import Foundation
 public extension FormatRule {
     static let markTypes = FormatRule(
         help: "Add a MARK comment before top-level types and extensions.",
-        examples: """
-        ```diff
-        + // MARK: - FooViewController
-        +
-         final class FooViewController: UIViewController { }
-
-        + // MARK: UICollectionViewDelegate
-        +
-         extension FooViewController: UICollectionViewDelegate { }
-
-        + // MARK: - String + FooProtocol
-        +
-         extension String: FooProtocol { }
-        ```
-        """,
         runOnceOnly: true,
         disabledByDefault: true,
         options: ["marktypes", "typemark", "markextensions", "extensionmark", "groupedextension"],
@@ -263,5 +248,21 @@ public extension FormatRule {
 
         let updatedTokens = declarations.flatMap(\.tokens)
         formatter.replaceTokens(in: 0 ..< formatter.tokens.count, with: updatedTokens)
+    } examples: {
+        """
+        ```diff
+        + // MARK: - FooViewController
+        +
+         final class FooViewController: UIViewController { }
+
+        + // MARK: UICollectionViewDelegate
+        +
+         extension FooViewController: UICollectionViewDelegate { }
+
+        + // MARK: - String + FooProtocol
+        +
+         extension String: FooProtocol { }
+        ```
+        """
     }
 }

--- a/Sources/Rules/ModifierOrder.swift
+++ b/Sources/Rules/ModifierOrder.swift
@@ -12,25 +12,6 @@ public extension FormatRule {
     /// Standardise the order of property modifiers
     static let modifierOrder = FormatRule(
         help: "Use consistent ordering for member modifiers.",
-        examples: """
-        ```diff
-        - lazy public weak private(set) var foo: UIView?
-        + public private(set) lazy weak var foo: UIView?
-        ```
-
-        ```diff
-        - final public override func foo()
-        + override public final func foo()
-        ```
-
-        ```diff
-        - convenience private init()
-        + private convenience init()
-        ```
-
-        **NOTE:** If the `--modifierorder` option isn't set, the default order will be:
-        `\(_FormatRules.defaultModifierOrder.flatMap { $0 }.joined(separator: "`, `"))`
-        """,
         options: ["modifierorder"]
     ) { formatter in
         formatter.forEach(.keyword) { i, token in
@@ -89,6 +70,26 @@ public extension FormatRule {
             }
             formatter.replaceTokens(in: lastIndex ..< i, with: sortedModifiers)
         }
+    } examples: {
+        """
+        ```diff
+        - lazy public weak private(set) var foo: UIView?
+        + public private(set) lazy weak var foo: UIView?
+        ```
+
+        ```diff
+        - final public override func foo()
+        + override public final func foo()
+        ```
+
+        ```diff
+        - convenience private init()
+        + private convenience init()
+        ```
+
+        **NOTE:** If the `--modifierorder` option isn't set, the default order will be:
+        `\(_FormatRules.defaultModifierOrder.flatMap { $0 }.joined(separator: "`, `"))`
+        """
     }
 }
 

--- a/Sources/Rules/NoExplicitOwnership.swift
+++ b/Sources/Rules/NoExplicitOwnership.swift
@@ -11,12 +11,6 @@ import Foundation
 public extension FormatRule {
     static let noExplicitOwnership = FormatRule(
         help: "Don't use explicit ownership modifiers (borrowing / consuming).",
-        examples: """
-        ```diff
-        - borrowing func foo(_ bar: consuming Bar) { ... }
-        + func foo(_ bar: Bar) { ... }
-        ```
-        """,
         disabledByDefault: true
     ) { formatter in
         formatter.forEachToken { keywordIndex, token in
@@ -49,5 +43,12 @@ public extension FormatRule {
                 formatter.removeTokens(in: keywordIndex ..< nextTokenIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - borrowing func foo(_ bar: consuming Bar) { ... }
+        + func foo(_ bar: Bar) { ... }
+        ```
+        """
     }
 }

--- a/Sources/Rules/NumberFormatting.swift
+++ b/Sources/Rules/NumberFormatting.swift
@@ -17,17 +17,6 @@ public extension FormatRule {
         size (the number of digits in each group) and a threshold (the minimum number of
         digits in a number before grouping is applied).
         """,
-        examples: """
-        ```diff
-        - let color = 0xFF77A5
-        + let color = 0xff77a5
-        ```
-
-        ```diff
-        - let big = 123456.123
-        + let big = 123_456.123
-        ```
-        """,
         options: ["decimalgrouping", "binarygrouping", "octalgrouping", "hexgrouping",
                   "fractiongrouping", "exponentgrouping", "hexliteralcase", "exponentcase"]
     ) { formatter in
@@ -89,6 +78,18 @@ public extension FormatRule {
             }
             formatter.replaceToken(at: i, with: .number(result, type))
         }
+    } examples: {
+        """
+        ```diff
+        - let color = 0xFF77A5
+        + let color = 0xff77a5
+        ```
+
+        ```diff
+        - let big = 123456.123
+        + let big = 123_456.123
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/OpaqueGenericParameters.swift
+++ b/Sources/Rules/OpaqueGenericParameters.swift
@@ -16,30 +16,6 @@ public extension FormatRule {
         primary associated types for common standard library types, so definitions like
         `T where T: Collection, T.Element == Foo` are updated to `some Collection<Foo>`.
         """,
-        examples: """
-        ```diff
-        - func handle<T: Fooable>(_ value: T) {
-        + func handle(_ value: some Fooable) {
-              print(value)
-          }
-
-        - func handle<T>(_ value: T) where T: Fooable, T: Barable {
-        + func handle(_ value: some Fooable & Barable) {
-              print(value)
-          }
-
-        - func handle<T: Collection>(_ value: T) where T.Element == Foo {
-        + func handle(_ value: some Collection<Foo>) {
-              print(value)
-          }
-
-        // With `--someany enabled` (the default)
-        - func handle<T>(_ value: T) {
-        + func handle(_ value: some Any) {
-              print(value)
-          }
-        ```
-        """,
         options: ["someany"]
     ) { formatter in
         formatter.forEach(.keyword) { keywordIndex, keyword in
@@ -293,5 +269,30 @@ public extension FormatRule {
                 formatter.removeTokens(in: genericSignatureStartIndex ... newGenericSignatureEndIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - func handle<T: Fooable>(_ value: T) {
+        + func handle(_ value: some Fooable) {
+              print(value)
+          }
+
+        - func handle<T>(_ value: T) where T: Fooable, T: Barable {
+        + func handle(_ value: some Fooable & Barable) {
+              print(value)
+          }
+
+        - func handle<T: Collection>(_ value: T) where T.Element == Foo {
+        + func handle(_ value: some Collection<Foo>) {
+              print(value)
+          }
+
+        // With `--someany enabled` (the default)
+        - func handle<T>(_ value: T) {
+        + func handle(_ value: some Any) {
+              print(value)
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -11,7 +11,39 @@ import Foundation
 public extension FormatRule {
     static let organizeDeclarations = FormatRule(
         help: "Organize declarations within class, struct, enum, actor, and extension bodies.",
-        examples: """
+        runOnceOnly: true,
+        disabledByDefault: true,
+        orderAfter: [.extensionAccessControl, .redundantFileprivate],
+        options: [
+            "categorymark", "markcategories", "beforemarks",
+            "lifecycle", "organizetypes", "structthreshold", "classthreshold",
+            "enumthreshold", "extensionlength", "organizationmode",
+            "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
+            "groupblanklines", "sortswiftuiprops",
+        ],
+        sharedOptions: ["sortedpatterns", "lineaftermarks"]
+    ) { formatter in
+        guard !formatter.options.fragment else { return }
+
+        formatter.mapRecursiveDeclarations { declaration in
+            switch declaration {
+            // Organize the body of type declarations
+            case let .type(kind, open, body, close, originalRange):
+                let organizedType = formatter.organizeDeclaration((kind, open, body, close))
+                return .type(
+                    kind: organizedType.kind,
+                    open: organizedType.open,
+                    body: organizedType.body,
+                    close: organizedType.close,
+                    originalRange: originalRange
+                )
+
+            case .conditionalCompilation, .declaration:
+                return declaration
+            }
+        }
+    } examples: {
+        """
         Default value for `--visibilityorder` when using `--organizationmode visibility`:
         `\(VisibilityCategory.defaultOrdering(for: .visibility).map(\.rawValue).joined(separator: ", "))`
 
@@ -115,38 +147,7 @@ public extension FormatRule {
         +
          }
         ```
-        """,
-        runOnceOnly: true,
-        disabledByDefault: true,
-        orderAfter: [.extensionAccessControl, .redundantFileprivate],
-        options: [
-            "categorymark", "markcategories", "beforemarks",
-            "lifecycle", "organizetypes", "structthreshold", "classthreshold",
-            "enumthreshold", "extensionlength", "organizationmode",
-            "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
-            "groupblanklines", "sortswiftuiprops",
-        ],
-        sharedOptions: ["sortedpatterns", "lineaftermarks"]
-    ) { formatter in
-        guard !formatter.options.fragment else { return }
-
-        formatter.mapRecursiveDeclarations { declaration in
-            switch declaration {
-            // Organize the body of type declarations
-            case let .type(kind, open, body, close, originalRange):
-                let organizedType = formatter.organizeDeclaration((kind, open, body, close))
-                return .type(
-                    kind: organizedType.kind,
-                    open: organizedType.open,
-                    body: organizedType.body,
-                    close: organizedType.close,
-                    originalRange: originalRange
-                )
-
-            case .conditionalCompilation, .declaration:
-                return declaration
-            }
-        }
+        """
     }
 }
 

--- a/Sources/Rules/PreferForLoop.swift
+++ b/Sources/Rules/PreferForLoop.swift
@@ -11,34 +11,6 @@ import Foundation
 public extension FormatRule {
     static let preferForLoop = FormatRule(
         help: "Convert functional `forEach` calls to for loops.",
-        examples: """
-        ```diff
-          let strings = ["foo", "bar", "baaz"]
-        - strings.forEach { placeholder in
-        + for placeholder in strings {
-              print(placeholder)
-          }
-
-          // Supports anonymous closures
-        - strings.forEach {
-        + for string in strings {
-        -     print($0)
-        +     print(string)
-          }
-
-        - foo.item().bar[2].baazValues(option: true).forEach {
-        + for baazValue in foo.item().bar[2].baazValues(option: true) {
-        -     print($0)
-        +     print(baazValue)
-          }
-
-          // Doesn't affect long multiline functional chains
-          placeholderStrings
-              .filter { $0.style == .fooBar }
-              .map { $0.uppercased() }
-              .forEach { print($0) }
-        ```
-        """,
         options: ["anonymousforeach", "onelineforeach"]
     ) { formatter in
         formatter.forEach(.identifier("forEach")) { forEachIndex, _ in
@@ -259,6 +231,35 @@ public extension FormatRule {
                 with: newTokens
             )
         }
+    } examples: {
+        """
+        ```diff
+          let strings = ["foo", "bar", "baaz"]
+        - strings.forEach { placeholder in
+        + for placeholder in strings {
+              print(placeholder)
+          }
+
+          // Supports anonymous closures
+        - strings.forEach {
+        + for string in strings {
+        -     print($0)
+        +     print(string)
+          }
+
+        - foo.item().bar[2].baazValues(option: true).forEach {
+        + for baazValue in foo.item().bar[2].baazValues(option: true) {
+        -     print($0)
+        +     print(baazValue)
+          }
+
+          // Doesn't affect long multiline functional chains
+          placeholderStrings
+              .filter { $0.style == .fooBar }
+              .map { $0.uppercased() }
+              .forEach { print($0) }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/PreferKeyPath.swift
+++ b/Sources/Rules/PreferKeyPath.swift
@@ -10,16 +10,7 @@ import Foundation
 
 public extension FormatRule {
     static let preferKeyPath = FormatRule(
-        help: "Convert trivial `map { $0.foo }` closures to keyPath-based syntax.",
-        examples: """
-        ```diff
-        - let barArray = fooArray.map { $0.bar }
-        + let barArray = fooArray.map(\\.bar)
-
-        - let barArray = fooArray.compactMap { $0.optionalBar }
-        + let barArray = fooArray.compactMap(\\.optionalBar)
-        ```
-        """
+        help: "Convert trivial `map { $0.foo }` closures to keyPath-based syntax."
     ) { formatter in
         formatter.forEach(.startOfScope("{")) { i, _ in
             guard formatter.options.swiftVersion >= "5.2",
@@ -84,5 +75,15 @@ public extension FormatRule {
             }
             formatter.replaceTokens(in: prevIndex + 1 ... endIndex, with: replacementTokens)
         }
+    } examples: {
+        """
+        ```diff
+        - let barArray = fooArray.map { $0.bar }
+        + let barArray = fooArray.map(\\.bar)
+
+        - let barArray = fooArray.compactMap { $0.optionalBar }
+        + let barArray = fooArray.compactMap(\\.optionalBar)
+        ```
+        """
     }
 }

--- a/Sources/Rules/PropertyType.swift
+++ b/Sources/Rules/PropertyType.swift
@@ -11,33 +11,6 @@ import Foundation
 public extension FormatRule {
     static let propertyType = FormatRule(
         help: "Convert property declarations to use inferred types (`let foo = Foo()`) or explicit types (`let foo: Foo = .init()`).",
-        examples: """
-        ```diff
-        - let foo: Foo = .init()
-        + let foo: Foo = .init()
-
-        - let bar: Bar = .defaultValue
-        + let bar = .defaultValue
-
-        - let baaz: Baaz = .buildBaaz(foo: foo, bar: bar)
-        + let baaz = Baaz.buildBaaz(foo: foo, bar: bar)
-
-          let float: CGFloat = 10.0
-          let array: [String] = []
-          let anyFoo: AnyFoo = foo
-
-          // with --inferredtypes always:
-        - let foo: Foo =
-        + let foo =
-            if condition {
-        -     .init(bar)
-        +     Foo(bar)
-            } else {
-        -     .init(baaz)
-        +     Foo(baaz)
-            }
-        ```
-        """,
         disabledByDefault: true,
         orderAfter: [.redundantType],
         options: ["inferredtypes", "preservesymbols"],
@@ -231,5 +204,33 @@ public extension FormatRule {
                 formatter.insert([.delimiter(":"), .space(" ")] + typeTokens, at: property.identifierIndex + 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let foo: Foo = .init()
+        + let foo: Foo = .init()
+
+        - let bar: Bar = .defaultValue
+        + let bar = .defaultValue
+
+        - let baaz: Baaz = .buildBaaz(foo: foo, bar: bar)
+        + let baaz = Baaz.buildBaaz(foo: foo, bar: bar)
+
+          let float: CGFloat = 10.0
+          let array: [String] = []
+          let anyFoo: AnyFoo = foo
+
+          // with --inferredtypes always:
+        - let foo: Foo =
+        + let foo =
+            if condition {
+        -     .init(bar)
+        +     Foo(bar)
+            } else {
+        -     .init(baaz)
+        +     Foo(baaz)
+            }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantBackticks.swift
+++ b/Sources/Rules/RedundantBackticks.swift
@@ -11,8 +11,16 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant backticks around non-keywords, or in places where keywords don't need escaping
     static let redundantBackticks = FormatRule(
-        help: "Remove redundant backticks around identifiers.",
-        examples: """
+        help: "Remove redundant backticks around identifiers."
+    ) { formatter in
+        formatter.forEach(.identifier) { i, token in
+            guard token.string.first == "`", !formatter.backticksRequired(at: i) else {
+                return
+            }
+            formatter.replaceToken(at: i, with: .identifier(token.unescaped()))
+        }
+    } examples: {
+        """
         ```diff
         - let `infix` = bar
         + let infix = bar
@@ -23,12 +31,5 @@ public extension FormatRule {
         + func foo(with default: Int) {}
         ```
         """
-    ) { formatter in
-        formatter.forEach(.identifier) { i, token in
-            guard token.string.first == "`", !formatter.backticksRequired(at: i) else {
-                return
-            }
-            formatter.replaceToken(at: i, with: .identifier(token.unescaped()))
-        }
     }
 }

--- a/Sources/Rules/RedundantBreak.swift
+++ b/Sources/Rules/RedundantBreak.swift
@@ -11,19 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant `break` keyword from switch cases
     static let redundantBreak = FormatRule(
-        help: "Remove redundant `break` in switch case.",
-        examples: """
-        ```diff
-          switch foo {
-            case bar:
-                print("bar")
-        -       break
-            default:
-                print("default")
-        -       break
-          }
-        ```
-        """
+        help: "Remove redundant `break` in switch case."
     ) { formatter in
         formatter.forEach(.keyword("break")) { i, _ in
             guard formatter.last(.nonSpaceOrCommentOrLinebreak, before: i) != .startOfScope(":"),
@@ -39,5 +27,18 @@ public extension FormatRule {
             }
             formatter.removeTokens(in: startIndex ..< endIndex)
         }
+    } examples: {
+        """
+        ```diff
+          switch foo {
+            case bar:
+                print("bar")
+        -       break
+            default:
+                print("default")
+        -       break
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantClosure.swift
+++ b/Sources/Rules/RedundantClosure.swift
@@ -14,21 +14,6 @@ public extension FormatRule {
         Removes redundant closures bodies, containing a single statement,
         which are called immediately.
         """,
-        examples: """
-        ```diff
-        - let foo = { Foo() }()
-        + let foo = Foo()
-        ```
-
-        ```diff
-        - lazy var bar = {
-        -     Bar(baaz: baaz,
-        -         quux: quux)
-        - }()
-        + lazy var bar = Bar(baaz: baaz,
-        +                    quux: quux)
-        ```
-        """,
         disabledByDefault: false,
         orderAfter: [.redundantReturn]
     ) { formatter in
@@ -204,5 +189,21 @@ public extension FormatRule {
                 formatter.removeTokens(in: startIndex ... closureStartIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let foo = { Foo() }()
+        + let foo = Foo()
+        ```
+
+        ```diff
+        - lazy var bar = {
+        -     Bar(baaz: baaz,
+        -         quux: quux)
+        - }()
+        + lazy var bar = Bar(baaz: baaz,
+        +                    quux: quux)
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantExtensionACL.swift
+++ b/Sources/Rules/RedundantExtensionACL.swift
@@ -11,18 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant access control level modifiers in extensions
     static let redundantExtensionACL = FormatRule(
-        help: "Remove redundant access control modifiers.",
-        examples: """
-        ```diff
-          public extension URL {
-        -   public func queryParameter(_ name: String) -> String { ... }
-          }
-
-          public extension URL {
-        +   func queryParameter(_ name: String) -> String { ... }
-          }
-        ```
-        """
+        help: "Remove redundant access control modifiers."
     ) { formatter in
         formatter.forEach(.keyword("extension")) { i, _ in
             var acl = ""
@@ -42,5 +31,17 @@ public extension FormatRule {
                 endIndex = aclIndex
             }
         }
+    } examples: {
+        """
+        ```diff
+          public extension URL {
+        -   public func queryParameter(_ name: String) -> String { ... }
+          }
+
+          public extension URL {
+        +   func queryParameter(_ name: String) -> String { ... }
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantFileprivate.swift
+++ b/Sources/Rules/RedundantFileprivate.swift
@@ -11,29 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Replace `fileprivate` with `private` where possible
     static let redundantFileprivate = FormatRule(
-        help: "Prefer `private` over `fileprivate` where equivalent.",
-        examples: """
-        ```diff
-        -  fileprivate let someConstant = "someConstant"
-        +  private let someConstant = "someConstant"
-        ```
-
-        In Swift 4 and above, `fileprivate` can also be replaced with `private` for
-        members that are only accessed from extensions in the same file:
-
-        ```diff
-          class Foo {
-        -   fileprivate var foo = "foo"
-        +   private var foo = "foo"
-          }
-
-          extension Foo {
-            func bar() {
-              print(self.foo)
-            }
-          }
-        ```
-        """
+        help: "Prefer `private` over `fileprivate` where equivalent."
     ) { formatter in
         guard !formatter.options.fragment else { return }
 
@@ -117,6 +95,29 @@ public extension FormatRule {
                 formatter.replaceToken(at: i, with: .keyword("private"))
             }
         }
+    } examples: {
+        """
+        ```diff
+        -  fileprivate let someConstant = "someConstant"
+        +  private let someConstant = "someConstant"
+        ```
+
+        In Swift 4 and above, `fileprivate` can also be replaced with `private` for
+        members that are only accessed from extensions in the same file:
+
+        ```diff
+          class Foo {
+        -   fileprivate var foo = "foo"
+        +   private var foo = "foo"
+          }
+
+          extension Foo {
+            func bar() {
+              print(self.foo)
+            }
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantGet.swift
+++ b/Sources/Rules/RedundantGet.swift
@@ -11,20 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant `get {}` clause inside read-only computed property
     static let redundantGet = FormatRule(
-        help: "Remove unneeded `get` clause inside computed properties.",
-        examples: """
-        ```diff
-          var foo: Int {
-        -   get {
-        -     return 5
-        -   }
-          }
-
-          var foo: Int {
-        +   return 5
-          }
-        ```
-        """
+        help: "Remove unneeded `get` clause inside computed properties."
     ) { formatter in
         formatter.forEach(.identifier("get")) { i, _ in
             if formatter.isAccessorKeyword(at: i, checkKeyword: false),
@@ -43,5 +30,19 @@ public extension FormatRule {
                 // TODO: fix-up indenting of lines in between removed braces
             }
         }
+    } examples: {
+        """
+        ```diff
+          var foo: Int {
+        -   get {
+        -     return 5
+        -   }
+          }
+
+          var foo: Int {
+        +   return 5
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantInit.swift
+++ b/Sources/Rules/RedundantInit.swift
@@ -12,12 +12,6 @@ public extension FormatRule {
     /// Strip redundant `.init` from type instantiations
     static let redundantInit = FormatRule(
         help: "Remove explicit `init` if not required.",
-        examples: """
-        ```diff
-        - String.init("text")
-        + String("text")
-        ```
-        """,
         orderAfter: [.propertyType]
     ) { formatter in
         formatter.forEach(.identifier("init")) { initIndex, _ in
@@ -70,5 +64,12 @@ public extension FormatRule {
             formatter.removeTokens(in: initIndex + 1 ..< openParenIndex)
             formatter.removeTokens(in: dotIndex ... initIndex)
         }
+    } examples: {
+        """
+        ```diff
+        - String.init("text")
+        + String("text")
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantInternal.swift
+++ b/Sources/Rules/RedundantInternal.swift
@@ -10,24 +10,7 @@ import Foundation
 
 public extension FormatRule {
     static let redundantInternal = FormatRule(
-        help: "Remove redundant internal access control.",
-        examples: """
-        ```diff
-        - internal class Foo {
-        + class Foo {
-        -     internal let bar: String
-        +     let bar: String
-
-        -     internal func baaz() {}
-        +     func baaz() {}
-
-        -     internal init() {
-        +     init() {
-                  bar = "bar"
-              }
-          }
-        ```
-        """
+        help: "Remove redundant internal access control."
     ) { formatter in
         formatter.forEach(.keyword("internal")) { internalKeywordIndex, _ in
             // Don't remove import acl
@@ -55,5 +38,23 @@ public extension FormatRule {
 
             formatter.removeTokens(in: internalKeywordIndex ... (internalKeywordIndex + 1))
         }
+    } examples: {
+        """
+        ```diff
+        - internal class Foo {
+        + class Foo {
+        -     internal let bar: String
+        +     let bar: String
+
+        -     internal func baaz() {}
+        +     func baaz() {}
+
+        -     internal init() {
+        +     init() {
+                  bar = "bar"
+              }
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantLet.swift
+++ b/Sources/Rules/RedundantLet.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant let/var for unnamed variables
     static let redundantLet = FormatRule(
-        help: "Remove redundant `let`/`var` from ignored variables.",
-        examples: """
-        ```diff
-        - let _ = foo()
-        + _ = foo()
-        ```
-        """
+        help: "Remove redundant `let`/`var` from ignored variables."
     ) { formatter in
         formatter.forEach(.identifier("_")) { i, _ in
             guard formatter.next(.nonSpaceOrCommentOrLinebreak, after: i) != .delimiter(":"),
@@ -44,5 +38,12 @@ public extension FormatRule {
             }
             formatter.removeTokens(in: prevIndex ..< nextNonSpaceIndex)
         }
+    } examples: {
+        """
+        ```diff
+        - let _ = foo()
+        + _ = foo()
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantLetError.swift
+++ b/Sources/Rules/RedundantLetError.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant `let error` from `catch` statements
     static let redundantLetError = FormatRule(
-        help: "Remove redundant `let error` from `catch` clause.",
-        examples: """
-        ```diff
-        - do { ... } catch let error { log(error) }
-        + do { ... } catch { log(error) }
-        ```
-        """
+        help: "Remove redundant `let error` from `catch` clause."
 
     ) { formatter in
         formatter.forEach(.keyword("catch")) { i, _ in
@@ -31,5 +25,12 @@ public extension FormatRule {
                 formatter.removeTokens(in: letIndex ..< scopeIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - do { ... } catch let error { log(error) }
+        + do { ... } catch { log(error) }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantNilInit.swift
+++ b/Sources/Rules/RedundantNilInit.swift
@@ -12,31 +12,6 @@ public extension FormatRule {
     /// Remove or insert  redundant `= nil` initialization for Optional properties
     static let redundantNilInit = FormatRule(
         help: "Remove/insert redundant `nil` default value (Optional vars are nil by default).",
-        examples: """
-        `--nilinit remove`
-
-        ```diff
-        - var foo: Int? = nil
-        + var foo: Int?
-        ```
-
-        ```diff
-        // doesn't apply to `let` properties
-        let foo: Int? = nil
-        ```
-
-        ```diff
-        // doesn't affect non-nil initialization
-        var foo: Int? = 0
-        ```
-
-        `--nilinit insert`
-
-        ```diff
-        - var foo: Int?
-        + var foo: Int? = nil
-        ```
-        """,
         options: ["nilinit"]
     ) { formatter in
         // Check modifiers don't include `lazy`
@@ -69,6 +44,32 @@ public extension FormatRule {
             // Find the nil
             formatter.search(from: i, isStoredProperty: formatter.isStoredProperty(atIntroducerIndex: i))
         }
+    } examples: {
+        """
+        `--nilinit remove`
+
+        ```diff
+        - var foo: Int? = nil
+        + var foo: Int?
+        ```
+
+        ```diff
+        // doesn't apply to `let` properties
+        let foo: Int? = nil
+        ```
+
+        ```diff
+        // doesn't affect non-nil initialization
+        var foo: Int? = 0
+        ```
+
+        `--nilinit insert`
+
+        ```diff
+        - var foo: Int?
+        + var foo: Int? = nil
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantObjc.swift
+++ b/Sources/Rules/RedundantObjc.swift
@@ -11,23 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant @objc annotation
     static let redundantObjc = FormatRule(
-        help: "Remove redundant `@objc` annotations.",
-        examples: """
-        ```diff
-        - @objc @IBOutlet var label: UILabel!
-        + @IBOutlet var label: UILabel!
-        ```
-
-        ```diff
-        - @IBAction @objc func goBack() {}
-        + @IBAction func goBack() {}
-        ```
-
-        ```diff
-        - @objc @NSManaged private var foo: String?
-        + @NSManaged private var foo: String?
-        ```
-        """
+        help: "Remove redundant `@objc` annotations."
     ) { formatter in
         let objcAttributes = [
             "@IBOutlet", "@IBAction", "@IBSegueAction",
@@ -91,6 +75,23 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - @objc @IBOutlet var label: UILabel!
+        + @IBOutlet var label: UILabel!
+        ```
+
+        ```diff
+        - @IBAction @objc func goBack() {}
+        + @IBAction func goBack() {}
+        ```
+
+        ```diff
+        - @objc @NSManaged private var foo: String?
+        + @NSManaged private var foo: String?
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantOptionalBinding.swift
+++ b/Sources/Rules/RedundantOptionalBinding.swift
@@ -13,19 +13,6 @@ public extension FormatRule {
         help: "Remove redundant identifiers in optional binding conditions.",
         // We can convert `if let foo = self.foo` to just `if let foo`,
         // but only if `redundantSelf` can first remove the `self.`.
-        examples: """
-        ```diff
-        - if let foo = foo {
-        + if let foo {
-              print(foo)
-          }
-
-        - guard let self = self else {
-        + guard let self else {
-              return
-          }
-        ```
-        """,
         orderAfter: [.redundantSelf]
     ) { formatter in
         formatter.forEachToken { i, token in
@@ -52,5 +39,19 @@ public extension FormatRule {
                 formatter.removeTokens(in: identiferIndex + 1 ... nextIdentifierIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if let foo = foo {
+        + if let foo {
+              print(foo)
+          }
+
+        - guard let self = self else {
+        + guard let self else {
+              return
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantParens.swift
+++ b/Sources/Rules/RedundantParens.swift
@@ -11,28 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant parens around the arguments for loops, if statements, closures, etc.
     static let redundantParens = FormatRule(
-        help: "Remove redundant parentheses.",
-        examples: """
-        ```diff
-        - if (foo == true) {}
-        + if foo == true {}
-        ```
-
-        ```diff
-        - while (i < bar.count) {}
-        + while i < bar.count {}
-        ```
-
-        ```diff
-        - queue.async() { ... }
-        + queue.async { ... }
-        ```
-
-        ```diff
-        - let foo: Int = ({ ... })()
-        + let foo: Int = { ... }()
-        ```
-        """
+        help: "Remove redundant parentheses."
     ) { formatter in
         // TODO: unify with conditionals logic in trailingClosures
         let conditionals = Set(["in", "while", "if", "case", "switch", "where", "for", "guard"])
@@ -234,6 +213,28 @@ public extension FormatRule {
                 formatter.removeParen(at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if (foo == true) {}
+        + if foo == true {}
+        ```
+
+        ```diff
+        - while (i < bar.count) {}
+        + while i < bar.count {}
+        ```
+
+        ```diff
+        - queue.async() { ... }
+        + queue.async { ... }
+        ```
+
+        ```diff
+        - let foo: Int = ({ ... })()
+        + let foo: Int = { ... }()
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantPattern.swift
+++ b/Sources/Rules/RedundantPattern.swift
@@ -11,18 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant pattern in case statements
     static let redundantPattern = FormatRule(
-        help: "Remove redundant pattern matching parameter syntax.",
-        examples: """
-        ```diff
-        - if case .foo(_, _) = bar {}
-        + if case .foo = bar {}
-        ```
-
-        ```diff
-        - let (_, _) = bar
-        + let _ = bar
-        ```
-        """
+        help: "Remove redundant pattern matching parameter syntax."
     ) { formatter in
         formatter.forEach(.startOfScope("(")) { i, _ in
             let prevIndex = formatter.index(of: .nonSpaceOrComment, before: i)
@@ -64,6 +53,18 @@ public extension FormatRule {
                 formatter.insert(.space(" "), at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - if case .foo(_, _) = bar {}
+        + if case .foo = bar {}
+        ```
+
+        ```diff
+        - let (_, _) = bar
+        + let _ = bar
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantProperty.swift
+++ b/Sources/Rules/RedundantProperty.swift
@@ -11,15 +11,6 @@ import Foundation
 public extension FormatRule {
     static let redundantProperty = FormatRule(
         help: "Simplifies redundant property definitions that are immediately returned.",
-        examples: """
-        ```diff
-          func foo() -> Foo {
-        -   let foo = Foo()
-        -   return foo
-        +   return Foo()
-          }
-        ```
-        """,
         disabledByDefault: true,
         orderAfter: [.propertyType]
     ) { formatter in
@@ -57,5 +48,15 @@ public extension FormatRule {
                 with: [.keyword("return"), .space(" ")]
             )
         }
+    } examples: {
+        """
+        ```diff
+          func foo() -> Foo {
+        -   let foo = Foo()
+        -   return foo
+        +   return Foo()
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantRawValues.swift
+++ b/Sources/Rules/RedundantRawValues.swift
@@ -11,20 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant raw string values for case statements
     static let redundantRawValues = FormatRule(
-        help: "Remove redundant raw string values for enum cases.",
-        examples: """
-        ```diff
-          enum Foo: String {
-        -   case bar = "bar"
-            case baz = "quux"
-          }
-
-          enum Foo: String {
-        +   case bar
-            case baz = "quux"
-          }
-        ```
-        """
+        help: "Remove redundant raw string values for enum cases."
     ) { formatter in
         formatter.forEach(.keyword("enum")) { i, _ in
             guard let nameIndex = formatter.index(
@@ -59,5 +46,19 @@ public extension FormatRule {
                 }) ?? formatter.index(of: .keyword("case"), after: index)
             }
         }
+    } examples: {
+        """
+        ```diff
+          enum Foo: String {
+        -   case bar = "bar"
+            case baz = "quux"
+          }
+
+          enum Foo: String {
+        +   case bar
+            case baz = "quux"
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantReturn.swift
+++ b/Sources/Rules/RedundantReturn.swift
@@ -11,30 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove redundant return keyword
     static let redundantReturn = FormatRule(
-        help: "Remove unneeded `return` keyword.",
-        examples: """
-        ```diff
-        - array.filter { return $0.foo == bar }
-        + array.filter { $0.foo == bar }
-
-          // Swift 5.1+ (SE-0255)
-          var foo: String {
-        -     return "foo"
-        +     "foo"
-          }
-
-          // Swift 5.9+ (SE-0380) and with conditionalAssignment rule enabled
-          func foo(_ condition: Bool) -> String {
-              if condition {
-        -         return "foo"
-        +         "foo"
-              } else {
-        -         return "bar"
-        +         "bar"
-              }
-          }
-        ```
-        """
+        help: "Remove unneeded `return` keyword."
     ) { formatter in
         // indices of returns that are safe to remove
         var returnIndices = [Int]()
@@ -181,6 +158,30 @@ public extension FormatRule {
                 formatter.removeTokens(in: returnKeywordRangeToRemove)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - array.filter { return $0.foo == bar }
+        + array.filter { $0.foo == bar }
+
+          // Swift 5.1+ (SE-0255)
+          var foo: String {
+        -     return "foo"
+        +     "foo"
+          }
+
+          // Swift 5.9+ (SE-0380) and with conditionalAssignment rule enabled
+          func foo(_ condition: Bool) -> String {
+              if condition {
+        -         return "foo"
+        +         "foo"
+              } else {
+        -         return "bar"
+        +         "bar"
+              }
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantSelf.swift
+++ b/Sources/Rules/RedundantSelf.swift
@@ -12,7 +12,13 @@ public extension FormatRule {
     /// Insert or remove redundant self keyword
     static let redundantSelf = FormatRule(
         help: "Insert/remove explicit `self` where applicable.",
-        examples: """
+        options: ["self", "selfrequired"]
+    ) { formatter in
+        _ = formatter.options.selfRequired
+        _ = formatter.options.explicitSelf
+        formatter.addOrRemoveSelf(static: false)
+    } examples: {
+        """
         ```diff
           func foobar(foo: Int, bar: Int) {
             self.foo = foo
@@ -52,11 +58,6 @@ public extension FormatRule {
         +   self.baz = 42
           }
         ```
-        """,
-        options: ["self", "selfrequired"]
-    ) { formatter in
-        _ = formatter.options.selfRequired
-        _ = formatter.options.explicitSelf
-        formatter.addOrRemoveSelf(static: false)
+        """
     }
 }

--- a/Sources/Rules/RedundantType.swift
+++ b/Sources/Rules/RedundantType.swift
@@ -12,45 +12,6 @@ public extension FormatRule {
     /// Removes explicit type declarations from initialization declarations
     static let redundantType = FormatRule(
         help: "Remove redundant type from variable declarations.",
-        examples: """
-        ```diff
-        // inferred
-        - let view: UIView = UIView()
-        + let view = UIView()
-
-        // explicit
-        - let view: UIView = UIView()
-        + let view: UIView = .init()
-
-        // infer-locals-only
-          class Foo {
-        -     let view: UIView = UIView()
-        +     let view: UIView = .init()
-
-              func method() {
-        -         let view: UIView = UIView()
-        +         let view = UIView()
-              }
-          }
-
-        // Swift 5.9+, inferred (SE-0380)
-        - let foo: Foo = if condition {
-        + let foo = if condition {
-              Foo("foo")
-          } else {
-              Foo("bar")
-          }
-
-        // Swift 5.9+, explicit (SE-0380)
-          let foo: Foo = if condition {
-        -     Foo("foo")
-        +     .init("foo")
-          } else {
-        -     Foo("bar")
-        +     .init("foo")
-          }
-        ```
-        """,
         options: ["redundanttype"]
     ) { formatter in
         formatter.forEach(.operator("=", .infix)) { i, _ in
@@ -172,6 +133,46 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        // inferred
+        - let view: UIView = UIView()
+        + let view = UIView()
+
+        // explicit
+        - let view: UIView = UIView()
+        + let view: UIView = .init()
+
+        // infer-locals-only
+          class Foo {
+        -     let view: UIView = UIView()
+        +     let view: UIView = .init()
+
+              func method() {
+        -         let view: UIView = UIView()
+        +         let view = UIView()
+              }
+          }
+
+        // Swift 5.9+, inferred (SE-0380)
+        - let foo: Foo = if condition {
+        + let foo = if condition {
+              Foo("foo")
+          } else {
+              Foo("bar")
+          }
+
+        // Swift 5.9+, explicit (SE-0380)
+          let foo: Foo = if condition {
+        -     Foo("foo")
+        +     .init("foo")
+          } else {
+        -     Foo("bar")
+        +     .init("foo")
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/RedundantTypedThrows.swift
+++ b/Sources/Rules/RedundantTypedThrows.swift
@@ -12,19 +12,6 @@ public extension FormatRule {
     static let redundantTypedThrows = FormatRule(
         help: """
         Converts `throws(any Error)` to `throws`, and converts `throws(Never)` to non-throwing.
-        """,
-        examples: """
-        ```diff
-        - func foo() throws(Never) -> Int {
-        + func foo() -> Int {
-              return 0
-          }
-
-        - func foo() throws(any Error) -> Int {
-        + func foo() throws -> Int {
-              throw MyError.foo
-          }
-        ```
         """
     ) { formatter in
         formatter.forEach(.keyword("throws")) { throwsIndex, _ in
@@ -52,5 +39,19 @@ public extension FormatRule {
                 formatter.removeTokens(in: startOfScope ... endOfScope)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - func foo() throws(Never) -> Int {
+        + func foo() -> Int {
+              return 0
+          }
+
+        - func foo() throws(any Error) -> Int {
+        + func foo() throws -> Int {
+              throw MyError.foo
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/RedundantVoidReturnType.swift
+++ b/Sources/Rules/RedundantVoidReturnType.swift
@@ -12,17 +12,6 @@ public extension FormatRule {
     /// Remove redundant void return values for function and closure declarations
     static let redundantVoidReturnType = FormatRule(
         help: "Remove explicit `Void` return type.",
-        examples: """
-        ```diff
-        - func foo() -> Void {
-            // returns nothing
-          }
-
-        + func foo() {
-            // returns nothing
-          }
-        ```
-        """,
         options: ["closurevoid"]
     ) { formatter in
         formatter.forEach(.operator("->", .infix)) { i, _ in
@@ -65,5 +54,17 @@ public extension FormatRule {
             }
             formatter.removeTokens(in: startRemoveIndex ..< formatter.index(of: .nonSpace, after: endIndex)!)
         }
+    } examples: {
+        """
+        ```diff
+        - func foo() -> Void {
+            // returns nothing
+          }
+
+        + func foo() {
+            // returns nothing
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/Semicolons.swift
+++ b/Sources/Rules/Semicolons.swift
@@ -12,24 +12,6 @@ public extension FormatRule {
     /// Remove semicolons, except where doing so would change the meaning of the code
     static let semicolons = FormatRule(
         help: "Remove semicolons.",
-        examples: """
-        ```diff
-        - let foo = 5;
-        + let foo = 5
-        ```
-
-        ```diff
-        - let foo = 5; let bar = 6
-        + let foo = 5
-        + let bar = 6
-        ```
-
-        ```diff
-        // semicolon is not removed if it would affect the behavior of the code
-        return;
-        goto(fail)
-        ```
-        """,
         options: ["semicolons"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -66,5 +48,24 @@ public extension FormatRule {
                 formatter.removeToken(at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let foo = 5;
+        + let foo = 5
+        ```
+
+        ```diff
+        - let foo = 5; let bar = 6
+        + let foo = 5
+        + let bar = 6
+        ```
+
+        ```diff
+        // semicolon is not removed if it would affect the behavior of the code
+        return;
+        goto(fail)
+        ```
+        """
     }
 }

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -15,66 +15,6 @@ public extension FormatRule {
         and declarations between // swiftformat:sort:begin and
         // swiftformat:sort:end comments.
         """,
-        examples: """
-        ```diff
-          // swiftformat:sort
-          enum FeatureFlags {
-        -     case upsellB
-        -     case fooFeature
-        -     case barFeature
-        -     case upsellA(
-        -         fooConfiguration: Foo,
-        -         barConfiguration: Bar)
-        +     case barFeature
-        +     case fooFeature
-        +     case upsellA(
-        +         fooConfiguration: Foo,
-        +         barConfiguration: Bar)
-        +     case upsellB
-          }
-
-        config:
-        ```
-            sortedpatterns: 'Feature'
-        ```
-
-          enum FeatureFlags {
-        -     case upsellB
-        -     case fooFeature
-        -     case barFeature
-        -     case upsellA(
-        -         fooConfiguration: Foo,
-        -         barConfiguration: Bar)
-        +     case barFeature
-        +     case fooFeature
-        +     case upsellA(
-        +         fooConfiguration: Foo,
-        +         barConfiguration: Bar)
-        +     case upsellB
-          }
-
-          enum FeatureFlags {
-              // swiftformat:sort:begin
-        -     case upsellB
-        -     case fooFeature
-        -     case barFeature
-        -     case upsellA(
-        -         fooConfiguration: Foo,
-        -         barConfiguration: Bar)
-        +     case barFeature
-        +     case fooFeature
-        +     case upsellA(
-        +         fooConfiguration: Foo,
-        +         barConfiguration: Bar)
-        +     case upsellB
-              // swiftformat:sort:end
-
-              var anUnsortedProperty: Foo {
-                  Foo()
-              }
-          }
-        ```
-        """,
         options: ["sortedpatterns"],
         sharedOptions: ["organizetypes"]
     ) { formatter in
@@ -211,5 +151,66 @@ public extension FormatRule {
                 )
             }
         }
+    } examples: {
+        """
+        ```diff
+          // swiftformat:sort
+          enum FeatureFlags {
+        -     case upsellB
+        -     case fooFeature
+        -     case barFeature
+        -     case upsellA(
+        -         fooConfiguration: Foo,
+        -         barConfiguration: Bar)
+        +     case barFeature
+        +     case fooFeature
+        +     case upsellA(
+        +         fooConfiguration: Foo,
+        +         barConfiguration: Bar)
+        +     case upsellB
+          }
+
+        config:
+        ```
+            sortedpatterns: 'Feature'
+        ```
+
+          enum FeatureFlags {
+        -     case upsellB
+        -     case fooFeature
+        -     case barFeature
+        -     case upsellA(
+        -         fooConfiguration: Foo,
+        -         barConfiguration: Bar)
+        +     case barFeature
+        +     case fooFeature
+        +     case upsellA(
+        +         fooConfiguration: Foo,
+        +         barConfiguration: Bar)
+        +     case upsellB
+          }
+
+          enum FeatureFlags {
+              // swiftformat:sort:begin
+        -     case upsellB
+        -     case fooFeature
+        -     case barFeature
+        -     case upsellA(
+        -         fooConfiguration: Foo,
+        -         barConfiguration: Bar)
+        +     case barFeature
+        +     case fooFeature
+        +     case upsellA(
+        +         fooConfiguration: Foo,
+        +         barConfiguration: Bar)
+        +     case upsellB
+              // swiftformat:sort:end
+
+              var anUnsortedProperty: Foo {
+                  Foo()
+              }
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/SortImports.swift
+++ b/Sources/Rules/SortImports.swift
@@ -12,29 +12,6 @@ public extension FormatRule {
     /// Sort import statements
     static let sortImports = FormatRule(
         help: "Sort import statements alphabetically.",
-        examples: """
-        ```diff
-        - import Foo
-        - import Bar
-        + import Bar
-        + import Foo
-        ```
-
-        ```diff
-        - import B
-        - import A
-        - #if os(iOS)
-        -   import Foo-iOS
-        -   import Bar-iOS
-        - #endif
-        + import A
-        + import B
-        + #if os(iOS)
-        +   import Bar-iOS
-        +   import Foo-iOS
-        + #endif
-        ```
-        """,
         options: ["importgrouping"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
@@ -56,6 +33,30 @@ public extension FormatRule {
             }
             formatter.replaceTokens(in: range, with: sortedTokens)
         }
+    } examples: {
+        """
+        ```diff
+        - import Foo
+        - import Bar
+        + import Bar
+        + import Foo
+        ```
+
+        ```diff
+        - import B
+        - import A
+        - #if os(iOS)
+        -   import Foo-iOS
+        -   import Bar-iOS
+        - #endif
+        + import A
+        + import B
+        + #if os(iOS)
+        +   import Bar-iOS
+        +   import Foo-iOS
+        + #endif
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/SortTypealiases.swift
+++ b/Sources/Rules/SortTypealiases.swift
@@ -10,21 +10,7 @@ import Foundation
 
 public extension FormatRule {
     static let sortTypealiases = FormatRule(
-        help: "Sort protocol composition typealiases alphabetically.",
-        examples: """
-        ```diff
-        - typealias Placeholders = Foo & Bar & Baaz & Quux
-        + typealias Placeholders = Baaz & Bar & Foo & Quux
-
-          typealias Dependencies
-        -     = FooProviding
-        +     = BaazProviding
-              & BarProviding
-        -     & BaazProviding
-        +     & FooProviding
-              & QuuxProviding
-        ```
-        """
+        help: "Sort protocol composition typealiases alphabetically."
     ) { formatter in
         formatter.forEach(.keyword("typealias")) { typealiasIndex, _ in
             guard let (equalsIndex, andTokenIndices, endIndex) = formatter.parseProtocolCompositionTypealias(at: typealiasIndex),
@@ -145,5 +131,20 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - typealias Placeholders = Foo & Bar & Baaz & Quux
+        + typealias Placeholders = Baaz & Bar & Foo & Quux
+
+          typealias Dependencies
+        -     = FooProviding
+        +     = BaazProviding
+              & BarProviding
+        -     & BaazProviding
+        +     & FooProviding
+              & QuuxProviding
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundBraces.swift
+++ b/Sources/Rules/SpaceAroundBraces.swift
@@ -12,18 +12,7 @@ public extension FormatRule {
     /// Ensure that there is space between an opening brace and the preceding
     /// identifier, and between a closing brace and the following identifier.
     static let spaceAroundBraces = FormatRule(
-        help: "Add or remove space around curly braces.",
-        examples: """
-        ```diff
-        - foo.filter{ return true }.map{ $0 }
-        + foo.filter { return true }.map { $0 }
-        ```
-
-        ```diff
-        - foo( {} )
-        + foo({})
-        ```
-        """
+        help: "Add or remove space around curly braces."
     ) { formatter in
         formatter.forEach(.startOfScope("{")) { i, _ in
             if let prevToken = formatter.token(at: i - 1) {
@@ -46,5 +35,17 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - foo.filter{ return true }.map{ $0 }
+        + foo.filter { return true }.map { $0 }
+        ```
+
+        ```diff
+        - foo( {} )
+        + foo({})
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundBrackets.swift
+++ b/Sources/Rules/SpaceAroundBrackets.swift
@@ -17,18 +17,7 @@ public extension FormatRule {
     /// * There is space between a closing bracket and following identifier
     /// * There is space between a closing bracket and following opening brace
     static let spaceAroundBrackets = FormatRule(
-        help: "Add or remove space around square brackets.",
-        examples: """
-        ```diff
-        - foo as[String]
-        + foo as [String]
-        ```
-
-        ```diff
-        - foo = bar [5]
-        + foo = bar[5]
-        ```
-        """
+        help: "Add or remove space around square brackets."
     ) { formatter in
         formatter.forEach(.startOfScope("[")) { i, _ in
             let index = i - 1
@@ -78,5 +67,17 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - foo as[String]
+        + foo as [String]
+        ```
+
+        ```diff
+        - foo = bar [5]
+        + foo = bar[5]
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundComments.swift
+++ b/Sources/Rules/SpaceAroundComments.swift
@@ -11,18 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Add space around comments, except at the start or end of a line
     static let spaceAroundComments = FormatRule(
-        help: "Add space before and/or after comments.",
-        examples: """
-        ```diff
-        - let a = 5// assignment
-        + let a = 5 // assignment
-        ```
-
-        ```diff
-        - func foo() {/* ... */}
-        + func foo() { /* ... */ }
-        ```
-        """
+        help: "Add space before and/or after comments."
     ) { formatter in
         formatter.forEach(.startOfScope("//")) { i, _ in
             if let prevToken = formatter.token(at: i - 1), !prevToken.isSpaceOrLinebreak {
@@ -53,5 +42,17 @@ public extension FormatRule {
                 formatter.insert(.space(" "), at: startIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let a = 5// assignment
+        + let a = 5 // assignment
+        ```
+
+        ```diff
+        - func foo() {/* ... */}
+        + func foo() { /* ... */ }
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundGenerics.swift
+++ b/Sources/Rules/SpaceAroundGenerics.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Ensure there is no space between an opening chevron and the preceding identifier
     static let spaceAroundGenerics = FormatRule(
-        help: "Remove space around angle brackets.",
-        examples: """
-        ```diff
-        - Foo <Bar> ()
-        + Foo<Bar>()
-        ```
-        """
+        help: "Remove space around angle brackets."
     ) { formatter in
         formatter.forEach(.startOfScope("<")) { i, _ in
             if formatter.token(at: i - 1)?.isSpace == true,
@@ -26,5 +20,12 @@ public extension FormatRule {
                 formatter.removeToken(at: i - 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - Foo <Bar> ()
+        + Foo<Bar>()
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundOperators.swift
+++ b/Sources/Rules/SpaceAroundOperators.swift
@@ -17,22 +17,6 @@ public extension FormatRule {
     ///   preceded by a space, unless it appears at the beginning of a line.
     static let spaceAroundOperators = FormatRule(
         help: "Add or remove space around operators or delimiters.",
-        examples: """
-        ```diff
-        - foo . bar()
-        + foo.bar()
-        ```
-
-        ```diff
-        - a+b+c
-        + a + b + c
-        ```
-
-        ```diff
-        - func ==(lhs: Int, rhs: Int) -> Bool
-        + func == (lhs: Int, rhs: Int) -> Bool
-        ```
-        """,
         options: ["operatorfunc", "nospaceoperators", "ranges", "typedelimiter"]
     ) { formatter in
         formatter.forEachToken { i, token in
@@ -157,5 +141,22 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - foo . bar()
+        + foo.bar()
+        ```
+
+        ```diff
+        - a+b+c
+        + a + b + c
+        ```
+
+        ```diff
+        - func ==(lhs: Int, rhs: Int) -> Bool
+        + func == (lhs: Int, rhs: Int) -> Bool
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceAroundParens.swift
+++ b/Sources/Rules/SpaceAroundParens.swift
@@ -18,18 +18,7 @@ public extension FormatRule {
     /// * There is space between a closing paren and following opening brace
     /// * There is no space between a closing paren and following opening square bracket
     static let spaceAroundParens = FormatRule(
-        help: "Add or remove space around parentheses.",
-        examples: """
-        ```diff
-        - init (foo)
-        + init(foo)
-        ```
-
-        ```diff
-        - switch(x){
-        + switch (x) {
-        ```
-        """
+        help: "Add or remove space around parentheses."
     ) { formatter in
         formatter.forEach(.startOfScope("(")) { i, _ in
             let index = i - 1
@@ -89,6 +78,18 @@ public extension FormatRule {
                 break
             }
         }
+    } examples: {
+        """
+        ```diff
+        - init (foo)
+        + init(foo)
+        ```
+
+        ```diff
+        - switch(x){
+        + switch (x) {
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/SpaceInsideBraces.swift
+++ b/Sources/Rules/SpaceInsideBraces.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Ensure that there is space immediately inside braces
     static let spaceInsideBraces = FormatRule(
-        help: "Add space inside curly braces.",
-        examples: """
-        ```diff
-        - foo.filter {return true}
-        + foo.filter { return true }
-        ```
-        """
+        help: "Add space inside curly braces."
     ) { formatter in
         formatter.forEach(.startOfScope("{")) { i, _ in
             if let nextToken = formatter.token(at: i + 1) {
@@ -37,5 +31,12 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - foo.filter {return true}
+        + foo.filter { return true }
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceInsideBrackets.swift
+++ b/Sources/Rules/SpaceInsideBrackets.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove space immediately inside square brackets
     static let spaceInsideBrackets = FormatRule(
-        help: "Remove space inside square brackets.",
-        examples: """
-        ```diff
-        - [ 1, 2, 3 ]
-        + [1, 2, 3]
-        ```
-        """
+        help: "Remove space inside square brackets."
     ) { formatter in
         formatter.forEach(.startOfScope("[")) { i, _ in
             if formatter.token(at: i + 1)?.isSpace == true,
@@ -33,5 +27,12 @@ public extension FormatRule {
                 formatter.removeToken(at: i - 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - [ 1, 2, 3 ]
+        + [1, 2, 3]
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceInsideComments.swift
+++ b/Sources/Rules/SpaceInsideComments.swift
@@ -12,18 +12,7 @@ public extension FormatRule {
     /// Add space inside comments, taking care not to mangle headerdoc or
     /// carefully preformatted comments, such as star boxes, etc.
     static let spaceInsideComments = FormatRule(
-        help: "Add leading and/or trailing space inside comments.",
-        examples: """
-        ```diff
-        - let a = 5 //assignment
-        + let a = 5 // assignment
-        ```
-
-        ```diff
-        - func foo() { /*...*/ }
-        + func foo() { /* ... */ }
-        ```
-        """
+        help: "Add leading and/or trailing space inside comments."
     ) { formatter in
         formatter.forEach(.startOfScope("//")) { i, _ in
             guard case let .commentBody(string)? = formatter.token(at: i + 1),
@@ -63,5 +52,17 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let a = 5 //assignment
+        + let a = 5 // assignment
+        ```
+
+        ```diff
+        - func foo() { /*...*/ }
+        + func foo() { /* ... */ }
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceInsideGenerics.swift
+++ b/Sources/Rules/SpaceInsideGenerics.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove space immediately inside chevrons
     static let spaceInsideGenerics = FormatRule(
-        help: "Remove space inside angle brackets.",
-        examples: """
-        ```diff
-        - Foo< Bar, Baz >
-        + Foo<Bar, Baz>
-        ```
-        """
+        help: "Remove space inside angle brackets."
     ) { formatter in
         formatter.forEach(.startOfScope("<")) { i, _ in
             if formatter.token(at: i + 1)?.isSpace == true {
@@ -31,5 +25,12 @@ public extension FormatRule {
                 formatter.removeToken(at: i - 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - Foo< Bar, Baz >
+        + Foo<Bar, Baz>
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpaceInsideParens.swift
+++ b/Sources/Rules/SpaceInsideParens.swift
@@ -11,13 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Remove space immediately inside parens
     static let spaceInsideParens = FormatRule(
-        help: "Remove space inside parentheses.",
-        examples: """
-        ```diff
-        - ( a, b)
-        + (a, b)
-        ```
-        """
+        help: "Remove space inside parentheses."
     ) { formatter in
         formatter.forEach(.startOfScope("(")) { i, _ in
             if formatter.token(at: i + 1)?.isSpace == true,
@@ -33,5 +27,12 @@ public extension FormatRule {
                 formatter.removeToken(at: i - 1)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - ( a, b)
+        + (a, b)
+        ```
+        """
     }
 }

--- a/Sources/Rules/SpacingGuards.swift
+++ b/Sources/Rules/SpacingGuards.swift
@@ -6,19 +6,6 @@ import Foundation
 public extension FormatRule {
     static let spacingGuards = FormatRule(
         help: "Remove space between guard statements, and add spaces after last guard.",
-        examples: """
-        ```diff
-            guard let spicy = self.makeSpicy() else {
-                return
-            }
-        -
-            guard let soap = self.clean() else {
-                return
-            }
-        +
-            let doTheJob = nikekov()
-        ```
-        """,
         disabledByDefault: true
     ) { formatter in
         formatter.forEach(.keyword("guard")) { guardIndex, _ in
@@ -45,5 +32,19 @@ public extension FormatRule {
             let indexesBetween = Set(endOfScopeOfGuard + 1 ..< nextNonSpaceAndNonLinebreakIndex)
             formatter.leaveOrSetLinebreaksInIndexes(indexesBetween, linebreaksCount: isGuard ? 1 : 2)
         }
+    } examples: {
+        """
+        ```diff
+            guard let spicy = self.makeSpicy() else {
+                return
+            }
+        -
+            guard let soap = self.clean() else {
+                return
+            }
+        +
+            let doTheJob = nikekov()
+        ```
+        """
     }
 }

--- a/Sources/Rules/StrongOutlets.swift
+++ b/Sources/Rules/StrongOutlets.swift
@@ -11,16 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Strip unnecessary `weak` from @IBOutlet properties (except delegates and datasources)
     static let strongOutlets = FormatRule(
-        help: "Remove `weak` modifier from `@IBOutlet` properties.",
-        examples: """
-        As per Apple's recommendation
-        (https://developer.apple.com/videos/play/wwdc2015/407/ @ 32:30).
-
-        ```diff
-        - @IBOutlet weak var label: UILabel!
-        + @IBOutlet var label: UILabel!
-        ```
-        """
+        help: "Remove `weak` modifier from `@IBOutlet` properties."
     ) { formatter in
         formatter.forEach(.keyword("@IBOutlet")) { i, _ in
             guard let varIndex = formatter.index(of: .keyword("var"), after: i),
@@ -40,5 +31,15 @@ public extension FormatRule {
             }
             formatter.removeToken(at: weakIndex)
         }
+    } examples: {
+        """
+        As per Apple's recommendation
+        (https://developer.apple.com/videos/play/wwdc2015/407/ @ 32:30).
+
+        ```diff
+        - @IBOutlet weak var label: UILabel!
+        + @IBOutlet var label: UILabel!
+        ```
+        """
     }
 }

--- a/Sources/Rules/StrongifiedSelf.swift
+++ b/Sources/Rules/StrongifiedSelf.swift
@@ -11,17 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Removed backticks from `self` when strongifying
     static let strongifiedSelf = FormatRule(
-        help: "Remove backticks around `self` in Optional unwrap expressions.",
-        examples: """
-        ```diff
-        - guard let `self` = self else { return }
-        + guard let self = self else { return }
-        ```
-
-        **NOTE:** assignment to un-escaped `self` is only supported in Swift 4.2 and
-        above, so the `strongifiedSelf` rule is disabled unless the Swift version is
-        set to 4.2 or above.
-        """
+        help: "Remove backticks around `self` in Optional unwrap expressions."
     ) { formatter in
         formatter.forEach(.identifier("`self`")) { i, _ in
             guard formatter.options.swiftVersion >= "4.2",
@@ -34,5 +24,16 @@ public extension FormatRule {
             }
             formatter.replaceToken(at: i, with: .identifier("self"))
         }
+    } examples: {
+        """
+        ```diff
+        - guard let `self` = self else { return }
+        + guard let self = self else { return }
+        ```
+
+        **NOTE:** assignment to un-escaped `self` is only supported in Swift 4.2 and
+        above, so the `strongifiedSelf` rule is disabled unless the Swift version is
+        set to 4.2 or above.
+        """
     }
 }

--- a/Sources/Rules/Todos.swift
+++ b/Sources/Rules/Todos.swift
@@ -11,18 +11,7 @@ import Foundation
 public extension FormatRule {
     /// Ensure that TODO, MARK and FIXME comments are followed by a : as required
     static let todos = FormatRule(
-        help: "Use correct formatting for `TODO:`, `MARK:` or `FIXME:` comments.",
-        examples: """
-        ```diff
-        - /* TODO fix this properly */
-        + /* TODO: fix this properly */
-        ```
-
-        ```diff
-        - // MARK - UIScrollViewDelegate
-        + // MARK: - UIScrollViewDelegate
-        ```
-        """
+        help: "Use correct formatting for `TODO:`, `MARK:` or `FIXME:` comments."
     ) { formatter in
         formatter.forEachToken { i, token in
             guard case var .commentBody(string) = token else {
@@ -76,5 +65,17 @@ public extension FormatRule {
                 formatter.insertSpace(" ", at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - /* TODO fix this properly */
+        + /* TODO: fix this properly */
+        ```
+
+        ```diff
+        - // MARK - UIScrollViewDelegate
+        + // MARK: - UIScrollViewDelegate
+        ```
+        """
     }
 }

--- a/Sources/Rules/TrailingClosures.swift
+++ b/Sources/Rules/TrailingClosures.swift
@@ -12,17 +12,6 @@ public extension FormatRule {
     /// Convert closure arguments to trailing closure syntax where possible
     static let trailingClosures = FormatRule(
         help: "Use trailing closure syntax where applicable.",
-        examples: """
-        ```diff
-        - DispatchQueue.main.async(execute: { ... })
-        + DispatchQueue.main.async {
-        ```
-
-        ```diff
-        - let foo = bar.map({ ... }).joined()
-        + let foo = bar.map { ... }.joined()
-        ```
-        """,
         options: ["trailingclosures", "nevertrailing"]
     ) { formatter in
         let useTrailing = Set([
@@ -75,5 +64,17 @@ public extension FormatRule {
             formatter.replaceTokens(in: startIndex ..< openingBraceIndex, with:
                 wasParen ? [.space(" ")] : [.endOfScope(")"), .space(" ")])
         }
+    } examples: {
+        """
+        ```diff
+        - DispatchQueue.main.async(execute: { ... })
+        + DispatchQueue.main.async {
+        ```
+
+        ```diff
+        - let foo = bar.map({ ... }).joined()
+        + let foo = bar.map { ... }.joined()
+        ```
+        """
     }
 }

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -13,21 +13,6 @@ public extension FormatRule {
     /// This is useful for preventing noise in commits when items are added to end of array.
     static let trailingCommas = FormatRule(
         help: "Add or remove trailing comma from the last item in a collection literal.",
-        examples: """
-        ```diff
-          let array = [
-            foo,
-            bar,
-        -   baz
-          ]
-
-          let array = [
-            foo,
-            bar,
-        +   baz,
-          ]
-        ```
-        """,
         options: ["commas"]
     ) { formatter in
         formatter.forEach(.endOfScope("]")) { i, _ in
@@ -66,5 +51,21 @@ public extension FormatRule {
                 return
             }
         }
+    } examples: {
+        """
+        ```diff
+          let array = [
+            foo,
+            bar,
+        -   baz
+          ]
+
+          let array = [
+            foo,
+            bar,
+        +   baz,
+          ]
+        ```
+        """
     }
 }

--- a/Sources/Rules/TypeSugar.swift
+++ b/Sources/Rules/TypeSugar.swift
@@ -12,22 +12,6 @@ public extension FormatRule {
     /// Replace Array<T>, Dictionary<T, U> and Optional<T> with [T], [T: U] and T?
     static let typeSugar = FormatRule(
         help: "Prefer shorthand syntax for Arrays, Dictionaries and Optionals.",
-        examples: """
-        ```diff
-        - var foo: Array<String>
-        + var foo: [String]
-        ```
-
-        ```diff
-        - var foo: Dictionary<String, Int>
-        + var foo: [String: Int]
-        ```
-
-        ```diff
-        - var foo: Optional<(Int) -> Void>
-        + var foo: ((Int) -> Void)?
-        ```
-        """,
         options: ["shortoptionals"]
     ) { formatter in
         formatter.forEach(.startOfScope("<")) { i, _ in
@@ -117,5 +101,22 @@ public extension FormatRule {
                 formatter.removeTokens(in: swiftTokenIndex ..< typeIndex)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - var foo: Array<String>
+        + var foo: [String]
+        ```
+
+        ```diff
+        - var foo: Dictionary<String, Int>
+        + var foo: [String: Int]
+        ```
+
+        ```diff
+        - var foo: Optional<(Int) -> Void>
+        + var foo: ((Int) -> Void)?
+        ```
+        """
     }
 }

--- a/Sources/Rules/UnusedArguments.swift
+++ b/Sources/Rules/UnusedArguments.swift
@@ -12,37 +12,6 @@ public extension FormatRule {
     /// Replace unused arguments with an underscore
     static let unusedArguments = FormatRule(
         help: "Mark unused function arguments with `_`.",
-        examples: """
-        ```diff
-        - func foo(bar: Int, baz: String) {
-            print("Hello \\(baz)")
-          }
-
-        + func foo(bar _: Int, baz: String) {
-            print("Hello \\(baz)")
-          }
-        ```
-
-        ```diff
-        - func foo(_ bar: Int) {
-            ...
-          }
-
-        + func foo(_: Int) {
-            ...
-          }
-        ```
-
-        ```diff
-        - request { response, data in
-            self.data += data
-          }
-
-        + request { _, data in
-            self.data += data
-          }
-        ```
-        """,
         options: ["stripunusedargs"]
     ) { formatter in
         guard !formatter.options.fragment else { return }
@@ -201,6 +170,38 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - func foo(bar: Int, baz: String) {
+            print("Hello \\(baz)")
+          }
+
+        + func foo(bar _: Int, baz: String) {
+            print("Hello \\(baz)")
+          }
+        ```
+
+        ```diff
+        - func foo(_ bar: Int) {
+            ...
+          }
+
+        + func foo(_: Int) {
+            ...
+          }
+        ```
+
+        ```diff
+        - request { response, data in
+            self.data += data
+          }
+
+        + request { _, data in
+            self.data += data
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/UnusedPrivateDeclaration.swift
+++ b/Sources/Rules/UnusedPrivateDeclaration.swift
@@ -12,15 +12,6 @@ public extension FormatRule {
     /// Remove unused private and fileprivate declarations
     static let unusedPrivateDeclaration = FormatRule(
         help: "Remove unused private and fileprivate declarations.",
-        examples: """
-        ```diff
-          struct Foo {
-        -     fileprivate var foo = "foo"
-        -     fileprivate var baz = "baz"
-              var bar = "bar"
-          }
-        ```
-        """,
         disabledByDefault: true,
         options: ["preservedecls"]
     ) { formatter in
@@ -71,5 +62,15 @@ public extension FormatRule {
                 formatter.removeTokens(in: declaration.originalRange)
             }
         }
+    } examples: {
+        """
+        ```diff
+          struct Foo {
+        -     fileprivate var foo = "foo"
+        -     fileprivate var baz = "baz"
+              var bar = "bar"
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/Void.swift
+++ b/Sources/Rules/Void.swift
@@ -12,32 +12,6 @@ public extension FormatRule {
     /// Normalize the use of void in closure arguments and return values
     static let void = FormatRule(
         help: "Use `Void` for type declarations and `()` for values.",
-        examples: """
-        ```diff
-        - let foo: () -> ()
-        + let foo: () -> Void
-        ```
-
-        ```diff
-        - let bar: Void -> Void
-        + let bar: () -> Void
-        ```
-
-        ```diff
-        - let baz: (Void) -> Void
-        + let baz: () -> Void
-        ```
-
-        ```diff
-        - func quux() -> (Void)
-        + func quux() -> Void
-        ```
-
-        ```diff
-        - callback = { _ in Void() }
-        + callback = { _ in () }
-        ```
-        """,
         options: ["voidtype"]
     ) { formatter in
         let hasLocalVoid = formatter.hasLocalVoid()
@@ -115,6 +89,33 @@ public extension FormatRule {
             }
             // TODO: other cases
         }
+    } examples: {
+        """
+        ```diff
+        - let foo: () -> ()
+        + let foo: () -> Void
+        ```
+
+        ```diff
+        - let bar: Void -> Void
+        + let bar: () -> Void
+        ```
+
+        ```diff
+        - let baz: (Void) -> Void
+        + let baz: () -> Void
+        ```
+
+        ```diff
+        - func quux() -> (Void)
+        + func quux() -> Void
+        ```
+
+        ```diff
+        - callback = { _ in Void() }
+        + callback = { _ in () }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/WrapArguments.swift
+++ b/Sources/Rules/WrapArguments.swift
@@ -12,7 +12,16 @@ public extension FormatRule {
     /// Normalize argument wrapping style
     static let wrapArguments = FormatRule(
         help: "Align wrapped function arguments or collection elements.",
-        examples: """
+        orderAfter: [.wrap],
+        options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "callsiteparen",
+                  "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapeffects", "conditionswrap"],
+        sharedOptions: ["indent", "trimwhitespace", "linebreaks",
+                        "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
+    ) { formatter in
+        formatter.wrapCollectionsAndArguments(completePartialWrapping: true,
+                                              wrapSingleArguments: false)
+    } examples: {
+        """
         **NOTE:** For backwards compatibility with previous versions, if no value is
         provided for `--wrapparameters`, the value for `--wraparguments` will be used.
 
@@ -79,14 +88,6 @@ public extension FormatRule {
           else {}
         ```
 
-        """,
-        orderAfter: [.wrap],
-        options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "callsiteparen",
-                  "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapeffects", "conditionswrap"],
-        sharedOptions: ["indent", "trimwhitespace", "linebreaks",
-                        "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
-    ) { formatter in
-        formatter.wrapCollectionsAndArguments(completePartialWrapping: true,
-                                              wrapSingleArguments: false)
+        """
     }
 }

--- a/Sources/Rules/WrapAttributes.swift
+++ b/Sources/Rules/WrapAttributes.swift
@@ -11,43 +11,6 @@ import Foundation
 public extension FormatRule {
     static let wrapAttributes = FormatRule(
         help: "Wrap @attributes onto a separate line, or keep them on the same line.",
-        examples: """
-        `--funcattributes prev-line`
-
-        ```diff
-        - @objc func foo() {}
-
-        + @objc
-        + func foo() { }
-        ```
-
-        `--funcattributes same-line`
-
-        ```diff
-        - @objc
-        - func foo() { }
-
-        + @objc func foo() {}
-        ```
-
-        `--typeattributes prev-line`
-
-        ```diff
-        - @objc class Foo {}
-
-        + @objc
-        + class Foo { }
-        ```
-
-        `--typeattributes same-line`
-
-        ```diff
-        - @objc
-        - enum Foo { }
-
-        + @objc enum Foo {}
-        ```
-        """,
         options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs", "computedvarattrs", "complexattrs", "noncomplexattrs"],
         sharedOptions: ["linebreaks", "maxwidth"]
     ) { formatter in
@@ -146,6 +109,44 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        `--funcattributes prev-line`
+
+        ```diff
+        - @objc func foo() {}
+
+        + @objc
+        + func foo() { }
+        ```
+
+        `--funcattributes same-line`
+
+        ```diff
+        - @objc
+        - func foo() { }
+
+        + @objc func foo() {}
+        ```
+
+        `--typeattributes prev-line`
+
+        ```diff
+        - @objc class Foo {}
+
+        + @objc
+        + class Foo { }
+        ```
+
+        `--typeattributes same-line`
+
+        ```diff
+        - @objc
+        - enum Foo { }
+
+        + @objc enum Foo {}
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/WrapConditionalBodies.swift
+++ b/Sources/Rules/WrapConditionalBodies.swift
@@ -11,7 +11,17 @@ import Foundation
 public extension FormatRule {
     static let wrapConditionalBodies = FormatRule(
         help: "Wrap the bodies of inline conditional statements onto a new line.",
-        examples: """
+        disabledByDefault: true,
+        sharedOptions: ["linebreaks", "indent"]
+    ) { formatter in
+        formatter.forEachToken(where: { [.keyword("if"), .keyword("else")].contains($0) }) { i, _ in
+            guard let startIndex = formatter.index(of: .startOfScope("{"), after: i) else {
+                return formatter.fatalError("Expected {", at: i)
+            }
+            formatter.wrapStatementBody(at: startIndex)
+        }
+    } examples: {
+        """
         ```diff
         - guard let foo = bar else { return baz }
         + guard let foo = bar else {
@@ -25,15 +35,6 @@ public extension FormatRule {
         +    return bar
         + }
         ```
-        """,
-        disabledByDefault: true,
-        sharedOptions: ["linebreaks", "indent"]
-    ) { formatter in
-        formatter.forEachToken(where: { [.keyword("if"), .keyword("else")].contains($0) }) { i, _ in
-            guard let startIndex = formatter.index(of: .startOfScope("{"), after: i) else {
-                return formatter.fatalError("Expected {", at: i)
-            }
-            formatter.wrapStatementBody(at: startIndex)
-        }
+        """
     }
 }

--- a/Sources/Rules/WrapEnumCases.swift
+++ b/Sources/Rules/WrapEnumCases.swift
@@ -12,18 +12,6 @@ public extension FormatRule {
     /// Formats enum cases declaration into one case per line
     static let wrapEnumCases = FormatRule(
         help: "Rewrite comma-delimited enum cases to one case per line.",
-        examples: """
-        ```diff
-          enum Foo {
-        -   case bar, baz
-          }
-
-          enum Foo {
-        +   case bar
-        +   case baz
-          }
-        ```
-        """,
         disabledByDefault: true,
         options: ["wrapenumcases"],
         sharedOptions: ["linebreaks"]
@@ -62,6 +50,19 @@ public extension FormatRule {
                 formatter.insert([.keyword("case")], at: nextNonSpaceIndex + 1 + offset)
                 formatter.insertSpace(" ", at: nextNonSpaceIndex + 2 + offset)
             }
+    } examples: {
+        """
+        ```diff
+          enum Foo {
+        -   case bar, baz
+          }
+
+          enum Foo {
+        +   case bar
+        +   case baz
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/WrapLoopBodies.swift
+++ b/Sources/Rules/WrapLoopBodies.swift
@@ -11,21 +11,6 @@ import Foundation
 public extension FormatRule {
     static let wrapLoopBodies = FormatRule(
         help: "Wrap the bodies of inline loop statements onto a new line.",
-        examples: """
-        ```diff
-        - for foo in array { print(foo) }
-        + for foo in array {
-        +     print(foo)
-        + }
-        ```
-
-        ```diff
-        - while let foo = bar.next() { print(foo) }
-        + while let foo = bar.next() {
-        +     print(foo)
-        + }
-        ```
-        """,
         orderAfter: [.preferForLoop],
         sharedOptions: ["linebreaks", "indent"]
     ) { formatter in
@@ -40,5 +25,21 @@ public extension FormatRule {
                 return formatter.fatalError("Expected {", at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - for foo in array { print(foo) }
+        + for foo in array {
+        +     print(foo)
+        + }
+        ```
+
+        ```diff
+        - while let foo = bar.next() { print(foo) }
+        + while let foo = bar.next() {
+        +     print(foo)
+        + }
+        ```
+        """
     }
 }

--- a/Sources/Rules/WrapMultilineConditionalAssignment.swift
+++ b/Sources/Rules/WrapMultilineConditionalAssignment.swift
@@ -11,21 +11,6 @@ import Foundation
 public extension FormatRule {
     static let wrapMultilineConditionalAssignment = FormatRule(
         help: "Wrap multiline conditional assignment expressions after the assignment operator.",
-        examples: #"""
-        ```diff
-        - let planetLocation = if let star = planet.star {
-        -     "The \(star.name) system"
-        - } else {
-        -     "Rogue planet"
-        - }
-        + let planetLocation =
-        +     if let star = planet.star {
-        +         "The \(star.name) system"
-        +     } else {
-        +         "Rogue planet"
-        +     }
-        ```
-        """#,
         disabledByDefault: true,
         orderAfter: [.conditionalAssignment],
         sharedOptions: ["linebreaks"]
@@ -71,5 +56,21 @@ public extension FormatRule {
                 formatter.insertLinebreak(at: startOfConditionalExpression - 1)
             }
         }
+    } examples: {
+        #"""
+        ```diff
+        - let planetLocation = if let star = planet.star {
+        -     "The \(star.name) system"
+        - } else {
+        -     "Rogue planet"
+        - }
+        + let planetLocation =
+        +     if let star = planet.star {
+        +         "The \(star.name) system"
+        +     } else {
+        +         "Rogue planet"
+        +     }
+        ```
+        """#
     }
 }

--- a/Sources/Rules/WrapMultilineStatementBraces.swift
+++ b/Sources/Rules/WrapMultilineStatementBraces.swift
@@ -11,7 +11,28 @@ import Foundation
 public extension FormatRule {
     static let wrapMultilineStatementBraces = FormatRule(
         help: "Wrap the opening brace of multiline statements.",
-        examples: """
+        orderAfter: [.braces, .indent, .wrapArguments],
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.forEach(.startOfScope("{")) { i, _ in
+            guard formatter.last(.nonSpaceOrComment, before: i)?.isLinebreak == false,
+                  formatter.shouldWrapMultilineStatementBrace(at: i),
+                  let endIndex = formatter.endOfScope(at: i)
+            else {
+                return
+            }
+            let indent = formatter.currentIndentForLine(at: endIndex)
+            // Insert linebreak
+            formatter.insertLinebreak(at: i)
+            // Align the opening brace with closing brace
+            formatter.insertSpace(indent, at: i + 1)
+            // Clean up trailing space on the previous line
+            if case .space? = formatter.token(at: i - 1) {
+                formatter.removeToken(at: i - 1)
+            }
+        }
+    } examples: {
+        """
         ```diff
           if foo,
         -   bar {
@@ -65,26 +86,6 @@ public extension FormatRule {
             // ...
           }
         ```
-        """,
-        orderAfter: [.braces, .indent, .wrapArguments],
-        sharedOptions: ["linebreaks"]
-    ) { formatter in
-        formatter.forEach(.startOfScope("{")) { i, _ in
-            guard formatter.last(.nonSpaceOrComment, before: i)?.isLinebreak == false,
-                  formatter.shouldWrapMultilineStatementBrace(at: i),
-                  let endIndex = formatter.endOfScope(at: i)
-            else {
-                return
-            }
-            let indent = formatter.currentIndentForLine(at: endIndex)
-            // Insert linebreak
-            formatter.insertLinebreak(at: i)
-            // Align the opening brace with closing brace
-            formatter.insertSpace(indent, at: i + 1)
-            // Clean up trailing space on the previous line
-            if case .space? = formatter.token(at: i - 1) {
-                formatter.removeToken(at: i - 1)
-            }
-        }
+        """
     }
 }

--- a/Sources/Rules/WrapSwitchCases.swift
+++ b/Sources/Rules/WrapSwitchCases.swift
@@ -12,20 +12,6 @@ public extension FormatRule {
     /// Writes one switch case per line
     static let wrapSwitchCases = FormatRule(
         help: "Wrap comma-delimited switch cases onto multiple lines.",
-        examples: """
-        ```diff
-          switch foo {
-        -   case .bar, .baz:
-              break
-          }
-
-          switch foo {
-        +   case .foo,
-        +        .bar:
-              break
-          }
-        ```
-        """,
         disabledByDefault: true,
         sharedOptions: ["linebreaks", "tabwidth", "indent", "smarttabs"]
     ) { formatter in
@@ -46,5 +32,20 @@ public extension FormatRule {
                 startIndex = commaIndex
             }
         }
+    } examples: {
+        """
+        ```diff
+          switch foo {
+        -   case .bar, .baz:
+              break
+          }
+
+          switch foo {
+        +   case .foo,
+        +        .bar:
+              break
+          }
+        ```
+        """
     }
 }


### PR DESCRIPTION
I saw you moved the rule examples from `Examples.swift` into each corresponding rule file. This is a nice improvement! It's good to have the rules more self-contained like this.

One downside of the current organization is that it often moves the rule implementation a lot lower in the file, making it no longer above-the-fold when you open the file. This makes it more challenging to quickly jump to the rule implementation by doing something like command-shift-O and typing in the rule name, which is my normal workflow.

Without examples before the implementation closure:

<img width="1226" alt="Screenshot 2024-08-24 at 2 58 05 PM" src="https://github.com/user-attachments/assets/12d4c962-6fe7-438a-a841-b77712105880">

With examples before the implementation closure:

<img width="1191" alt="Screenshot 2024-08-24 at 2 59 25 PM" src="https://github.com/user-attachments/assets/fbd75bc8-ac70-4769-8204-cae818613fb4">

### Potential improvements

Maybe we can come up with an organization approach that keeps the examples below the rule implementation?

This PR includes one approach I could think of -- we could just move the examples param to be after the rule implementation closure. We could use multiple-trailing-closure syntax for this in a way that I think looks and feels pretty idiomatic. I included some examples of that change in this PR. If you think that sounds reasonable I can apply the change to the remaining rules as well.

Alternatively we could put the examples in a different extension at the bottom of the file, like:

```swift
extension Examples {
  static let sortDeclarations = """
    ...
    """
}
```

and then collect all of the examples with a registry.

I think either would be a nice improvement. What do you think @nicklockwood? I'm happy to work on landing either of these.