### PR TITLE
Windows installer: Avoid usr/bin directory structure

### DIFF
--- a/Platforms/Windows/SwiftFormat.wxs
+++ b/Platforms/Windows/SwiftFormat.wxs
@@ -22,25 +22,21 @@
     <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="ManufacturerFolder" Name="nicklockwood">
         <Directory Id="INSTALLDIR" Name="SwiftFormat">
-          <Directory Id="_usr" Name="usr">
-            <Directory Id="_usr_bin" Name="bin">
-              <Merge Id="SwiftRuntime" DiskId="1" Language="0" SourceFile="$(SwiftRedistDir)\$(MergeModuleFileName)" />
-            </Directory>
-          </Directory>
+          <Merge Id="SwiftRuntime" DiskId="1" Language="0" SourceFile="$(SwiftRedistDir)\$(MergeModuleFileName)" />
         </Directory>
       </Directory>
     </StandardDirectory>
 
-    <Component Directory="_usr_bin" Id="swiftformat.exe">
+    <Component Directory="INSTALLDIR" Id="swiftformat.exe">
       <File Id="swiftformat.exe" Source="$(var.SwiftFormatBuildDir)\swiftformat.exe" Checksum="yes" KeyPath="yes" />
     </Component>
 
     <ComponentGroup Id="EnvironmentVariables">
       <Component Id="SystemEnvironmentVariables" Condition="ALLUSERS=1" Directory="INSTALLDIR" Guid="b46687c3-f836-47e5-9b43-d9fd2552a731">
-        <Environment Id="SystemPath" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]usr\bin" />
+        <Environment Id="SystemPath" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]" />
       </Component>
       <Component Id="UserEnvironmentVariables" Condition="NOT ALLUSERS=1" Directory="INSTALLDIR" Guid="a1c1ada1-6eb3-4e42-a667-6b0720807ce4">
-        <Environment Id="UserPath" Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[INSTALLDIR]usr\bin" />
+        <Environment Id="UserPath" Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[INSTALLDIR]" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
This directory structure is not natural on Windows, especially for installed apps. Changes the installer to put binaries directly into `C:\Program Files\nicklockwood\SwiftFormat`.