### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Snapshots/Euclid/Sources/CSG.swift
+++ b/Snapshots/Euclid/Sources/CSG.swift
@@ -88,7 +88,7 @@ public extension Mesh {
         return reduce(meshes, using: { $0.subtract($1) })
     }
 
-    /// Returns a new mesh reprenting only the volume exclusively occupied by
+    /// Returns a new mesh representing only the volume exclusively occupied by
     /// one shape or the other, but not both.
     ///
     ///     +-------+            +-------+
@@ -124,7 +124,7 @@ public extension Mesh {
         return multimerge(meshes, using: { $0.xor($1) })
     }
 
-    /// Returns a new mesh reprenting the volume shared by both the mesh
+    /// Returns a new mesh representing the volume shared by both the mesh
     /// parameter and the receiver. If these do not intersect, an empty
     /// mesh will be returned.
     ///

--- a/Snapshots/Euclid/Sources/Polygon.swift
+++ b/Snapshots/Euclid/Sources/Polygon.swift
@@ -128,7 +128,7 @@ public extension Polygon {
         return polygons
     }
 
-    /// Tesselates polygon into triangles using the "ear clipping" method
+    /// Tessellates polygon into triangles using the "ear clipping" method
     func triangulate() -> [Polygon] {
         var vertices = self.vertices
         guard vertices.count > 3 else {

--- a/Snapshots/Expression/README.md
+++ b/Snapshots/Expression/README.md
@@ -228,7 +228,7 @@ This is an alphanumeric identifier representing a constant or variable in an exp
 
 Like Swift, Expression allows unicode characters in identifiers, such as emoji and scientific symbols. Unlike Swift, Expression's identifiers may also contain periods (.) as separators, which is useful for name-spacing (as demonstrated in the Layout example app).
 
-The parser also accepts quoted strings as identifiers. Single quotes (') , double quotes (") , or backticks (`) may be used. Since `Expression` only deals with numeric values, it's up to your application to map these string indentifiers to numbers (if you are using [AnyExpression](#anyexpression) then this is handled automatically).
+The parser also accepts quoted strings as identifiers. Single quotes (') , double quotes (") , or backticks (`) may be used. Since `Expression` only deals with numeric values, it's up to your application to map these string identifiers to numbers (if you are using [AnyExpression](#anyexpression) then this is handled automatically).
 
 Unlike regular identifiers, quoted identifiers can contain any unicode character, including spaces. Newlines, quotes and other special characters can be escaped using a backslash (\). Escape sequences are decoded for you, but the outer quotes are retained so you can distinguish strings from other identifiers.
 

--- a/Snapshots/Expression/Sources/AnyExpression.swift
+++ b/Snapshots/Expression/Sources/AnyExpression.swift
@@ -579,7 +579,7 @@ public struct AnyExpression: CustomStringConvertible {
     /// All symbols used in the expression
     public var symbols: Set<Symbol> { return expression.symbols }
 
-    /// Returns the optmized, pretty-printed expression if it was valid
+    /// Returns the optimized, pretty-printed expression if it was valid
     /// Otherwise, returns the original (invalid) expression string
     public var description: String { return describer() }
 }

--- a/Snapshots/Expression/Sources/Expression.swift
+++ b/Snapshots/Expression/Sources/Expression.swift
@@ -508,7 +508,7 @@ public final class Expression: CustomStringConvertible {
         }
     }
 
-    /// Returns the optmized, pretty-printed expression if it was valid
+    /// Returns the optimized, pretty-printed expression if it was valid
     /// Otherwise, returns the original (invalid) expression string
     public var description: String { return root.description }
 

--- a/Snapshots/Issues/1644.swift
+++ b/Snapshots/Issues/1644.swift
@@ -245,7 +245,7 @@ public extension Playdate {
         /// Adds a new menu item that can be checked or unchecked by the player.
         /// - Parameters:
         ///   - title: The title displayed by the menu item.
-        ///   - checked: Wether or not the menu item is checked.
+        ///   - checked: Whether or not the menu item is checked.
         ///   - callback: The callback invoked when the menu item is selected by the user.
         ///   - userdata: The userdata to associate with the menu item.
         /// - Returns: The menu item
@@ -262,7 +262,7 @@ public extension Playdate {
         /// Adds a new menu item that can be checked or unchecked by the player.
         /// - Parameters:
         ///   - title: The title displayed by the menu item.
-        ///   - checked: Wether or not the menu item is checked.
+        ///   - checked: Whether or not the menu item is checked.
         ///   - callback: The callback invoked when the menu item is selected by the user.
         ///   - userdata: The userdata to associate with the menu item.
         /// - Returns: The menu item

--- a/Snapshots/Layout/Layout/LayoutNode+XML.swift
+++ b/Snapshots/Layout/Layout/LayoutNode+XML.swift
@@ -11,7 +11,7 @@ public extension LayoutNode {
     }
 
     /// Creates a LayoutNode from a parse XML file
-    /// The optional `url` parameter tells Layout where the node was loded from
+    /// The optional `url` parameter tells Layout where the node was loaded from
     /// The optional` relativeTo` parameter helps to locate the original source file
     convenience init(xmlData: Data, url: URL? = nil, relativeTo: String? = #file) throws {
         try self.init(layout: Layout(xmlData: xmlData, url: url, relativeTo: relativeTo))

--- a/Snapshots/Layout/Layout/UICollectionView+Layout.swift
+++ b/Snapshots/Layout/Layout/UICollectionView+Layout.swift
@@ -356,7 +356,7 @@ public extension UICollectionView {
             }
             let cell = dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
             if let node = cell.layoutNode {
-                node.update() // Ensure frame is updated before re-use
+                node.update() // Ensure frame is updated before reuse
                 return node
             }
             switch layoutData {

--- a/Snapshots/Layout/README.md
+++ b/Snapshots/Layout/README.md
@@ -1315,7 +1315,7 @@ loadLayout(
 <UISegmentedControl items="firstTwoItems, 'Third'"/>
 ```
 
-You can use the same array literal syntax inside [macros](#macros), if you need to re-use the values:
+You can use the same array literal syntax inside [macros](#macros), if you need to reuse the values:
 
 ```xml
 <UIView>

--- a/Snapshots/Sprinter/README.md
+++ b/Snapshots/Sprinter/README.md
@@ -136,7 +136,7 @@ It may seem cumbersome to have to create a `StringFormat` object before printing
 
 2. The expensive string parsing and `NumberFormatter` initialization steps can be performed once and then stored, not repeated each time the string is displayed.
 
-For these reasons, it's recommended that you store and re-use your `FormatString` objects. You can either do this up-front for all strings, or lazily the first time each string is displayed - whichever makes more sense for your app.
+For these reasons, it's recommended that you store and reuse your `FormatString` objects. You can either do this up-front for all strings, or lazily the first time each string is displayed - whichever makes more sense for your app.
 
 A good approach would be to create a wrapper function that encapsulates your app-specific string requirements. For example, you might want to ignore string format errors in production (since it's too late to fix by that point), and just display a blank string instead. Here is an example wrapper that you might use in your app:
 

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -13,7 +13,7 @@ import Foundation
 /// A declaration, like a property, function, or type.
 /// https://docs.swift.org/swift-book/documentation/the-swift-programming-language/declarations/
 ///
-/// Forms a tree of declaratons, since `type` declarations have a body
+/// Forms a tree of declarations, since `type` declarations have a body
 /// that contains child declarations.
 enum Declaration: Hashable {
     /// A type-like declaration with body of additional declarations (`class`, `struct`, etc)
@@ -345,7 +345,7 @@ extension Formatter {
 
         // Prefer keeping linebreaks at the end of a declaration's tokens,
         // instead of the start of the next delaration's tokens.
-        //  - This inclues any spaces on blank lines, but doesn't include the
+        //  - This includes any spaces on blank lines, but doesn't include the
         //    indentation associated with the next declaration.
         while let linebreakSearchIndex = endOfDeclaration,
               token(at: linebreakSearchIndex + 1)?.isSpaceOrLinebreak == true

--- a/Sources/Rules/PreferForLoop.swift
+++ b/Sources/Rules/PreferForLoop.swift
@@ -272,7 +272,7 @@ extension Formatter {
         //  4. a trailing closure like `map { ... }`
         //  5. Some other combination of parens / subscript like `(foo).`
         //     or even `foo["bar"]()()`.
-        // And any of these can be preceeded by one of the others
+        // And any of these can be preceded by one of the others
         switch tokens[index] {
         case let .identifier(identifierName):
             // Allowlist certain dot chain elements that should be ignored.

--- a/Sources/Rules/SortTypealiases.swift
+++ b/Sources/Rules/SortTypealiases.swift
@@ -111,7 +111,7 @@ public extension FormatRule {
                 }
 
                 // Make sure there's always a linebreak after any comments, to prevent
-                // them from accidentially commenting out following elements of the typealias
+                // them from accidentally commenting out following elements of the typealias
                 if elementIndex != sortedElements.indices.last,
                    sortedElements[elementIndex].allTokens.last?.isComment == true,
                    let nextToken = formatter.nextToken(after: parsedElements[elementIndex].endIndex),

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -559,8 +559,8 @@ class CommandLineTests: XCTestCase {
                 url.path,
             ], in: "")
         }
-        let ouput = try String(contentsOf: outputURL)
-        XCTAssert(ouput.contains("\"rule_id\" : \"emptyBraces\""))
+        let output = try String(contentsOf: outputURL)
+        XCTAssert(output.contains("\"rule_id\" : \"emptyBraces\""))
     }
 
     func testGithubActionsLogReporterEndToEnd() throws {
@@ -655,8 +655,8 @@ class CommandLineTests: XCTestCase {
                 url.path,
             ], in: "")
         }
-        let ouput = try String(contentsOf: outputURL)
-        XCTAssert(ouput.contains("<error line=\"1\" column=\"0\" severity=\"warning\""))
+        let output = try String(contentsOf: outputURL)
+        XCTAssert(output.contains("<error line=\"1\" column=\"0\" severity=\"warning\""))
     }
 
     func testLintCommandOutputsOrganizeDeclarationOrderingViolations() {

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -4515,7 +4515,7 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
-    // MARK: Supressed Conformances
+    // MARK: Suppressed Conformances
 
     func testNoncopyableStructDeclaration() {
         let input = "struct Foo: ~Copyable {}"


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=atleast,filetests,fo,funguses,larvas,lifeycle,indention,inout,ist,puls,setis,theses`
```
./Snapshots/Layout/README.md:1318: re-use ==> reuse
./Snapshots/Layout/Layout/LayoutNode+XML.swift:14: loded ==> loaded
./Snapshots/Layout/Layout/UICollectionView+Layout.swift:359: re-use ==> reuse
./Snapshots/Euclid/Sources/CSG.swift:91: reprenting ==> representing, repenting
./Snapshots/Euclid/Sources/CSG.swift:127: reprenting ==> representing, repenting
./Snapshots/Euclid/Sources/Polygon.swift:131: Tesselates ==> Tessellates
./Snapshots/Sprinter/README.md:139: re-use ==> reuse
./Snapshots/Expression/README.md:231: indentifiers ==> identifiers
./Snapshots/Expression/Sources/AnyExpression.swift:582: optmized ==> optimized
./Snapshots/Expression/Sources/Expression.swift:511: optmized ==> optimized
./Snapshots/Issues/1644.swift:248: Wether ==> Weather, Whether
./Snapshots/Issues/1644.swift:265: Wether ==> Weather, Whether
./Tests/CommandLineTests.swift:506: ouput ==> output
./Tests/CommandLineTests.swift:507: ouput ==> output
./Tests/CommandLineTests.swift:602: ouput ==> output
./Tests/CommandLineTests.swift:603: ouput ==> output
./Tests/TokenizerTests.swift:4518: Supressed ==> Suppressed
./Sources/FormattingHelpers.swift:2031: compliation ==> compilation, complication
./Sources/FormattingHelpers.swift:2206: readded ==> re-added, read
./Sources/Rules.swift:7507: accidentially ==> accidentally
./Sources/Rules.swift:7644: preceeded ==> preceded, proceeded
```
% `codespell --ignore-words-list=atleast,filetests,fo,funguses,larvas,lifecycle,indention,inout,ist,puls,setis,theses --write-changes`

---

`funguses` and `larvas` are incorrect plurals but let's let that slide for now.