### PR TITLE
Fix the arm64 release build workflow

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.revision }}
 
-      - run: swift build -c release -Xswiftc -gnone -Xswiftc -target -Xswiftc ${{ matrix.target-triple }}
+      - run: swift build -c release --triple ${{ matrix.target-triple }} -Xswiftc -gnone
 
       - uses: microsoft/setup-msbuild@v2.0.0
 


### PR DESCRIPTION
The build was failing because the path to the exe couldn't be found https://github.com/nicklockwood/SwiftFormat/actions/runs/10746115398/job/29806432973#step:6:232
The exe was being built under a path that included the default target triple instead of the arm64 one specified, because the target triple was passed to swiftc directly and bypassed SPM, which determines the output folder. The fix is to instead pass the target triple to SPM and let it forward it to swiftc.