### PR TITLE
Change the Windows build workflow to use official Swift releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Oldest working version. 5.6 fails with "error: could not build C module 'CDispatch'"
-          - branch: swift-5.7-release
-            tag: 5.7-RELEASE
+          # Oldest working version.
+          # 5.6 fails with "error: could not build C module 'CDispatch'"
+          # 5.7 fails with "error: expressions are not allowed at the top level" for "XCTMain(tests)"
+          - branch: swift-5.8-release
+            tag: 5.8-RELEASE
           # Version used by the release workflow
           - branch: swift-5.10.1-release
             tag: 5.10.1-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2023-06-05-a
+          - branch: swift-5.6-release
+            tag: 5.6-RELEASE
+          - branch: swift-5.10.1-release # Version used by the release workflow
+            tag: 5.10.1-RELEASE
     runs-on: windows-latest
     name: ${{ matrix.tag }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: swift-5.6-release
-            tag: 5.6-RELEASE
-          - branch: swift-5.10.1-release # Version used by the release workflow
+          # Oldest working version. 5.6 fails with "error: could not build C module 'CDispatch'"
+          - branch: swift-5.7-release
+            tag: 5.7-RELEASE
+          # Version used by the release workflow
+          - branch: swift-5.10.1-release
             tag: 5.10.1-RELEASE
     runs-on: windows-latest
-    name: ${{ matrix.tag }}
+    name: windows (${{ matrix.tag }})
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          tag: 5.10.1-RELEASE
+          tag: 5.10.1-RELEASE # The 5.10 installer is the first that includes the Swift runtime msm files.
           branch: swift-5.10.1-release
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a matrix to the Windows build workflow to build with two Swift versions: a minbar version and the version used by the release workflow, as we should avoid using a development snapshot if we can.