### PR TITLE
Automatically use correct version number when building binaries for custom releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set Version Number
+        run: echo "Using version number $GITHUB_REF_NAME" && sed -i '' "s/let swiftFormatVersion = \"[^\"]*\"/let swiftFormatVersion = \"$GITHUB_REF_NAME\"/" Sources/SwiftFormat.swift
       - name: Build macOS binary
         run: swift build -c release --arch arm64 --arch x86_64
       - name: Upload artifacts
@@ -24,7 +26,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build it
+      - name: Set Version Number
+        run: echo "Using version number $GITHUB_REF_NAME" && sed -i "s/let swiftFormatVersion = \"[^\"]*\"/let swiftFormatVersion = \"$GITHUB_REF_NAME\"/" Sources/SwiftFormat.swift
+      - name: Build Linux binary
         run: |
           swift build --configuration release --static-swift-stdlib --enable-dead-strip
           SWIFTFORMAT_BIN_PATH=`swift build --configuration release --show-bin-path`


### PR DESCRIPTION
When cutting new releases in https://github.com/calda/SwiftFormat/releases, we just tag some commit on `develop`. This means the [version number](https://github.com/nicklockwood/SwiftFormat/blob/main/Sources/SwiftFormat.swift#L35) in `SwiftFormat.swift` is incorrect, which causes occasionally issues with the cache (which is keyed off of this version number string).

The simplest fix is to automate this by making sure the version number in `SwiftFormat.swift` matches the name of the release. This is a no-op in the default case where the version number is already correct, like in this repo, but will help keep the workflow simple in custom cases like our release flow.

Using [this custom release](https://github.com/calda/SwiftFormat/releases/tag/0.55-custom-version-number-test-5) I confirmed that `swiftformat --version` prints `0.55-custom-version-number-test-5` and that the `swiftformat.cache` includes that version number as part of the cache key.