### PR TITLE
Fix issue where forEach with 'guard ... else { return }' would be preserved unnecessarily

### DIFF
--- a/Sources/Rules/PreferForLoop.swift
+++ b/Sources/Rules/PreferForLoop.swift
@@ -167,13 +167,13 @@ public extension FormatRule {
                     return
                 }
 
-                // We can convert `return`s to `continue`, but only when `return` is on its own line.
+                // We can convert `return`s to `continue`, but only when `return` is the last token in the scope.
                 // It's legal to write something like `return print("foo")` in a `forEach` as long as
                 // you're still returning a `Void` value. Since `continue print("foo")` isn't legal,
                 // we should just ignore this closure.
                 if formatter.tokens[closureBodyIndex] == .keyword("return"),
                    let tokenAfterReturnKeyword = formatter.next(.nonSpaceOrComment, after: closureBodyIndex),
-                   !tokenAfterReturnKeyword.isLinebreak
+                   !(tokenAfterReturnKeyword.isLinebreak || tokenAfterReturnKeyword == .endOfScope("}"))
                 {
                     return
                 }

--- a/Tests/Rules/PreferForLoopTests.swift
+++ b/Tests/Rules/PreferForLoopTests.swift
@@ -388,4 +388,22 @@ class PreferForLoopTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .preferForLoop)
     }
+
+    func testConvertsForEachWithGuardElseReturn() {
+        let input = """
+        strings.forEach { string in
+            guard !string.isEmpty else { return }
+            print(string)
+        }
+        """
+
+        let output = """
+        for string in strings {
+            guard !string.isEmpty else { continue }
+            print(string)
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferForLoop, exclude: [.wrapConditionalBodies, .spacingGuards])
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the following `forEach` call would be unnecessarily preserved rather than being converted to a for loop:

```swift
strings.forEach { string in
    guard !string.isEmpty else { return }
    print(string)
}
```

Now it's converted to a for loop as expected:

```swift
for string in strings {
    guard !string.isEmpty else { continue }
    print(string)
}
```