### PR TITLE
Add support for specifying Swift language mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,13 +649,23 @@ Swift version
 
 Most SwiftFormat rules are version-agnostic, but some are applicable only to newer Swift versions. These rules will be disabled automatically if the Swift version is not specified, so to make sure that the full functionality is available you should specify the version of Swift that is used by your project.
 
-You can specify the Swift version in one of two ways:
+You can specify the Swift compiler version in one of two ways:
 
-The preferred option is to add a `.swift-version` file to your project directory. This is a text file that should contain the minimum Swift version supported by your project, and is a standard already used by other tools.
+You can specify your project's Swift compiler version using the `--swiftversion` command line argument. You can also add the `--swiftversion` option to your `.swiftformat` file.
 
-The `.swift-version` file applies hierarchically; If you have submodules in your project that use a different Swift version, you can add separate `.swift-version` files to those directories.
+Another option is to add a `.swift-version` file to your project directory. This is a text file that should contain the minimum Swift version supported by your project, and is also supported by some other tools.
 
-The other option to specify the Swift version using the `--swiftversion` command line argument. Note that this will be overridden by any `.swift-version` files encountered while processing. You can also add the `--swiftversion` option to your `.swiftformat` file.
+The `.swift-version` file applies hierarchically; If you have submodules in your project that use a different Swift version, you can add separate `.swift-version` files to those directories. The `--swiftversion` argument takes precedence over any `.swift-version` files.
+
+
+Swift language mode
+-------------------
+
+SwiftFormat also allows you to specify the Swift _language mode_ used by your project. This is distinct from the Swift compiler version. For example, you can use the Swift 6.0 compiler with either the Swift 5 language mode or the Swift 6 language mode. Some SwiftFormat rules will behave differently under different Swift language modes.
+
+You can specify your project's Swift language mode using the `--languagemode` command line argument. You can also add the `--languagemode` option to your `.swiftformat` file.
+
+If not specified, SwiftFormat uses the default language mode of the specified Swift compiler version. The default language mode in Swift 5.x and Swift 6.x is the Swift 5 language mode. If your project uses the Swift 6 language mode, you should specify `--languagemode 6`.
 
 
 Config file
@@ -867,7 +877,7 @@ FAQ
 
 *Q. What versions of Swift are supported?*
 
-> A. The SwiftFormat framework and command-line tool can be compiled using Swift 4.2 and above, and can format programs written in Swift 4.x or 5. Swift 3.x is no longer actively supported. If you are still using Swift 3.x or earlier and find that SwiftFormat breaks your code, the best solution is probably to revert to an earlier SwiftFormat release, or enable only a small subset of rules. Use the `--swiftversion` argument to enable additional rules specific to later Swift versions.
+> A. The SwiftFormat framework and command-line tool can be compiled using Swift 5.3 and above, and can format programs written in Swift 4.x or 5. Swift 3.x is no longer actively supported. If you are still using Swift 3.x or earlier and find that SwiftFormat breaks your code, the best solution is probably to revert to an earlier SwiftFormat release, or enable only a small subset of rules. Use the `--swiftversion` argument to enable additional rules specific to later Swift versions.
 
 
 *Q. SwiftFormat made changes I didn't want it to. How can I find out which rules to disable?*

--- a/Rules.md
+++ b/Rules.md
@@ -34,6 +34,7 @@
 * [linebreakAtEndOfFile](#linebreakAtEndOfFile)
 * [linebreaks](#linebreaks)
 * [modifierOrder](#modifierOrder)
+* [noFileID](#noFileID)
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferForLoop](#preferForLoop)
@@ -1384,6 +1385,24 @@ Don't use explicit ownership modifiers (borrowing / consuming).
 ```diff
 - borrowing func foo(_ bar: consuming Bar) { ... }
 + func foo(_ bar: Bar) { ... }
+```
+
+</details>
+<br/>
+
+## noFileID
+
+Prefer #file over #fileID.
+
+<details>
+<summary>Examples</summary>
+
+In the Swift 6 language mode and later, #file has the same behavior as #fileID.
+In the Swift 5 language mode, #file matches the behavior of #filePath.
+
+```diff
+- func foo(file: StaticString = #fileID) { ... }
++ func foo(file: StaticString = #file) { ... }
 ```
 
 </details>

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -466,10 +466,15 @@ func argumentsFor(_ options: Options, excludingDefaults: Bool = false) -> [Strin
             else {
                 continue
             }
-            // Special case for swiftVersion
+            // Special case for swiftVersion and languageMode
             // TODO: find a better solution for this
             if descriptor.argumentName == Descriptors.swiftVersion.argumentName,
                value == Version.undefined.rawValue
+            {
+                continue
+            }
+            if descriptor.argumentName == Descriptors.languageMode.argumentName,
+               value == defaultLanguageMode(for: formatOptions.swiftVersion).rawValue
             {
                 continue
             }

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -194,6 +194,7 @@ func printHelp(as type: CLI.OutputType) {
     --fragment         \(stripMarkdown(Descriptors.fragment.help))
     --conflictmarkers  \(stripMarkdown(Descriptors.ignoreConflictMarkers.help))
     --swiftversion     \(stripMarkdown(Descriptors.swiftVersion.help))
+    --languagemode     \(stripMarkdown(Descriptors.languageMode.help))
     --minversion       The minimum SwiftFormat version to be used for these files
     --cache            Path to cache file, or "clear" or "ignore" the default cache
     --dryrun           Run in "dry" mode (without actually changing any files)

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -412,6 +412,7 @@ extension _Descriptors {
             fragment,
             ignoreConflictMarkers,
             swiftVersion,
+            languageMode,
         ]
     }
 
@@ -1254,8 +1255,14 @@ struct _Descriptors {
     let swiftVersion = OptionDescriptor(
         argumentName: "swiftversion",
         displayName: "Swift Version",
-        help: "The version of Swift used in the files being formatted",
+        help: "The Swift compiler version used in the files being formatted",
         keyPath: \.swiftVersion
+    )
+    let languageMode = OptionDescriptor(
+        argumentName: "languagemode",
+        displayName: "Swift Language Mode",
+        help: "The Swift language mode used in the files being formatted",
+        keyPath: \.languageMode
     )
     let preserveSymbols = OptionDescriptor(
         argumentName: "preservesymbols",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -714,6 +714,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var fragment: Bool
     public var ignoreConflictMarkers: Bool
     public var swiftVersion: Version
+    public var languageMode: Version
     public var fileInfo: FileInfo
     public var timeout: TimeInterval
 
@@ -836,6 +837,7 @@ public struct FormatOptions: CustomStringConvertible {
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
                 swiftVersion: Version = .undefined,
+                languageMode: Version? = nil,
                 fileInfo: FileInfo = FileInfo(),
                 timeout: TimeInterval = 1)
     {
@@ -952,6 +954,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers
         self.swiftVersion = swiftVersion
+        self.languageMode = languageMode ?? defaultLanguageMode(for: swiftVersion)
         self.fileInfo = fileInfo
         self.timeout = timeout
     }

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -51,6 +51,7 @@ let ruleRegistry: [String: FormatRule] = [
     "markTypes": .markTypes,
     "modifierOrder": .modifierOrder,
     "noExplicitOwnership": .noExplicitOwnership,
+    "noFileID": .noFileID,
     "numberFormatting": .numberFormatting,
     "opaqueGenericParameters": .opaqueGenericParameters,
     "organizeDeclarations": .organizeDeclarations,

--- a/Sources/Rules/NoFileID.swift
+++ b/Sources/Rules/NoFileID.swift
@@ -1,0 +1,34 @@
+//
+//  NoFileID.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 9/14/24.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let noFileID = FormatRule(
+        help: "Prefer #file over #fileID.")
+    { formatter in
+        // In the Swift 6 lanaguage mode and later, `#file` and `#fileID` have the same behavior.
+        guard formatter.options.languageMode >= "6" else {
+            return
+        }
+
+        formatter.forEach(.keyword("#fileID")) { index, _ in
+            formatter.replaceToken(at: index, with: .keyword("#file"))
+        }
+    } examples: {
+        """
+        In the Swift 6 language mode and later, #file has the same behavior as #fileID.
+        In the Swift 5 language mode, #file matches the behavior of #filePath.
+
+        ```diff
+        - func foo(file: StaticString = #fileID) { ... }
+        + func foo(file: StaticString = #file) { ... }
+        ```
+        """
+    }
+}

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -41,12 +41,35 @@ public let swiftFormatConfigurationFile = ".swiftformat"
 /// The standard Swift version file name
 public let swiftVersionFile = ".swift-version"
 
-/// Supported Swift versions
+/// Supported Swift compiler versions
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
     "6.0",
 ]
+
+/// Supported Swift language modes
+public let languageModes = [
+    "4", "4.2", "5", "6",
+]
+
+/// The default language mode for the given Swift compiler version
+func defaultLanguageMode(for compilerVersion: Version) -> Version {
+    switch compilerVersion {
+    case "4.0" ..< "4.2":
+        return "4"
+    case "4.2":
+        return "4.2"
+    case "5.0" ..< "6.0":
+        return "5"
+    case "6.0"...:
+        // The default language mode in Swift 6.0 is Swift 5 mode.
+        // https://developer.apple.com/documentation/swift/adoptingswift6
+        return "5"
+    default:
+        return .undefined
+    }
+}
 
 /// An enumeration of the types of error that may be thrown by SwiftFormat
 public enum FormatError: Error, CustomStringConvertible, LocalizedError, CustomNSError {

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -620,6 +620,11 @@
 		2E8DE7602C57FEB30032BF25 /* InitCoderUnavailableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F52C57FEB30032BF25 /* InitCoderUnavailableTests.swift */; };
 		2E8DE7612C57FEB30032BF25 /* RedundantFileprivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */; };
 		2E8DE7622C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */; };
+		2E9DE5062C95F9A1000FEDF8 /* NoFileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */; };
+		2E9DE5072C95F9A1000FEDF8 /* NoFileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */; };
+		2E9DE5082C95F9A1000FEDF8 /* NoFileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */; };
+		2E9DE5092C95F9A1000FEDF8 /* NoFileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */; };
+		2E9DE50F2C95FBB6000FEDF8 /* NoFileIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE50A2C95FB4F000FEDF8 /* NoFileIDTests.swift */; };
 		2EF737522C5E881C00128F91 /* CodeOrganizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */; };
 		2EF737542C5E897800128F91 /* ProjectFilePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737532C5E897800128F91 /* ProjectFilePaths.swift */; };
 		2EF737562C5ED19600128F91 /* DocCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737552C5ED19600128F91 /* DocCommentsTests.swift */; };
@@ -997,6 +1002,8 @@
 		2E8DE6F52C57FEB30032BF25 /* InitCoderUnavailableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitCoderUnavailableTests.swift; sourceTree = "<group>"; };
 		2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantFileprivateTests.swift; sourceTree = "<group>"; };
 		2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSingleLineCommentsTests.swift; sourceTree = "<group>"; };
+		2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFileID.swift; sourceTree = "<group>"; };
+		2E9DE50A2C95FB4F000FEDF8 /* NoFileIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFileIDTests.swift; sourceTree = "<group>"; };
 		2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeOrganizationTests.swift; sourceTree = "<group>"; };
 		2EF737532C5E897800128F91 /* ProjectFilePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFilePaths.swift; sourceTree = "<group>"; };
 		2EF737552C5ED19600128F91 /* DocCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocCommentsTests.swift; sourceTree = "<group>"; };
@@ -1253,6 +1260,7 @@
 				2E2BABE12C57F6DD00590239 /* MarkTypes.swift */,
 				2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */,
 				2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */,
+				2E9DE5052C95F9A1000FEDF8 /* NoFileID.swift */,
 				2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */,
 				2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */,
 				2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */,
@@ -1373,6 +1381,7 @@
 				2E8DE6E72C57FEB30032BF25 /* MarkTypesTests.swift */,
 				2E8DE6A02C57FEB30032BF25 /* ModifierOrderTests.swift */,
 				2E8DE6D42C57FEB30032BF25 /* NoExplicitOwnershipTests.swift */,
+				2E9DE50A2C95FB4F000FEDF8 /* NoFileIDTests.swift */,
 				2E8DE6B02C57FEB30032BF25 /* NumberFormattingTests.swift */,
 				2E8DE69E2C57FEB30032BF25 /* OpaqueGenericParametersTests.swift */,
 				2E8DE6E22C57FEB30032BF25 /* OrganizeDeclarationsTests.swift */,
@@ -1912,6 +1921,7 @@
 				2E2BAC0F2C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				2E2BAD072C57F6DD00590239 /* RedundantPattern.swift in Sources */,
 				2E2BACE72C57F6DD00590239 /* TrailingSpace.swift in Sources */,
+				2E9DE5062C95F9A1000FEDF8 /* NoFileID.swift in Sources */,
 				2E2BACEF2C57F6DD00590239 /* ConditionalAssignment.swift in Sources */,
 				9BDB4F1E2C9477FF00C93995 /* PrivateStateVariables.swift in Sources */,
 				2E2BAD172C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */,
@@ -1939,6 +1949,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E9DE50F2C95FBB6000FEDF8 /* NoFileIDTests.swift in Sources */,
 				2E8DE74A2C57FEB30032BF25 /* RedundantExtensionACLTests.swift in Sources */,
 				01A0EAB41D5DB4D000A0A8E3 /* XCTestCase+testFormatting.swift in Sources */,
 				2E8DE7602C57FEB30032BF25 /* InitCoderUnavailableTests.swift in Sources */,
@@ -2198,6 +2209,7 @@
 				2E2BACAC2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
 				01045A9A2119979400D2BE3D /* Arguments.swift in Sources */,
 				580496D62C584E8F004B7DBF /* EmptyExtension.swift in Sources */,
+				2E9DE5072C95F9A1000FEDF8 /* NoFileID.swift in Sources */,
 				2E2BAD482C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
 				2E2BAD082C57F6DD00590239 /* RedundantPattern.swift in Sources */,
 				2E2BAD042C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
@@ -2256,6 +2268,7 @@
 				2E2BACED2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
 				2E2BAC692C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				E487211D201D885A0014845E /* RulesViewController.swift in Sources */,
+				2E9DE5082C95F9A1000FEDF8 /* NoFileID.swift in Sources */,
 				2E2BAC212C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
 				01045A9B2119979400D2BE3D /* Arguments.swift in Sources */,
 				2E2BAC712C57F6DD00590239 /* AssertionFailures.swift in Sources */,
@@ -2401,6 +2414,7 @@
 				2E2BACEE2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
 				2E2BAC6A2C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */,
+				2E9DE5092C95F9A1000FEDF8 /* NoFileID.swift in Sources */,
 				2E2BAC222C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
 				E4E4D3CC2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
 				2E2BAC722C57F6DD00590239 /* AssertionFailures.swift in Sources */,

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -449,7 +449,7 @@ class ArgumentsTests: XCTestCase {
         XCTAssertEqual(swift5Options.languageMode, "5")
 
         let swift6Options = FormatOptions(swiftVersion: "6.0")
-        XCTAssertEqual(swift5Options.languageMode, "5")
+        XCTAssertEqual(swift6Options.languageMode, "5")
 
         let swift6LangModeOptions = FormatOptions(swiftVersion: "6.0", languageMode: "6")
         XCTAssertEqual(swift6LangModeOptions.languageMode, "6")

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -428,12 +428,31 @@ class ArgumentsTests: XCTestCase {
         XCTAssertEqual(args["swiftversion"], "5.1")
     }
 
+    func testParseArgumentsContainingLanguageVersion() throws {
+        let config = "--languagemode 6"
+        let data = Data(config.utf8)
+        let args = try parseConfigFile(data)
+        XCTAssertEqual(args.count, 1)
+        XCTAssertEqual(args["languagemode"], "6")
+    }
+
     func testParseArgumentsContainingDisableAll() throws {
         let config = "--disable all"
         let data = Data(config.utf8)
         let args = try parseConfigFile(data)
         let options = try Options(args, in: "/")
         XCTAssertEqual(options.rules, [])
+    }
+
+    func testPopulatesDefaultLanguageMode() throws {
+        let swift5Options = FormatOptions(swiftVersion: "5.0")
+        XCTAssertEqual(swift5Options.languageMode, "5")
+
+        let swift6Options = FormatOptions(swiftVersion: "6.0")
+        XCTAssertEqual(swift5Options.languageMode, "5")
+
+        let swift6LangModeOptions = FormatOptions(swiftVersion: "6.0", languageMode: "6")
+        XCTAssertEqual(swift6LangModeOptions.languageMode, "6")
     }
 
     // MARK: config file serialization

--- a/Tests/Rules/NoFileIDTests.swift
+++ b/Tests/Rules/NoFileIDTests.swift
@@ -1,0 +1,40 @@
+//
+//  NoFileIDTests.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 9/14/24.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class NoFileIDTests: XCTestCase {
+    func testPreservesFileIDInSwift5Mode() {
+        let input = """
+        func foo(file: StaticString = #fileID) {
+            print(file)
+        }
+        """
+
+        let options = FormatOptions(languageMode: "5")
+        testFormatting(for: input, rule: .noFileID, options: options)
+    }
+
+    func testUpdatesFileIDInSwift6Mode() {
+        let input = """
+        func foo(file: StaticString = #fileID) {
+            print(file)
+        }
+        """
+
+        let output = """
+        func foo(file: StaticString = #file) {
+            print(file)
+        }
+        """
+
+        let options = FormatOptions(languageMode: "6")
+        testFormatting(for: input, output, rule: .noFileID, options: options)
+    }
+}


### PR DESCRIPTION
This PR adds a new `--languagemode` option to support specifying the Swift language mode. This will make it possible for us to add rules that depend on the language mode rather than a just minimum compiler version.

This PR also adds a small new rule that takes advantage of this: in Swift 6 mode, `#file` and `#fileID` have the same behavior, and `#file` is preferred over `#fileID`.