### PR TITLE
Make examples closure required for every FormatRule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -202,6 +202,18 @@ swift version is set to 4.1 or above.
 Replace obsolete @UIApplicationMain and @NSApplicationMain attributes
 with @main for Swift 5.3 and above.
 
+<details>
+<summary>Examples</summary>
+
+```diff
+- @UIApplicationMain
++ @main
+  class AppDelegate: UIResponder, UIApplicationDelegate {}
+```
+
+</details>
+<br/>
+
 ## assertionFailures
 
 Changes all instances of assert(false, ...) to assertionFailure(...)
@@ -393,6 +405,21 @@ Option | Description
 ## blankLinesBetweenChainedFunctions
 
 Remove blank lines between chained functions but keep the linebreaks.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  [0, 1, 2]
+      .map { $0 * 2 }
+-
+-
+-
+      .map { $0 * 3 }
+```
+
+</details>
+<br/>
 
 ## blankLinesBetweenImports
 
@@ -831,6 +858,19 @@ Option | Description
 --- | ---
 `--enumnamespaces` | Change type to enum: "always" (default) or "structs-only"
 
+<details>
+<summary>Examples</summary>
+
+```diff
+- class FeatureConstants {
++ enum FeatureConstants {
+      static let foo = "foo"
+      static let bar = "bar"
+  }
+
+</details>
+<br/>
+
 ## extensionAccessControl
 
 Configure the placement of an extension's access control keyword.
@@ -1022,6 +1062,24 @@ Option | Description
 ## headerFileName
 
 Ensure file name in header comment matches the actual file name.
+
+<details>
+<summary>Examples</summary>
+
+For a file named `Bar.swift`:
+
+```diff
+- //  Foo.swift
++ //  Bar.swift
+  //  SwiftFormat
+  //
+  //  Created by Nick Lockwood on 5/3/23.
+
+  struct Bar {}
+```
+
+</details>
+<br/>
 
 ## hoistAwait
 
@@ -1229,6 +1287,20 @@ Move leading delimiters to the end of the previous line.
 ## linebreakAtEndOfFile
 
 Add empty blank line at end of file.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  struct Foo {↩
+      let bar: Bar↩
+- }
++ }↩
++
+```
+
+</details>
+<br/>
 
 ## linebreaks
 
@@ -2119,6 +2191,23 @@ by using `--self init-only`:
 
 Remove explicit `Self` where applicable.
 
+<details>
+<summary>Examples</summary>
+
+```diff
+  enum Foo {
+      static let bar = Bar()
+
+      static func baaz() -> Bar {
+-         Self.bar()
++         bar()
+      }
+  }
+```
+
+</details>
+<br/>
+
 ## redundantType
 
 Remove redundant type from variable declarations.
@@ -2362,6 +2451,20 @@ Option | Description
 ## sortSwitchCases
 
 Sort switch cases alphabetically.
+
+<details>
+<summary>Examples</summary>
+
+```dif
+  switch self {
+- case .b, .a, .c, .e, .d:
++ case .a, .b, .c, .d, .e:
+      return nil
+  }
+```
+
+</details>
+<br/>
 
 ## sortTypealiases
 
@@ -2750,6 +2853,23 @@ Remove trailing space at end of a line.
 Option | Description
 --- | ---
 `--trimwhitespace` | Trim trailing space: "always" (default) or "nonblank-lines"
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let foo: Foo␣
++ let foo: Foo
+- ␣␣␣␣
++
+- func bar() {␣␣
++ func bar() {
+  ␣␣␣␣print("foo")
+  }
+```
+
+</details>
+<br/>
 
 ## typeSugar
 
@@ -3236,3 +3356,19 @@ Prefer constant values to be on the right-hand-side of expressions.
 Option | Description
 --- | ---
 `--yodaswap` | Swap yoda values: "always" (default) or "literals-only"
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- if 5 == foo,
++ if foo == 5,
+-    nil != bar,
++    bar != nil,
+-    .default == baaz,
++    baaz == .default,
+  { ... }
+```
+
+</details>
+<br/>

--- a/Sources/FormatRule.swift
+++ b/Sources/FormatRule.swift
@@ -45,7 +45,7 @@ public final class FormatRule: Equatable, Comparable, CustomStringConvertible {
     let deprecationMessage: String?
 
     /// Null rule, used for testing
-    static let none: FormatRule = .init(help: "") { _ in }
+    static let none: FormatRule = .init(help: "") { _ in } examples: { nil }
 
     var isDeprecated: Bool {
         deprecationMessage != nil
@@ -63,7 +63,7 @@ public final class FormatRule: Equatable, Comparable, CustomStringConvertible {
          options: [String] = [],
          sharedOptions: [String] = [],
          _ fn: @escaping (Formatter) -> Void,
-         examples: (() -> String)? = nil)
+         examples: () -> String?)
     {
         self.fn = fn
         self.help = help
@@ -73,7 +73,7 @@ public final class FormatRule: Equatable, Comparable, CustomStringConvertible {
         self.options = options
         self.sharedOptions = sharedOptions
         self.deprecationMessage = deprecationMessage
-        self.examples = examples?()
+        self.examples = examples()
     }
 
     public func apply(with formatter: Formatter) {

--- a/Sources/Rules/ApplicationMain.swift
+++ b/Sources/Rules/ApplicationMain.swift
@@ -28,5 +28,13 @@ public extension FormatRule {
         }) { i, _ in
             formatter.replaceToken(at: i, with: .keyword("@main"))
         }
+    } examples: {
+        """
+        ```diff
+        - @UIApplicationMain
+        + @main
+          class AppDelegate: UIResponder, UIApplicationDelegate {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/BlankLinesBetweenChainedFunctions.swift
+++ b/Sources/Rules/BlankLinesBetweenChainedFunctions.swift
@@ -37,5 +37,16 @@ public extension FormatRule {
                 formatter.removeTokens(in: endOfLine + 1 ..< startOfLine)
             }
         }
+    } examples: {
+        """
+        ```diff
+          [0, 1, 2]
+              .map { $0 * 2 }
+        -
+        -
+        -
+              .map { $0 * 3 }
+        ```
+        """
     }
 }

--- a/Sources/Rules/EnumNamespaces.swift
+++ b/Sources/Rules/EnumNamespaces.swift
@@ -57,6 +57,15 @@ public extension FormatRule {
                 }
             }
         }
+    } examples: {
+        """
+        ```diff
+        - class FeatureConstants {
+        + enum FeatureConstants {
+              static let foo = "foo"
+              static let bar = "bar"
+          }
+        """
     }
 }
 

--- a/Sources/Rules/HeaderFileName.swift
+++ b/Sources/Rules/HeaderFileName.swift
@@ -30,5 +30,19 @@ public extension FormatRule {
                 formatter.replaceToken(at: i, with: .commentBody(fileName))
             }
         }
+    } examples: {
+        """
+        For a file named `Bar.swift`:
+
+        ```diff
+        - //  Foo.swift
+        + //  Bar.swift
+          //  SwiftFormat
+          //
+          //  Created by Nick Lockwood on 5/3/23.
+
+          struct Bar {}
+        ```
+        """
     }
 }

--- a/Sources/Rules/LinebreakAtEndOfFile.swift
+++ b/Sources/Rules/LinebreakAtEndOfFile.swift
@@ -30,5 +30,15 @@ public extension FormatRule {
         if formatter.isEnabled, !wasLinebreak {
             formatter.insertLinebreak(at: formatter.tokens.count)
         }
+    } examples: {
+        """
+        ```diff
+          struct Foo {↩
+              let bar: Bar↩
+        - }
+        + }↩
+        +
+        ```
+        """
     }
 }

--- a/Sources/Rules/Linebreaks.swift
+++ b/Sources/Rules/Linebreaks.swift
@@ -17,5 +17,7 @@ public extension FormatRule {
         formatter.forEach(.linebreak) { i, _ in
             formatter.replaceToken(at: i, with: formatter.linebreakToken(for: i))
         }
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/RedundantStaticSelf.swift
+++ b/Sources/Rules/RedundantStaticSelf.swift
@@ -14,5 +14,18 @@ public extension FormatRule {
         help: "Remove explicit `Self` where applicable."
     ) { formatter in
         formatter.addOrRemoveSelf(static: true)
+    } examples: {
+        """
+        ```diff
+          enum Foo {
+              static let bar = Bar()
+
+              static func baaz() -> Bar {
+        -         Self.bar()
+        +         bar()
+              }
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/SortSwitchCases.swift
+++ b/Sources/Rules/SortSwitchCases.swift
@@ -66,6 +66,16 @@ public extension FormatRule {
                     formatter.replaceTokens(in: switchCaseRanges[switchCase.offset].beforeDelimiterRange, with: newTokens)
                 }
             }
+    } examples: {
+        """
+        ```dif
+          switch self {
+        - case .b, .a, .c, .e, .d:
+        + case .a, .b, .c, .d, .e:
+              return nil
+          }
+        ```
+        """
     }
 }
 

--- a/Sources/Rules/SortedImports.swift
+++ b/Sources/Rules/SortedImports.swift
@@ -19,5 +19,7 @@ public extension FormatRule {
         _ = formatter.options.importGrouping
         _ = formatter.options.linebreak
         FormatRule.sortImports.apply(with: formatter)
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/SortedSwitchCases.swift
+++ b/Sources/Rules/SortedSwitchCases.swift
@@ -15,5 +15,7 @@ public extension FormatRule {
         deprecationMessage: "Use sortSwitchCases instead."
     ) { formatter in
         FormatRule.sortSwitchCases.apply(with: formatter)
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/Specifiers.swift
+++ b/Sources/Rules/Specifiers.swift
@@ -17,5 +17,7 @@ public extension FormatRule {
     ) { formatter in
         _ = formatter.options.modifierOrder
         FormatRule.modifierOrder.apply(with: formatter)
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/TrailingSpace.swift
+++ b/Sources/Rules/TrailingSpace.swift
@@ -23,5 +23,18 @@ public extension FormatRule {
                 formatter.removeToken(at: i)
             }
         }
+    } examples: {
+        """
+        ```diff
+        - let foo: Foo␣
+        + let foo: Foo
+        - ␣␣␣␣
+        +
+        - func bar() {␣␣
+        + func bar() {
+          ␣␣␣␣print("foo")
+          }
+        ```
+        """
     }
 }

--- a/Sources/Rules/Wrap.swift
+++ b/Sources/Rules/Wrap.swift
@@ -64,5 +64,7 @@ public extension FormatRule {
 
         formatter.wrapCollectionsAndArguments(completePartialWrapping: true,
                                               wrapSingleArguments: true)
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/WrapSingleLineComments.swift
+++ b/Sources/Rules/WrapSingleLineComments.swift
@@ -61,5 +61,7 @@ public extension FormatRule {
                 .commentBody(commentPrefix + words.joined(separator: " ")),
             ])
         }
+    } examples: {
+        nil
     }
 }

--- a/Sources/Rules/YodaConditions.swift
+++ b/Sources/Rules/YodaConditions.swift
@@ -36,6 +36,18 @@ public extension FormatRule {
             formatter.replaceToken(at: i, with: .operator(inverseOp, .infix))
             formatter.replaceTokens(in: startIndex ... prevIndex, with: expression)
         }
+    } examples: {
+        """
+        ```diff
+        - if 5 == foo,
+        + if foo == 5,
+        -    nil != bar,
+        +    bar != nil,
+        -    .default == baaz,
+        +    baaz == .default,
+          { ... }
+        ```
+        """
     }
 }
 


### PR DESCRIPTION
This PR makes the `examples` closure required for every FormatRule. In practice we want almost all rules to have an example.

This PR also adds an example for most of the rules that currently don't have one.