### PR TITLE
Git helpers improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Build and Test
         run: |
+          # Set up a git user for the git tests
+          git config user.name "test user"
+          git config user.email "test.user@noreply.com"
+
           xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat (Framework)" -sdk macosx clean build test -enableCodeCoverage YES -derivedDataPath Build/
           cd Build/Build/ProfileData
           cd $(ls -d */|head -n 1)
@@ -56,6 +60,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Build and Test
         run: |
+          # Set up a git user for the git tests
+          git config --global user.name "test user"
+          git config --global user.email "test.user@noreply.com"
+
           # Needed to be allowed to run git commands in the tests
           # https://github.com/actions/runner-images/issues/6775
           git config --global --add safe.directory /__w/SwiftFormat/SwiftFormat
@@ -140,5 +148,3 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Editor Extension
         run: xcodebuild -project SwiftFormat.xcodeproj -scheme "SwiftFormat (Editor Extension)" -sdk macosx clean build
-
-        

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ DerivedData
 /Snapshots/Private
 swiftformat.artifactbundle.zip
 
+# Stores temporary files during tests
+.temp/
+
 # AppCode
 .idea

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -704,6 +704,17 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
                             status = .finished(.ok)
                             return
                         }
+
+                        let resourceValues = try getResourceValues(
+                            for: stdinURL.standardizedFileURL,
+                            keys: [.creationDateKey, .pathKey]
+                        )
+
+                        let fileInfo = collectFileInfo(inputURL: stdinURL,
+                                                       options: options,
+                                                       resourceValues: resourceValues)
+
+                        options.formatOptions?.fileInfo = fileInfo
                     }
                     let outputTokens = try applyRules(
                         input, options: options, lineRange: lineRange,

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -203,21 +203,9 @@ public func enumerateFiles(withInputURL inputURL: URL,
         let fileOptions = options.fileOptions ?? .default
         if resourceValues.isRegularFile == true {
             if fileOptions.supportedFileExtensions.contains(inputURL.pathExtension) {
-                let fileHeaderRuleEnabled = options.rules?.contains(FormatRule.fileHeader.name) ?? false
-                let shouldGetGitInfo = fileHeaderRuleEnabled &&
-                    options.formatOptions?.fileHeader.needsGitInfo == true
-
-                let gitInfo = shouldGetGitInfo ? GitFileInfo(url: inputURL) : nil
-
-                let fileInfo = FileInfo(
-                    filePath: resourceValues.path,
-                    creationDate: gitInfo?.creationDate ?? resourceValues.creationDate,
-                    replacements: [
-                        .author: ReplacementType(gitInfo?.author),
-                        .authorName: ReplacementType(gitInfo?.authorName),
-                        .authorEmail: ReplacementType(gitInfo?.authorEmail),
-                    ].compactMapValues { $0 }
-                )
+                let fileInfo = collectFileInfo(inputURL: inputURL,
+                                               options: options,
+                                               resourceValues: resourceValues)
 
                 var options = options
                 options.formatOptions?.fileInfo = fileInfo
@@ -288,6 +276,24 @@ public func enumerateFiles(withInputURL inputURL: URL,
         }
     }
     return errors
+}
+
+func collectFileInfo(inputURL: URL, options: Options, resourceValues: URLResourceValues) -> FileInfo {
+    let fileHeaderRuleEnabled = options.rules?.contains(FormatRule.fileHeader.name) ?? false
+    let shouldGetGitInfo = fileHeaderRuleEnabled &&
+        options.formatOptions?.fileHeader.needsGitInfo == true
+
+    let gitInfo = shouldGetGitInfo ? GitFileInfo(url: inputURL) : nil
+
+    return FileInfo(
+        filePath: resourceValues.path,
+        creationDate: gitInfo?.creationDate ?? resourceValues.creationDate,
+        replacements: [
+            .author: ReplacementType(gitInfo?.author),
+            .authorName: ReplacementType(gitInfo?.authorName),
+            .authorEmail: ReplacementType(gitInfo?.authorEmail),
+        ].compactMapValues { $0 }
+    )
 }
 
 /// Process configuration in all directories in specified path.


### PR DESCRIPTION
Hello, I found some issues with git using the file header rule 🙂 

- Info not being fetched when using stdin (noticed when using the cli to lint in git hooks)
- Defaults not working when file is not committed (it should default to the current git user)
  - Also added a test for this
- Checks for staged moved files so the git info can be properly fetched before committing 
  - Currently it will be detected as a new file, and then after committing the change it will be properly followed