### PR TITLE
Fix conditional body wrapping inside single line string interpolation

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1109,6 +1109,11 @@ extension Formatter {
     /// Wrap a single-line statement body onto multiple lines
     func wrapStatementBody(at i: Int) {
         assert(token(at: i) == .startOfScope("{"))
+
+        guard !isInSingleLineStringLiteral(at: i) else {
+            return
+        }
+
         var openBraceIndex = i
 
         // We need to make sure to move past any closures in the conditional

--- a/Tests/Rules/WrapConditionalBodiesTests.swift
+++ b/Tests/Rules/WrapConditionalBodiesTests.swift
@@ -256,4 +256,29 @@ class WrapConditionalBodiesTests: XCTestCase {
         testFormatting(for: input, output, rule: .wrapConditionalBodies,
                        exclude: [.braces, .indent, .elseOnSameLine])
     }
+
+    func testInsideStringLiteralDoesNothing() {
+        let input = """
+        "\\(list.map { if $0 % 2 == 0 { return 0 } else { return 1 } })"
+        """
+        testFormatting(for: input, rule: .wrapConditionalBodies)
+    }
+
+    func testInsideMultilineStringLiteral() {
+        let input = """
+        let foo = \"""
+        \\(list.map { if $0 % 2 == 0 { return 0 } else { return 1 } })
+        \"""
+        """
+        let output = """
+        let foo = \"""
+        \\(list.map { if $0 % 2 == 0 {
+            return 0
+        } else {
+            return 1
+        } })
+        \"""
+        """
+        testFormatting(for: input, output, rule: .wrapConditionalBodies)
+    }
 }


### PR DESCRIPTION
We experienced a problem with the `wrapConditionalBodies` rule, where it would break compilation if a conditional body is inside a single line string as part of string interpolation.

![Screenshot 2024-09-20 at 15 02 10](https://github.com/user-attachments/assets/ca159d45-730e-4d65-8f09-d03f6275b0d5)

I've fixed the issue and added test coverage. The fix is using the same check that was added to [fix an almost identical problem with ternary operator wrapping](https://github.com/nicklockwood/SwiftFormat/commit/cc885d7cfcb6f34527e8603888aa456cab9a872b).