### PR TITLE
Fix regression in `wrapMultilineStatementBraces` rule from bad `isStartOfClosure` result

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -571,13 +571,7 @@ extension Formatter {
                 }
                 return last(.nonSpaceOrCommentOrLinebreak, before: prevIndex) != .keyword("func")
             default:
-                if let nextIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: i),
-                   isAccessorKeyword(at: nextIndex) || isAccessorKeyword(at: prevIndex)
-                {
-                    return false
-                } else {
-                    return !isConditionalStatement(at: startOfScope)
-                }
+                return false
             }
             fallthrough
         case .identifier, .number, .operator("?", .postfix), .operator("!", .postfix),

--- a/Tests/Rules/WrapMultilineStatementBracesTests.swift
+++ b/Tests/Rules/WrapMultilineStatementBracesTests.swift
@@ -703,4 +703,25 @@ class WrapMultilineStatementBracesTests: XCTestCase {
         testFormatting(for: input, rules: [.wrapMultilineStatementBraces, .wrap],
                        options: options, exclude: [.indent, .redundantClosure, .wrapConditionalBodies])
     }
+
+    func testWrapMultilineStatementBraceAfterWhereClauseWithTuple() {
+        let input = """
+        extension Foo {
+            public func testWithWhereClause<A, B, Outcome>(
+                a: A,
+                b: B)
+                -> Outcome where
+                Outcome == (A, B)
+            {
+                return (a, b)
+            }
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine
+        )
+        testFormatting(for: input, rules: [.wrapMultilineStatementBraces, .braces], options: options)
+    }
 }


### PR DESCRIPTION
This PR fixes a regression in `wrapMultilineStatementBraces` that appears to be caused by https://github.com/nicklockwood/SwiftFormat/commit/71a08dd8816a190307c95d376716a325fe1b307f.

On `develop`, code like this:

```swift
extension Foo {
    public func testWithWhereClause<A, B, Outcome>(
        a: A,
        b: B)
        -> Outcome where
        Outcome == (A, B)
    {
        return (a, b)
    }
}
```

is currently being reformatted to:

```swift
extension Foo {
    public func testWithWhereClause<A, B, Outcome>(
        a: A,
        b: B)
        -> Outcome where
        Outcome == (A, B) {
            return (a, b)
       }
}
```