### PR TITLE
Fix environmentEntry edge cases

### DIFF
--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -164,12 +164,17 @@ enum Declaration: Hashable {
 
     /// Whether or not this declaration represents a stored instance property
     var isStoredInstanceProperty: Bool {
-        guard keyword == "let" || keyword == "var" else { return false }
-
         // A static property is not an instance property
-        if modifiers.contains("static") {
-            return false
-        }
+        modifiers.contains("static") ? false : isStoredProperty
+    }
+
+    /// Whether or not this declaration represents a static stored instance property
+    var isStaticStoredProperty: Bool {
+        modifiers.contains("static") ? isStoredProperty : false
+    }
+
+    var isStoredProperty: Bool {
+        guard keyword == "let" || keyword == "var" else { return false }
 
         // If this property has a body, then it's a stored property
         // if and only if the declaration body has a `didSet` or `willSet` keyword,

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -165,12 +165,12 @@ enum Declaration: Hashable {
     /// Whether or not this declaration represents a stored instance property
     var isStoredInstanceProperty: Bool {
         // A static property is not an instance property
-        modifiers.contains("static") ? false : isStoredProperty
+        !modifiers.contains("static") && isStoredProperty
     }
 
     /// Whether or not this declaration represents a static stored instance property
     var isStaticStoredProperty: Bool {
-        modifiers.contains("static") ? isStoredProperty : false
+        modifiers.contains("static") && isStoredProperty
     }
 
     var isStoredProperty: Bool {

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -696,7 +696,7 @@ extension Declaration {
     }
 }
 
-extension Formatter {
+private extension Formatter {
     /// The open `{` for given property declaration's body, if present
     func startOfPropertyBody(at introducerIndex: Int, endOfPropertyIndex: Int) -> Int? {
         guard tokens[introducerIndex] == .keyword("let") || tokens[introducerIndex] == .keyword("var") else {

--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -691,7 +691,7 @@ extension Declaration {
     }
 }
 
-private extension Formatter {
+extension Formatter {
     /// The open `{` for given property declaration's body, if present
     func startOfPropertyBody(at introducerIndex: Int, endOfPropertyIndex: Int) -> Int? {
         guard tokens[introducerIndex] == .keyword("let") || tokens[introducerIndex] == .keyword("var") else {

--- a/Sources/Rules/EnvironmentEntry.swift
+++ b/Sources/Rules/EnvironmentEntry.swift
@@ -129,11 +129,18 @@ extension Formatter {
                 environmentValuesDeclaration.body?.compactMap { propertyDeclaration -> (EnvironmentValueProperty)? in
                     guard propertyDeclaration.isSimpleDeclaration,
                           propertyDeclaration.keyword == "var",
-                          let key = propertyDeclaration.tokens.first(where: { environmentKeys[$0.string] != nil })?.string
+                          let key = propertyDeclaration.tokens.first(where: { environmentKeys[$0.string] != nil })?.string,
+                          let environmentKey = environmentKeys[key]
                     else { return nil }
+
+                    let propertyFormatter = Formatter(propertyDeclaration.tokens)
+                    guard let indexOfSetter = propertyFormatter.index(of: .identifier("set"), after: -1),
+                          propertyFormatter.isAccessorKeyword(at: indexOfSetter)
+                    else { return nil }
+
                     return EnvironmentValueProperty(
                         key: key,
-                        associatedEnvironmentKey: environmentKeys[key]!,
+                        associatedEnvironmentKey: environmentKey,
                         declaration: propertyDeclaration
                     )
                 }

--- a/Sources/Rules/EnvironmentEntry.swift
+++ b/Sources/Rules/EnvironmentEntry.swift
@@ -63,13 +63,13 @@ struct EnvironmentValueProperty {
 extension Formatter {
     func findAllEnvironmentKeys(_ declarations: [Declaration]) -> [EnvironmentKey] {
         declarations.compactMap { declaration -> EnvironmentKey? in
-            guard declaration.keyword == "struct",
+            guard declaration.keyword == "struct" || declaration.keyword == "enum",
                   declaration.openTokens.contains(.identifier("EnvironmentKey")),
                   let keyName = declaration.openTokens.first(where: \.isIdentifier),
                   let structDeclarationBody = declaration.body,
                   structDeclarationBody.count == 1,
                   let defaultValueDeclaration = structDeclarationBody.first(where: {
-                      $0.keyword == "var" && $0.name == "defaultValue"
+                      ($0.keyword == "var" || $0.keyword == "let") && $0.name == "defaultValue"
                   })
             else { return nil }
 
@@ -179,7 +179,6 @@ extension Formatter {
         }
     }
 }
-
 
 extension Declaration {
     var isStoredStaticProperty: Bool {

--- a/Sources/Rules/EnvironmentEntry.swift
+++ b/Sources/Rules/EnvironmentEntry.swift
@@ -83,7 +83,7 @@ extension Formatter {
     }
 
     func findEnvironmentKeyDefaultValue(_ defaultValueDeclaration: Declaration) -> (tokens: ArraySlice<Token>?, isMultiline: Bool)? {
-        if defaultValueDeclaration.isStoredStaticProperty,
+        if defaultValueDeclaration.isStaticStoredProperty,
            let equalsIndex = index(of: .operator("=", .infix), after: defaultValueDeclaration.originalRange.lowerBound),
            equalsIndex <= defaultValueDeclaration.originalRange.upperBound,
            let valueStartIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),

--- a/Sources/Rules/EnvironmentEntry.swift
+++ b/Sources/Rules/EnvironmentEntry.swift
@@ -133,8 +133,10 @@ extension Formatter {
                           let environmentKey = environmentKeys[key]
                     else { return nil }
 
+                    // Ensure the property has a setter and a getter, this can avoid edge cases where
+                    // a property references a `EnvironmentKey` and consumes it to perform some computation.
                     let propertyFormatter = Formatter(propertyDeclaration.tokens)
-                    guard let indexOfSetter = propertyFormatter.index(of: .identifier("set"), after: -1),
+                    guard let indexOfSetter = propertyDeclaration.tokens.firstIndex(where: { $0 == .identifier("set") }),
                           propertyFormatter.isAccessorKeyword(at: indexOfSetter)
                     else { return nil }
 

--- a/Tests/Rules/EnvironmentEntryTests.swift
+++ b/Tests/Rules/EnvironmentEntryTests.swift
@@ -344,48 +344,6 @@ final class EnvironmentEntryTests: XCTestCase {
         testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
     }
 
-    func testEntryMacroReplacementWhenKeyHasKeySuffix() {
-        let input = """
-        private struct ScreenStyleKey: EnvironmentKey {
-            static var defaultValue: Style { .init() }
-        }
-
-        extension EnvironmentValues {
-            public var screenStyle: Style {
-                get { self[ScreenStyleKey.self] }
-                set { self[ScreenStyleKey.self] = newValue }
-            }
-        }
-        """
-        let output = """
-        extension EnvironmentValues {
-            @Entry public var screenStyle: Style = .init()
-        }
-        """
-        testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
-    }
-
-    func testEntryMacroReplacementWhenKeyHasAcronymInKeyPrefix() {
-        let input = """
-        private struct DLSScreenStyleEnvironmentKey: EnvironmentKey {
-            static var defaultValue: DLSScreenStyle { .init() }
-        }
-
-        extension EnvironmentValues {
-            private var dlsScreenStyle: DLSScreenStyle {
-                get { self[DLSScreenStyleEnvironmentKey.self] }
-                set { self[DLSScreenStyleEnvironmentKey.self] = newValue }
-            }
-        }
-        """
-        let output = """
-        extension EnvironmentValues {
-            @Entry private var dlsScreenStyle: DLSScreenStyle = .init()
-        }
-        """
-        testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
-    }
-
     func testEntryMacroReplacementWithEnumEnvironmentKey() {
         let input = """
         private enum InputShouldChangeKey: EnvironmentKey {

--- a/Tests/Rules/EnvironmentEntryTests.swift
+++ b/Tests/Rules/EnvironmentEntryTests.swift
@@ -364,4 +364,51 @@ final class EnvironmentEntryTests: XCTestCase {
         """
         testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
     }
+
+    func testEntryMacroReplacementWhenDefaultValueIsLet() {
+        let input = """
+        private struct ScreenStyleKey: EnvironmentKey {
+            static let defaultValue: Style = .init()
+        }
+
+        extension EnvironmentValues {
+            public var screenStyle: Style {
+                get { self[ScreenStyleKey.self] }
+                set { self[ScreenStyleKey.self] = newValue }
+            }
+        }
+        """
+        let output = """
+        extension EnvironmentValues {
+            @Entry public var screenStyle: Style = .init()
+        }
+        """
+        testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
+    }
+
+    func testEntryMacroReplacementWithoutExplicitTypeAnnotation() {
+        let input = """
+        private struct ScreenStyleKey: EnvironmentKey {
+            static let defaultValue = Style()
+        }
+
+        extension EnvironmentValues {
+            public var screenStyle: Style {
+                get { self[ScreenStyleKey.self] }
+                set { self[ScreenStyleKey.self] = newValue }
+            }
+        }
+        """
+        let output = """
+        extension EnvironmentValues {
+            @Entry public var screenStyle: Style = Style()
+        }
+        """
+        testFormatting(
+            for: input, output,
+            rule: .environmentEntry,
+            options: FormatOptions(swiftVersion: "6.0"),
+            exclude: [.redundantType]
+        )
+    }
 }

--- a/Tests/Rules/EnvironmentEntryTests.swift
+++ b/Tests/Rules/EnvironmentEntryTests.swift
@@ -385,4 +385,25 @@ final class EnvironmentEntryTests: XCTestCase {
         """
         testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
     }
+
+    func testEntryMacroReplacementWithEnumEnvironmentKey() {
+        let input = """
+        private enum InputShouldChangeKey: EnvironmentKey {
+            static var defaultValue: InputShouldChangeHandler { nil }
+        }
+
+        extension EnvironmentValues {
+            public var inputShouldChange: InputShouldChangeHandler {
+                get { self[InputShouldChangeKey.self] }
+                set { self[InputShouldChangeKey.self] = newValue }
+            }
+        }
+        """
+        let output = """
+        extension EnvironmentValues {
+            @Entry public var inputShouldChange: InputShouldChangeHandler = nil
+        }
+        """
+        testFormatting(for: input, output, rule: .environmentEntry, options: FormatOptions(swiftVersion: "6.0"))
+    }
 }

--- a/Tests/Rules/EnvironmentEntryTests.swift
+++ b/Tests/Rules/EnvironmentEntryTests.swift
@@ -411,4 +411,28 @@ final class EnvironmentEntryTests: XCTestCase {
             exclude: [.redundantType]
         )
     }
+
+    func testEnvironmentValuesPropertyWithoutSetterIsNotModified() {
+        let input = """
+        struct AEnvironmentKey: EnvironmentKey {
+            static var defaultValue: A = .default
+        }
+
+        extension EnvironmentValues {
+            public var fallbackA: A {
+                if self[AEnvironmentKey.self] {
+                    A()
+                } else {
+                    something()
+                }
+            }
+        }
+        """
+        testFormatting(
+            for: input,
+            rule: .environmentEntry,
+            options: FormatOptions(swiftVersion: "6.0"),
+            exclude: [.redundantType]
+        )
+    }
 }


### PR DESCRIPTION
This PR fixes some edge cases of the `environmentEntry` rule introduced in https://github.com/nicklockwood/SwiftFormat/pull/1908.

The fixes include:

- Allow enums as `EnvironmentKey`s
- Allow `let`s as the `EnvironmentKey.defaultValue`
- Allow direct value assignment of `EnvironmentKey.defaultValue`. (`static var defaultValue: Bool = true`)
- Allow `EnvironmentKey`s with any name as long as it is references in a `EnvironmentValues` property (`struct MyKey: EnvironmentKey`)
- Fix an issue where the `@Entry` macro was added after any access control modifier like `public`, `private`, etc.

cc: @calda 