### PR TITLE
Fix issue where `--beforemarks` unexpectedly checked function bodies for matching keywords

### DIFF
--- a/Sources/DeclarationHelpers.swift
+++ b/Sources/DeclarationHelpers.swift
@@ -555,10 +555,6 @@ extension Declaration {
                 return .beforeMarks
             }
 
-            for token in declarationParser.tokens {
-                if beforeMarks.contains(token.string) { return .beforeMarks }
-            }
-
             let isStaticDeclaration = declarationParser.index(
                 of: .keyword("static"),
                 before: declarationTypeTokenIndex

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3482,4 +3482,50 @@ class OrganizeDeclarationsTests: XCTestCase {
             rule: .organizeDeclarations
         )
     }
+
+    func testIssue1907() {
+        let input = """
+        public final class Test: ObservableObject {
+            var someProperty: Int? = 0
+
+            // MARK: - Public -
+
+            public func somePublicFunction() {
+                print("Hello")
+                print("Hello")
+                print("Hello")
+                print("Hello")
+                print("Hello")
+            }
+
+            // MARK: - Internal -
+
+            func someInternalFunction() {
+                guard let someProperty else {
+                    return
+                }
+
+                print("Hello")
+                print("Hello")
+                print("Hello")
+                print("Hello")
+                print("Hello")
+            }
+
+            // MARK: - Private -
+
+            private func somePrivateFunction() {
+                print("Hello")
+                print("Hello")
+            }
+        }
+        """
+
+        let options = FormatOptions(
+            categoryMarkComment: "MARK: - %c -",
+            beforeMarks: ["class", "let", "var"]
+        )
+
+        testFormatting(for: input, rule: .organizeDeclarations, options: options)
+    }
 }


### PR DESCRIPTION
This PR fixes #1907.

`--beforemarks` was unexpectedly checking function bodies for matching keywords, so in this example with `--beforemarks var,let` the `someInternalFunction` declaration was unexpectedly being included in `beforeMarks` (because its body contained the `let` keyword):

```swift
public final class Test: ObservableObject {
    var someProperty: Int? = 0

    func someInternalFunction() {
        guard let someProperty: Int else {
            return
        }

        print("Hello")
        print("Hello")
        print("Hello")
        print("Hello")
        print("Hello")
    }
  
    // MARK: - Public -

    public func somePublicFunction() {
        print("Hello")
        print("Hello")
        print("Hello")
        print("Hello")
        print("Hello")
    }

    // MARK: - Private -

    private func somePrivateFunction() {
        print("Hello")
        print("Hello")
    }
}
```