### PR TITLE
Use static Linux SDK in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+Dockerfile
+.dockerignore
+.git
+.github
+.gitignore
+
+# Everything from .gitignore
+# OS X
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.dot
+.build
+.swiftpm
+
+/Snapshots/Private
+swiftformat.artifactbundle.zip
+
+# AppCode
+.idea

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,11 +31,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -52,6 +47,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64, linux/arm64
+          no-cache: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false

--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -35,8 +35,10 @@ import Foundation
     import Darwin.POSIX
 #elseif os(Windows)
     import ucrt
-#else
+#elseif canImport(Glibc)
     import Glibc
+#elseif canImport(Musl)
+    import Musl
 #endif
 
 #if SWIFT_PACKAGE

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . /workspace
 ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
 	./Scripts/build-linux-release.sh && \
-	mv /workspace/.build/release/swiftformat /workspace
+	cp /workspace/.build/release/swiftformat /workspace
 
 FROM scratch AS runner
 COPY --from=builder /workspace/swiftformat /usr/bin/swiftformat

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
 	./Scripts/build-linux-release.sh && \
 	cp /workspace/.build/release/swiftformat /workspace
-RUN strip /workspace/swiftformat
 
 FROM scratch AS runner
 COPY --from=builder /workspace/swiftformat /usr/bin/swiftformat

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
 	./Scripts/build-linux-release.sh && \
 	cp /workspace/.build/release/swiftformat /workspace
+RUN strip /workspace/swiftformat
 
 FROM scratch AS runner
 COPY --from=builder /workspace/swiftformat /usr/bin/swiftformat

--- a/Scripts/build-linux-release.sh
+++ b/Scripts/build-linux-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eo pipefail
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
+
+BUILD_ARGS=(
+	--product swiftformat
+	--configuration release
+)
+
+if [[ -z "$TARGETPLATFORM" ]]; then
+	ARCH="$(uname -m)"
+else
+	if [[ "$TARGETPLATFORM" = "linux/amd64" ]]; then
+		ARCH="x86_64"
+	elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then
+		ARCH="aarch64"
+	else
+		echo "Unsupported target platform: $TARGETPLATFORM"
+		exit 1
+	fi
+fi
+BUILD_ARGS+=(--swift-sdk "${ARCH}-swift-linux-musl")
+
+swift build "${BUILD_ARGS[@]}"


### PR DESCRIPTION
Partially fixes #1894 
`provenance: false` is for removing `unknown/unknown` from the OS/Arch tab here: https://github.com/nicklockwood/SwiftFormat/pkgs/container/swiftformat/272228423?tag=latest
Everything else should be self-explanatory.
Building for regular distribution on Linux could be done with the --output flag of docker build: https://docs.docker.com/build/building/export/