### PR TITLE
Update documentation: equalize Swift Version Specification Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,12 +651,10 @@ Most SwiftFormat rules are version-agnostic, but some are applicable only to new
 
 You can specify the Swift version in one of two ways:
 
-The preferred option is to add a `.swift-version` file to your project directory. This is a text file that should contain the minimum Swift version supported by your project, and is a standard already used by other tools.
+1. Use the `--swiftversion` command line argument. Note that this will be overridden by any `.swift-version` files encountered while processing. You can also add the `--swiftversion` option to your `.swiftformat` file.
 
+1. Add a `.swift-version` file to your project directory. This is a text file that should contain the minimum Swift version supported by your project, and is a standard already used by other tools.  
 The `.swift-version` file applies hierarchically; If you have submodules in your project that use a different Swift version, you can add separate `.swift-version` files to those directories.
-
-The other option to specify the Swift version using the `--swiftversion` command line argument. Note that this will be overridden by any `.swift-version` files encountered while processing. You can also add the `--swiftversion` option to your `.swiftformat` file.
-
 
 Config file
 -----------


### PR DESCRIPTION
### Description

I am proposing two changes to the documentation regarding Swift version specification.

_Firstly_, I suggest removing the recommendation to use `.swift-version`.  
I found no compelling reason to continue recommending this approach, especially since CocoaPods has not supported this file for [quite some time](https://blog.cocoapods.org/CocoaPods-1.7.0-beta/#:~:text=Finally%2C%20a%20warning%20will%20be%20displayed%20during%20lint%20that%20encourages%20pod%20authors%20to%20migrate%20away%20from%20using%20the%20.swift%2Dversion%20file%20and%20in%20a%20future%20major%20release%20of%20CocoaPods%20we%20plan%20to%20completely%20remove%20support%20for%20it.).  
If you know why this approach should be recommended, please let me know.

_Secondly_, I propose reordering the methods for specifying the Swift version, placing `--swiftversion` at the top.  
I believe this reflects its more common use, as in my opinion, the `.swift-version` file is less frequently used.