### PR TITLE
Update `sortTypealiases` rule to support `any` keyword

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1262,11 +1262,15 @@ extension Formatter {
     ///  - `(type) & (type)`
     func parseType(
         at startOfTypeIndex: Int,
-        excludeLowercaseIdentifiers: Bool = false
-    )
-        -> (name: String, range: ClosedRange<Int>)?
-    {
-        guard let baseType = parseNonOptionalType(at: startOfTypeIndex, excludeLowercaseIdentifiers: excludeLowercaseIdentifiers) else { return nil }
+        excludeLowercaseIdentifiers: Bool = false,
+        excludeProtocolCompositions: Bool = false
+    ) -> (name: String, range: ClosedRange<Int>)? {
+        guard let baseType = parseNonOptionalType(
+            at: startOfTypeIndex,
+            excludeLowercaseIdentifiers: excludeLowercaseIdentifiers,
+            excludeProtocolCompositions: excludeProtocolCompositions
+        )
+        else { return nil }
 
         // Any type can be optional, so check for a trailing `?` or `!`.
         // There cannot be any other tokens between the type and the operator:
@@ -1282,7 +1286,13 @@ extension Formatter {
         }
 
         // Any type can be followed by a `.` or `&` which can then continue the type
-        let continuationOperators: [Token] = [.operator(".", .infix), .operator("&", .infix)]
+        let continuationOperators: [Token]
+        if excludeProtocolCompositions {
+            continuationOperators = [.operator(".", .infix)]
+        } else {
+            continuationOperators = [.operator(".", .infix), .operator("&", .infix)]
+        }
+
         if let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: baseType.range.upperBound),
            continuationOperators.contains(tokens[nextTokenIndex]),
            let followingToken = index(of: .nonSpaceOrCommentOrLinebreak, after: nextTokenIndex),
@@ -1297,17 +1307,25 @@ extension Formatter {
 
     private func parseNonOptionalType(
         at startOfTypeIndex: Int,
-        excludeLowercaseIdentifiers: Bool
-    )
-        -> (name: String, range: ClosedRange<Int>)?
-    {
+        excludeLowercaseIdentifiers: Bool,
+        excludeProtocolCompositions: Bool
+    ) -> (name: String, range: ClosedRange<Int>)? {
         let startToken = tokens[startOfTypeIndex]
+
+        /// Helpers that calls `parseType` with all of the optional params passed in by default
+        func parseType(at index: Int) -> (name: String, range: ClosedRange<Int>)? {
+            self.parseType(
+                at: index,
+                excludeLowercaseIdentifiers: excludeLowercaseIdentifiers,
+                excludeProtocolCompositions: excludeProtocolCompositions
+            )
+        }
 
         // Parse types of the form `[...]`
         if startToken == .startOfScope("["), let endOfScope = endOfScope(at: startOfTypeIndex) {
             // Validate that the inner type is also valid
             guard let innerTypeStartIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfTypeIndex),
-                  let innerType = parseType(at: innerTypeStartIndex, excludeLowercaseIdentifiers: excludeLowercaseIdentifiers),
+                  let innerType = parseType(at: innerTypeStartIndex),
                   let indexAfterType = index(of: .nonSpaceOrCommentOrLinebreak, after: innerType.range.upperBound)
             else { return nil }
 
@@ -1316,7 +1334,7 @@ extension Formatter {
             if indexAfterType != endOfScope {
                 guard tokens[indexAfterType] == .delimiter(":"),
                       let secondTypeIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: indexAfterType),
-                      let secondType = parseType(at: secondTypeIndex, excludeLowercaseIdentifiers: excludeLowercaseIdentifiers),
+                      let secondType = parseType(at: secondTypeIndex),
                       let indexAfterSecondType = index(of: .nonSpaceOrCommentOrLinebreak, after: secondType.range.upperBound),
                       indexAfterSecondType == endOfScope
                 else { return nil }
@@ -2211,28 +2229,25 @@ extension Formatter {
     {
         guard let equalsIndex = index(of: .operator("=", .infix), after: typealiasIndex),
               let startOfType = index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
-              let type = parseType(at: startOfType)
+              let fullProtocolCompositionType = parseType(at: startOfType)
         else { return nil }
 
-        let andTokenIndices = type.range.filter { index in
-            tokens[index] == .operator("&", .infix)
+        var andTokenIndices: [Int] = []
+        var currentIndex = startOfType
+
+        while let nextType = parseType(at: currentIndex, excludeProtocolCompositions: true),
+              let nextAndToken = index(of: .nonSpaceOrCommentOrLinebreak, after: nextType.range.upperBound),
+              tokens[nextAndToken] == .operator("&", .infix),
+              let tokenAfterAndToken = index(of: .nonSpaceOrCommentOrLinebreak, after: nextAndToken)
+        {
+            andTokenIndices.append(nextAndToken)
+            currentIndex = tokenAfterAndToken
         }
 
+        // If we didn't find any `&` tokens then this isn't a protocol composition typealias.
         guard !andTokenIndices.isEmpty else { return nil }
 
-        // Quick fix for types we don't support yet
-        let firstRange = tokens[equalsIndex ..< andTokenIndices[0]]
-        guard !firstRange.contains(where: {
-            ["any", "[", "(", ":"].contains($0.string)
-        }), firstRange.filter({
-            $0 == .startOfScope("<")
-        }).count == firstRange.filter({
-            $0 == .endOfScope(">")
-        }).count else {
-            return nil
-        }
-
-        return (equalsIndex, andTokenIndices, type.range.upperBound)
+        return (equalsIndex, andTokenIndices, fullProtocolCompositionType.range.upperBound)
     }
 
     /// A function argument like `with foo: Foo`.

--- a/Sources/Rules/SortTypealiases.swift
+++ b/Sources/Rules/SortTypealiases.swift
@@ -76,7 +76,21 @@ public extension FormatRule {
 
             // Sort each element by type name
             var sortedElements = parsedElements.sorted(by: { lhsElement, rhsElement in
-                lhsElement.type.lexicographicallyPrecedes(rhsElement.type)
+                // Exclude the any keyword if present when comparing types.
+                // Otherwise, all `any` types will be sorted to the end of the list.
+                // (lowercase letters come after uppercase letters in this sort order).
+                var lhsType = lhsElement.type
+                var rhsType = rhsElement.type
+
+                if lhsType.hasPrefix("any") {
+                    lhsType = String(lhsType.dropFirst(3))
+                }
+
+                if rhsType.hasPrefix("any") {
+                    rhsType = String(rhsType.dropFirst(3))
+                }
+
+                return lhsType.lexicographicallyPrecedes(rhsType)
             })
 
             // Don't modify the file if the typealias is already sorted

--- a/Tests/Rules/SortTypealiasesTests.swift
+++ b/Tests/Rules/SortTypealiasesTests.swift
@@ -92,6 +92,46 @@ class SortTypealiasesTests: XCTestCase {
         testFormatting(for: input, output, rule: .sortTypealiases)
     }
 
+    func testSortWrappedMultilineTypealiasWithAny() {
+        let input = """
+        typealias Dependencies
+            = any FooProviding
+            & any BarProviding
+            & any BaazProviding
+            & any QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies
+            = any BaazProviding
+            & any BarProviding
+            & any FooProviding
+            & any QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: .sortTypealiases)
+    }
+
+    func testSortWrappedMultilineTypealiasWithMixedAny() {
+        let input = """
+        typealias Dependencies
+            = any FooProviding
+            & BarProviding
+            & any BaazProviding
+            & QuuxProviding
+        """
+
+        let output = """
+        typealias Dependencies
+            = any BaazProviding
+            & BarProviding
+            & any FooProviding
+            & QuuxProviding
+        """
+
+        testFormatting(for: input, output, rule: .sortTypealiases)
+    }
+
     func testSortWrappedMultilineTypealiasWithComments() {
         let input = """
         typealias Dependencies


### PR DESCRIPTION
As a follow-up to the fix for https://github.com/nicklockwood/SwiftFormat/issues/1929 this PR updates the `sortTypealaises` rule to support the `any` keyword.