### PR TITLE
Update release workflow to only download necessary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: downloaded_artifacts
+          pattern: swiftformat_*
       - name: Display structure of downloaded files
         run: ls -R downloaded_artifacts
       - name: Build artifact bundle


### PR DESCRIPTION
The recent Linux docker build changes broke the `Upload release artifacts` step in the `release.yml` GitHub actions workflow. The `actions/download-artifact@v4` step fails to download the docker image artifact.

We can avoid that by specifying that it should only download artifacts matching a given pattern. (The artifacts it needs to download are named `swiftformat_macos`, `swiftformat_linux`, and `swiftformat_linux_aarch64`).