### PR TITLE
Update emptyExtensions rule to support @retroactive extensions

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1255,8 +1255,10 @@ extension Formatter {
     ///  - `some ...`
     ///  - `borrowing ...`
     ///  - `consuming ...`
+    ///  - `sending ...`
     ///  - `@escaping ...`
     ///  - `@unchecked ...`
+    ///  - `@retroactive ...`
     ///  - `~...`
     ///  - `(type).(type)`
     ///  - `(type) & (type)`
@@ -1352,9 +1354,9 @@ extension Formatter {
             return (name: tokens[typeRange].stringExcludingLinebreaks, range: typeRange)
         }
 
-        // Parse types of the form `any ...`, `some ...`, `borrowing ...`, `consuming ...`,
-        // `@unchecked ...`, `@escaping ...`, `~...`,
-        let typePrefixes = Set(["any", "some", "borrowing", "consuming", "@unchecked", "@escaping", "~"])
+        // Parse types of the form `any ...`, `some ...`, `borrowing ...`, `consuming ...`, `sending ...`,
+        // `@unchecked ...`, `@escaping ...`, `~...`, `@retroactive ...`,
+        let typePrefixes = Set(["any", "some", "borrowing", "consuming", "sending", "@unchecked", "@escaping", "~", "@retroactive"])
         if typePrefixes.contains(startToken.string),
            let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfTypeIndex),
            let followingType = parseType(at: nextToken)

--- a/Tests/Rules/EmptyExtensionsTests.swift
+++ b/Tests/Rules/EmptyExtensionsTests.swift
@@ -35,6 +35,9 @@ class EmptyExtensionsTests: XCTestCase {
     func testDoNotRemoveEmptyConformingExtension() {
         let input = """
         extension String: Equatable {}
+        extension Foo: @unchecked Sendable {}
+        extension Bar: @retroactive @unchecked Sendable {}
+        extension Module.Bar: @retroactive @unchecked Swift.Sendable {}
         """
         testFormatting(for: input, rule: .emptyExtensions)
     }


### PR DESCRIPTION
This PR updates the `emptyExtensions` rule to support `@retroactive` extensions.

Currently the rule will unexpectedly remove an extension like:

```swift
extension FileManager: @retroactive @unchecked Sendable {}
```