### PR TITLE
Stop using busybox for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
 	cp /workspace/.build/release/swiftformat /workspace
 
 # https://github.com/nicklockwood/SwiftFormat/issues/1930
-FROM busybox:stable AS runner
+FROM scratch AS runner
 COPY --from=builder /workspace/swiftformat /usr/bin/swiftformat
 ENTRYPOINT [ "/usr/bin/swiftformat" ]
 CMD ["."]


### PR DESCRIPTION
## Background
- fix: #1930 
  - I had a problem that `swiftformat` command can fail with the image in 0.55.3

## Details
- I tried the new image on GitHub Actions workflow and found it works well
  - https://github.com/ski-u/SwiftFormatWithGitHubActions/pull/7