### PR TITLE
Fix issue where organizeDeclarations rule would unexpectedly remove non-mark comment

### DIFF
--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -524,8 +524,7 @@ extension Formatter {
             Array(Set([
                 // The user's specific category separator template
                 $0.markCommentBody(from: options.categoryMarkComment, with: options.organizationMode),
-                // Other common variants that we would want to replace with the correct variant
-                $0.markCommentBody(from: "%c", with: options.organizationMode),
+                // Always look for MARKs even if the user is using a different template
                 $0.markCommentBody(from: "MARK: %c", with: options.organizationMode),
             ]))
         }.compactMap { $0 }

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -1568,9 +1568,9 @@ class OrganizeDeclarationsTests: XCTestCase {
 
             init() {}
 
-            // Public
+            // mark: Public
 
-            // - Public
+            // mark - Public
 
             public func bar() {}
 
@@ -3592,5 +3592,18 @@ class OrganizeDeclarationsTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .organizeDeclarations, exclude: [.blankLinesAtStartOfScope])
+    }
+
+    func testPreservesUnrelatedComments() {
+        let input = """
+        enum Test {
+            /// Test Properties
+            static let foo = "foo"
+            static let bar = "bar"
+            static let baaz = "baaz"
+        }
+        """
+
+        testFormatting(for: input, rule: .organizeDeclarations)
     }
 }


### PR DESCRIPTION
This PR fixes an issue I noticed where the organizeDeclarations rule would unexpectedly remove a non-mark comment.

In this case, the comment is within the edit distance threshold of a comment like `// Static Properties`, meaning it would be unexpectedly removed:

```diff
        enum Test {
-           /// Test Properties
            static let foo = "foo"
            static let bar = "bar"
            static let baaz = "baaz"
        }
```

Instead it seems better to only look for and remove MARK comments.