### PR TITLE
Fix leaking markdown code cage

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -848,6 +848,7 @@ Option | Description
       static let foo = "foo"
       static let bar = "bar"
   }
+```
 
 </details>
 <br/>


### PR DESCRIPTION
A code comment cage was leaking, so the next rule got put into the preceeding rules Example dropdown.