### PR TITLE
Fix edge cases with swiftTesting rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2921,6 +2921,10 @@ set to 4.2 or above.
 
 Prefer the Swift Testing library over XCTest.
 
+Option | Description
+--- | ---
+`--xctestsymbols` | Comma-delimited list of symbols that depend on XCTest
+
 <details>
 <summary>Examples</summary>
 
@@ -2928,6 +2932,7 @@ Prefer the Swift Testing library over XCTest.
   @testable import MyFeatureLib
 - import XCTest
 + import Testing
++ import Foundation
 
 - final class MyFeatureTests: XCTestCase {
 -     func testMyFeatureHasNoBugs() {
@@ -2938,7 +2943,7 @@ Prefer the Swift Testing library over XCTest.
 -         XCTAssertNil(myFeature.crashReport)
 -     }
 - }
-+ @MainActor
++ @MainActor @Suite(.serialized)
 + final class MyFeatureTests { 
 +     @Test func myFeatureHasNoBugs() {
 +         let myFeature = MyFeature()

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1241,6 +1241,12 @@ struct _Descriptors {
         help: "Comma-delimited list of symbols to be ignored by the rule",
         keyPath: \.preservedSymbols
     )
+    let additionalXCTestSymbols = OptionDescriptor(
+        argumentName: "xctestsymbols",
+        displayName: "Additional XCTest symbols",
+        help: "Comma-delimited list of symbols that depend on XCTest",
+        keyPath: \.additionalXCTestSymbols
+    )
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sortswiftuiprops",
         displayName: "Sort SwiftUI Dynamic Properties",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -731,6 +731,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var timeZone: FormatTimeZone
     public var nilInit: NilInitType
     public var preservedPrivateDeclarations: Set<String>
+    public var additionalXCTestSymbols: Set<String>
     public var equatableMacro: EquatableMacro
     public var preferFileMacro: Bool
 
@@ -859,6 +860,7 @@ public struct FormatOptions: CustomStringConvertible {
                 timeZone: FormatTimeZone = .system,
                 nilInit: NilInitType = .remove,
                 preservedPrivateDeclarations: Set<String> = [],
+                additionalXCTestSymbols: Set<String> = [],
                 equatableMacro: EquatableMacro = .none,
                 preferFileMacro: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
@@ -977,6 +979,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.timeZone = timeZone
         self.nilInit = nilInit
         self.preservedPrivateDeclarations = preservedPrivateDeclarations
+        self.additionalXCTestSymbols = additionalXCTestSymbols
         self.equatableMacro = equatableMacro
         self.preferFileMacro = preferFileMacro
         // Doesn't really belong here, but hard to put elsewhere

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2059,7 +2059,7 @@ extension Formatter {
     }
 
     /// Adds imports for the given list of modules to this file if not already present
-    func addImports(_ importsToAddIfNeeded: Set<String>) {
+    func addImports(_ importsToAddIfNeeded: [String]) {
         let importRanges = parseImports()
         let currentImports = Set(importRanges.flatMap { $0.map(\.module) })
 
@@ -2601,7 +2601,7 @@ extension Formatter {
         var argumentLabels: [FunctionCallArgument] = []
 
         var currentIndex = startOfScope
-        repeat {
+        while currentIndex < endOfScope {
             let endOfPreviousArgument = currentIndex
             let endOfCurrentArgument = index(of: .delimiter(","), in: endOfPreviousArgument + 1 ..< endOfScope) ?? endOfScope
 
@@ -2625,7 +2625,7 @@ extension Formatter {
             } else {
                 currentIndex = endOfCurrentArgument
             }
-        } while true
+        }
 
         return argumentLabels
     }


### PR DESCRIPTION
This PR fixes edge cases I noticed with the new `swiftTesting` rule that would cause build failures or runtime issues. For example:
 - Adds `@Suite(.serialized)` by default to match the XCTest behavior where tests run serially by default. Existing tests may not expect to be ran concurrently. I saw issues related to this in Airbnb's test suite.
 - Adds `import Foundation` by default, since XCTest exports `Foundation` (common for test cases to rely on Foundation types)
 - Adds `import UIKit` if the file uses any UIKit symbols (common in tests for app codebases) since XCTest exports UIKit
 - Fixed lots of issues where operators would cause build failures. Some examples of invalid code that we were generating before include `!foo == bar`, `!foo is Bar`, `try? foo == bar`, etc. (should be (`!(foo == bar)`, `!(foo is Bar)`, `(try? foo) == bar`).

With these fixes, Airbnb's unit test suite builds, runs, and passes successfully after applying the `swiftTesting` rule (after also manually fixing a relatively reasonable number of more minor edge cases).