### PR TITLE
Fix issue where type under organizeDeclarations line count threshold would ignore `swiftformat:sort` directive

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1682,6 +1682,37 @@ extension Formatter {
             return last(.keyword, before: startOfScopeIndex) == .keyword("func")
         }
     }
+
+    /// Whether or not the length of the type at the given index exceeds the minimum threshold to be organized
+    func typeLengthExceedsOrganizationThreshold(at typeKeywordIndex: Int) -> Bool {
+        let organizationThreshold: Int
+        switch tokens[typeKeywordIndex].string {
+        case "class", "actor":
+            organizationThreshold = options.organizeClassThreshold
+        case "struct":
+            organizationThreshold = options.organizeStructThreshold
+        case "enum":
+            organizationThreshold = options.organizeEnumThreshold
+        case "extension":
+            organizationThreshold = options.organizeExtensionThreshold
+        default:
+            organizationThreshold = 0
+        }
+
+        guard organizationThreshold != 0,
+              let startOfScope = index(of: .startOfScope("{"), after: typeKeywordIndex),
+              let endOfScope = endOfScope(at: startOfScope)
+        else {
+            return true
+        }
+
+        let lineCount = tokens[startOfScope ... endOfScope]
+            .filter(\.isLinebreak)
+            .count
+            - 1
+
+        return lineCount >= organizationThreshold
+    }
 }
 
 extension Formatter {

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -21,7 +21,7 @@ public extension FormatRule {
             "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
             "groupblanklines", "sortswiftuiprops",
         ],
-        sharedOptions: ["sortedpatterns", "lineaftermarks"]
+        sharedOptions: ["sortedpatterns", "lineaftermarks", "linebreaks"]
     ) { formatter in
         guard !formatter.options.fragment else { return }
 
@@ -146,7 +146,7 @@ extension Formatter {
     func organizeDeclaration(_ typeDeclaration: TypeDeclaration) {
         guard !typeDeclaration.body.isEmpty,
               options.organizeTypes.contains(typeDeclaration.keyword),
-              typeLengthExceedsOrganizationThreshold(typeDeclaration)
+              typeLengthExceedsOrganizationThreshold(at: typeDeclaration.keywordIndex)
         else { return }
 
         // Parse category order from options
@@ -189,34 +189,6 @@ extension Formatter {
             groups: consecutivePropertyGroups,
             order: categoryOrder
         )
-    }
-
-    /// Whether or not the length of this types exceeds the minimum threshold to be organized
-    func typeLengthExceedsOrganizationThreshold(_ typeDeclaration: TypeDeclaration) -> Bool {
-        let organizationThreshold: Int
-        switch typeDeclaration.keyword {
-        case "class", "actor":
-            organizationThreshold = options.organizeClassThreshold
-        case "struct":
-            organizationThreshold = options.organizeStructThreshold
-        case "enum":
-            organizationThreshold = options.organizeEnumThreshold
-        case "extension":
-            organizationThreshold = options.organizeExtensionThreshold
-        default:
-            organizationThreshold = 0
-        }
-
-        guard organizationThreshold != 0 else {
-            return true
-        }
-
-        let lineCount = typeDeclaration.body
-            .flatMap(\.tokens)
-            .filter(\.isLinebreak)
-            .count
-
-        return lineCount >= organizationThreshold
     }
 
     typealias CategorizedDeclaration = (declaration: Declaration, category: Category)

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -16,7 +16,7 @@ public extension FormatRule {
         // swiftformat:sort:end comments.
         """,
         options: ["sortedpatterns"],
-        sharedOptions: ["organizetypes", "linebreaks"]
+        sharedOptions: ["linebreaks", "organizetypes", "structthreshold", "classthreshold", "enumthreshold", "extensionlength"]
     ) { formatter in
         formatter.forEachToken(
             where: {
@@ -57,15 +57,16 @@ public extension FormatRule {
                       let typeCloseBrace = formatter.endOfScope(at: typeOpenBrace),
                       let firstTypeBodyToken = formatter.index(of: .nonLinebreak, after: typeOpenBrace),
                       let lastTypeBodyToken = formatter.index(of: .nonLinebreak, before: typeCloseBrace),
-                      let declarationKeyword = formatter.lastSignificantKeyword(at: typeOpenBrace),
+                      let declarationKeywordIndex = formatter.indexOfLastSignificantKeyword(at: typeOpenBrace),
                       lastTypeBodyToken > typeOpenBrace
                 else { return }
 
                 // Sorting the body of a type conflicts with the `organizeDeclarations`
-                // keyword if enabled for this type of declaration. In that case,
+                // keyword if enabled for this declaration. In that case,
                 // defer to the sorting implementation in `organizeDeclarations`.
                 if formatter.options.enabledRules.contains(FormatRule.organizeDeclarations.name),
-                   formatter.options.organizeTypes.contains(declarationKeyword)
+                   formatter.options.organizeTypes.contains(formatter.tokens[declarationKeywordIndex].string),
+                   formatter.typeLengthExceedsOrganizationThreshold(at: declarationKeywordIndex)
                 {
                     return
                 }

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -155,12 +155,6 @@ class MetadataTests: XCTestCase {
                 allSharedOptions.subtract(ruleOptions)
                 var referencedOptions = [OptionDescriptor]()
                 for index in scopeStart + 1 ..< formatter.tokens.count {
-                    guard (formatter.token(at: index - 1) == .operator(".", .infix)
-                        && formatter.token(at: index - 2) == .identifier("formatter"))
-                        || (formatter.token(at: index) == .identifier("options") && formatter.token(at: index - 1)?.isOperator(".") == false)
-                    else {
-                        continue
-                    }
                     switch formatter.tokens[index] {
                     // Find all of the options called via `options.optionName`
                     case .identifier("options") where formatter.token(at: index + 1) == .operator(".", .infix):
@@ -204,6 +198,13 @@ class MetadataTests: XCTestCase {
                     case .identifier("removeSelf"):
                         referencedOptions += [
                             Descriptors.selfRequired,
+                        ]
+                    case .identifier("typeLengthExceedsOrganizationThreshold"):
+                        referencedOptions += [
+                            Descriptors.organizeClassThreshold,
+                            Descriptors.organizeStructThreshold,
+                            Descriptors.organizeEnumThreshold,
+                            Descriptors.organizeExtensionThreshold,
                         ]
                     default:
                         continue

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3785,4 +3785,26 @@ class OrganizeDeclarationsTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .organizeDeclarations, exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
+
+    func testOrganizeDeclarationsSortsEnumNamespace() {
+        let input = """
+        // swiftformat:sort
+        public enum Constants {
+            public static let foo = "foo"
+            public static let bar = "bar"
+            public static let baaz = "baaz"
+        }
+        """
+
+        let output = """
+        // swiftformat:sort
+        public enum Constants {
+            public static let baaz = "baaz"
+            public static let bar = "bar"
+            public static let foo = "foo"
+        }
+        """
+
+        testFormatting(for: input, [output], rules: [.organizeDeclarations, .sortDeclarations])
+    }
 }

--- a/Tests/Rules/SortDeclarationsTests.swift
+++ b/Tests/Rules/SortDeclarationsTests.swift
@@ -286,4 +286,50 @@ class SortDeclarationsTests: XCTestCase {
 
         testFormatting(for: input, rule: .sortDeclarations)
     }
+
+    func testSortEnumNamespaceSmallerThanOrganizeDeclarationsEnumThreshold() {
+        let input = """
+        // swiftformat:sort
+        public enum Constants {
+            public static let foo = "foo"
+            public static let bar = "bar"
+            public static let baaz = "baaz"
+        }
+        """
+
+        let output = """
+        // swiftformat:sort
+        public enum Constants {
+            public static let baaz = "baaz"
+            public static let bar = "bar"
+            public static let foo = "foo"
+        }
+        """
+
+        let options = FormatOptions(organizeEnumThreshold: 20)
+        testFormatting(for: input, [output], rules: [.sortDeclarations, .organizeDeclarations], options: options)
+    }
+
+    func testSortStructSmallerThanOrganizeDeclarationsEnumThreshold() {
+        let input = """
+        // swiftformat:sort
+        public struct Foo {
+            public let foo = "foo"
+            public let bar = "bar"
+            public let baaz = "baaz"
+        }
+        """
+
+        let output = """
+        // swiftformat:sort
+        public struct Foo {
+            public let baaz = "baaz"
+            public let bar = "bar"
+            public let foo = "foo"
+        }
+        """
+
+        let options = FormatOptions(organizeStructThreshold: 20)
+        testFormatting(for: input, [output], rules: [.sortDeclarations, .organizeDeclarations])
+    }
 }


### PR DESCRIPTION
When sorting a type body with both `sortDeclarations` and `organizeDeclarations` are enabled, the `sortDeclarations` rule defers to the `organizeDeclararions` rule, which has a specialized sorting implementation.

However, the `orgganizeDeclarations` rule won't apply to any type below the configurable line count threshold. Since noth `sortDeclarations` and `organizeDeclarations` are disabled in this case, any `swiftformat:sort` would be ignored.

Now, the `sortDeclarations` rule checks whether the type is under the `organizeDeclarations` threshold, and if so will now sort the type body.