### PR TITLE
Use swift 6.0.3 toolchain in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # Base image and static SDK have to be updated together.
-FROM --platform=$BUILDPLATFORM swift:6.0.2 AS builder
+FROM --platform=$BUILDPLATFORM swift:6.0.3 AS builder
 WORKDIR /workspace
 RUN swift sdk install \
-	https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-	--checksum aa5515476a403797223fc2aad4ca0c3bf83995d5427fb297cab1d93c68cee075
+	https://download.swift.org/swift-6.0.3-release/static-sdk/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+	--checksum 67f765e0030e661a7450f7e4877cfe008db4f57f177d5a08a6e26fd661cdd0bd
 
 COPY . /workspace
 ARG TARGETPLATFORM


### PR DESCRIPTION
We've started to experience some weird behavior with the newest releases of SwiftFormat (specifically related to #1930 and #1949). We have our own custom dockerfile layered on top of swiftformats that looks like this:

```dockerfile
FROM ghcr.io/nicklockwood/swiftformat:latest as swiftformat
FROM alpine:latest
LABEL description="Swiftformat image containing some additional utility binaries and our default format ruleset"

RUN apk add --no-cache bash

# Copy all our custom swiftformat tools into this image
COPY company-swiftformat.sh /usr/bin/company-swiftformat.sh
COPY company-default-swiftformat-rules /etc/company-default-swiftformat-rules
COPY --from=swiftformat /usr/bin/swiftformat /usr/bin/swiftformat

WORKDIR /project
ENTRYPOINT ["/usr/bin/company-swiftformat.sh"]
CMD [ "." ]
```

That just adds a wrapper script and our default rules to the image. For reference here's that wrapper script:

```sh
#!/usr/bin/env bash

set -euo pipefail

usage() {
    cat <<-EOF
	Usage: $(basename "$0") [OPTIONS] [PATH]

	Applies swiftformat rules to the project. By default, this applies our
	standard set of company formatting rules.

	OPTIONS:
	    -h, --help See usage docs
	EOF
}

if [[ $# -eq 1 ]]; then
    case "$1" in
        -h|--help)
            usage
            swiftformat --help
            exit 0
            ;;
    esac
fi

swiftformat --baseconfig /etc/company-default-swiftformat-rules "$@"
```

We then use this on CI by invoking `company-swiftformat.sh --lint` using our image. However, as of the last 2 versions of SwiftFormat, this results in a segfault:

```
/usr/bin/company-swiftformat.sh: line 31:     7 Segmentation fault      (core dumped) swiftformat --baseconfig /etc/company-default-swiftformat-rules "$@"
```

Interestingly, as mentioned in #1930, if we add the `--verbose` flag everything works fine. I'm not 100% sure what the underlying cause is, but upgrading the docker image to use the latest `6.0.3` toolchain has resolved the problem in everything we've tested.

As a point of question: is there a particular question that the Docker image is built with a swift 6 toolchain while the build CI in this repo uses `5.3` and `5.10`? I see that there's another open PR to update to swift 6 (#1837), but am unsure if the difference is intentional or just an accident. I don't think it's cuasing a problem, just something of note.