### PR TITLE
Improve handling of parenthesis and type access in new multiline function chains rule

### DIFF
--- a/Sources/Rules/WrapMultilineFunctionChains.swift
+++ b/Sources/Rules/WrapMultilineFunctionChains.swift
@@ -39,6 +39,17 @@ public extension FormatRule {
                 return
             }
 
+            // If a type access (identifier with first character capitalized) immediately follows
+            // this operator on the same line, don't add a linebreak as it is likely a nested type.
+            if let nextNonSpaceIndex = formatter.index(of: .nonSpaceOrComment, after: operatorIndex),
+               nextNonSpaceIndex <= chainEndIndex,
+               formatter.onSameLine(operatorIndex, nextNonSpaceIndex),
+               case let .identifier(name) = formatter.token(at: nextNonSpaceIndex),
+               name.first?.isUppercase == true
+            {
+                return
+            }
+
             // If a closing scope immediately precedes this operator on the same line, insert a
             // line break
             if let previousNonSpaceIndex = formatter.index(of: .nonSpaceOrComment, before: operatorIndex),
@@ -85,6 +96,7 @@ extension Formatter {
             switch (prevToken, penultimateToken) {
             case (.endOfScope, .identifier),
                  (.endOfScope, .number),
+                 (.endOfScope, .endOfScope),
                  (.identifier, .number),
                  (.number, .identifier),
                  (.identifier, .identifier),
@@ -156,6 +168,7 @@ extension Formatter {
             switch (previousToken, nextToken) {
             case (.startOfScope, .identifier),
                  (.startOfScope, .number),
+                 (.startOfScope, .startOfScope),
                  (.identifier, .number),
                  (.number, .identifier),
                  (.identifier, .identifier),

--- a/Tests/Rules/WrapMultilineFunctionChainsTests.swift
+++ b/Tests/Rules/WrapMultilineFunctionChainsTests.swift
@@ -184,6 +184,24 @@ class WrapMultilineFunctionChainsTests: XCTestCase {
         testFormatting(for: input, rules: [.wrapMultilineFunctionChains, .indent])
     }
 
+    func testNamespacedAccessNotWrapped() {
+        let input = """
+        Namespace.NestedNamespace.property
+            .map { $0 * 2 }
+        """
+
+        testFormatting(for: input, rules: [.wrapMultilineFunctionChains, .indent])
+    }
+
+    func testNestedNamespacedAccessNotWrapped() {
+        let input = """
+        Namespace.NestedNamespace.DeeplyNestedNamespace.property
+            .function()
+        """
+
+        testFormatting(for: input, rules: [.wrapMultilineFunctionChains, .indent])
+    }
+
     func testMultilineTypesNotWrapped() {
         let input = """
         func tableCellSelection(for selection: Selection?) -> Selection
@@ -306,5 +324,17 @@ class WrapMultilineFunctionChainsTests: XCTestCase {
         """
 
         testFormatting(for: input, [], rules: [.wrapMultilineFunctionChains, .indent])
+    }
+
+    func testParenthesisInSingleLineDoNoWrap() {
+        let input = """
+        MainActor.assumeIsolated {
+            let value = try await someFunction()
+        }
+
+        (invoke() as Value).method()
+        """
+
+        testFormatting(for: input, [], rules: [.wrapMultilineFunctionChains, .indent], exclude: [.hoistTry])
     }
 }


### PR DESCRIPTION
Including a few more test cases