### PR TITLE
Fix indentation of trailing closures after chained multiline method calls

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2372,7 +2372,7 @@ extension Formatter {
                     continue
                 case .startOfScope("{") where lastKeyword == "var":
                     lastKeyword = ""
-                    if isStartOfClosure(at: index, in: scopeStack.last?.token) {
+                    if isStartOfClosure(at: index) {
                         fallthrough
                     }
                     var prevIndex = index - 1

--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -979,7 +979,7 @@ private struct Inference {
                     continue
                 case .startOfScope("{") where lastKeyword == "var":
                     lastKeyword = ""
-                    if formatter.isStartOfClosure(at: index, in: scopeStack.last) {
+                    if formatter.isStartOfClosure(at: index) {
                         fallthrough
                     }
                     var prevIndex = index - 1

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -513,7 +513,7 @@ extension Formatter {
         return index(of: .operator("->", .infix), in: startIndex + 1 ..< endIndex)
     }
 
-    func isStartOfClosure(at i: Int, in _: Token? = nil) -> Bool {
+    func isStartOfClosure(at i: Int) -> Bool {
         guard token(at: i) == .startOfScope("{") else {
             return false
         }
@@ -1057,7 +1057,7 @@ extension Formatter {
            last(.nonSpaceOrCommentOrLinebreak, before: i) == .endOfScope("}"),
            let nextIndex = index(of: .nonSpaceOrComment, after: i, if: { $0 == .delimiter(":") }),
            let nextNextIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: nextIndex),
-           isStartOfClosure(at: nextNextIndex, in: nil)
+           isStartOfClosure(at: nextNextIndex)
         {
             return true
         }

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -1575,6 +1575,64 @@ class IndentTests: XCTestCase {
                        exclude: [.wrapMultilineStatementBraces])
     }
 
+    func testIndentTrailingClosureAfterChainedMethodCall() {
+        let input = """
+        Foo()
+            .bar(
+                baaz: baaz,
+                quux: quux)
+            {
+                print("Trailing closure")
+            }
+            .methodCallAfterTrailingClosure()
+
+        Foo().bar(baaz: baaz, quux, quux) {
+            print("Trailing closure")
+        }
+        """
+
+        let options = FormatOptions(closingParenPosition: .sameLine)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testIndentNonTrailingClosureAfterChainedMethodCall() {
+        let input = """
+        Foo()
+            .bar(
+                baaz: baaz,
+                quux: quux,
+                closure: {
+                    print("Trailing closure")
+                })
+
+        Foo().bar(baaz: baaz, quux, quux, closure: {
+            print("Trailing closure")
+        })
+        """
+
+        let options = FormatOptions(closingParenPosition: .sameLine)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testIndentTrailingClosureAfterNonChainedMethodCall() {
+        let input = """
+        Foo(
+            baaz: baaz,
+            quux: quux)
+        {
+            print("Trailing closure")
+        }
+        .methodCallAfterTrailingClosure()
+
+        Foo().bar(baaz: baaz, quux, quux, closure: {
+            print("Trailing closure")
+        })
+        """
+
+        let options = FormatOptions(closingParenPosition: .sameLine)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
     func testNoDoubleIndentTrailingClosureBodyIfLineStartsWithClosingBrace() {
         let input = """
         let alert = Foo.alert(buttonCallback: {


### PR DESCRIPTION
This PR fixes the indentation of trailing closures after chained multiline method calls.

### Before

```swift
Foo()
    .bar(
        baaz: baaz,
        quux: quux)
{
    print("Trailing closure")
}
```

### After

```swift
Foo()
    .bar(
        baaz: baaz,
        quux: quux)
    {
        print("Trailing closure")
    }
```