### PR TITLE
Add trailing commas for new cases in Swift 6.1

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3068,7 +3068,7 @@ Option | Description
 
 ## trailingCommas
 
-Add or remove trailing comma from the last item in a collection literal.
+Add or remove trailing commas where applicable.
 
 Option | Description
 --- | ---
@@ -3089,6 +3089,16 @@ Option | Description
     bar,
 +   baz,
   ]
+```
+
+```diff
+func foo(
+-   bar _: Int
+) {}
+
+func foo(
++   bar _: Int,
+) {}
 ```
 
 </details>

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 public extension FormatRule {
-    /// Ensure that the last item in a multi-line array literal is followed by a comma.
+    /// Ensure that the last item in a multi-line collection literal, parameter or argument list,
+    /// or enum case with associated values is followed by a comma.
     /// This is useful for preventing noise in commits when items are added to end of array.
     static let trailingCommas = FormatRule(
-        help: "Add or remove trailing comma from the last item in a collection literal.",
+        help: "Add or remove trailing commas where applicable.",
         options: ["commas"]
     ) { formatter in
         formatter.forEach(.endOfScope("]")) { i, _ in

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -45,7 +45,7 @@ public let swiftVersionFile = ".swift-version"
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
-    "6.0",
+    "6.0", "6.1",
 ]
 
 /// Supported Swift language modes

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -272,4 +272,60 @@ class TrailingCommasTests: XCTestCase {
         let options = FormatOptions(trailingCommas: false)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
+
+    func testTrailingCommasAddedToFunctionParameters() {
+        let input = "func foo(\n    bar _: Int\n) {}"
+        let output = "func foo(\n    bar _: Int,\n) {}"
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromFunctionParameters() {
+        let input = "func foo(\n    bar _: Int,\n) {}"
+        let output = "func foo(\n    bar _: Int\n) {}"
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToFunctionArguments() {
+        let input = "foo(\n    bar _: Int\n) {}"
+        let output = "foo(\n    bar _: Int,\n) {}"
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromFunctionArguments() {
+        let input = "foo(\n    bar _: Int,\n) {}"
+        let output = "foo(\n    bar _: Int\n) {}"
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToEnumCaseAssociatedValue() {
+        let input = "enum Foo {\n    case bar(\n        baz: String\n    )\n}"
+        let output = "enum Foo {\n    case bar(\n        baz: String,\n    )\n}"
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromEnumCaseAssociatedValue() {
+        let input = "enum Foo {\n    case bar(\n        baz: String,\n    )\n}"
+        let output = "enum Foo {\n    case bar(\n        baz: String\n    )\n}"
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToInitializer() {
+        let input = "let foo: Foo = .init(\n    1\n)"
+        let output = "let foo: Foo = .init(\n    1,\n)"
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromInitializer() {
+        let input = "let foo: Foo = .init(\n    1,\n)"
+        let output = "let foo: Foo = .init(\n    1\n)"
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
 }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -274,57 +274,129 @@ class TrailingCommasTests: XCTestCase {
     }
 
     func testTrailingCommasAddedToFunctionParameters() {
-        let input = "func foo(\n    bar _: Int\n) {}"
-        let output = "func foo(\n    bar _: Int,\n) {}"
+        let input = """
+        func foo(
+            bar _: Int
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+        ) {}
+        """
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasRemovedFromFunctionParameters() {
-        let input = "func foo(\n    bar _: Int,\n) {}"
-        let output = "func foo(\n    bar _: Int\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int
+        ) {}
+        """
         let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasAddedToFunctionArguments() {
-        let input = "foo(\n    bar _: Int\n) {}"
-        let output = "foo(\n    bar _: Int,\n) {}"
+        let input = """
+        foo(
+            bar _: Int
+        ) {}
+        """
+        let output = """
+        foo(
+            bar _: Int,
+        ) {}
+        """
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasRemovedFromFunctionArguments() {
-        let input = "foo(\n    bar _: Int,\n) {}"
-        let output = "foo(\n    bar _: Int\n) {}"
+        let input = """
+        foo(
+            bar _: Int,
+        ) {}
+        """
+        let output = """
+        foo(
+            bar _: Int
+        ) {}
+        """
         let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasAddedToEnumCaseAssociatedValue() {
-        let input = "enum Foo {\n    case bar(\n        baz: String\n    )\n}"
-        let output = "enum Foo {\n    case bar(\n        baz: String,\n    )\n}"
+        let input = """
+        enum Foo {
+            case bar(
+                baz: String
+            )
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar(
+                baz: String,
+            )
+        }
+        """
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasRemovedFromEnumCaseAssociatedValue() {
-        let input = "enum Foo {\n    case bar(\n        baz: String,\n    )\n}"
-        let output = "enum Foo {\n    case bar(\n        baz: String\n    )\n}"
+        let input = """
+        enum Foo {
+            case bar(
+                baz: String,
+            )
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar(
+                baz: String
+            )
+        }
+        """
         let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasAddedToInitializer() {
-        let input = "let foo: Foo = .init(\n    1\n)"
-        let output = "let foo: Foo = .init(\n    1,\n)"
+        let input = """
+        let foo: Foo = .init(
+            1
+        )
+        """
+        let output = """
+        let foo: Foo = .init(
+            1,
+        )
+        """
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommasRemovedFromInitializer() {
-        let input = "let foo: Foo = .init(\n    1,\n)"
-        let output = "let foo: Foo = .init(\n    1\n)"
+        let input = """
+        let foo: Foo = .init(
+            1,
+        )
+        """
+        let output = """
+        let foo: Foo = .init(
+            1
+        )
+        """
         let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }


### PR DESCRIPTION
This PR adds trailing commas for several new cases in [Swift 6.1](https://www.swift.org/blog/swift-6.1-released/): function and initializer parameters and arguments, `enum` case associated values.

It addresses these issues: [#1999](https://github.com/nicklockwood/SwiftFormat/issues/1999), [#1995](https://github.com/nicklockwood/SwiftFormat/issues/1995)

### Before:
```
let foo: Foo = .init(
    1
)
```
```
func foo(
    bar _: Int
) {}
```
```
foo(
    1
)
```
```
enum Foo {
    case bar(
        baz: String
    )
}
```

### After:
```
let foo: Foo = .init(
    1,
)
```
```
func foo(
    bar _: Int,
) {}
```
```
foo(
    1,
)
```
```
enum Foo {
    case bar(
        baz: String,
    )
}
```

I'm planning to implement trailing commas for tuples, generic parameter lists, closure capture lists, and string interpolations in my next PRs.
