### PR TITLE
Fix parameter pack parsing bug in redundantSelf rule

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2791,7 +2791,8 @@ extension Formatter {
                 case .keyword("throws"),
                      .keyword("rethrows"),
                      .keyword("where"),
-                     .keyword("is"):
+                     .keyword("is"),
+                     .keyword("repeat"):
                     return false // Keep looking
                 case .keyword where !$0.isAttribute:
                     return true // Not valid between end of arguments and start of body

--- a/Tests/Rules/RedundantSelfTests.swift
+++ b/Tests/Rules/RedundantSelfTests.swift
@@ -3405,4 +3405,66 @@ class RedundantSelfTests: XCTestCase {
         """
         XCTAssertNoThrow(try format(input, rules: [.redundantSelf]))
     }
+
+    func testUnderstandsParameterPacks_issue_1992() {
+        let input = """
+        @resultBuilder
+        public enum DirectoryContentBuilder {
+            public static func buildPartialBlock<each Accumulated>(
+                accumulated: repeat each Accumulated,
+                next: some DirectoryContent
+            ) -> some DirectoryContent where repeat each Accumulated: DirectoryContent {
+                Accumulate(
+                    accumulated: repeat each accumulated,
+                    next: next
+                )
+            }
+
+            public static func buildEither<First, Second>(
+                first component: First
+            ) -> _Either<First, Second> where First: DirectoryContent, Second: DirectoryContent {
+                .first(component)
+            }
+
+            struct List<Element>: DirectoryContent where Element: DirectoryContent {
+                init(_ list: [Element]) {
+                    self._list = list
+                }
+
+                private let _list: [Element]
+            }
+        }
+        """
+
+        let output = """
+        @resultBuilder
+        public enum DirectoryContentBuilder {
+            public static func buildPartialBlock<each Accumulated>(
+                accumulated: repeat each Accumulated,
+                next: some DirectoryContent
+            ) -> some DirectoryContent where repeat each Accumulated: DirectoryContent {
+                Accumulate(
+                    accumulated: repeat each accumulated,
+                    next: next
+                )
+            }
+
+            public static func buildEither<First, Second>(
+                first component: First
+            ) -> _Either<First, Second> where First: DirectoryContent, Second: DirectoryContent {
+                .first(component)
+            }
+
+            struct List<Element>: DirectoryContent where Element: DirectoryContent {
+                init(_ list: [Element]) {
+                    _list = list
+                }
+
+                private let _list: [Element]
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .redundantSelf)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where parameter packs could confuse the `redundantSelf` rule, causing it to throw an error. Fixes #1992.