### PR TITLE
Update parsing helpers to support parameter pack types and expressions

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1272,6 +1272,8 @@ extension Formatter {
     ///  - `borrowing ...`
     ///  - `consuming ...`
     ///  - `sending ...`
+    ///  - `repeat ...`
+    ///  - `each ...`
     ///  - `@escaping ...`
     ///  - `@unchecked ...`
     ///  - `@retroactive ...`
@@ -1403,9 +1405,9 @@ extension Formatter {
             return (name: tokens[typeRange].stringExcludingLinebreaks, range: typeRange)
         }
 
-        // Parse types of the form `any ...`, `some ...`, `borrowing ...`, `consuming ...`, `sending ...`,
+        // Parse types of the form `any ...`, `some ...`, `borrowing ...`, `consuming ...`, `sending ...`, `repeat ...`, `each ...`,
         // `@unchecked ...`, `@escaping ...`, `~...`, `@retroactive ...`,
-        let typePrefixes = Set(["any", "some", "borrowing", "consuming", "sending", "@unchecked", "@escaping", "~", "@retroactive"])
+        let typePrefixes = Set(["any", "some", "borrowing", "consuming", "sending", "repeat", "each", "@unchecked", "@escaping", "~", "@retroactive"])
         if typePrefixes.contains(startToken.string),
            let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfTypeIndex),
            let followingType = parseType(at: nextToken)
@@ -1467,8 +1469,9 @@ extension Formatter {
         startingAt startIndex: Int,
         allowConditionalExpressions: Bool = false
     ) -> ClosedRange<Int>? {
-        // Any expression can start with a prefix operator, or `await`
-        if tokens[startIndex].isOperator(ofType: .prefix) || tokens[startIndex].string == "await",
+        // Any expression can start with a prefix operator, or `await`, `repeat`, `each`
+        let prefixKeywords = ["await", "repeat", "each"]
+        if tokens[startIndex].isOperator(ofType: .prefix) || prefixKeywords.contains(tokens[startIndex].string),
            let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: startIndex),
            let followingExpression = parseExpressionRange(startingAt: nextTokenIndex, allowConditionalExpressions: allowConditionalExpressions)
         {

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2195,6 +2195,21 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 5)?.name, "some View")
     }
 
+    func testParameterPackTypes() {
+        let formatter = Formatter(tokenize("""
+        func foo<each T>() -> repeat each T {
+          return repeat each T.self
+        }
+
+        func eachFirst<each T: Collection>(_ item: repeat each T) -> (repeat (each T).Element?) {
+            return (repeat (each item).first)
+        }
+        """))
+        XCTAssertEqual(formatter.parseType(at: 4)?.name, "each T")
+        XCTAssertEqual(formatter.parseType(at: 13)?.name, "repeat each T")
+        XCTAssertEqual(formatter.parseType(at: 62)?.name, "repeat (each T).Element?")
+    }
+
     func testParseInvalidType() {
         let formatter = Formatter(tokenize("""
         let foo = { foo, bar in (foo, bar) }
@@ -2276,6 +2291,9 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssert(isSingleExpression(#"await { await printAsync(foo) }()"#))
         XCTAssert(isSingleExpression(#"try await { try await printAsyncThrows(foo) }()"#))
         XCTAssert(isSingleExpression(#"Foo<Bar>()"#))
+        XCTAssert(isSingleExpression(#"each foo"#))
+        XCTAssert(isSingleExpression(#"repeat each foo.var.baaz"#))
+        XCTAssert(isSingleExpression(#"repeat (each item).first"#))
         XCTAssert(isSingleExpression(#"Foo<Bar, Baaz>(quux: quux)"#))
         XCTAssert(!isSingleExpression(#"if foo { "foo" } else { "bar" }"#))
         XCTAssert(!isSingleExpression(#"foo.bar, baaz.quux"#))


### PR DESCRIPTION
This PR updates the `parseType` and `parseExpressionRange` helpers to support parameter pack types and expressions, which start with `each` or `repeat each`.