### PR TITLE
Update fatal error messages to include rule name

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -222,7 +222,13 @@ public class Formatter: NSObject {
 
     func fatalError(_ error: String, at tokenIndex: Int) {
         let line = originalLine(at: tokenIndex)
-        errors.append(.parsing(error + " on line \(line)"))
+        var message = error + " on line \(line)"
+
+        if let currentRuleName = currentRule?.name {
+            message = "[\(currentRuleName)] \(message)"
+        }
+
+        errors.append(.parsing(message))
         ruleDisabled = true
     }
 }

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -265,7 +265,7 @@ class FormatterTests: XCTestCase {
     func testMalformedDirective2() {
         let input = "// swiftformat: --disable all"
         XCTAssertThrowsError(try format(input, rules: FormatRules.default).output) { error in
-            XCTAssertEqual("\(error)", "Expected directive after \'swiftformat:\' prefix on line 1")
+            XCTAssert(error.localizedDescription.hasSuffix("Expected directive after \'swiftformat:\' prefix on line 1."))
         }
     }
 


### PR DESCRIPTION
This PR updates fatal error messages to include the current rule name. This will make it easier to diagnose issues like #1992, where a specific rule was crashing the formatter.

Before:

```
error: The static modifier is not valid outside a type body on line 56 in /Users/cal/Downloads/Calligraphy/Sources/Calligraphy/DirectoryContentBuilder.swift
```

After:

```
error: [redundantSelf] The static modifier is not valid outside a type body on line 56 in /Users/cal/Downloads/Calligraphy/Sources/Calligraphy/DirectoryContentBuilder.swift
```