### PR TITLE
Update tokenizer to support parameter pack syntax in generics

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1847,9 +1847,9 @@ public func tokenize(_ source: String) -> [Token] {
                     return
                 case .keyword("throws"):
                     break
-                case .keyword where !token.isAttribute, .endOfScope:
-                    // If we encountered a keyword, or closing scope token that wasn't >
-                    // then the opening < must have been an operator after all
+                case .keyword where !token.isAttribute && token != .keyword("repeat"), .endOfScope:
+                    // If we encountered a keyword other than `repeat`, or closing scope
+                    // token that wasn't > then the opening < must have been an operator after all
                     convertOpeningChevronToOperator(at: scopeIndex)
                     processToken()
                     return

--- a/Tests/Rules/SpaceAroundOperatorsTests.swift
+++ b/Tests/Rules/SpaceAroundOperatorsTests.swift
@@ -621,6 +621,17 @@ class SpaceAroundOperatorsTests: XCTestCase {
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
+    func testSpaceNotInsertedInParameterPackGenericArgument() {
+        let input = """
+        func zip<Other, each Another>(
+            with _: Optional<Other>,
+            _: repeat Optional<each Another>
+        ) -> Optional<(Wrapped, Other, repeat each Another)> {}
+        """
+
+        testFormatting(for: input, rule: .spaceAroundOperators, exclude: [.typeSugar])
+    }
+
     // spaceAroundRangeOperators: .remove
 
     func testNoSpaceAroundRangeOperatorsWithCustomOptions() {

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -2553,6 +2553,29 @@ class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokenize(input), output)
     }
 
+    func testParameterPackGeneric() {
+        let input = "Optional<(Wrapped, Other, repeat each Another)>"
+        let output: [Token] = [
+            .identifier("Optional"),
+            .startOfScope("<"),
+            .startOfScope("("),
+            .identifier("Wrapped"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("Other"),
+            .delimiter(","),
+            .space(" "),
+            .keyword("repeat"),
+            .space(" "),
+            .identifier("each"),
+            .space(" "),
+            .identifier("Another"),
+            .endOfScope(")"),
+            .endOfScope(">"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
+
     func testFunctionThatLooksLikeGenericType() {
         let input = "y<CGRectGetMaxY(r)"
         let output: [Token] = [


### PR DESCRIPTION
This PR updates the tokenizer to support parameter pack syntax (`repeat each`) in generic angle brackets.

In an example like `Optional<(Wrapped, Other, repeat each Another)>` from #2000, the tokenizer was parsing the `<` as an operator instead of a `startOfScope`, because it was confused by the `repeat` keyword.

Fixes #2000.