### PR TITLE
Add support of trailing commas in all cases containing round parentheses in Swift 6.1

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3101,6 +3101,30 @@ func foo(
 ) {}
 ```
 
+```diff
+let foo = (
+    bar: 0,
+-   baz: 1
+)
+
+let foo = (
+    bar: 0,
++   baz: 1,
+)
+```
+
+```diff
+@Foo(
+    "bar",
+-   "baz"
+)
+
+@Foo(
+    "bar",
++   "baz",
+)
+```
+
 </details>
 <br/>
 

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -10,20 +10,7 @@ import Foundation
 
 public extension FormatRule {
     /// Ensure that the last item in a multi-line list is followed by a comma, where applicable.
-    /// This includes:
-    /// - array and dictionary literals
-    /// - function and initializer parameters and arguments
-    /// - enum case associated values
-    /// - tuple literals
-    /// - tuple expressions in `return`, `throw`, `switch`, `case let`, `if`, `guard`, `while`
-    /// - macro and attribute argument lists (e.g. `#macro(...)`, `@Attribute(...)`)
-    /// - string interpolation expressions
-    ///
-    /// Trailing commas help reduce version control noise when appending new elements to a list.
-    ///
-    /// Trailing commas will not be added in contexts where they are invalid:
-    /// - empty parentheses `()`
-    /// - type annotations (e.g. `let value: (Int, String)`)
+    /// This is useful for preventing noise in commits when items are added to end of array.
     static let trailingCommas = FormatRule(
         help: "Add or remove trailing commas where applicable.",
         options: ["commas"]

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -9,9 +9,21 @@
 import Foundation
 
 public extension FormatRule {
-    /// Ensure that the last item in a multi-line collection literal, parameter or argument list,
-    /// or enum case with associated values is followed by a comma.
-    /// This is useful for preventing noise in commits when items are added to end of array.
+    /// Ensure that the last item in a multi-line list is followed by a comma, where applicable.
+    /// This includes:
+    /// - array and dictionary literals
+    /// - function and initializer parameters and arguments
+    /// - enum case associated values
+    /// - tuple literals
+    /// - tuple expressions in `return`, `throw`, `switch`, `case let`, `if`, `guard`, `while`
+    /// - macro and attribute argument lists (e.g. `#macro(...)`, `@Attribute(...)`)
+    /// - string interpolation expressions
+    ///
+    /// Trailing commas help reduce version control noise when appending new elements to a list.
+    ///
+    /// Trailing commas will not be added in contexts where they are invalid:
+    /// - empty parentheses `()`
+    /// - type annotations (e.g. `let value: (Int, String)`)
     static let trailingCommas = FormatRule(
         help: "Add or remove trailing commas where applicable.",
         options: ["commas"]
@@ -134,6 +146,18 @@ public extension FormatRule {
         let foo = (
             bar: 0,
         +   baz: 1,
+        )
+        ```
+
+        ```diff
+        @Foo(
+            "bar",
+        -   "baz"
+        )
+
+        @Foo(
+            "bar",
+        +   "baz",
         )
         ```
         """

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -66,17 +66,8 @@ public extension FormatRule {
                 return
             }
 
-            switch formatter.tokens[prevToStartTokenIndex] {
-            case let .keyword(value):
-                if ["if", "guard", "while"].contains(value) {
-                    return
-                } else {
-                    break
-                }
-            case .delimiter(":"):
+            guard formatter.tokens[prevToStartTokenIndex] != .delimiter(":") else {
                 return
-            default:
-                break
             }
 
             guard let prevToEndTokenIndex = formatter.index(of: .nonSpaceOrComment, before: i) else {

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -400,4 +400,504 @@ class TrailingCommasTests: XCTestCase {
         let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
+
+    func testTrailingCommasAddedToTuple() {
+        let input = """
+        let foo = (
+            bar: 0,
+            baz: 1
+        )
+        """
+        let output = """
+        let foo = (
+            bar: 0,
+            baz: 1,
+        )
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromTuple() {
+        let input = """
+        let foo = (
+            bar: 0,
+            baz: 1,
+        )
+        """
+        let output = """
+        let foo = (
+            bar: 0,
+            baz: 1
+        )
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToReturnTuple() {
+        let input = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz
+            )
+        }
+        """
+        let output = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromReturnTuple() {
+        let input = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz,
+            )
+        }
+        """
+        let output = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToThrow() {
+        let input = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar
+            )
+        }
+        """
+        let output = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromThrow() {
+        let input = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar,
+            )
+        }
+        """
+        let output = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToSwitch() {
+        let input = """
+        let foo = (
+            bar: 0,
+            baz: 1
+        )
+        switch (
+            foo.bar,
+            foo.baz
+        ) {
+        case (
+            0,
+            1
+        ): break
+        default: break
+        }
+        """
+        let output = """
+        let foo = (
+            bar: 0,
+            baz: 1,
+        )
+        switch (
+            foo.bar,
+            foo.baz,
+        ) {
+        case (
+            0,
+            1,
+        ): break
+        default: break
+        }
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToIf() {
+        let input = """
+        if (
+            true
+        ) {}
+        """
+        let output = """
+        if (
+            true,
+        ) {}
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasRemovedFromIf() {
+        let input = """
+        if (
+            true,
+        ) {}
+        """
+        let output = """
+        if (
+            true
+        ) {}
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasAddedToGuard() {
+        let input = """
+        guard (
+            true
+        ) else {
+            return
+        }
+        """
+        let output = """
+        guard (
+            true,
+        ) else {
+            return
+        }
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasRemovedFromGuard() {
+        let input = """
+        guard (
+            true,
+        ) else {
+            return
+        }
+        """
+        let output = """
+        guard (
+            true
+        ) else {
+            return
+        }
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasAddedToWhile() {
+        let input = """
+        while (
+            true
+        ) {}
+        """
+        let output = """
+        while (
+            true,
+        ) {}
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasRemovedFromWhile() {
+        let input = """
+        while (
+            true,
+        ) {}
+        """
+        let output = """
+        while (
+            true
+        ) {}
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasAddedToBool() {
+        let input = """
+        let foo: Bool = (
+            true && true
+        )
+        """
+        let output = """
+        let foo: Bool = (
+            true && true,
+        )
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasRemovedFromBool() {
+        let input = """
+        let foo: Bool = (
+            true && true,
+        )
+        """
+        let output = """
+        let foo: Bool = (
+            true && true
+        )
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas,
+                       options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasNotAddedToTypeAnnotation() {
+        let input = """
+        let foo: (
+            bar: Int,
+            baz: Int
+        )
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToCaseLet() {
+        let input = """
+        let foo = (0, 1)
+        switch foo {
+        case let (
+            bar,
+            baz
+        ): break
+        }
+        """
+        let output = """
+        let foo = (0, 1)
+        switch foo {
+        case let (
+            bar,
+            baz,
+        ): break
+        }
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromCaseLet() {
+        let input = """
+        let foo = (0, 1)
+        switch foo {
+        case let (
+            bar,
+            baz,
+        ): break
+        }
+        """
+        let output = """
+        let foo = (0, 1)
+        switch foo {
+        case let (
+            bar,
+            baz
+        ): break
+        }
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasNotAddedToEmptyParentheses() {
+        let input = """
+        let foo = (
+
+        )
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas,
+                       options: options, exclude: [
+                           .blankLinesAtEndOfScope,
+                           .blankLinesAtStartOfScope,
+                       ])
+    }
+
+    func testTrailingCommasAddedToStringInterpolation() {
+        let input = """
+        let foo = \"""
+        Foo: \\(
+            1,
+            2
+        )
+        \"""
+        """
+        let output = """
+        let foo = \"""
+        Foo: \\(
+            1,
+            2,
+        )
+        \"""
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromStringInterpolation() {
+        let input = """
+        let foo = \"""
+        Foo: \\(
+            1,
+            2,
+        )
+        \"""
+        """
+        let output = """
+        let foo = \"""
+        Foo: \\(
+            1,
+            2
+        )
+        \"""
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToAttribute() {
+        let input = """
+        @Foo(
+            "bar",
+            "baz"
+        )
+        struct Qux {}
+        """
+        let output = """
+        @Foo(
+            "bar",
+            "baz",
+        )
+        struct Qux {}
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromAttribute() {
+        let input = """
+        @Foo(
+            "bar",
+            "baz",
+        )
+        struct Qux {}
+        """
+        let output = """
+        @Foo(
+            "bar",
+            "baz"
+        )
+        struct Qux {}
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToMacro() {
+        let input = """
+        #foo(
+            "bar",
+            "baz"
+        )
+        """
+        let output = """
+        #foo(
+            "bar",
+            "baz",
+        )
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromMacro() {
+        let input = """
+        #foo(
+            "bar",
+            "baz",
+        )
+        """
+        let output = """
+        #foo(
+            "bar",
+            "baz"
+        )
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
 }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -773,6 +773,40 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
+    func testTrailingCommaAddedToDestructuringLetTuple() {
+        let input = """
+        let (
+            foo,
+            bar
+        ) = (0, 1)
+        """
+        let output = """
+        let (
+            foo,
+            bar,
+        ) = (0, 1)
+        """
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommaRemovedFromDestructuringLetTuple() {
+        let input = """
+        let (
+            foo,
+            bar,
+        ) = (0, 1)
+        """
+        let output = """
+        let (
+            foo,
+            bar
+        ) = (0, 1)
+        """
+        let options = FormatOptions(trailingCommas: false, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
     func testTrailingCommasNotAddedToEmptyParentheses() {
         let input = """
         let foo = (


### PR DESCRIPTION
## Overview

This PR adds support of trailing commas in all cases containing round parentheses `()` in [Swift 6.1](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0439-trailing-comma-lists.md)

## Implemented earlier

Trailing commas were already supported in:

- Multi-line collections
- Parameter or argument lists
- Enum cases with associated values

## New features

Trailing commas are now **added** (or removed) for multi-line lists in the following contexts:

- Array and dictionary literals
- Function and initializer parameters and arguments
- Enum case associated values
- Tuple literals, including in `return`, `switch`, `case let`, `let`
- Parenthesized single expressions (e.g., `throw (error,)`, `if (true,)`, `guard (true,)`, `while (true,)`)
- Attribute arguments (e.g. `@Attribute(...)`)
- Macro arguments (e.g. `#macro(...)`)
- String interpolation expressions (when custom interpolation methods allow multiple arguments)

Trailing commas are **not added** in:

- Empty parentheses ()
- Type annotations (e.g. `let x: (Int, String)`)

## Future plans

I'm **planning** to add trailing commas in the following contexts in the next PR:

- Subscripts, including key path subscripts
- Closure capture lists
- Generic parameters

In addition to this, I'm planning to debug and fix failing tests in `TrailingCommasTests`

## Testing info

To test String interpolation, use this extension:

```
extension String.StringInterpolation {
    
    mutating func appendInterpolation(_ a: Int, _ b: Int) {
        appendLiteral("\(a)\(b)")
    }
}
```
