### PR TITLE
Fix issue where propertyTypes rule could break property using some keyword

### DIFF
--- a/Tests/Rules/PropertyTypesTests.swift
+++ b/Tests/Rules/PropertyTypesTests.swift
@@ -355,9 +355,24 @@ class PropertyTypesTests: XCTestCase {
 
         /// This compiles
         let myShape1: any ShapeStyle = .myShape
+        let myShape2: (any ShapeStyle) = .myShape
 
         // This would fail with "error: static member 'myShape' cannot be used on protocol metatype '(any ShapeStyle).Type'"
-        // let myShape2 = (any ShapeStyle).myShape
+        // let myShape3 = (any ShapeStyle).myShape
+        """
+
+        let options = FormatOptions(propertyTypes: .inferred)
+        testFormatting(for: input, rule: .propertyTypes, options: options)
+    }
+
+    func testPreservesTypeWithSomeKeyword() {
+        let input = """
+        /// This compiles
+        let myShape1: some ShapeStyle = .myShape
+        let myShape2: (some ShapeStyle) = .myShape
+
+        // This would fail to compile
+        // let myShape4 = (some ShapeStyle).myShape
         """
 
         let options = FormatOptions(propertyTypes: .inferred)


### PR DESCRIPTION
This PR fixes an issue where the `propertyTypes` rule could convert something like:

```swift
var scrollTargetBehavior: (some ScrollTargetBehavior) = .paging
```

to:

```swift
var scrollTargetBehavior: (some ScrollTargetBehavior).paging
```

which no longer compiles, since you can't use static member lookup on a `some` type like this.

We need to handle `some` like how we handle `any`.