### PR TITLE
Fix support for `--closingparen same-line` `--callsiteparen balanced`

### DIFF
--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -167,6 +167,22 @@ class WrapArgumentsTests: XCTestCase {
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
+    func testWrapParametersFunctionCallClosingParenBalancedAndForce() {
+        let input = """
+        foo(
+            bar: 42,
+            baz: "foo")
+        """
+        let output = """
+        foo(
+            bar: 42,
+            baz: "foo"
+        )
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, closingParenPosition: .sameLine, callSiteClosingParenPosition: .balanced)
+        testFormatting(for: input, output, rule: .wrapArguments, options: options)
+    }
+
     func testIndentMultilineStringWhenWrappingArguments() {
         let input = """
         foobar(foo: \"\""


### PR DESCRIPTION
This PR fixes support for using `--callsiteparen balanced` with `--closingparen same-line`. Previously this configuration would result in the `--callsiteparen balanced` option having no effect.