### PR TITLE
Update `--wrapeffects` and `--wrapreturntype` to support protocol requirements

### DIFF
--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -1689,6 +1689,33 @@ class WrapArgumentsTests: XCTestCase {
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
+    func testWrapReturnOnMultilineFunctionDeclarationInProtocol() {
+        let input = """
+        protocol MyProtocol {
+            func multilineFunction(
+                foo _: String,
+                bar _: String) -> String
+        }
+        """
+
+        let output = """
+        protocol MyProtocol {
+            func multilineFunction(
+                foo _: String,
+                bar _: String)
+                -> String
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline
+        )
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: options)
+    }
+
     func testWrapReturnAndEffectOnMultilineFunctionDeclaration() {
         let input = """
         func multilineFunction(
@@ -1756,6 +1783,35 @@ class WrapArgumentsTests: XCTestCase {
             foo _: String,
             bar _: String)
             async throws -> String {}
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: options)
+    }
+
+    func testWrapEffectOnMultilineProtocolRequirement() {
+        let input = """
+        protocol MyProtocol {
+            func multilineFunction(
+                foo _: String,
+                bar _: String) async throws
+                -> String
+        }
+        """
+
+        let output = """
+        protocol MyProtocol {
+            func multilineFunction(
+                foo _: String,
+                bar _: String)
+                async throws -> String
+        }
         """
 
         let options = FormatOptions(


### PR DESCRIPTION
This PR updates `--wrapeffects` and `--wrapreturntype` to support protocol requirements. Previously these rules weren't applied in those cases because the logic was looking for the `.startOfScope("{")` of the function body, which doesn't exist in this case.

https://github.com/nicklockwood/SwiftFormat/pull/2017 reduces the amount of work we have to do to correctly parse these parts of the function declaration.