### PR TITLE
Update acronyms rule to respect list of `--preservedsymbols`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -136,6 +136,7 @@ Capitalize acronyms when the first character is capitalized.
 Option | Description
 --- | ---
 `--acronyms` | Acronyms to auto-capitalize. Defaults to "ID,URL,UUID"
+`--preservedsymbols` | Comma-delimited list of symbols to be ignored by the rule
 
 <details>
 <summary>Examples</summary>

--- a/Sources/Rules/Acronyms.swift
+++ b/Sources/Rules/Acronyms.swift
@@ -12,10 +12,14 @@ public extension FormatRule {
     static let acronyms = FormatRule(
         help: "Capitalize acronyms when the first character is capitalized.",
         disabledByDefault: true,
-        options: ["acronyms"]
+        options: ["acronyms", "preservedsymbols"]
     ) { formatter in
         formatter.forEachToken { index, token in
             guard token.is(.identifier) || token.isComment else { return }
+
+            guard !formatter.options.preservedSymbols.contains(token.string) else {
+                return
+            }
 
             var updatedText = token.string
 

--- a/Tests/Rules/AcronymsTests.swift
+++ b/Tests/Rules/AcronymsTests.swift
@@ -75,4 +75,19 @@ class AcronymsTests: XCTestCase {
 
         testFormatting(for: input, rule: .acronyms)
     }
+
+    func testRespectsPreserveSymbols() {
+        let input = """
+        let destinationUrl = api.externallyProvidedUrl
+        api.route(toUrl: destinationUrl)
+        """
+
+        let output = """
+        let destinationURL = api.externallyProvidedUrl
+        api.route(toUrl: destinationURL)
+        """
+
+        let options = FormatOptions(preservedSymbols: ["externallyProvidedUrl", "toUrl"])
+        testFormatting(for: input, output, rule: .acronyms, options: options)
+    }
 }


### PR DESCRIPTION
This PR updates the acronyms rule to respect the `--preservedsymbols` option. Symbols included there will not be autocorrected. Fixes https://github.com/nicklockwood/SwiftFormat/issues/2019.