### PR TITLE
Fix Linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
   linux:
     name: Build SwiftFormat for Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The Linux release build is failing because `ubuntu-20.04` support has been removed. This PR updates the job to `ubuntu-latest`. Tested the job here, which passed: https://github.com/nicklockwood/SwiftFormat/actions/runs/14840548772

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2023