### PR TITLE
Add AutoUpdatingIndex and AutoUpdatingRange based on existing auto-updating Declaration functionality

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -846,13 +846,17 @@ private struct WeakAutoUpdatingReference {
 }
 
 /// An auto-updating index within an associated `Formatter`
-final class AutoUpdatingIndex: AutoUpdatingReference {
+final class AutoUpdatingIndex: AutoUpdatingReference, CustomStringConvertible {
     var index: Int
     let formatter: Formatter
 
     var range: ClosedRange<Int> {
         get { index ... index }
         set { index = newValue.lowerBound }
+    }
+
+    var description: String {
+        index.description
     }
 
     init(index: Int, formatter: Formatter) {
@@ -867,9 +871,21 @@ final class AutoUpdatingIndex: AutoUpdatingReference {
 }
 
 // An auto-updating subrange of indicies in a `Formatter`
-final class AutoUpdatingRange: AutoUpdatingReference {
+final class AutoUpdatingRange: AutoUpdatingReference, CustomStringConvertible {
     var range: ClosedRange<Int>
     let formatter: Formatter
+
+    var lowerBound: Int {
+        range.lowerBound
+    }
+
+    var upperBound: Int {
+        range.upperBound
+    }
+
+    var description: String {
+        range.description
+    }
 
     init(range: ClosedRange<Int>, formatter: Formatter) {
         self.range = range

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1915,7 +1915,9 @@ extension Formatter {
             // Include all whitespace and comments in the conformance's source range,
             // so if we remove it later all of the extra whitespace will get cleaned up
             let sourceRangeEnd: Int
-            if let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: typeEndIndex) {
+            if let nextTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: typeEndIndex),
+               nextTokenIndex - 1 <= genericSignatureEndIndex
+            {
                 sourceRangeEnd = nextTokenIndex - 1
             } else {
                 sourceRangeEnd = typeEndIndex

--- a/Tests/Rules/OpaqueGenericParametersTests.swift
+++ b/Tests/Rules/OpaqueGenericParametersTests.swift
@@ -691,4 +691,24 @@ class OpaqueGenericParametersTests: XCTestCase {
         testFormatting(for: input, output, rule: .opaqueGenericParameters,
                        options: options, exclude: [.unusedArguments])
     }
+
+    func testUpdatesProtocolRequirements() {
+        let input = """
+        protocol FooProtocol {
+            func foo<T>(_ foos: T) where T: Collection, T.Element == Foo
+            func bar<T: Collection>(_ bars: T)
+        }
+        """
+
+        let output = """
+        protocol FooProtocol {
+            func foo(_ foos: some Collection<Foo>) 
+            func bar(_ bars: some Collection)
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .opaqueGenericParameters,
+                       options: options, exclude: [.unusedArguments, .trailingSpace])
+    }
 }

--- a/Tests/Rules/SortDeclarationsTests.swift
+++ b/Tests/Rules/SortDeclarationsTests.swift
@@ -330,6 +330,6 @@ class SortDeclarationsTests: XCTestCase {
         """
 
         let options = FormatOptions(organizeStructThreshold: 20)
-        testFormatting(for: input, [output], rules: [.sortDeclarations, .organizeDeclarations])
+        testFormatting(for: input, [output], rules: [.sortDeclarations, .organizeDeclarations], options: options)
     }
 }


### PR DESCRIPTION
`Declaration`s are a dynamic, auto-updating reference to a subrange of indices within a `Formatter`. This is helpful because it lets you avoid invalidating existing indices, or having to manually increment/decrement index values while making changes.

This PR generalizes that auto-updating functionality into `AutoUpdatingIndex` and `AutoUpdatingRange` values that can be used within other rules.