### PR TITLE
Add breakLineAt End & Start OfScope rule

### DIFF
--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -93,7 +93,8 @@ class PerformanceTests: XCTestCase {
             hoistPatternLet: false,
             elseOnNextLine: true,
             explicitSelf: .insert,
-            experimentalRules: true
+            experimentalRules: true,
+            breakLineAtEndOfTypes: true
         )
         measure {
             _ = tokens.map { try! format($0, options: options) }

--- a/Rules.md
+++ b/Rules.md
@@ -409,7 +409,7 @@ Option | Description
 
 ## blankLinesAtEndOfScope
 
-Remove trailing blank line at the end of a scope.
+Remove or insert trailing blank line at the end of a scope.
 
 <details>
 <summary>Examples</summary>
@@ -440,6 +440,16 @@ Remove trailing blank line at the end of a scope.
   ]
 ```
 
+With --typeblanklines insert:
+
+```diff
+  class MyClass {
+      // Implementation
+-     }
++
++     }
+```
+
 </details>
 <br/>
 
@@ -449,7 +459,7 @@ Remove leading blank line at the start of a scope.
 
 Option | Description
 --- | ---
-`--typeblanklines` | "remove" (default) or "preserve" blank lines from types
+`--typeblanklines` | "remove" (default), "insert", or "preserve" blank lines in types
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -411,6 +411,10 @@ Option | Description
 
 Remove or insert trailing blank line at the end of a scope.
 
+Option | Description
+--- | ---
+`--typeblanklines` | breakLine: "remove" (default), "insert", or "preserve"
+
 <details>
 <summary>Examples</summary>
 
@@ -440,14 +444,13 @@ Remove or insert trailing blank line at the end of a scope.
   ]
 ```
 
-With --typeblanklines insert:
+With `--typeblanklines insert`:
 
 ```diff
-  class MyClass {
-      // Implementation
--     }
+  struct Foo {
+      let bar: Bar
 +
-+     }
+  }
 ```
 
 </details>
@@ -459,7 +462,7 @@ Remove leading blank line at the start of a scope.
 
 Option | Description
 --- | ---
-`--typeblanklines` | "remove" (default), "insert", or "preserve" blank lines in types
+`--typeblanklines` | breakLine: "remove" (default), "insert", or "preserve"
 
 <details>
 <summary>Examples</summary>
@@ -488,6 +491,15 @@ Option | Description
     bar,
     baz,
   ]
+```
+
+With `--typeblanklines insert`:
+
+```diff
+  struct Foo {
++
+      let bar: Bar
+  }
 ```
 
 </details>

--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -387,43 +387,15 @@ extension Declaration {
     }
 
     /// Ensures that this declaration ends with at least one trailing blank line,
-    /// by a blank like to the end of this declaration if not already present.
+    /// by adding a blank line to the end of this declaration if not already present.
     func addTrailingBlankLineIfNeeded() {
-        while tokens.numberOfTrailingLinebreaks() < 2 {
-            formatter.insertLinebreak(at: range.upperBound)
-        }
+        formatter.addTrailingBlankLineIfNeeded(in: range)
     }
 
     /// Ensures that this declaration doesn't end with a trailing blank line
     /// by removing any trailing blank lines.
     func removeTrailingBlankLinesIfPresent() {
-        while tokens.numberOfTrailingLinebreaks() > 1 {
-            guard let lastNewlineIndex = formatter.lastIndex(of: .linebreak, in: Range(range)) else { break }
-            formatter.removeTokens(in: lastNewlineIndex ... range.upperBound)
-        }
-    }
-}
-
-extension RandomAccessCollection where Element == Token, Index == Int {
-    // The number of trailing newlines in this array of tokens,
-    // taking into account any spaces that may be between the linebreaks.
-    func numberOfTrailingLinebreaks() -> Int {
-        guard !isEmpty else { return 0 }
-
-        var numberOfTrailingLinebreaks = 0
-        var searchIndex = indices.last!
-
-        while searchIndex >= indices.first!,
-              self[searchIndex].isSpaceOrLinebreak
-        {
-            if self[searchIndex].isLinebreak {
-                numberOfTrailingLinebreaks += 1
-            }
-
-            searchIndex -= 1
-        }
-
-        return numberOfTrailingLinebreaks
+        formatter.removeTrailingBlankLinesIfPresent(in: range)
     }
 }
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1154,13 +1154,11 @@ struct _Descriptors {
         help: "Change type to enum: \"always\" (default) or \"structs-only\"",
         keyPath: \.enumNamespaces
     )
-    let removeStartOrEndBlankLinesFromTypes = OptionDescriptor(
+    let typeBlankLines = OptionDescriptor(
         argumentName: "typeblanklines",
-        displayName: "Remove blank lines from types",
-        help: "\"remove\" (default) or \"preserve\" blank lines from types",
-        keyPath: \.removeStartOrEndBlankLinesFromTypes,
-        trueValues: ["remove"],
-        falseValues: ["preserve"]
+        displayName: "Blank lines types",
+        help: "breakLine: \"remove\" (default), \"insert\", or \"preserve\"",
+        keyPath: \.typeBlankLines
     )
     let genericTypes = OptionDescriptor(
         argumentName: "generictypes",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -731,7 +731,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var indentStrings: Bool
     public var closureVoidReturn: ClosureVoidReturn
     public var enumNamespaces: EnumNamespacesMode
-    public var removeStartOrEndBlankLinesFromTypes: Bool
+    public var typeBlankLines: TypeBlankLines
     public var genericTypes: String
     public var useSomeAny: Bool
     public var wrapEffects: WrapEffects
@@ -863,7 +863,7 @@ public struct FormatOptions: CustomStringConvertible {
                 indentStrings: Bool = false,
                 closureVoidReturn: ClosureVoidReturn = .remove,
                 enumNamespaces: EnumNamespacesMode = .always,
-                removeStartOrEndBlankLinesFromTypes: Bool = true,
+                typeBlankLines: TypeBlankLines = .remove,
                 genericTypes: String = "",
                 useSomeAny: Bool = true,
                 wrapEffects: WrapEffects = .preserve,
@@ -898,7 +898,6 @@ public struct FormatOptions: CustomStringConvertible {
         self.useVoid = useVoid
         self.indentCase = indentCase
         self.trailingCommas = trailingCommas
-        self.indentComments = indentComments
         self.truncateBlankLines = truncateBlankLines
         self.insertBlankLines = insertBlankLines
         self.removeBlankLines = removeBlankLines
@@ -985,7 +984,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.indentStrings = indentStrings
         self.closureVoidReturn = closureVoidReturn
         self.enumNamespaces = enumNamespaces
-        self.removeStartOrEndBlankLinesFromTypes = removeStartOrEndBlankLinesFromTypes
+        self.typeBlankLines = typeBlankLines
         self.genericTypes = genericTypes
         self.useSomeAny = useSomeAny
         self.wrapEffects = wrapEffects
@@ -1004,6 +1003,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.preferFileMacro = preferFileMacro
         self.lineBetweenConsecutiveGuards = lineBetweenConsecutiveGuards
         // Doesn't really belong here, but hard to put elsewhere
+        self.indentComments = indentComments
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers
         self.swiftVersion = swiftVersion
@@ -1129,4 +1129,10 @@ public struct Options {
     public func shouldSkipFile(_ inputURL: URL) -> Bool {
         fileOptions?.shouldSkipFile(inputURL) ?? false
     }
+}
+
+public enum TypeBlankLines: String, CaseIterable {
+    case remove
+    case insert
+    case preserve
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -484,6 +484,13 @@ public enum DeclarationOrganizationMode: String, CaseIterable {
     case type
 }
 
+/// Whether to insert or remove blank lines from the start / end of type bodies
+public enum TypeBlankLines: String, CaseIterable {
+    case remove
+    case insert
+    case preserve
+}
+
 /// Format to use when printing dates
 public enum DateFormat: Equatable, RawRepresentable, CustomStringConvertible {
     case dayMonthYear
@@ -1129,10 +1136,4 @@ public struct Options {
     public func shouldSkipFile(_ inputURL: URL) -> Bool {
         fileOptions?.shouldSkipFile(inputURL) ?? false
     }
-}
-
-public enum TypeBlankLines: String, CaseIterable {
-    case remove
-    case insert
-    case preserve
 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1069,6 +1069,17 @@ extension Formatter {
         }
     }
 
+    /// Whether the given index is a `startOfScope("{")` that represents the start of a type body
+    func isStartOfTypeBody(at scopeIndex: Int) -> Bool {
+        guard tokens[scopeIndex] == .startOfScope("{") else { return false }
+
+        guard let lastKeyword = lastSignificantKeyword(at: scopeIndex, excluding: ["where"]) else {
+            return false
+        }
+
+        return Token.swiftTypeKeywords.contains(lastKeyword)
+    }
+
     func isTrailingClosureLabel(at i: Int) -> Bool {
         if case .identifier? = token(at: i),
            last(.nonSpaceOrCommentOrLinebreak, before: i) == .endOfScope("}"),

--- a/Sources/Rules/BlankLinesAtEndOfScope.swift
+++ b/Sources/Rules/BlankLinesAtEndOfScope.swift
@@ -17,107 +17,33 @@ public extension FormatRule {
         options: ["typeblanklines"],
         sharedOptions: ["typeblanklines"]
     ) { formatter in
-        // First pass: Find all non-type scopes or type scopes that need blank lines removed
-        formatter.forEach(.startOfScope) { startOfScopeIndex, _ in
-            guard let endOfScopeIndex = formatter.endOfScope(at: startOfScopeIndex) else { return }
-            let endOfScope = formatter.tokens[endOfScopeIndex]
+        formatter.forEach(.startOfScope) { startOfScope, token in
+            guard ["{", "(", "[", "<"].contains(token.string) else { return }
 
-            guard ["}", ")", "]", ">"].contains(endOfScope.string) else { return }
+            guard let endOfScope = formatter.endOfScope(at: startOfScope),
+                  formatter.index(of: .nonSpaceOrComment, after: startOfScope) != endOfScope
+            else { return }
 
             // If there is extra code after the closing scope on the same line, ignore it
-            if let nextToken = formatter.next(.nonSpaceOrComment, after: endOfScopeIndex), !nextToken.isLinebreak {
+            if let nextTokenAfterClosingScope = formatter.next(.nonSpaceOrComment, after: endOfScope),
+               !nextTokenAfterClosingScope.isLinebreak
+            {
                 return
             }
 
-            // Check if this is a type declaration
-            let isTypeDeclaration = formatter.isTypeDeclaration(at: startOfScopeIndex)
+            let rangeInsideScope = ClosedRange(startOfScope + 1 ..< endOfScope)
 
-            // Find previous non-space token
-            var index = endOfScopeIndex - 1
-            var indexOfFirstLineBreak: Int?
-            var indexOfLastLineBreak: Int?
-            loop: while let token = formatter.token(at: index) {
-                switch token {
-                case .linebreak:
-                    indexOfFirstLineBreak = index
-                    if indexOfLastLineBreak == nil {
-                        indexOfLastLineBreak = index
-                    }
-                case .space:
-                    break
-                default:
-                    break loop
-                }
-                index -= 1
-            }
-
-            // For types, check the typeBlankLines option
-            if isTypeDeclaration {
+            if formatter.isStartOfTypeBody(at: startOfScope) {
                 switch formatter.options.typeBlankLines {
-                case .remove:
-                    // Remove blank lines before closing brace in types
-                    if let indexOfFirstLineBreak,
-                       indexOfFirstLineBreak != indexOfLastLineBreak
-                    {
-                        formatter.removeTokens(in: indexOfFirstLineBreak ..< indexOfLastLineBreak!)
-                    }
-                case .preserve:
-                    // Do nothing - preserve existing blank lines
-                    break
                 case .insert:
-                    // For insert, we'll handle in a separate pass
+                    formatter.addTrailingBlankLineIfNeeded(in: rangeInsideScope)
+                case .remove:
+                    formatter.removeTrailingBlankLinesIfPresent(in: rangeInsideScope)
+                case .preserve:
                     break
                 }
             } else {
-                // For non-types, always remove blank lines
-                if let indexOfFirstLineBreak,
-                   indexOfFirstLineBreak != indexOfLastLineBreak
-                {
-                    formatter.removeTokens(in: indexOfFirstLineBreak ..< indexOfLastLineBreak!)
-                }
-            }
-        }
-
-        // Second pass: Handle typeBlankLines = .insert for type declarations
-        if formatter.options.typeBlankLines == .insert {
-            formatter.forEach(.startOfScope("{")) { startOfScopeIndex, _ in
-                // Only process type declarations
-                guard formatter.isTypeDeclaration(at: startOfScopeIndex),
-                      let endOfScopeIndex = formatter.endOfScope(at: startOfScopeIndex) else { return }
-
-                // Find last non-whitespace token before the closing brace
-                guard let lastContentIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: endOfScopeIndex) else { return }
-
-                // Count linebreaks between last content and closing brace
-                var linebreakCount = 0
-                var hasWhitespaceAfterLastLinebreak = false
-
-                // Iterate through tokens between last content and closing brace
-                for i in (lastContentIndex + 1) ..< endOfScopeIndex {
-                    let token = formatter.tokens[i]
-                    if token.isLinebreak {
-                        linebreakCount += 1
-                        hasWhitespaceAfterLastLinebreak = false
-                    } else if token.isSpace {
-                        hasWhitespaceAfterLastLinebreak = true
-                    }
-                }
-
-                // We want exactly one blank line, which means 2 linebreaks
-                // If we don't have exactly 2 linebreaks, or if there's no whitespace after the last linebreak,
-                // we need to modify the tokens
-                if linebreakCount != 2 || !hasWhitespaceAfterLastLinebreak {
-                    // Remove existing whitespace and linebreaks
-                    formatter.removeTokens(in: (lastContentIndex + 1) ..< endOfScopeIndex)
-
-                    // Insert first linebreak
-                    formatter.insertLinebreak(at: lastContentIndex + 1)
-
-                    // Insert second linebreak (creates the blank line)
-                    formatter.insertLinebreak(at: lastContentIndex + 2)
-
-                    // Don't add indentation - the closing brace should be at the same level as the opening brace
-                }
+                formatter.removeTrailingBlankLinesIfPresent(in: rangeInsideScope)
             }
         }
     } examples: {
@@ -148,25 +74,14 @@ public extension FormatRule {
           ]
         ```
 
-        With --typeblanklines insert:
+        With `--typeblanklines insert`:
 
         ```diff
-          class MyClass {
-              // Implementation
-        -     }
+          struct Foo {
+              let bar: Bar
         +
-        +     }
+          }
         ```
         """
-    }
-}
-
-private extension Formatter {
-    func isTypeDeclaration(at scopeIndex: Int) -> Bool {
-        guard let lastKeyword = lastSignificantKeyword(at: scopeIndex, excluding: ["where"]) else {
-            return false
-        }
-
-        return ["class", "actor", "struct", "enum", "protocol", "extension"].contains(lastKeyword)
     }
 }

--- a/Sources/Rules/BlankLinesAtEndOfScope.swift
+++ b/Sources/Rules/BlankLinesAtEndOfScope.swift
@@ -11,26 +11,26 @@ import Foundation
 public extension FormatRule {
     /// Remove blank lines immediately before a closing brace, bracket, paren or chevron
     /// unless it's followed by more code on the same line (e.g. } else { )
+    /// Also insert blank lines before closing braces for type declarations if configured
     static let blankLinesAtEndOfScope = FormatRule(
-        help: "Remove trailing blank line at the end of a scope.",
+        help: "Remove or insert trailing blank line at the end of a scope.",
+        options: ["typeblanklines"],
         sharedOptions: ["typeblanklines"]
     ) { formatter in
+        // First pass: Find all non-type scopes or type scopes that need blank lines removed
         formatter.forEach(.startOfScope) { startOfScopeIndex, _ in
             guard let endOfScopeIndex = formatter.endOfScope(at: startOfScopeIndex) else { return }
             let endOfScope = formatter.tokens[endOfScopeIndex]
 
-            guard ["}", ")", "]", ">"].contains(endOfScope.string),
-                  // If there is extra code after the closing scope on the same line, ignore it
-                  (formatter.next(.nonSpaceOrComment, after: endOfScopeIndex).map(\.isLinebreak)) ?? true
-            else { return }
+            guard ["}", ")", "]", ">"].contains(endOfScope.string) else { return }
 
-            // Consumers can choose whether or not this rule should apply to type bodies
-            if !formatter.options.removeStartOrEndBlankLinesFromTypes,
-               ["class", "actor", "struct", "enum", "protocol", "extension"].contains(
-                   formatter.lastSignificantKeyword(at: startOfScopeIndex, excluding: ["where"]))
-            {
+            // If there is extra code after the closing scope on the same line, ignore it
+            if let nextToken = formatter.next(.nonSpaceOrComment, after: endOfScopeIndex), !nextToken.isLinebreak {
                 return
             }
+
+            // Check if this is a type declaration
+            let isTypeDeclaration = formatter.isTypeDeclaration(at: startOfScopeIndex)
 
             // Find previous non-space token
             var index = endOfScopeIndex - 1
@@ -50,12 +50,74 @@ public extension FormatRule {
                 }
                 index -= 1
             }
-            if formatter.options.removeBlankLines,
-               let indexOfFirstLineBreak,
-               indexOfFirstLineBreak != indexOfLastLineBreak
-            {
-                formatter.removeTokens(in: indexOfFirstLineBreak ..< indexOfLastLineBreak!)
-                return
+
+            // For types, check the typeBlankLines option
+            if isTypeDeclaration {
+                switch formatter.options.typeBlankLines {
+                case .remove:
+                    // Remove blank lines before closing brace in types
+                    if let indexOfFirstLineBreak,
+                       indexOfFirstLineBreak != indexOfLastLineBreak
+                    {
+                        formatter.removeTokens(in: indexOfFirstLineBreak ..< indexOfLastLineBreak!)
+                    }
+                case .preserve:
+                    // Do nothing - preserve existing blank lines
+                    break
+                case .insert:
+                    // For insert, we'll handle in a separate pass
+                    break
+                }
+            } else {
+                // For non-types, always remove blank lines
+                if let indexOfFirstLineBreak,
+                   indexOfFirstLineBreak != indexOfLastLineBreak
+                {
+                    formatter.removeTokens(in: indexOfFirstLineBreak ..< indexOfLastLineBreak!)
+                }
+            }
+        }
+
+        // Second pass: Handle typeBlankLines = .insert for type declarations
+        if formatter.options.typeBlankLines == .insert {
+            formatter.forEach(.startOfScope("{")) { startOfScopeIndex, _ in
+                // Only process type declarations
+                guard formatter.isTypeDeclaration(at: startOfScopeIndex),
+                      let endOfScopeIndex = formatter.endOfScope(at: startOfScopeIndex) else { return }
+
+                // Find last non-whitespace token before the closing brace
+                guard let lastContentIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: endOfScopeIndex) else { return }
+
+                // Count linebreaks between last content and closing brace
+                var linebreakCount = 0
+                var hasWhitespaceAfterLastLinebreak = false
+
+                // Iterate through tokens between last content and closing brace
+                for i in (lastContentIndex + 1) ..< endOfScopeIndex {
+                    let token = formatter.tokens[i]
+                    if token.isLinebreak {
+                        linebreakCount += 1
+                        hasWhitespaceAfterLastLinebreak = false
+                    } else if token.isSpace {
+                        hasWhitespaceAfterLastLinebreak = true
+                    }
+                }
+
+                // We want exactly one blank line, which means 2 linebreaks
+                // If we don't have exactly 2 linebreaks, or if there's no whitespace after the last linebreak,
+                // we need to modify the tokens
+                if linebreakCount != 2 || !hasWhitespaceAfterLastLinebreak {
+                    // Remove existing whitespace and linebreaks
+                    formatter.removeTokens(in: (lastContentIndex + 1) ..< endOfScopeIndex)
+
+                    // Insert first linebreak
+                    formatter.insertLinebreak(at: lastContentIndex + 1)
+
+                    // Insert second linebreak (creates the blank line)
+                    formatter.insertLinebreak(at: lastContentIndex + 2)
+
+                    // Don't add indentation - the closing brace should be at the same level as the opening brace
+                }
             }
         }
     } examples: {
@@ -85,6 +147,26 @@ public extension FormatRule {
             baz,
           ]
         ```
+
+        With --typeblanklines insert:
+
+        ```diff
+          class MyClass {
+              // Implementation
+        -     }
+        +
+        +     }
+        ```
         """
+    }
+}
+
+private extension Formatter {
+    func isTypeDeclaration(at scopeIndex: Int) -> Bool {
+        guard let lastKeyword = lastSignificantKeyword(at: scopeIndex, excluding: ["where"]) else {
+            return false
+        }
+
+        return ["class", "actor", "struct", "enum", "protocol", "extension"].contains(lastKeyword)
     }
 }

--- a/Tests/Rules/BlankLinesAtEndOfScopeTests.swift
+++ b/Tests/Rules/BlankLinesAtEndOfScopeTests.swift
@@ -82,7 +82,7 @@ class BlankLinesAtEndOfScopeTests: XCTestCase {
 
         }
         """
-        testFormatting(for: input, rule: .blankLinesAtEndOfScope, options: .init(removeStartOrEndBlankLinesFromTypes: false))
+        testFormatting(for: input, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .preserve))
     }
 
     func testBlankLineAtEndOfScopeRemovedFromMethodInType() {
@@ -102,6 +102,22 @@ class BlankLinesAtEndOfScopeTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(removeStartOrEndBlankLinesFromTypes: false))
+        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .preserve))
+    }
+
+    func testBlankLinesInsertedAtEndOfType() {
+        let input = """
+        class FooClass {
+            func fooMethod() {}
+        }
+        """
+
+        let output = """
+        class FooClass {
+            func fooMethod() {}
+
+        }
+        """
+        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .insert))
     }
 }

--- a/Tests/Rules/BlankLinesAtEndOfScopeTests.swift
+++ b/Tests/Rules/BlankLinesAtEndOfScopeTests.swift
@@ -11,26 +11,76 @@ import XCTest
 
 class BlankLinesAtEndOfScopeTests: XCTestCase {
     func testBlankLinesRemovedAtEndOfFunction() {
-        let input = "func foo() {\n    // code\n\n}"
-        let output = "func foo() {\n    // code\n}"
+        let input = """
+        func foo() {
+            // code
+
+        }
+        """
+
+        let output = """
+        func foo() {
+            // code
+        }
+        """
+
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope)
     }
 
     func testBlankLinesRemovedAtEndOfParens() {
-        let input = "(\n    foo: Int\n\n)"
-        let output = "(\n    foo: Int\n)"
+        let input = """
+        (
+            foo: Int
+
+        )
+        """
+        let output = """
+        (
+            foo: Int
+        )
+        """
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope)
     }
 
     func testBlankLinesRemovedAtEndOfBrackets() {
-        let input = "[\n    foo,\n    bar,\n\n]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [
+            foo,
+            bar,
+
+        ]
+        """
+
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
+
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope)
     }
 
     func testBlankLineNotRemovedBeforeElse() {
-        let input = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n\n}"
-        let output = "if x {\n\n    // do something\n\n} else if y {\n\n    // do something else\n}"
+        let input = """
+        if x {
+            // do something
+
+        } else if y {
+
+            // do something else
+
+        }
+        """
+        let output = """
+        if x {
+            // do something
+
+        } else if y {
+
+            // do something else
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope,
                        exclude: [.blankLinesAtStartOfScope])
     }
@@ -102,22 +152,60 @@ class BlankLinesAtEndOfScopeTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .preserve))
+        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .preserve), exclude: [.blankLinesAtStartOfScope])
     }
 
     func testBlankLinesInsertedAtEndOfType() {
         let input = """
         class FooClass {
+
+            struct FooStruct {
+
+                func nestedFunc() {}
+            }
+
             func fooMethod() {}
         }
         """
 
         let output = """
         class FooClass {
+
+            struct FooStruct {
+
+                func nestedFunc() {}
+
+            }
+
             func fooMethod() {}
 
         }
         """
         testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .insert))
+    }
+
+    func testBlankLinesRemovedAtEndOfType() {
+        let input = """
+        class FooClass {
+            struct FooStruct {
+                func nestedFunc() {}
+            }
+
+            func fooMethod() {}
+        }
+        """
+
+        let output = """
+        class FooClass {
+            struct FooStruct {
+                func nestedFunc() {}
+
+            }
+
+            func fooMethod() {}
+
+        }
+        """
+        testFormatting(for: input, output, rule: .blankLinesAtEndOfScope, options: .init(typeBlankLines: .insert), exclude: [.blankLinesAtStartOfScope])
     }
 }

--- a/Tests/Rules/BlankLinesAtStartOfScopeTests.swift
+++ b/Tests/Rules/BlankLinesAtStartOfScopeTests.swift
@@ -11,25 +11,58 @@ import XCTest
 
 class BlankLinesAtStartOfScopeTests: XCTestCase {
     func testBlankLinesRemovedAtStartOfFunction() {
-        let input = "func foo() {\n\n    // code\n}"
-        let output = "func foo() {\n    // code\n}"
+        let input = """
+        func foo() {
+
+            // code
+        }
+        """
+        let output = """
+        func foo() {
+            // code
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesAtStartOfScope)
     }
 
     func testBlankLinesRemovedAtStartOfParens() {
-        let input = "(\n\n    foo: Int\n)"
-        let output = "(\n    foo: Int\n)"
+        let input = """
+        (
+
+            foo: Int
+        )
+        """
+        let output = """
+        (
+            foo: Int
+        )
+        """
         testFormatting(for: input, output, rule: .blankLinesAtStartOfScope)
     }
 
     func testBlankLinesRemovedAtStartOfBrackets() {
-        let input = "[\n\n    foo,\n    bar,\n]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [
+
+            foo,
+            bar,
+        ]
+        """
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
         testFormatting(for: input, output, rule: .blankLinesAtStartOfScope)
     }
 
     func testBlankLinesNotRemovedBetweenElementsInsideBrackets() {
-        let input = "[foo,\n\n bar]"
+        let input = """
+        [foo,
+
+         bar]
+        """
         testFormatting(for: input, rule: .blankLinesAtStartOfScope, exclude: [.wrapArguments])
     }
 
@@ -108,12 +141,14 @@ class BlankLinesAtStartOfScopeTests: XCTestCase {
         let input = """
         class Foo {
             func bar() {}
+
         }
         """
         let output = """
         class Foo {
 
             func bar() {}
+
         }
         """
         testFormatting(for: input, output, rule: .blankLinesAtStartOfScope, options: .init(typeBlankLines: .insert))
@@ -222,5 +257,34 @@ class BlankLinesAtStartOfScopeTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .blankLinesAtStartOfScope)
+    }
+
+    func testBlankLinesInsertedAtStartOfType() {
+        let input = """
+        class FooClass {
+            struct FooStruct {
+                func nestedFunc() {}
+
+            }
+
+            func fooMethod() {}
+
+        }
+        """
+
+        let output = """
+        class FooClass {
+
+            struct FooStruct {
+
+                func nestedFunc() {}
+
+            }
+
+            func fooMethod() {}
+
+        }
+        """
+        testFormatting(for: input, output, rule: .blankLinesAtStartOfScope, options: .init(typeBlankLines: .insert))
     }
 }

--- a/Tests/Rules/BlankLinesAtStartOfScopeTests.swift
+++ b/Tests/Rules/BlankLinesAtStartOfScopeTests.swift
@@ -81,7 +81,7 @@ class BlankLinesAtStartOfScopeTests: XCTestCase {
             func fooMethod() {}
         }
         """
-        testFormatting(for: input, rule: .blankLinesAtStartOfScope, options: .init(removeStartOrEndBlankLinesFromTypes: false))
+        testFormatting(for: input, rule: .blankLinesAtStartOfScope, options: .init(typeBlankLines: .preserve))
     }
 
     func testBlankLineAtStartOfScopeRemovedFromMethodInType() {
@@ -101,7 +101,22 @@ class BlankLinesAtStartOfScopeTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .blankLinesAtStartOfScope, options: .init(removeStartOrEndBlankLinesFromTypes: false))
+        testFormatting(for: input, output, rule: .blankLinesAtStartOfScope, options: .init(typeBlankLines: .preserve))
+    }
+
+    func testBlankLineInsertedAtStartOfType() {
+        let input = """
+        class Foo {
+            func bar() {}
+        }
+        """
+        let output = """
+        class Foo {
+
+            func bar() {}
+        }
+        """
+        testFormatting(for: input, output, rule: .blankLinesAtStartOfScope, options: .init(typeBlankLines: .insert))
     }
 
     func testFalsePositive() {

--- a/Tests/XCTestCase+testFormatting.swift
+++ b/Tests/XCTestCase+testFormatting.swift
@@ -88,7 +88,7 @@ extension XCTestCase {
         do {
             formatResult = try format(input, rules: rules, options: options)
         } catch {
-            XCTFail("Failed to format input, threw error \(error)")
+            XCTFail("Failed to format input, threw error \(error)", file: file, line: line)
             return
         }
         XCTAssertEqual(formatResult.output, output, file: file, line: line)


### PR DESCRIPTION
This pull request introduces a new formatting rule, `breakLineAtEndOfTypes`, to enforce a blank line before the closing brace of type declarations (e.g., `class`, `struct`, `enum`). It includes updates to the core formatting logic, configuration options, and test cases, as well as project file changes to integrate the new rule.

### New Rule Implementation
* Added a new rule, `breakLineAtEndOfTypes`, to ensure a blank line exists before the closing brace of type declarations. This rule supports types such as `class`, `struct`, `enum`, `protocol`, `extension`, and `actor`. (`Sources/Rules/BreakLineAtEndOfTypes.swift`)

### Configuration and Options
* Introduced a new `breakLineAtEndOfTypes` property in the `FormatOptions` struct to enable or disable the rule. Default value is `false`. (`Sources/Options.swift`) [[1]](diffhunk://#diff-9eff97ea9de0018b8a2d12c19b9581b48574ceb2fe6a2fcdc46b4140ecc606efR693) [[2]](diffhunk://#diff-9eff97ea9de0018b8a2d12c19b9581b48574ceb2fe6a2fcdc46b4140ecc606efR819) [[3]](diffhunk://#diff-9eff97ea9de0018b8a2d12c19b9581b48574ceb2fe6a2fcdc46b4140ecc606efL933-R935)
* Added a corresponding `OptionDescriptor` for `breakLineAtEndOfTypes` to allow configuration through command-line arguments or configuration files. (`Sources/OptionDescriptor.swift`)

### Testing
* Added comprehensive test cases in `BreakLineAtEndOfTypesTests.swift` to validate the new rule against various scenarios, including classes, structs, enums, protocols, extensions, and actors. Tests also cover edge cases like preserving existing blank lines and handling disabled options. (`Tests/Rules/BreakLineAtEndOfTypesTests.swift`)

### Project Integration
* Updated the Xcode project file to include the new source file (`BreakLineAtEndOfTypes.swift`) and its corresponding test file (`BreakLineAtEndOfTypesTests.swift`). (`SwiftFormat.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR678-R682) [[2]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR1025-R1026) [[3]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR1200) [[4]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR1318) [[5]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR1830) [[6]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR2008) [[7]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR2152) [[8]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR2198) [[9]](diffhunk://#diff-4e93cfbbd0c5d249521c1df7dfc0587a30c8529449302a3a507e8e660af0b0edR2341)
* Added a new test scheme, `SwiftFormatTests.xcscheme`, to include the new test cases in the test suite. (`SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormatTests.xcscheme`)

### Minor Adjustments
* Updated `PerformanceTests` to include the new rule in its configuration options for performance measurement. (`PerformanceTests/PerformanceTests.swift`)