### PR TITLE
Fix some new bugs on develop branch

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -449,8 +449,15 @@ extension Formatter {
                 index = commaIndex
             }
 
+            // If the closing paren is on the same line, and there's only a single item in the list,
+            // don't insert an opening paren (unless we're over the line width limit). This prevents
+            // issues with an open paren being wrapped unnecessarily and sitting on its own line in
+            // cases like long closure types in parens.
+            let insertLinebreakAfterOpeningParen = self.index(of: .delimiter(","), after: i) != nil
+                || lineLength(at: endOfLine(at: i)) > maxWidth
+
             // Insert linebreak and indent after opening paren
-            if let nextIndex = self.index(of: .nonSpaceOrComment, after: i) {
+            if insertLinebreakAfterOpeningParen, let nextIndex = self.index(of: .nonSpaceOrComment, after: i) {
                 if !tokens[nextIndex].isLinebreak {
                     insertLinebreak(at: nextIndex)
                     endOfScope += 1

--- a/Sources/Rules/DocComments.swift
+++ b/Sources/Rules/DocComments.swift
@@ -59,8 +59,10 @@ public extension FormatRule {
             var preserveRegularComments = false
             if useDocComment,
                let declarationKeyword = formatter.index(after: endOfComment, where: \.isDeclarationTypeKeyword),
-               let endOfDeclaration = formatter.endOfDeclaration(atDeclarationKeyword: declarationKeyword),
-               let nextDeclarationKeyword = formatter.index(after: endOfDeclaration, where: \.isDeclarationTypeKeyword)
+               let nextDeclarationKeyword = formatter.index(
+                   after: formatter.endOfDeclaration(atDeclarationKeyword: declarationKeyword),
+                   where: \.isDeclarationTypeKeyword
+               )
             {
                 let linebreaksBetweenDeclarations = formatter.tokens[declarationKeyword ... nextDeclarationKeyword]
                     .filter(\.isLinebreak).count

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2603,28 +2603,32 @@ class ParsingHelpersTests: XCTestCase {
 
     func testParseFunctionDeclarationWithEffects() {
         let input = """
-        func foo(bar: Bar, baaz: Baaz) async throws(GenericError<Foo>) -> Foo<Bar, Baaz> {
-            Foo(bar: bar, baaz: baaz)
+        struct FooBar {
+
+            func foo(bar: Bar, baaz: Baaz) async throws(GenericError<Foo>) -> Foo<Bar, Baaz> {
+                Foo(bar: bar, baaz: baaz)
+            }
+
         }
         """
 
         let formatter = Formatter(tokenize(input))
-        let function = formatter.parseFunctionDeclaration(keywordIndex: 0)!
+        let function = formatter.parseFunctionDeclaration(keywordIndex: 8)!
 
-        XCTAssertEqual(function.keywordIndex, 0)
+        XCTAssertEqual(function.keywordIndex, 8)
         XCTAssertEqual(function.name, "foo")
         XCTAssertEqual(function.genericParameterRange, nil)
         XCTAssertEqual(formatter.tokens[function.argumentsRange].string, "(bar: Bar, baaz: Baaz)")
         XCTAssertEqual(function.arguments.count, 2)
         XCTAssertEqual(formatter.tokens[function.effectsRange!].string, "async throws(GenericError<Foo>)")
         XCTAssertEqual(function.effects, ["async", "throws(GenericError<Foo>)"])
-        XCTAssertEqual(function.returnOperatorIndex, 26)
+        XCTAssertEqual(function.returnOperatorIndex, 34)
         XCTAssertEqual(formatter.tokens[function.returnType!.range].string, "Foo<Bar, Baaz>")
         XCTAssertEqual(function.whereClauseRange, nil)
         XCTAssertEqual(formatter.tokens[function.bodyRange!].string, """
         {
-            Foo(bar: bar, baaz: baaz)
-        }
+                Foo(bar: bar, baaz: baaz)
+            }
         """)
     }
 

--- a/Tests/Rules/OpaqueGenericParametersTests.swift
+++ b/Tests/Rules/OpaqueGenericParametersTests.swift
@@ -711,4 +711,18 @@ class OpaqueGenericParametersTests: XCTestCase {
         testFormatting(for: input, output, rule: .opaqueGenericParameters,
                        options: options, exclude: [.unusedArguments, .trailingSpace])
     }
+
+    func testPreservesGenericUsedInBodyAtEndOfScope() {
+        let input = """
+        extension ModelTransformer {
+          public static func decodableTransformer<T: Decodable>(for _: T.Type) -> ValueTransformer {
+            CodableTransformer<T>.default
+          }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .opaqueGenericParameters,
+                       options: options, exclude: [.unusedArguments, .indent])
+    }
 }

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -29,12 +29,14 @@ class WrapArgumentsTests: XCTestCase {
     func testWrapArgumentsDoesntIndentTrailingComment() {
         let input = """
         foo( // foo
-        bar: Int
+        bar: Int,
+        baaz: Int
         )
         """
         let output = """
         foo( // foo
-            bar: Int
+            bar: Int,
+            baaz: Int
         )
         """
         testFormatting(for: input, output, rule: .wrapArguments)
@@ -1016,14 +1018,15 @@ class WrapArgumentsTests: XCTestCase {
 
     func testNoMangleCommentedLinesWhenWrappingArguments() {
         let input = """
-        foo(bar: bar
+        foo(bar: bar, quux: quux
         //    ,
         //    baz: baz
             ) {}
         """
         let output = """
         foo(
-            bar: bar
+            bar: bar,
+            quux: quux
         //    ,
         //    baz: baz
         ) {}
@@ -1034,13 +1037,14 @@ class WrapArgumentsTests: XCTestCase {
 
     func testNoMangleCommentedLinesWhenWrappingArgumentsWithNoCommas() {
         let input = """
-        foo(bar: bar
+        foo(bar: bar, quux: quux
         //    baz: baz
             ) {}
         """
         let output = """
         foo(
-            bar: bar
+            bar: bar,
+            quux: quux
         //    baz: baz
         ) {}
         """
@@ -1990,6 +1994,79 @@ class WrapArgumentsTests: XCTestCase {
         )
 
         testFormatting(for: input, [output], rules: [.wrapArguments, .braces], options: options)
+    }
+
+    func testWrapReturnIfMultilineOnClosureArgument() {
+        let input = """
+        func multilineFunctionWithClosureArgument(
+            closure: ((
+                _ view: ChartContainerView<Self>,
+                _ content: Content,
+                _ traitCollection: UITraitCollection,
+                _ state: ItemCellState) -> Void)? = nil) -> String
+        {
+            print(closure)
+        }
+        """
+
+        let output = """
+        func multilineFunctionWithClosureArgument(
+            closure: ((
+                _ view: ChartContainerView<Self>,
+                _ content: Content,
+                _ traitCollection: UITraitCollection,
+                _ state: ItemCellState)
+                -> Void)? = nil)
+            -> String
+        {
+            print(closure)
+        }
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            maxWidth: 100
+        )
+
+        testFormatting(for: input, [output], rules: [.wrapArguments, .wrap, .indent], options: options)
+    }
+
+    func testPreservesReturnInClosure() {
+        let input = """
+        public private(set) var foo: ((
+            UIAccessibility.Notification,
+            Any?,
+            Bool,
+            TimeInterval,
+            String,
+            Int,
+            String) -> Void)?
+        """
+
+        let output = """
+        public private(set) var foo: ((
+            UIAccessibility.Notification,
+            Any?,
+            Bool,
+            TimeInterval,
+            String,
+            Int,
+            String)
+            -> Void)?
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            wrapCollections: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            maxWidth: 100,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, [output], rules: [.wrapArguments, .wrap], options: options)
     }
 
     func testFormatReturnTypeOnMultilineFunctionDeclarationWithBlockComment() {


### PR DESCRIPTION
This PR fixes some new bugs that I noticed in the current set of changes on develop

1. `formatter.endOfDeclaration` would unexpectedly return `nil` for the last declaration in a type body. This was causing `parseFunctionDeclaration` to return `bodyRange: nil` in this case, which could cause build failures in the `opaqueGenericParameters` rule.

2. `--wrapreturntype if-multiline` is now applied to closure types, now that the implementation no longer requires the scope to have a body with a `{` token. This was causing an interaction with the open paren wrapping that looked weird and unnecessary.

```swift
// Before
var foo: (
    (
        Any?,
        Bool,
        TimeInterval,
        String,
        Int,
        String)
        -> Void)?

// With this fix
var foo: ((
    Any?,
    Bool,
    TimeInterval,
    String,
    Int,
    String)
    -> Void)?
```