### PR TITLE
Add section about nightly builds to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,10 @@ Tests are run automatically on all pull requests, branches and tags. These are t
 
 There is a separate Performance Tests scheme that you should run manually if your code changes are likely to affect performance.
 
+## Prerelease builds
+
+If you contribute a new rule or option, it would be published in the following major version release. To start using the new rule or option right away in your own project, you could use a prerelease build of the develop branch. More information is available [here](https://github.com/nicklockwood/SwiftFormat#nightly-builds).
+
 ## Renaming a Rule Option
 
 * Add a copy of the option in `OptionDescriptor.swift` under the `// MARK: - RENAMED` section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,15 +84,16 @@ This is relevant only to maintainers:
 * Update SwiftFormat.podspec.json
 * Run tests and ensure they pass
 * Select SwiftFormat (Command Line Tool) and run Product > Archive
+  * This step requires a distribution signing certificate
 * Replace binary in CommandLineTool directory
 * Select SwiftFormat for Xcode and run Product > Archive
 * Notarize and export built app
+  * This step requires App Store Connect access, so only Nick can do this.
 * Tag commit and push to main
 * pod trunk push --allow-warnings
 * Run Build for Windows and download binaries
 * Unzip Windows msi zips and rename
 * Publish a new release
-* Download swiftformat_linux.zip from the Build Release Artifacts action
-* Zip the macOS swiftformat build
 * Attach all binaries to release
+  * The artifact bundle, macOS executable, and Linux executables are uploaded to the release automatically.
 * Create and Publish Docker image

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Table of Contents
     - [On CI using Danger](#on-ci-using-danger)
     - [Bazel build](#bazel-build)
     - [Docker](#docker)
+    - [Nightly Builds](#nightly-builds)
 - [Configuration](#configuration)
     - [Options](#options)
     - [Rules](#rules)
@@ -73,8 +74,6 @@ That depends - There are several ways you can use SwiftFormat:
 
 Command-line tool
 -------------------
-
-**NOTE:** if you are using any of the following methods to install SwiftFormat on macOS 10.14.3 or earlier and are experiencing a crash on launch, you may need to install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998). See [known issues](#known-issues) for details.
 
 **Installation:**
 
@@ -521,6 +520,17 @@ Linting example:
 ```bash
 docker run --rm -v /local/source/path:/work ghcr.io/nicklockwood/swiftformat:latest /work --lint
 ```
+
+Nightly Builds
+--------------
+
+***Nightly builds are subject to breaking changes.***
+
+New rules, options, and fixes are merged to the [`develop`](https://github.com/nicklockwood/SwiftFormat/commits/develop/) branch before being incorporated into an official release. You may want to use a prerelease version of SwiftFormat that includes the latest unreleased changes.
+
+Nightly builds of the `develop` branch are available in the [calda/SwiftFormat-nightly](https://github.com/calda/SwiftFormat-nightly) repo. A new release is published every day, unless there have been no changes to `develop` since the last release. You can download executables for the latest nightly release [here](https://github.com/calda/SwiftFormat-nightly/releases/latest).
+
+Commit SHAs on `develop` are unstable since that branch is occasionally rebased, but artifact URLs and tags in [calda/SwiftFormat-nightly](https://github.com/calda/SwiftFormat-nightly) are stable references that can be used from other repos or tools.
 
 Configuration
 -------------


### PR DESCRIPTION
This PR adds a section about the new nightly build setup in [calda/SwiftFormat-nightly](https://github.com/calda/SwiftFormat-nightly) to the README