### PR TITLE
Remove need for signing certificate when building release builds of command line tool in Xcode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ This is relevant only to maintainers:
 * Update SwiftFormat.podspec.json
 * Run tests and ensure they pass
 * Select SwiftFormat (Command Line Tool) and run Product > Archive
-  * This step requires a distribution signing certificate
 * Replace binary in CommandLineTool directory
 * Select SwiftFormat for Xcode and run Product > Archive
 * Notarize and export built app

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -1742,17 +1742,15 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0810;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1630;
 				ORGANIZATIONNAME = "Nick Lockwood";
 				TargetAttributes = {
 					01A0EAA31D5DB4CF00A0A8E3 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = 8VQKF583ED;
 						LastSwiftMigration = "";
 					};
 					01A0EAAD1D5DB4D000A0A8E3 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = 8VQKF583ED;
 						LastSwiftMigration = "";
 					};
 					01A0EAC91D5DB5F500A0A8E3 = {
@@ -2821,6 +2819,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2853,6 +2852,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2880,6 +2880,7 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2897,8 +2898,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2934,9 +2937,10 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 8VQKF583ED;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)Tool";

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/Performance Tests.xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/Performance Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Command Line Tool).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Command Line Tool).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Editor Extension).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Editor Extension).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Framework).xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat (Framework).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
+++ b/SwiftFormat.xcodeproj/xcshareddata/xcschemes/SwiftFormat for Xcode.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Currently building release builds of the command line tool in Xcode requires a signing certificate.

Builds produced from the command line with `swift build -c release` don't need to be signed. That made me realize we can just remove the "Team" and "Signing Certificate" requirement.

### Before

<img width="734" alt="image" src="https://github.com/user-attachments/assets/88ddc54d-53e2-44bf-940b-a4a34f0176c1" />

### After

<img width="739" alt="image" src="https://github.com/user-attachments/assets/c37e3dd6-5358-43eb-b44d-0c54cbdffb12" />

Release builds and Product > Archive still work correctly.