### PR TITLE
Update `acronyms` rule to use `--preserveacronyms` option instead of `--preservedsymbols`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -136,7 +136,7 @@ Capitalize acronyms when the first character is capitalized.
 Option | Description
 --- | ---
 `--acronyms` | Acronyms to auto-capitalize. Defaults to "ID,URL,UUID"
-`--preservedsymbols` | Comma-delimited list of symbols to be ignored by the rule
+`--preserveacronyms` | List of symbols to be ignored by the acyronyms rule
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1123,6 +1123,12 @@ struct _Descriptors {
         help: "Acronyms to auto-capitalize. Defaults to \"ID,URL,UUID\"",
         keyPath: \.acronyms
     )
+    let preserveAcronyms = OptionDescriptor(
+        argumentName: "preserveacronyms",
+        displayName: "Preserve Acronymes",
+        help: "List of symbols to be ignored by the acyronyms rule",
+        keyPath: \.preserveAcronyms
+    )
     let indentStrings = OptionDescriptor(
         argumentName: "indentstrings",
         displayName: "Indent Strings",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -718,6 +718,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var inferredTypesInConditionalExpressions: Bool
     public var emptyBracesSpacing: EmptyBracesSpacing
     public var acronyms: Set<String>
+    public var preserveAcronyms: Set<String>
     public var indentStrings: Bool
     public var closureVoidReturn: ClosureVoidReturn
     public var enumNamespaces: EnumNamespacesMode
@@ -847,6 +848,7 @@ public struct FormatOptions: CustomStringConvertible {
                 inferredTypesInConditionalExpressions: Bool = false,
                 emptyBracesSpacing: EmptyBracesSpacing = .noSpace,
                 acronyms: Set<String> = ["ID", "URL", "UUID"],
+                preserveAcronyms: Set<String> = [],
                 indentStrings: Bool = false,
                 closureVoidReturn: ClosureVoidReturn = .remove,
                 enumNamespaces: EnumNamespacesMode = .always,
@@ -966,6 +968,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.inferredTypesInConditionalExpressions = inferredTypesInConditionalExpressions
         self.emptyBracesSpacing = emptyBracesSpacing
         self.acronyms = acronyms
+        self.preserveAcronyms = preserveAcronyms
         self.indentStrings = indentStrings
         self.closureVoidReturn = closureVoidReturn
         self.enumNamespaces = enumNamespaces

--- a/Sources/Rules/Acronyms.swift
+++ b/Sources/Rules/Acronyms.swift
@@ -12,12 +12,12 @@ public extension FormatRule {
     static let acronyms = FormatRule(
         help: "Capitalize acronyms when the first character is capitalized.",
         disabledByDefault: true,
-        options: ["acronyms", "preservedsymbols"]
+        options: ["acronyms", "preserveacronyms"]
     ) { formatter in
         formatter.forEachToken { index, token in
             guard token.is(.identifier) || token.isComment else { return }
 
-            guard !formatter.options.preservedSymbols.contains(token.string) else {
+            guard !formatter.options.preserveAcronyms.contains(token.string) else {
                 return
             }
 

--- a/Tests/Rules/AcronymsTests.swift
+++ b/Tests/Rules/AcronymsTests.swift
@@ -87,7 +87,7 @@ class AcronymsTests: XCTestCase {
         api.route(toUrl: destinationURL)
         """
 
-        let options = FormatOptions(preservedSymbols: ["externallyProvidedUrl", "toUrl"])
+        let options = FormatOptions(preserveAcronyms: ["externallyProvidedUrl", "toUrl"])
         testFormatting(for: input, output, rule: .acronyms, options: options)
     }
 }


### PR DESCRIPTION
Resolves #2019