### PR TITLE
Update `organizeDeclarations` / `parseDeclarations` to support property declarations with if expression values

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2285,7 +2285,6 @@ extension Formatter {
                         }
                         lastKeyword = ""
                     case "if", "while", "guard", "for":
-                        assert(!isTypeRoot)
                         // Guard is included because it's an error to reference guard vars in body
                         var scopedNames = localNames
                         let removeSelf = explicitSelf != .insert && !usingDynamicLookup && (

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1750,6 +1750,10 @@ extension Formatter {
             if let scopeStart = index(of: .startOfScope("{"), after: declarationKeywordIndex) {
                 searchIndex = endOfScope(at: scopeStart) ?? searchIndex
             }
+        case .keyword("let"), .keyword("var"):
+            if let propertyDeclaration = parsePropertyDeclaration(atIntroducerIndex: declarationKeywordIndex) {
+                searchIndex = propertyDeclaration.range.upperBound
+            }
         default:
             break
         }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1759,6 +1759,40 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(declarations[0].tokens.map(\.string).joined(), input)
     }
 
+    func testParseIfExpressionDeclaration() {
+        let input = """
+        private lazy var x: [Any] =
+          if let b {
+            [b]
+          } else if false {
+            []
+          } else {
+            [1, 2]
+          }
+
+        private lazy var y = f()
+        """
+
+        let formatter = Formatter(tokenize(input))
+        let declarations = formatter.parseDeclarations()
+        XCTAssertEqual(declarations.count, 2)
+
+        XCTAssertEqual(declarations[0].tokens.string, """
+        private lazy var x: [Any] =
+          if let b {
+            [b]
+          } else if false {
+            []
+          } else {
+            [1, 2]
+          }
+
+
+        """)
+
+        XCTAssertEqual(declarations[1].tokens.string, "private lazy var y = f()")
+    }
+
     // MARK: declarationScope
 
     func testDeclarationScope_classAndGlobals() {

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3807,4 +3807,51 @@ class OrganizeDeclarationsTests: XCTestCase {
 
         testFormatting(for: input, [output], rules: [.organizeDeclarations, .sortDeclarations])
     }
+
+    func testIssue2045() {
+        let input = """
+        public final class A {
+
+          // MARK: Lifecycle
+
+          public init(a _: Int) {}
+
+          convenience init() {
+            self.init(a: 0)
+          }
+
+          // MARK: Public
+
+          public func a() {}
+
+          // MARK: Private
+
+          private enum Error: Swift.Error {
+            case e
+          }
+
+          private let a1: Float = 0
+          private lazy var b: String? = ""
+          private let a2 = 0
+
+          private lazy var x: [Any] =
+            if let b {
+              [b]
+            } else if false {
+              []
+            } else {
+              [1, 2]
+            }
+
+          private lazy var y = f()
+
+          private var z: Set<String> = []
+        }
+
+        func f() -> Int { 0 }
+        """
+
+        let options = FormatOptions(indent: "  ")
+        testFormatting(for: input, rule: .organizeDeclarations, options: options, exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where `organizeDeclarations` would break if the code included a property like:

```swift
private lazy var x: [Any] =
  if let b {
    [b]
  } else if false {
    []
  } else {
    [1, 2]
  }
```

The `let` keyword in `if let b` was being confused for a subsequent `let b` declaration. 

Fixes #2045.