### PR TITLE
Fix issue where `--wrapeffects` option would incorrectly unwrap `async let` properties following function call

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2765,13 +2765,22 @@ extension Formatter {
                 effects.insert(tokens[effectIndex ... endOfTypedThrows].string)
                 effectsRange = firstIndexAfterArguments ... endOfTypedThrows
                 currentIndex = endOfTypedThrows
+                continue
             }
 
-            else {
-                effects.insert(effect)
-                effectsRange = firstIndexAfterArguments ... effectIndex
-                currentIndex = effectIndex
+            // If an `async` keyword is immediately followed by `let` on the same line, this is probably an `async let` property.
+            // It's possible an `async` keyword to be followed by a `let` keyword without being an `async let` property
+            // (e.g. if the attached function doesn't have a body), so this seems fundamentally ambiguous in the grammar.
+            if effect == "async",
+               let nextToken = index(of: .nonSpaceOrComment, after: effectIndex),
+               tokens[nextToken] == .keyword("let")
+            {
+                break
             }
+
+            effects.insert(effect)
+            effectsRange = firstIndexAfterArguments ... effectIndex
+            currentIndex = effectIndex
         }
 
         if let effectsRange = effectsRange {

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -2291,6 +2291,88 @@ class WrapArgumentsTests: XCTestCase {
         )
     }
 
+    func testWrapEffectsNeverDoesntUnwrapAsyncLet() {
+        let input = """
+        async let createdAd = createAd(
+            subcategoryID: subcategory.id,
+            shopID: shop?.id)
+        async let locationCity = createEditAdWorker.loadNearestCity(coordinates: coordinates)
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, rule: .wrapArguments, options: options)
+    }
+
+    func testWrapEffectsWrapsAsyncEffectBeforeLetProperty() {
+        let input = """
+        @attached(body) macro GenerateBody() = #externalMacro(module: "...", type: "...")
+
+        @GenerateBody // generates the body
+        func foo(
+            _ bar: Baaz,
+            _ baaz: Baaz) async
+
+        let quux: Quux
+        """
+
+        let output = """
+        @attached(body) macro GenerateBody() = #externalMacro(module: "...", type: "...")
+
+        @GenerateBody // generates the body
+        func foo(
+            _ bar: Baaz,
+            _ baaz: Baaz)
+        async
+
+        let quux: Quux
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, [output], rules: [.wrapArguments, .indent], options: options)
+    }
+
+    func testWrapsThrowsBeforeAsyncLet() {
+        let input = """
+        @GenerateBody // generates the body
+        func foo(
+            _ bar: Baaz,
+            _ baaz: Baaz) throws
+
+        async let quux: Quux
+        """
+
+        let output = """
+        @GenerateBody // generates the body
+        func foo(
+            _ bar: Baaz,
+            _ baaz: Baaz)
+            throws
+
+        async let quux: Quux
+        """
+
+        let options = FormatOptions(
+            wrapArguments: .beforeFirst,
+            closingParenPosition: .sameLine,
+            wrapReturnType: .ifMultiline,
+            wrapEffects: .ifMultiline
+        )
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: options)
+    }
+
     func testDoesntWrapReturnOnMultilineThrowingFunction() {
         let input = """
         func multilineFunction(foo _: String,


### PR DESCRIPTION
This PR fixes an issue where the `--wrapeffects` option would incorrectly unwrap `async let` properties following a function call.

Fixes #2044.