### PR TITLE
Update `redundantEquatable` rule to handle non-Equatable types with == support like tuples

### DIFF
--- a/Sources/Rules/PropertyTypes.swift
+++ b/Sources/Rules/PropertyTypes.swift
@@ -54,11 +54,9 @@ public extension FormatRule {
                 // before we check for types like `any Type` or `Type?`.
                 var typeTokensWithoutParens = typeTokens
                 while typeTokensWithoutParens.first == .startOfScope("("),
-                      typeTokensWithoutParens.last == .endOfScope(")")
+                      typeTokensWithoutParens.last == .endOfScope(")"),
+                      !typeTokensWithoutParens.string.isTupleType
                 {
-                    // This doesn't handle tuples, where the parens wouldn't be redundant,
-                    // but that's fine because a tuple can never be used in this sort of pattern:
-                    // `let foo: (foo: Foo, bar: Bar) = .staticMemberOnTuple // not possible`
                     typeTokensWithoutParens = Array(typeTokensWithoutParens.dropFirst().dropLast())
                 }
 

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2232,6 +2232,29 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.parseType(at: 2)?.name, "Foo.Bar.Baaz.Quux.InnerType1.InnerType2")
     }
 
+    func testParseTuples() {
+        let input = """
+        let tuple: (foo: Foo, bar: Bar)
+        let closure: (foo: Foo, bar: Bar) -> Void
+        let valueWithRedundantParens: (Foo)
+        let voidValue: ()
+        """
+
+        let formatter = Formatter(tokenize(input))
+
+        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(foo: Foo, bar: Bar)")
+        XCTAssertTrue(formatter.isStartOfTuple(at: 5))
+
+        XCTAssertEqual(formatter.parseType(at: 23)?.name, "(foo: Foo, bar: Bar) -> Void")
+        XCTAssertFalse(formatter.isStartOfTuple(at: 23))
+
+        XCTAssertEqual(formatter.parseType(at: 45)?.name, "(Foo)")
+        XCTAssertFalse(formatter.isStartOfTuple(at: 45))
+
+        XCTAssertEqual(formatter.parseType(at: 54)?.name, "()")
+        XCTAssertFalse(formatter.isStartOfTuple(at: 54))
+    }
+
     // MARK: - parseExpressionRange
 
     func testParseIndividualExpressions() {

--- a/Tests/Rules/RedundantEquatableTests.swift
+++ b/Tests/Rules/RedundantEquatableTests.swift
@@ -518,4 +518,34 @@ final class RedundantEquatableTests: XCTestCase {
 
         testFormatting(for: input, [output], rules: [.redundantEquatable, .emptyBraces, .wrapAttributes, .emptyExtensions, .consecutiveBlankLines], options: options)
     }
+
+    func testPreserveCustomEquatableImplementationComparingAnyClass() {
+        // `AnyClass` defines an `==` operator but is not Equatable.
+        let input = """
+        struct Foo: Equatable {
+            let classValue: AnyClass
+
+            static func == (lhs: Foo, rhs: Foo) -> Bool {
+                lhs.classValue == rhs.classValue
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .redundantEquatable)
+    }
+
+    func testPreserveCustomEquatableImplementationComparingTuple() {
+        // Tuples define an `==` operator but are not Equatable.
+        let input = """
+        struct Foo: Equatable {
+            let tupleValue: (string: String, int: Int)
+
+            static func == (lhs: Foo, rhs: Foo) -> Bool {
+                lhs.tupleValue == rhs.tupleValue
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .redundantEquatable)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the `redundantEquatable` rule would incorrectly remove the `==` implementation in cases like:

```swift
struct Foo: Equatable {
    let tupleValue: (string: String, int: Int)

    static func == (lhs: Foo, rhs: Foo) -> Bool {
        lhs.tupleValue == rhs.tupleValue
    }
}
```

Since tuples aren't Equatable, the compiler doesn't automatically synthesize an Equatable conformance.

This also applies to some built-in types like `AnyClass`. Eventually we may want an option to let consumers provide more non-Equatable types like this, but let's start with a hard-coded list until somebody asks for it.

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2043