### PR TITLE
Update `trailingCommas` rule to handle edge cases where Swift 6.1 unexpectedly doesn't allow trailing commas in tuple or closure types

### DIFF
--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -45,6 +45,15 @@ public extension FormatRule {
                     trailingCommaSupported = false
                 }
 
+                // In Swift 6.1, tuple types and closure types unexpectedly don't support trailing commas.
+                // https://github.com/swiftlang/swift/issues/81485
+                if let startOfScope = formatter.startOfScope(at: i),
+                   formatter.isTypePosition(at: startOfScope),
+                   formatter.isStartOfTupleType(at: startOfScope) || formatter.isStartOfClosureType(at: startOfScope)
+                {
+                    trailingCommaSupported = false
+                }
+
                 formatter.addOrRemoveTrailingComma(before: i, trailingCommaSupported: trailingCommaSupported)
 
             case .endOfScope(">"):

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -561,12 +561,17 @@ extension Collection where Element == Token, Index == Int {
     }
 
     /// A string representation of this array of tokens,
-    /// excluding any newlines and following indentation.
-    var stringExcludingLinebreaks: String {
+    /// excluding any newlines and following indentation, comments, or leading/trailing spaces.
+    var stringExcludingLinebreaksAndComments: String {
         var tokens: [Token] = []
 
         var index = indices.startIndex
         while index < indices.endIndex {
+            // Exclude any comments
+            while self[index].isComment, index < indices.endIndex {
+                index += 1
+            }
+
             // Skip over any linebreaks, and any indentation following the linebreak
             if self[index].isLinebreak {
                 index += 1
@@ -575,11 +580,13 @@ extension Collection where Element == Token, Index == Int {
                 }
             }
 
-            tokens.append(self[index])
-            index += 1
+            if index < indices.endIndex {
+                tokens.append(self[index])
+                index += 1
+            }
         }
 
-        return tokens.string
+        return tokens.string.trimmingCharacters(in: .whitespaces)
     }
 }
 

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2272,21 +2272,29 @@ class ParsingHelpersTests: XCTestCase {
         let closure: (foo: Foo, bar: Bar) -> Void
         let valueWithRedundantParens: (Foo)
         let voidValue: ()
+        let tupleWithComments: (
+            bar: String, // comment A
+            quux: String // comment B
+        )  // Trailing comment
         """
 
         let formatter = Formatter(tokenize(input))
 
         XCTAssertEqual(formatter.parseType(at: 5)?.name, "(foo: Foo, bar: Bar)")
-        XCTAssertTrue(formatter.isStartOfTuple(at: 5))
+        XCTAssertTrue(formatter.isStartOfTupleType(at: 5))
 
         XCTAssertEqual(formatter.parseType(at: 23)?.name, "(foo: Foo, bar: Bar) -> Void")
-        XCTAssertFalse(formatter.isStartOfTuple(at: 23))
+        XCTAssertFalse(formatter.isStartOfTupleType(at: 23))
+        XCTAssertTrue(formatter.isStartOfClosureType(at: 23))
 
         XCTAssertEqual(formatter.parseType(at: 45)?.name, "(Foo)")
-        XCTAssertFalse(formatter.isStartOfTuple(at: 45))
+        XCTAssertFalse(formatter.isStartOfTupleType(at: 45))
 
         XCTAssertEqual(formatter.parseType(at: 54)?.name, "()")
-        XCTAssertFalse(formatter.isStartOfTuple(at: 54))
+        XCTAssertFalse(formatter.isStartOfTupleType(at: 54))
+
+        XCTAssertTrue(formatter.isStartOfTupleType(at: 62))
+        XCTAssertEqual(formatter.parseType(at: 62)?.name, "(bar: String,  quux: String  )")
     }
 
     // MARK: - parseExpressionRange

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -479,6 +479,51 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
+    func testTrailingCommasPreservedInTupleTypeInSwift6_1() {
+        // Trailing commas are unexpectedly not supported in tuple types in Swift 6.1
+        // https://github.com/swiftlang/swift/issues/81485
+        let input = """
+        let foo: (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+        """
+
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasPreservedInTupleTypeInArrayInSwift6_1() {
+        // Trailing commas are unexpectedly not supported in tuple types in Swift 6.1
+        // https://github.com/swiftlang/swift/issues/81485
+        let input = """
+        let foo: [[(
+            bar: String,
+            quux: String // trailing comma not supported
+        )]]
+        """
+
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasPreservedInClosureTypeInSwift6_1() {
+        // Trailing commas are unexpectedly not supported in closure types in Swift 6.1
+        // https://github.com/swiftlang/swift/issues/81485
+        let input = """
+        let closure: (
+            String,
+            String // trailing comma not supported
+        ) -> (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+        """
+
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
     func testTrailingCommasAddedToReturnTuple() {
         let input = """
         func foo() -> (Int, Int) {


### PR DESCRIPTION
This PR fixes https://github.com/nicklockwood/SwiftFormat/issues/2050.

We found that Swift 6.1 _also_ doesn't support trailing commas in tuple or closure types: https://github.com/swiftlang/swift/issues/81485