### PR TITLE
Add option to `blankLinesAfterGuardStatements` rule to have blank line between consecutive guards

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -306,18 +306,18 @@ Remove blank lines between consecutive guard statements, and insert a blank afte
 
 Option | Description
 --- | ---
-`--linebtwnguards` | Insert line between guards: "true" (default) or "false"
+`--linebtwnguards` | Insert line between guards: "true" or "false" (default)
 
 <details>
 <summary>Examples</summary>
 
-`--linebtwnguards true` (default)
+`--linebtwnguards false` (default)
 
 ```diff
     guard let spicy = self.makeSpicy() else {
         return
     }
-
+-
     guard let soap = self.clean() else {
         return
     }
@@ -325,13 +325,13 @@ Option | Description
     let doTheJob = nikekov()
 ```
 
-`--linebtwnguards false`
+`--linebtwnguards true`
 
 ```diff
     guard let spicy = self.makeSpicy() else {
         return
     }
--
+
     guard let soap = self.clean() else {
         return
     }

--- a/Rules.md
+++ b/Rules.md
@@ -304,14 +304,34 @@ which is followed by a closing brace).
 
 Remove blank lines between consecutive guard statements, and insert a blank after the last guard statement.
 
+Option | Description
+--- | ---
+`--linebtwnguards` | Insert line between guards: "true" or "false" (default)
+
 <details>
 <summary>Examples</summary>
+
+`--linebtwnguards false` (default)
 
 ```diff
     guard let spicy = self.makeSpicy() else {
         return
     }
 -
+    guard let soap = self.clean() else {
+        return
+    }
++
+    let doTheJob = nikekov()
+```
+
+`--linebtwnguards true`
+
+```diff
+    guard let spicy = self.makeSpicy() else {
+        return
+    }
+
     guard let soap = self.clean() else {
         return
     }

--- a/Rules.md
+++ b/Rules.md
@@ -314,13 +314,26 @@ Option | Description
 `--linebtwnguards false` (default)
 
 ```diff
+    // Multiline guard
     guard let spicy = self.makeSpicy() else {
         return
-    }
+    } 
 -
+    guard let yummy = self.makeYummy() else {
+        return
+    }
     guard let soap = self.clean() else {
         return
     }
++
+    let doTheJob = nikekov()
+```
+```diff
+    // Single-line guard
+    guard let spicy = self.makeSpicy() else { return }
+-
+    guard let yummy = self.makeYummy() else { return }
+    guard let soap = self.clean() else { return }
 +
     let doTheJob = nikekov()
 ```
@@ -328,13 +341,28 @@ Option | Description
 `--linebtwnguards true`
 
 ```diff
+    // Multiline guard
     guard let spicy = self.makeSpicy() else {
         return
     }
 
+    guard let yummy = self.makeYummy() else {
+        return
+    }
++
     guard let soap = self.clean() else {
         return
     }
++
+    let doTheJob = nikekov()
+```
+```diff
+    // Single-line guard
+    guard let spicy = self.makeSpicy() else { return }
+
+    guard let yummy = self.makeYummy() else { return }
++
+    guard let soap = self.clean() else { return }
 +
     let doTheJob = nikekov()
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -306,18 +306,18 @@ Remove blank lines between consecutive guard statements, and insert a blank afte
 
 Option | Description
 --- | ---
-`--linebtwnguards` | Insert line between guards: "true" or "false" (default)
+`--linebtwnguards` | Insert line between guards: "true" (default) or "false"
 
 <details>
 <summary>Examples</summary>
 
-`--linebtwnguards false` (default)
+`--linebtwnguards true` (default)
 
 ```diff
     guard let spicy = self.makeSpicy() else {
         return
     }
--
+
     guard let soap = self.clean() else {
         return
     }
@@ -325,13 +325,13 @@ Option | Description
     let doTheJob = nikekov()
 ```
 
-`--linebtwnguards true`
+`--linebtwnguards false`
 
 ```diff
     guard let spicy = self.makeSpicy() else {
         return
     }
-
+-
     guard let soap = self.clean() else {
         return
     }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1276,7 +1276,7 @@ struct _Descriptors {
     let lineBetweenConsecutiveGuards = OptionDescriptor(
         argumentName: "linebtwnguards",
         displayName: "Blank Line Between Consecutive Guards",
-        help: "Insert line between guards: \"true\" (default) or \"false\"",
+        help: "Insert line between guards: \"true\" or \"false\" (default)",
         keyPath: \.lineBetweenConsecutiveGuards,
         trueValues: ["true"],
         falseValues: ["false"]

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1276,7 +1276,7 @@ struct _Descriptors {
     let lineBetweenConsecutiveGuards = OptionDescriptor(
         argumentName: "linebtwnguards",
         displayName: "Blank Line Between Consecutive Guards",
-        help: "Insert line between guards: \"true\" or \"false\" (default)",
+        help: "Insert line between guards: \"true\" (default) or \"false\"",
         keyPath: \.lineBetweenConsecutiveGuards,
         trueValues: ["true"],
         falseValues: ["false"]

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1273,6 +1273,14 @@ struct _Descriptors {
         trueValues: ["#file", "file"],
         falseValues: ["#fileID", "fileID"]
     )
+    let lineBetweenConsecutiveGuards = OptionDescriptor(
+        argumentName: "linebtwnguards",
+        displayName: "Blank Line Between Consecutive Guards",
+        help: "Insert line between guards: \"true\" or \"false\" (default)",
+        keyPath: \.lineBetweenConsecutiveGuards,
+        trueValues: ["true"],
+        falseValues: ["false"]
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -739,6 +739,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var additionalXCTestSymbols: Set<String>
     public var equatableMacro: EquatableMacro
     public var preferFileMacro: Bool
+    public var lineBetweenConsecutiveGuards: Bool
 
     /// Deprecated
     public var indentComments: Bool
@@ -869,6 +870,7 @@ public struct FormatOptions: CustomStringConvertible {
                 additionalXCTestSymbols: Set<String> = [],
                 equatableMacro: EquatableMacro = .none,
                 preferFileMacro: Bool = true,
+                lineBetweenConsecutiveGuards: Bool = false,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -989,6 +991,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.additionalXCTestSymbols = additionalXCTestSymbols
         self.equatableMacro = equatableMacro
         self.preferFileMacro = preferFileMacro
+        self.lineBetweenConsecutiveGuards = lineBetweenConsecutiveGuards
         // Doesn't really belong here, but hard to put elsewhere
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -870,7 +870,7 @@ public struct FormatOptions: CustomStringConvertible {
                 additionalXCTestSymbols: Set<String> = [],
                 equatableMacro: EquatableMacro = .none,
                 preferFileMacro: Bool = true,
-                lineBetweenConsecutiveGuards: Bool = false,
+                lineBetweenConsecutiveGuards: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -870,7 +870,7 @@ public struct FormatOptions: CustomStringConvertible {
                 additionalXCTestSymbols: Set<String> = [],
                 equatableMacro: EquatableMacro = .none,
                 preferFileMacro: Bool = true,
-                lineBetweenConsecutiveGuards: Bool = true,
+                lineBetweenConsecutiveGuards: Bool = false,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -47,13 +47,13 @@ public extension FormatRule {
         }
     } examples: {
         """
-        `--linebtwnguards true` (default)
+        `--linebtwnguards false` (default)
 
         ```diff
             guard let spicy = self.makeSpicy() else {
                 return
             }
-
+        -
             guard let soap = self.clean() else {
                 return
             }
@@ -61,13 +61,13 @@ public extension FormatRule {
             let doTheJob = nikekov()
         ```
 
-        `--linebtwnguards false`
+        `--linebtwnguards true`
 
         ```diff
             guard let spicy = self.makeSpicy() else {
                 return
             }
-        -
+
             guard let soap = self.clean() else {
                 return
             }

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -6,7 +6,8 @@ import Foundation
 public extension FormatRule {
     static let blankLinesAfterGuardStatements = FormatRule(
         help: "Remove blank lines between consecutive guard statements, and insert a blank after the last guard statement.",
-        disabledByDefault: true
+        disabledByDefault: true,
+        options: ["linebtwnguards"]
     ) { formatter in
         formatter.forEach(.keyword("guard")) { guardIndex, _ in
             guard var elseIndex = formatter.index(of: .keyword("else"), after: guardIndex) else {
@@ -34,17 +35,38 @@ public extension FormatRule {
                 return
             }
 
-            let linebreaks = nextToken == .keyword("guard") ? 1 : 2
+            let linebreaks = if formatter.options.lineBetweenConsecutiveGuards {
+                2
+            } else {
+                nextToken == .keyword("guard") ? 1 : 2
+            }
+
             let indexesBetween = Set(endOfGuardScope + 1 ..< nextNonSpaceAndNonLinebreakIndex)
             formatter.leaveOrSetLinebreaksInIndexes(indexesBetween, linebreaksCount: linebreaks)
         }
     } examples: {
         """
+        `--linebtwnguards false` (default)
+
         ```diff
             guard let spicy = self.makeSpicy() else {
                 return
             }
         -
+            guard let soap = self.clean() else {
+                return
+            }
+        +
+            let doTheJob = nikekov()
+        ```
+
+        `--linebtwnguards true`
+
+        ```diff
+            guard let spicy = self.makeSpicy() else {
+                return
+            }
+
             guard let soap = self.clean() else {
                 return
             }

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -47,13 +47,13 @@ public extension FormatRule {
         }
     } examples: {
         """
-        `--linebtwnguards false` (default)
+        `--linebtwnguards true` (default)
 
         ```diff
             guard let spicy = self.makeSpicy() else {
                 return
             }
-        -
+
             guard let soap = self.clean() else {
                 return
             }
@@ -61,13 +61,13 @@ public extension FormatRule {
             let doTheJob = nikekov()
         ```
 
-        `--linebtwnguards true`
+        `--linebtwnguards false`
 
         ```diff
             guard let spicy = self.makeSpicy() else {
                 return
             }
-
+        -
             guard let soap = self.clean() else {
                 return
             }

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -50,13 +50,26 @@ public extension FormatRule {
         `--linebtwnguards false` (default)
 
         ```diff
+            // Multiline guard
             guard let spicy = self.makeSpicy() else {
                 return
-            }
+            } 
         -
+            guard let yummy = self.makeYummy() else {
+                return
+            }
             guard let soap = self.clean() else {
                 return
             }
+        +
+            let doTheJob = nikekov()
+        ```
+        ```diff
+            // Single-line guard
+            guard let spicy = self.makeSpicy() else { return }
+        -
+            guard let yummy = self.makeYummy() else { return }
+            guard let soap = self.clean() else { return }
         +
             let doTheJob = nikekov()
         ```
@@ -64,13 +77,28 @@ public extension FormatRule {
         `--linebtwnguards true`
 
         ```diff
+            // Multiline guard
             guard let spicy = self.makeSpicy() else {
                 return
             }
 
+            guard let yummy = self.makeYummy() else {
+                return
+            }
+        +
             guard let soap = self.clean() else {
                 return
             }
+        +
+            let doTheJob = nikekov()
+        ```
+        ```diff
+            // Single-line guard
+            guard let spicy = self.makeSpicy() else { return }
+
+            guard let yummy = self.makeYummy() else { return }
+        +
+            guard let soap = self.clean() else { return }
         +
             let doTheJob = nikekov()
         ```

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -35,10 +35,11 @@ public extension FormatRule {
                 return
             }
 
-            let linebreaks = if formatter.options.lineBetweenConsecutiveGuards {
-                2
+            let linebreaks: Int
+            if formatter.options.lineBetweenConsecutiveGuards {
+                linebreaks = 2
             } else {
-                nextToken == .keyword("guard") ? 1 : 2
+                linebreaks = nextToken == .keyword("guard") ? 1 : 2
             }
 
             let indexesBetween = Set(endOfGuardScope + 1 ..< nextNonSpaceAndNonLinebreakIndex)

--- a/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
+++ b/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
@@ -34,15 +34,19 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         guard let one = test.one else {
             return
         }
+
         guard let two = test.two else {
             return
         }
+
         guard let three = test.three else {
             return
         }
+
         guard let four = test.four else {
             return
         }
+
         guard let five = test.five else {
             return
         }
@@ -51,7 +55,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testSpacesBetweenGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testSpacesBetweenGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard let one = test.one else {
             return
@@ -80,19 +84,15 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         guard let one = test.one else {
             return
         }
-
         guard let two = test.two else {
             return
         }
-
         guard let three = test.three else {
             return
         }
-
         guard let four = test.four else {
             return
         }
-
         guard let five = test.five else {
             return
         }
@@ -102,7 +102,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            options: FormatOptions(lineBetweenConsecutiveGuards: false),
             exclude: [.blankLinesBetweenScopes]
         )
     }
@@ -125,7 +125,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
     }
 
-    func testLinebreakAfterGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testLinebreakAfterGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard let one = test.one else {
             return
@@ -144,7 +144,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true)
+            options: FormatOptions(lineBetweenConsecutiveGuards: false)
         )
     }
 
@@ -169,6 +169,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
 
             return
         }
+
         guard let three = test.three() else {
             return
         }
@@ -177,7 +178,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testNotIncludedGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testNotIncludedGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard let one = test.one else {
             guard let two = test.two() else {
@@ -198,7 +199,6 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
 
             return
         }
-
         guard let three = test.three() else {
             return
         }
@@ -208,7 +208,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            options: FormatOptions(lineBetweenConsecutiveGuards: false),
             exclude: [.blankLinesBetweenScopes]
         )
     }
@@ -239,7 +239,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
     }
 
-    func testEndBracketAndIfWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testEndBracketAndIfWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard let something = test.something else {
             return
@@ -266,7 +266,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true)
+            options: FormatOptions(lineBetweenConsecutiveGuards: false)
         )
     }
 
@@ -300,7 +300,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.docComments])
     }
 
-    func testCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testCommentsWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard let somethingTwo = test.somethingTwo else {
             return
@@ -331,7 +331,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            options: FormatOptions(lineBetweenConsecutiveGuards: false),
             exclude: [.docComments]
         )
     }
@@ -346,7 +346,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
     }
 
-    func testNotInsertLineBreakWhenInlineFunctionAndBlankLineInsertedBetweenConsecutiveGuards() {
+    func testNotInsertLineBreakWhenInlineFunctionAndBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         let array = [1, 2, 3]
         guard array.map { String($0) }.isEmpty else {
@@ -356,7 +356,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(
             for: input,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            options: FormatOptions(lineBetweenConsecutiveGuards: false),
             exclude: [.wrapConditionalBodies]
         )
     }
@@ -376,7 +376,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
     }
 
-    func testNotInsertLineBreakInChainWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testNotInsertLineBreakInChainWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
         let input = """
         guard aBool,
               anotherBool,
@@ -391,7 +391,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(
             for: input,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            options: FormatOptions(lineBetweenConsecutiveGuards: false),
             exclude: [.wrapConditionalBodies]
         )
     }

--- a/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
+++ b/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
@@ -51,6 +51,62 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
+    func testSpacesBetweenGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else {
+            return
+        }
+        guard let two = test.two else {
+            return
+        }
+
+        guard let three = test.three else {
+            return
+        }
+
+
+        guard let four = test.four else {
+            return
+        }
+
+
+
+
+        guard let five = test.five else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else {
+            return
+        }
+
+        guard let two = test.two else {
+            return
+        }
+
+        guard let three = test.three else {
+            return
+        }
+
+        guard let four = test.four else {
+            return
+        }
+
+        guard let five = test.five else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.blankLinesBetweenScopes]
+        )
+    }
+
     func testLinebreakAfterGuard() {
         let input = """
         guard let one = test.one else {
@@ -67,6 +123,29 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
+    }
+
+    func testLinebreakAfterGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else {
+            return
+        }
+        let x = test()
+        """
+        let output = """
+        guard let one = test.one else {
+            return
+        }
+
+        let x = test()
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true)
+        )
     }
 
     func testIncludedGuard() {
@@ -98,6 +177,42 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
+    func testNotIncludedGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else {
+            guard let two = test.two() else {
+                return
+            }
+            return
+        }
+
+        guard let three = test.three() else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else {
+            guard let two = test.two() else {
+                return
+            }
+
+            return
+        }
+
+        guard let three = test.three() else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.blankLinesBetweenScopes]
+        )
+    }
+
     func testEndBracketAndIf() {
         let input = """
         guard let something = test.something else {
@@ -122,6 +237,37 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
+    }
+
+    func testEndBracketAndIfWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let something = test.something else {
+            return
+        }
+        if someone == someoneElse {
+            guard let nextTime else {
+                return
+            }
+        }
+        """
+        let output = """
+        guard let something = test.something else {
+            return
+        }
+
+        if someone == someoneElse {
+            guard let nextTime else {
+                return
+            }
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true)
+        )
     }
 
     func testComments() {
@@ -154,6 +300,42 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.docComments])
     }
 
+    func testCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let somethingTwo = test.somethingTwo else {
+            return
+        }
+        // commentOne
+        guard let somethingOne = test.somethingOne else {
+            return
+        }
+        // commentTwo
+        let something = xxx
+        """
+
+        let output = """
+        guard let somethingTwo = test.somethingTwo else {
+            return
+        }
+
+        // commentOne
+        guard let somethingOne = test.somethingOne else {
+            return
+        }
+
+        // commentTwo
+        let something = xxx
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.docComments]
+        )
+    }
+
     func testNotInsertLineBreakWhenInlineFunction() {
         let input = """
         let array = [1, 2, 3]
@@ -162,6 +344,21 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         }
         """
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
+    }
+
+    func testNotInsertLineBreakWhenInlineFunctionAndBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        let array = [1, 2, 3]
+        guard array.map { String($0) }.isEmpty else {
+            return
+        }
+        """
+        testFormatting(
+            for: input,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.wrapConditionalBodies]
+        )
     }
 
     func testNotInsertLineBreakInChain() {
@@ -177,5 +374,25 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         """
 
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
+    }
+
+    func testNotInsertLineBreakInChainWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard aBool,
+              anotherBool,
+              aTestArray
+              .map { $0 * 2 }
+              .filter { $0 == 4 }
+              .isEmpty,
+              yetAnotherBool
+        else { return }
+        """
+
+        testFormatting(
+            for: input,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.wrapConditionalBodies]
+        )
     }
 }

--- a/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
+++ b/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
@@ -34,19 +34,15 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         guard let one = test.one else {
             return
         }
-
         guard let two = test.two else {
             return
         }
-
         guard let three = test.three else {
             return
         }
-
         guard let four = test.four else {
             return
         }
-
         guard let five = test.five else {
             return
         }
@@ -55,7 +51,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testSpacesBetweenGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testSpacesBetweenGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             return
@@ -84,15 +80,19 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         guard let one = test.one else {
             return
         }
+
         guard let two = test.two else {
             return
         }
+
         guard let three = test.three else {
             return
         }
+
         guard let four = test.four else {
             return
         }
+
         guard let five = test.five else {
             return
         }
@@ -102,7 +102,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false),
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.blankLinesBetweenScopes]
         )
     }
@@ -125,7 +125,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
     }
 
-    func testLinebreakAfterGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testLinebreakAfterGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             return
@@ -144,7 +144,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false)
+            options: FormatOptions(lineBetweenConsecutiveGuards: true)
         )
     }
 
@@ -169,7 +169,6 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
 
             return
         }
-
         guard let three = test.three() else {
             return
         }
@@ -178,7 +177,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testNotIncludedGuardWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testNotIncludedGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             guard let two = test.two() else {
@@ -199,6 +198,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
 
             return
         }
+
         guard let three = test.three() else {
             return
         }
@@ -208,7 +208,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false),
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.blankLinesBetweenScopes]
         )
     }
@@ -239,7 +239,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
     }
 
-    func testEndBracketAndIfWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testEndBracketAndIfWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let something = test.something else {
             return
@@ -266,7 +266,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false)
+            options: FormatOptions(lineBetweenConsecutiveGuards: true)
         )
     }
 
@@ -300,7 +300,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.docComments])
     }
 
-    func testCommentsWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let somethingTwo = test.somethingTwo else {
             return
@@ -331,7 +331,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             output,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false),
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.docComments]
         )
     }
@@ -346,7 +346,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
     }
 
-    func testNotInsertLineBreakWhenInlineFunctionAndBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testNotInsertLineBreakWhenInlineFunctionAndBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         let array = [1, 2, 3]
         guard array.map { String($0) }.isEmpty else {
@@ -356,7 +356,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(
             for: input,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false),
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.wrapConditionalBodies]
         )
     }
@@ -376,7 +376,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
     }
 
-    func testNotInsertLineBreakInChainWhenBlankLineBetweenConsecutiveGuardsIsRemoved() {
+    func testNotInsertLineBreakInChainWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard aBool,
               anotherBool,
@@ -391,7 +391,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(
             for: input,
             rule: .blankLinesAfterGuardStatements,
-            options: FormatOptions(lineBetweenConsecutiveGuards: false),
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.wrapConditionalBodies]
         )
     }

--- a/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
+++ b/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SwiftFormat
 
 final class BlankLinesAfterGuardStatementsTests: XCTestCase {
-    func testSpacesBetweenGuard() {
+    func testSpacesBetweenMultiLineGuards() {
         let input = """
         guard let one = test.one else {
             return
@@ -51,7 +51,77 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testSpacesBetweenGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testSpacesBetweenSingleLineGuards() {
+        let input = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+
+        guard let three = test.three else { return }
+
+
+        guard let four = test.four else { return }
+
+
+
+
+        guard let five = test.five else { return }
+        """
+        let output = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+        guard let three = test.three else { return }
+        guard let four = test.four else { return }
+        guard let five = test.five else { return }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
+        )
+    }
+
+    func testSpacesBetweenSingleLineAndMultiLineGuards() {
+        let input = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+
+        guard let three = test.three else {
+            return
+        }
+
+
+        guard let four = test.four else { return }
+
+
+
+
+        guard let five = test.five else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+        guard let three = test.three else {
+            return
+        }
+        guard let four = test.four else { return }
+        guard let five = test.five else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
+        )
+    }
+
+    func testSpacesBetweenMultiLineGuardsWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             return
@@ -107,7 +177,87 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         )
     }
 
-    func testLinebreakAfterGuard() {
+    func testSpacesBetweenSingleLineGuardsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+
+        guard let three = test.three else { return }
+
+
+        guard let four = test.four else { return }
+
+
+
+
+        guard let five = test.five else { return }
+        """
+        let output = """
+        guard let one = test.one else { return }
+
+        guard let two = test.two else { return }
+
+        guard let three = test.three else { return }
+
+        guard let four = test.four else { return }
+
+        guard let five = test.five else { return }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
+        )
+    }
+
+    func testSpacesBetweenSingleLineAndMultiLineGuardsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else { return }
+        guard let two = test.two else { return }
+
+        guard let three = test.three else {
+            return
+        }
+
+
+        guard let four = test.four else { return }
+
+
+
+
+        guard let five = test.five else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else { return }
+
+        guard let two = test.two else { return }
+
+        guard let three = test.three else {
+            return
+        }
+
+        guard let four = test.four else { return }
+
+        guard let five = test.five else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
+        )
+    }
+
+    func testLinebreakAfterMultiLineGuard() {
         let input = """
         guard let one = test.one else {
             return
@@ -125,7 +275,26 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
     }
 
-    func testLinebreakAfterGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testLinebreakAfterSingleLineGuard() {
+        let input = """
+        guard let one = test.one else { return }
+        let x = test()
+        """
+        let output = """
+        guard let one = test.one else { return }
+
+        let x = test()
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.wrapConditionalBodies]
+        )
+    }
+
+    func testLinebreakAfterMultiLineGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             return
@@ -148,7 +317,27 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         )
     }
 
-    func testIncludedGuard() {
+    func testLinebreakAfterSingleLineGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else { return }
+        let x = test()
+        """
+        let output = """
+        guard let one = test.one else { return }
+
+        let x = test()
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.wrapConditionalBodies]
+        )
+    }
+
+    func testIncludedMultiLineGuard() {
         let input = """
         guard let one = test.one else {
             guard let two = test.two() else {
@@ -177,7 +366,37 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.blankLinesBetweenScopes])
     }
 
-    func testNotIncludedGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testIncludedSingleLineGuard() {
+        let input = """
+        guard let one = test.one else {
+            guard let two = test.two() else { return }
+            return
+        }
+
+        guard let three = test.three() else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else {
+            guard let two = test.two() else { return }
+
+            return
+        }
+        guard let three = test.three() else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
+        )
+    }
+
+    func testIncludedMultiLineGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let one = test.one else {
             guard let two = test.two() else {
@@ -210,6 +429,38 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             rule: .blankLinesAfterGuardStatements,
             options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.blankLinesBetweenScopes]
+        )
+    }
+
+    func testIncludedSingleLineGuardWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let one = test.one else {
+            guard let two = test.two() else { return }
+            return
+        }
+
+        guard let three = test.three() else {
+            return
+        }
+        """
+        let output = """
+        guard let one = test.one else {
+            guard let two = test.two() else { return }
+
+            return
+        }
+
+        guard let three = test.three() else {
+            return
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.blankLinesBetweenScopes, .wrapConditionalBodies]
         )
     }
 
@@ -237,6 +488,29 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements)
+    }
+
+    func testSingleLineGuardAndIf() {
+        let input = """
+        guard let something = test.something else { return }
+        if someone == someoneElse {
+            guard let nextTime else { return }
+        }
+        """
+        let output = """
+        guard let something = test.something else { return }
+
+        if someone == someoneElse {
+            guard let nextTime else { return }
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.wrapConditionalBodies]
+        )
     }
 
     func testEndBracketAndIfWhenBlankLineInsertedBetweenConsecutiveGuards() {
@@ -270,7 +544,31 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         )
     }
 
-    func testComments() {
+    func testSingleLineGuardAndIfWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let something = test.something else { return }
+        if someone == someoneElse {
+            guard let nextTime else { return }
+        }
+        """
+        let output = """
+        guard let something = test.something else { return }
+
+        if someone == someoneElse {
+            guard let nextTime else { return }
+        }
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.wrapConditionalBodies]
+        )
+    }
+
+    func testMultiLineGuardAndComments() {
         let input = """
         guard let somethingTwo = test.somethingTwo else {
             return
@@ -300,7 +598,34 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         testFormatting(for: input, output, rule: .blankLinesAfterGuardStatements, exclude: [.docComments])
     }
 
-    func testCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+    func testSingleLineGuardAndComments() {
+        let input = """
+        guard let somethingTwo = test.somethingTwo else { return }
+        // commentOne
+        guard let somethingOne = test.somethingOne else { return }
+        // commentTwo
+        let something = xxx
+        """
+
+        let output = """
+        guard let somethingTwo = test.somethingTwo else { return }
+
+        // commentOne
+        guard let somethingOne = test.somethingOne else { return }
+
+        // commentTwo
+        let something = xxx
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            exclude: [.docComments, .wrapConditionalBodies]
+        )
+    }
+
+    func testMultiLineGuardAndCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
         let input = """
         guard let somethingTwo = test.somethingTwo else {
             return
@@ -333,6 +658,34 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             rule: .blankLinesAfterGuardStatements,
             options: FormatOptions(lineBetweenConsecutiveGuards: true),
             exclude: [.docComments]
+        )
+    }
+
+    func testSingleLineGuardAndCommentsWhenBlankLineInsertedBetweenConsecutiveGuards() {
+        let input = """
+        guard let somethingTwo = test.somethingTwo else { return }
+        // commentOne
+        guard let somethingOne = test.somethingOne else { return }
+        // commentTwo
+        let something = xxx
+        """
+
+        let output = """
+        guard let somethingTwo = test.somethingTwo else { return }
+
+        // commentOne
+        guard let somethingOne = test.somethingOne else { return }
+
+        // commentTwo
+        let something = xxx
+        """
+
+        testFormatting(
+            for: input,
+            output,
+            rule: .blankLinesAfterGuardStatements,
+            options: FormatOptions(lineBetweenConsecutiveGuards: true),
+            exclude: [.docComments, .wrapConditionalBodies]
         )
     }
 


### PR DESCRIPTION
This PR adds `--linebtwnguards` option to `blankLinesAfterGuardStatements` rule which allows inserting/leaving one blank line between consecutive guards. The option name was chosen to match the style already written, such as `--lineaftermarks` in `blankLinesAroundMark` rule.

Example:

`--linebtwnguards false` (default)
```diff
    guard let spicy = self.makeSpicy() else {
        return
    }
-
    guard let soap = self.clean() else {
        return
    }
+
    let doTheJob = nikekov()
```

`--linebtwnguards true`
```diff
    guard let spicy = self.makeSpicy() else {
        return
    }

    guard let soap = self.clean() else {
        return
    }
+
    let doTheJob = nikekov()
```

It would be great to have this feature in SwiftFormat by default :)