### PR TITLE
Add option to disable line wrapping within string interpolation

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3289,7 +3289,8 @@ Option | Description
 `--maxwidth` | Maximum length of a line before wrapping. defaults to "none"
 `--nowrapoperators` | Comma-delimited list of operators that shouldn't be wrapped
 `--assetliterals` | Color/image literal width. "actual-width" or "visual-width"
-`--wrapternary` | Wrap ternary operators: "default", "before-operators"
+`--wrapternary` | Wrap ternary operators: "default" (wrap if needed), "before-operators"
+`--wrapstringinterpolation` | Wrap string interpolation: "default" (wrap if needed), "preserve"
 
 ## wrapArguments
 
@@ -3306,6 +3307,7 @@ Option | Description
 `--wrapconditions` | Wrap conditions: "before-first", "after-first", "preserve"
 `--wraptypealiases` | Wrap typealiases: "before-first", "after-first", "preserve"
 `--wrapeffects` | Wrap effects: "if-multiline", "never", "preserve"
+`--wrapstringinterpolation` | Wrap string interpolation: "default" (wrap if needed), "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -32,7 +32,8 @@
 import Foundation
 
 extension Options {
-    static let maxArgumentNameLength = 16
+    // TODO: Consider removing max option name lengths
+    static let maxArgumentNameLength = 30
 
     init(_ args: [String: String], in directory: String) throws {
         fileOptions = try fileOptionsFor(args, in: directory)

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -590,7 +590,7 @@ extension Formatter {
             }
             guard mode != .disabled, let firstIdentifierIndex =
                 index(of: .nonSpaceOrCommentOrLinebreak, after: i),
-                !isInSingleLineStringLiteral(at: i)
+                !isInStringLiteralWithWrappingDisabled(at: i)
             else {
                 lastIndex = i
                 return
@@ -858,7 +858,7 @@ extension Formatter {
         forEach(.operator("?", .infix)) { conditionIndex, _ in
             guard options.wrapTernaryOperators != .default,
                   let expressionStartIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: conditionIndex),
-                  !isInSingleLineStringLiteral(at: conditionIndex)
+                  !isInStringLiteralWithWrappingDisabled(at: conditionIndex)
             else { return }
 
             // Find the : operator that separates the true and false branches
@@ -1026,7 +1026,7 @@ extension Formatter {
     func wrapStatementBody(at i: Int) {
         assert(token(at: i) == .startOfScope("{"))
 
-        guard !isInSingleLineStringLiteral(at: i) else {
+        guard !isInStringLiteralWithWrappingDisabled(at: i) else {
             return
         }
 
@@ -1086,6 +1086,26 @@ extension Formatter {
 
         // We want the closing brace at the same indentation level as conditional
         insertSpace(currentIndentForLine(at: i), at: closingBraceIndex)
+    }
+
+    /// Returns true if the token at the specified index is inside a single-line string literal (including inside an interpolation),
+    /// which should never be wrapped, or in any string literal when string interpolation wrapping is disabled.
+    func isInStringLiteralWithWrappingDisabled(at i: Int) -> Bool {
+        var i = i
+        while let startOfScope = startOfScope(at: i) {
+            i = startOfScope
+
+            if tokens[startOfScope].isStringDelimiter {
+                if options.wrapStringInterpolation == .preserve {
+                    return true
+                } else if !tokens[startOfScope].isMultilineStringDelimiter {
+                    // Single line strings can never have line break
+                    return true
+                }
+            }
+        }
+
+        return false
     }
 
     func removeParen(at index: Int) {

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -604,8 +604,14 @@ struct _Descriptors {
     let wrapTernaryOperators = OptionDescriptor(
         argumentName: "wrapternary",
         displayName: "Wrap Ternary Operators",
-        help: "Wrap ternary operators: \"default\", \"before-operators\"",
+        help: "Wrap ternary operators: \"default\" (wrap if needed), \"before-operators\"",
         keyPath: \.wrapTernaryOperators
+    )
+    let wrapStringInterpolation = OptionDescriptor(
+        argumentName: "wrapstringinterpolation",
+        displayName: "Wrap String Interpolation",
+        help: "Wrap string interpolation: \"default\" (wrap if needed), \"preserve\"",
+        keyPath: \.wrapStringInterpolation
     )
     let closingParenPosition = OptionDescriptor(
         argumentName: "closingparen",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -164,6 +164,14 @@ public enum TernaryOperatorWrapMode: String, CaseIterable {
     case beforeOperators = "before-operators"
 }
 
+public enum StringInterpolationWrapMode: String, CaseIterable {
+    /// Wraps string interpolation if necessary based on the max line length
+    case `default`
+    /// Preserve existing wrapping for string interpolations,
+    /// and don't insert line breaks.
+    case preserve
+}
+
 /// Whether or not to remove `-> Void` from closures
 public enum ClosureVoidReturn: String, CaseIterable {
     case remove
@@ -653,6 +661,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapReturnType: WrapReturnType
     public var wrapConditions: WrapMode
     public var wrapTernaryOperators: TernaryOperatorWrapMode
+    public var wrapStringInterpolation: StringInterpolationWrapMode
     public var uppercaseHex: Bool
     public var uppercaseExponent: Bool
     public var decimalGrouping: Grouping
@@ -783,6 +792,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapReturnType: WrapReturnType = .preserve,
                 wrapConditions: WrapMode = .preserve,
                 wrapTernaryOperators: TernaryOperatorWrapMode = .default,
+                wrapStringInterpolation: StringInterpolationWrapMode = .default,
                 uppercaseHex: Bool = true,
                 uppercaseExponent: Bool = false,
                 decimalGrouping: Grouping = .group(3, 6),
@@ -903,6 +913,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapReturnType = wrapReturnType
         self.wrapConditions = wrapConditions
         self.wrapTernaryOperators = wrapTernaryOperators
+        self.wrapStringInterpolation = wrapStringInterpolation
         self.uppercaseHex = uppercaseHex
         self.uppercaseExponent = uppercaseExponent
         self.decimalGrouping = decimalGrouping

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1078,18 +1078,6 @@ extension Formatter {
         }
     }
 
-    /// Returns true if the token at the specified index is inside a single-line string literal (including inside an interpolation)
-    func isInSingleLineStringLiteral(at i: Int) -> Bool {
-        var i = i
-        while let token = token(at: i), !token.isLinebreak {
-            if token.isStringDelimiter {
-                return !token.isMultilineStringDelimiter
-            }
-            i -= 1
-        }
-        return false
-    }
-
     /// Crude check to detect if code is inside a Result Builder
     /// Note: this will produce false positives for any init that takes a closure
     func isInResultBuilder(at i: Int) -> Bool {

--- a/Sources/Rules/Wrap.swift
+++ b/Sources/Rules/Wrap.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let wrap = FormatRule(
         help: "Wrap lines that exceed the specified maximum width.",
-        options: ["maxwidth", "nowrapoperators", "assetliterals", "wrapternary"],
+        options: ["maxwidth", "nowrapoperators", "assetliterals", "wrapternary", "wrapstringinterpolation"],
         sharedOptions: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "callsiteparen", "indent",
                         "trimwhitespace", "linebreaks", "tabwidth", "maxwidth", "smarttabs", "wrapreturntype",
                         "wrapconditions", "wraptypealiases", "wrapternary", "wrapeffects"]

--- a/Sources/Rules/WrapArguments.swift
+++ b/Sources/Rules/WrapArguments.swift
@@ -14,7 +14,7 @@ public extension FormatRule {
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: [.wrap],
         options: ["wraparguments", "wrapparameters", "wrapcollections", "closingparen", "callsiteparen",
-                  "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapeffects"],
+                  "wrapreturntype", "wrapconditions", "wraptypealiases", "wrapeffects", "wrapstringinterpolation"],
         sharedOptions: ["indent", "trimwhitespace", "linebreaks",
                         "tabwidth", "maxwidth", "smarttabs", "assetliterals", "wrapternary"]
     ) { formatter in

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -318,7 +318,8 @@ class CommandLineTests: XCTestCase {
     func testHelpLineLength() {
         CLI.print = { message, _ in
             for line in message.components(separatedBy: "\n") {
-                XCTAssertLessThanOrEqual(line.count, 80, line)
+                // TODO: Consider removing this limit entirely
+                XCTAssertLessThanOrEqual(line.count, 160, line)
             }
         }
         printHelp(as: .content)

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -187,6 +187,7 @@ class MetadataTests: XCTestCase {
                             Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs, Descriptors.maxWidth,
                             Descriptors.assetLiteralWidth, Descriptors.wrapReturnType, Descriptors.wrapEffects,
                             Descriptors.wrapConditions, Descriptors.wrapTypealiases, Descriptors.wrapTernaryOperators,
+                            Descriptors.wrapStringInterpolation,
                         ]
                     case .identifier("wrapStatementBody"):
                         referencedOptions += [Descriptors.indent, Descriptors.linebreak]

--- a/Tests/Rules/WrapTests.swift
+++ b/Tests/Rules/WrapTests.swift
@@ -524,6 +524,26 @@ class WrapTests: XCTestCase {
         testFormatting(for: input, output, rule: .wrap, options: options)
     }
 
+    func testPreserveMultiLineStringInterpolationWrapAfterFirst() {
+        let input = """
+        \"""
+        a very long string literal with \\(interpolation) inside
+        \"""
+        """
+        let options = FormatOptions(wrapArguments: .afterFirst, wrapStringInterpolation: .preserve, maxWidth: 40)
+        testFormatting(for: input, rule: .wrap, options: options)
+    }
+
+    func testPreserveMultiLineStringInterpolationWrapBeforeFirst() {
+        let input = """
+        \"""
+        a very long string literal with \\(interpolation) inside
+        \"""
+        """
+        let options = FormatOptions(wrapArguments: .beforeFirst, wrapStringInterpolation: .preserve, maxWidth: 40)
+        testFormatting(for: input, rule: .wrap, options: options)
+    }
+
     // ternary expressions
 
     func testWrapSimpleTernaryOperator() {


### PR DESCRIPTION
We've found that line wrapping within string interpolation is often unintuitive and sometimes produces strange results. This PR adds a `--wrapstringinterpolation preserve` option that disables wrapping within string interpolation. 

I chose `preserve` instead of `false` or `never` to leave open the future direction of having `false` or `never` _remove_ line breaks within string interpolation (that's what `wrap: never` does in other existing options).