### PR TITLE
Update help formatting to support options with longer names and descriptions, remove character limit

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -306,12 +306,12 @@ Remove blank lines between consecutive guard statements, and insert a blank afte
 
 Option | Description
 --- | ---
-`--linebtwnguards` | Insert line between guards: "true" or "false" (default)
+`--linebetweenguards` | Insert line between guards: "true" or "false" (default)
 
 <details>
 <summary>Examples</summary>
 
-`--linebtwnguards false` (default)
+`--linebetweenguards false` (default)
 
 ```diff
     // Multiline guard
@@ -338,7 +338,7 @@ Option | Description
     let doTheJob = nikekov()
 ```
 
-`--linebtwnguards true`
+`--linebetweenguards true`
 
 ```diff
     // Multiline guard
@@ -621,7 +621,7 @@ Assign properties using if / switch expressions.
 
 Option | Description
 --- | ---
-`--condassignment` | Use cond. assignment: "after-property" (default) or "always"
+`--conditionalassignment` | Use if/switch expressions for conditional assignment: "after-property" (default) or "always"
 
 <details>
 <summary>Examples</summary>
@@ -766,7 +766,7 @@ Use doc comments for API declarations, otherwise use regular comments.
 
 Option | Description
 --- | ---
-`--doccomments` | Doc comments: "before-declarations" (default) or "preserve"
+`--doccomments` | Convert standard comments to doc comments: "before-declarations" (default) or "preserve"
 
 <details>
 <summary>Examples</summary>
@@ -1152,7 +1152,7 @@ instead of type constraints (`extension Array where Element == Foo`).
 
 Option | Description
 --- | ---
-`--generictypes` | Semicolon-delimited list of generic types and type parameters
+`--generictypes` | Semicolon-delimited list of generic types and type parameters. For example: "LinkedList<Element>;StateStore<State, Action>"
 
 <details>
 <summary>Examples</summary>
@@ -1606,14 +1606,14 @@ Option | Description
 `--structthreshold` | Minimum line count to organize struct body. Defaults to 0
 `--classthreshold` | Minimum line count to organize class body. Defaults to 0
 `--enumthreshold` | Minimum line count to organize enum body. Defaults to 0
-`--extensionlength` | Minimum line count to organize extension body. Defaults to 0
+`--extensionthreshold` | Minimum line count to organize extension body. Defaults to 0
 `--organizationmode` | Organize declarations by "visibility" (default) or "type"
 `--visibilityorder` | Order for visibility groups inside declaration
 `--typeorder` | Order for declaration type groups inside declaration
 `--visibilitymarks` | Marks for visibility groups (public:Public Fields,..)
 `--typemarks` | Marks for declaration type groups (classMethod:Baaz,..)
 `--groupblanklines` | Require a blank line after each subgroup. Default: true
-`--sortswiftuiprops` | Sort SwiftUI props: none, alphabetize, first-appearance-sort
+`--sortswiftuiproperties` | Sort SwiftUI props: "none", "alphabetize", "first-appearance-sort"
 
 <details>
 <summary>Examples</summary>
@@ -1762,8 +1762,8 @@ Convert functional `forEach` calls to for loops.
 
 Option | Description
 --- | ---
-`--anonymousforeach` | Convert anonymous forEach: "convert" (default) or "ignore"
-`--inlinedforeach` | Convert inline forEach to for: "convert", "ignore" (default)
+`--anonymousforeach` | Convert anonymous forEach closures to for loops: "convert" (default) or "ignore"
+`--singlelineforeach` | Convert single-line forEach closures to for loop: "convert", "ignore" (default)
 
 <details>
 <summary>Examples</summary>
@@ -1919,7 +1919,7 @@ Option | Description
 --- | ---
 `--propertytypes` | "inferred", "explicit", or "infer-locals-only" (default)
 `--inferredtypes` | "exclude-cond-exprs" (default) or "always"
-`--preservedsymbols` | Comma-delimited list of symbols to be ignored by the rule
+`--preservedpropertytypes` | Comma-delimited list of symbols to be ignored and preserved as-is by the propertyTypes rule
 
 <details>
 <summary>Examples</summary>
@@ -3427,10 +3427,10 @@ Option | Description
 --- | ---
 `--funcattributes` | Function @attributes: "preserve", "prev-line", or "same-line"
 `--typeattributes` | Type @attributes: "preserve", "prev-line", or "same-line"
-`--storedvarattrs` | Stored var @attribs: "preserve", "prev-line", or "same-line"
-`--computedvarattrs` | Computed var @attribs: "preserve", "prev-line", "same-line"
-`--complexattrs` | Complex @attributes: "preserve", "prev-line", or "same-line"
-`--noncomplexattrs` | List of @attributes to exclude from complexattrs rule
+`--storedvarattributes` | Stored var @attributes: "preserve", "prev-line", or "same-line"
+`--computedvarattributes` | Computed var @attributes: "preserve", "prev-line", "same-line"
+`--complexattributes` | Complex @attributes: "preserve", "prev-line", or "same-line"
+`--noncomplexattributes` | List of @attributes to exclude from --complexattributes options
 
 <details>
 <summary>Examples</summary>

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -32,9 +32,6 @@
 import Foundation
 
 extension Options {
-    // TODO: Consider removing max option name lengths
-    static let maxArgumentNameLength = 30
-
     init(_ args: [String: String], in directory: String) throws {
         fileOptions = try fileOptionsFor(args, in: directory)
         formatOptions = try formatOptionsFor(args)

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -109,15 +109,27 @@ public enum ExitCode: Int32 {
     case error = 70 // EX_SOFTWARE
 }
 
-func printOptions(as type: CLI.OutputType) {
+func printOptions(_ options: [OptionDescriptor] = Descriptors.formatting, as type: CLI.OutputType) {
     print("")
-    print(Descriptors.formatting.compactMap {
+    print(options.compactMap {
         guard !$0.isDeprecated else { return nil }
         var result = "--\($0.argumentName)"
-        for _ in 0 ..< Options.maxArgumentNameLength + 3 - result.count {
-            result += " "
+
+        let maxNameLengthForSingleLineFormatting = 16
+        let optionNameColumnWidth = maxNameLengthForSingleLineFormatting + 3
+
+        if $0.argumentName.count <= maxNameLengthForSingleLineFormatting {
+            for _ in 0 ..< optionNameColumnWidth - result.count {
+                result += " "
+            }
+            return result + stripMarkdown($0.help)
+        } else {
+            result += "\n"
+            for _ in 0 ..< optionNameColumnWidth {
+                result += " "
+            }
+            return result + stripMarkdown($0.help)
         }
-        return result + stripMarkdown($0.help)
     }.sorted().joined(separator: "\n"), as: type)
     print("")
 }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -93,7 +93,6 @@ class OptionDescriptor {
          trueValues: [String],
          falseValues: [String])
     {
-        assert(argumentName.count <= Options.maxArgumentNameLength)
         assert(argumentName == argumentName.lowercased())
         self.argumentName = argumentName
         self.displayName = displayName
@@ -968,7 +967,7 @@ struct _Descriptors {
         keyPath: \.organizeEnumThreshold
     )
     let organizeExtensionThreshold = OptionDescriptor(
-        argumentName: "extensionlength",
+        argumentName: "extensionthreshold",
         displayName: "Organize Extension Threshold",
         help: "Minimum line count to organize extension body. Defaults to 0",
         keyPath: \.organizeExtensionThreshold
@@ -1068,27 +1067,27 @@ struct _Descriptors {
         keyPath: \.typeAttributes
     )
     let storedVarAttributes = OptionDescriptor(
-        argumentName: "storedvarattrs",
+        argumentName: "storedvarattributes",
         displayName: "Stored Property Attributes",
-        help: "Stored var @attribs: \"preserve\", \"prev-line\", or \"same-line\"",
+        help: "Stored var @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         keyPath: \.storedVarAttributes
     )
     let computedVarAttributes = OptionDescriptor(
-        argumentName: "computedvarattrs",
+        argumentName: "computedvarattributes",
         displayName: "Computed Property Attributes",
-        help: "Computed var @attribs: \"preserve\", \"prev-line\", \"same-line\"",
+        help: "Computed var @attributes: \"preserve\", \"prev-line\", \"same-line\"",
         keyPath: \.computedVarAttributes
     )
     let complexAttributes = OptionDescriptor(
-        argumentName: "complexattrs",
+        argumentName: "complexattributes",
         displayName: "Complex Attributes",
         help: "Complex @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         keyPath: \.complexAttributes
     )
     let complexAttributesExceptions = OptionDescriptor(
-        argumentName: "noncomplexattrs",
+        argumentName: "noncomplexattributes",
         displayName: "Complex Attribute exceptions",
-        help: "List of @attributes to exclude from complexattrs rule",
+        help: "List of @attributes to exclude from --complexattributes options",
         keyPath: \.complexAttributesExceptions
     )
     let yodaSwap = OptionDescriptor(
@@ -1166,7 +1165,7 @@ struct _Descriptors {
     let genericTypes = OptionDescriptor(
         argumentName: "generictypes",
         displayName: "Additional generic types",
-        help: "Semicolon-delimited list of generic types and type parameters",
+        help: "Semicolon-delimited list of generic types and type parameters. For example: \"LinkedList<Element>;StateStore<State, Action>\"",
         keyPath: \.genericTypes,
         fromArgument: { $0 },
         toArgument: { $0 }
@@ -1182,15 +1181,15 @@ struct _Descriptors {
     let preserveAnonymousForEach = OptionDescriptor(
         argumentName: "anonymousforeach",
         displayName: "Anonymous forEach closures",
-        help: "Convert anonymous forEach: \"convert\" (default) or \"ignore\"",
+        help: "Convert anonymous forEach closures to for loops: \"convert\" (default) or \"ignore\"",
         keyPath: \.preserveAnonymousForEach,
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
     )
     let preserveSingleLineForEach = OptionDescriptor(
-        argumentName: "inlinedforeach",
-        displayName: "Inlined forEach closures",
-        help: "Convert inline forEach to for: \"convert\", \"ignore\" (default)",
+        argumentName: "singlelineforeach",
+        displayName: "Single-line forEach closures",
+        help: "Convert single-line forEach closures to for loop: \"convert\", \"ignore\" (default)",
         keyPath: \.preserveSingleLineForEach,
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
@@ -1198,15 +1197,15 @@ struct _Descriptors {
     let preserveDocComments = OptionDescriptor(
         argumentName: "doccomments",
         displayName: "Doc comments",
-        help: "Doc comments: \"before-declarations\" (default) or \"preserve\"",
+        help: "Convert standard comments to doc comments: \"before-declarations\" (default) or \"preserve\"",
         keyPath: \.preserveDocComments,
         trueValues: ["preserve"],
         falseValues: ["before-declarations", "declarations"]
     )
     let conditionalAssignmentOnlyAfterNewProperties = OptionDescriptor(
-        argumentName: "condassignment",
+        argumentName: "conditionalassignment",
         displayName: "Apply conditionalAssignment rule",
-        help: "Use cond. assignment: \"after-property\" (default) or \"always\"",
+        help: "Use if/switch expressions for conditional assignment: \"after-property\" (default) or \"always\"",
         keyPath: \.conditionalAssignmentOnlyAfterNewProperties,
         trueValues: ["after-property"],
         falseValues: ["always"]
@@ -1247,11 +1246,11 @@ struct _Descriptors {
         help: "Comma separated list of declaration names to exclude",
         keyPath: \.preservedPrivateDeclarations
     )
-    let preservedSymbols = OptionDescriptor(
-        argumentName: "preservedsymbols",
-        displayName: "Preserved Symbols",
-        help: "Comma-delimited list of symbols to be ignored by the rule",
-        keyPath: \.preservedSymbols
+    let preservedPropertyTypes = OptionDescriptor(
+        argumentName: "preservedpropertytypes",
+        displayName: "Preserved Property Types",
+        help: "Comma-delimited list of symbols to be ignored and preserved as-is by the propertyTypes rule",
+        keyPath: \.preservedPropertyTypes
     )
     let additionalXCTestSymbols = OptionDescriptor(
         argumentName: "xctestsymbols",
@@ -1260,9 +1259,9 @@ struct _Descriptors {
         keyPath: \.additionalXCTestSymbols
     )
     let swiftUIPropertiesSortMode = OptionDescriptor(
-        argumentName: "sortswiftuiprops",
+        argumentName: "sortswiftuiproperties",
         displayName: "Sort SwiftUI Dynamic Properties",
-        help: "Sort SwiftUI props: none, alphabetize, first-appearance-sort",
+        help: "Sort SwiftUI props: \"none\", \"alphabetize\", \"first-appearance-sort\"",
         keyPath: \.swiftUIPropertiesSortMode
     )
     let equatableMacro = OptionDescriptor(
@@ -1280,7 +1279,7 @@ struct _Descriptors {
         falseValues: ["#fileID", "fileID"]
     )
     let lineBetweenConsecutiveGuards = OptionDescriptor(
-        argumentName: "linebtwnguards",
+        argumentName: "linebetweenguards",
         displayName: "Blank Line Between Consecutive Guards",
         help: "Insert line between guards: \"true\" or \"false\" (default)",
         keyPath: \.lineBetweenConsecutiveGuards,
@@ -1361,7 +1360,7 @@ struct _Descriptors {
         argumentName: "varattributes",
         displayName: "Var Attributes",
         help: "Property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
-        deprecationMessage: "Use with `--storedvarattrs` or `--computedvarattrs` instead.",
+        deprecationMessage: "Use with `--storedvarattributes` or `--computedvarattributes` instead.",
         keyPath: \.varAttributes
     )
 
@@ -1411,7 +1410,7 @@ struct _Descriptors {
         keyPath: \.preserveSingleLineForEach,
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
-    ).renamed(to: "inlinedforeach")
+    ).renamed(to: "singlelineforeach")
 
     let redundantType = OptionDescriptor(
         argumentName: "redundanttype",
@@ -1419,4 +1418,71 @@ struct _Descriptors {
         help: "deprecated",
         keyPath: \.propertyTypes
     ).renamed(to: "propertytypes")
+
+    let inlinedForEach = OptionDescriptor(
+        argumentName: "inlinedforeach",
+        displayName: "Inlined forEach closures",
+        help: "deprecated",
+        keyPath: \.preserveSingleLineForEach,
+        trueValues: ["ignore", "preserve"],
+        falseValues: ["convert"]
+    ).renamed(to: "singlelineforeach")
+
+    let condAssignment = OptionDescriptor(
+        argumentName: "condassignment",
+        displayName: "Apply conditionalAssignment rule",
+        help: "deprecated",
+        keyPath: \.conditionalAssignmentOnlyAfterNewProperties,
+        trueValues: ["after-property"],
+        falseValues: ["always"]
+    ).renamed(to: "conditionalassignment")
+
+    let storedVarAttrs = OptionDescriptor(
+        argumentName: "storedvarattrs",
+        displayName: "Stored Property Attributes",
+        help: "deprecated",
+        keyPath: \.storedVarAttributes
+    ).renamed(to: "storedvarattributes")
+
+    let computedVarAttrs = OptionDescriptor(
+        argumentName: "computedvarattrs",
+        displayName: "Computed Property Attributes",
+        help: "deprecated",
+        keyPath: \.computedVarAttributes
+    ).renamed(to: "computedvarattributes")
+
+    let complexAttrs = OptionDescriptor(
+        argumentName: "complexattrs",
+        displayName: "Complex Attributes",
+        help: "deprecated",
+        keyPath: \.complexAttributes
+    ).renamed(to: "complexattributes")
+
+    let complexAttrsExceptions = OptionDescriptor(
+        argumentName: "noncomplexattrs",
+        displayName: "Complex Attribute exceptions",
+        help: "deprecated",
+        keyPath: \.complexAttributesExceptions
+    ).renamed(to: "noncomplexattributes")
+
+    let preservedSymbols = OptionDescriptor(
+        argumentName: "preservedsymbols",
+        displayName: "Preserved Symbols",
+        help: "deprecated",
+        keyPath: \.preservedPropertyTypes
+    ).renamed(to: "preservedpropertytypes")
+
+    let swiftUIPropsSortMode = OptionDescriptor(
+        argumentName: "sortswiftuiprops",
+        displayName: "Sort SwiftUI Dynamic Properties",
+        help: "deprecated",
+        keyPath: \.swiftUIPropertiesSortMode
+    ).renamed(to: "sortswiftuiproperties")
+
+    let organizeExtensionLength = OptionDescriptor(
+        argumentName: "extensionlength",
+        displayName: "Organize Extension Threshold",
+        help: "deprecated",
+        keyPath: \.organizeExtensionThreshold
+    ).renamed(to: "extensionthreshold")
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -723,7 +723,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
     public var propertyTypes: PropertyTypes
-    public var preservedSymbols: Set<String>
+    public var preservedPropertyTypes: Set<String>
     public var inferredTypesInConditionalExpressions: Bool
     public var emptyBracesSpacing: EmptyBracesSpacing
     public var acronyms: Set<String>
@@ -855,7 +855,7 @@ public struct FormatOptions: CustomStringConvertible {
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
                 propertyTypes: PropertyTypes = .inferLocalsOnly,
-                preservedSymbols: Set<String> = ["Package"],
+                preservedPropertyTypes: Set<String> = ["Package"],
                 inferredTypesInConditionalExpressions: Bool = false,
                 emptyBracesSpacing: EmptyBracesSpacing = .noSpace,
                 acronyms: Set<String> = ["ID", "URL", "UUID"],
@@ -977,7 +977,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement
         self.propertyTypes = propertyTypes
-        self.preservedSymbols = preservedSymbols
+        self.preservedPropertyTypes = preservedPropertyTypes
         self.inferredTypesInConditionalExpressions = inferredTypesInConditionalExpressions
         self.emptyBracesSpacing = emptyBracesSpacing
         self.acronyms = acronyms

--- a/Sources/Rules/BlankLinesAfterGuardStatements.swift
+++ b/Sources/Rules/BlankLinesAfterGuardStatements.swift
@@ -7,7 +7,7 @@ public extension FormatRule {
     static let blankLinesAfterGuardStatements = FormatRule(
         help: "Remove blank lines between consecutive guard statements, and insert a blank after the last guard statement.",
         disabledByDefault: true,
-        options: ["linebtwnguards"]
+        options: ["linebetweenguards"]
     ) { formatter in
         formatter.forEach(.keyword("guard")) { guardIndex, _ in
             guard var elseIndex = formatter.index(of: .keyword("else"), after: guardIndex) else {
@@ -47,7 +47,7 @@ public extension FormatRule {
         }
     } examples: {
         """
-        `--linebtwnguards false` (default)
+        `--linebetweenguards false` (default)
 
         ```diff
             // Multiline guard
@@ -74,7 +74,7 @@ public extension FormatRule {
             let doTheJob = nikekov()
         ```
 
-        `--linebtwnguards true`
+        `--linebetweenguards true`
 
         ```diff
             // Multiline guard

--- a/Sources/Rules/ConditionalAssignment.swift
+++ b/Sources/Rules/ConditionalAssignment.swift
@@ -12,7 +12,7 @@ public extension FormatRule {
     static let conditionalAssignment = FormatRule(
         help: "Assign properties using if / switch expressions.",
         orderAfter: [.redundantReturn],
-        options: ["condassignment"]
+        options: ["conditionalassignment"]
     ) { formatter in
         // If / switch expressions were added in Swift 5.9 (SE-0380)
         guard formatter.options.swiftVersion >= "5.9" else {

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -17,9 +17,9 @@ public extension FormatRule {
         options: [
             "categorymark", "markcategories", "beforemarks",
             "lifecycle", "organizetypes", "structthreshold", "classthreshold",
-            "enumthreshold", "extensionlength", "organizationmode",
+            "enumthreshold", "extensionthreshold", "organizationmode",
             "visibilityorder", "typeorder", "visibilitymarks", "typemarks",
-            "groupblanklines", "sortswiftuiprops",
+            "groupblanklines", "sortswiftuiproperties",
         ],
         sharedOptions: ["sortedpatterns", "lineaftermarks", "linebreaks"]
     ) { formatter in

--- a/Sources/Rules/PreferForLoop.swift
+++ b/Sources/Rules/PreferForLoop.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let preferForLoop = FormatRule(
         help: "Convert functional `forEach` calls to for loops.",
-        options: ["anonymousforeach", "inlinedforeach"]
+        options: ["anonymousforeach", "singlelineforeach"]
     ) { formatter in
         formatter.forEach(.identifier("forEach")) { forEachIndex, _ in
             // Make sure this is a function call preceded by a `.`

--- a/Sources/Rules/PropertyTypes.swift
+++ b/Sources/Rules/PropertyTypes.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
         help: "Convert property declarations to use inferred types (`let foo = Foo()`) or explicit types (`let foo: Foo = .init()`).",
         disabledByDefault: true,
         orderAfter: [.redundantType],
-        options: ["propertytypes", "inferredtypes", "preservedsymbols"]
+        options: ["propertytypes", "inferredtypes", "preservedpropertytypes"]
     ) { formatter in
         formatter.forEach(.operator("=", .infix)) { equalsIndex, _ in
             // Preserve all properties in conditional statements like `if let foo = Bar() { ... }`
@@ -86,7 +86,7 @@ public extension FormatRule {
                 }
 
                 // Preserve the formatting as-is if the type is manually excluded
-                if formatter.options.preservedSymbols.contains(type.name) {
+                if formatter.options.preservedPropertyTypes.contains(type.name) {
                     return
                 }
 
@@ -94,7 +94,7 @@ public extension FormatRule {
                 if formatter.tokens[rhsStartIndex].isOperator(".") {
                     // Preserve the formatting as-is if the identifier is manually excluded
                     if let identifierAfterDot = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: rhsStartIndex),
-                       formatter.options.preservedSymbols.contains(formatter.tokens[identifierAfterDot].string)
+                       formatter.options.preservedPropertyTypes.contains(formatter.tokens[identifierAfterDot].string)
                     { return }
 
                     // Update the . token from a prefix operator to an infix operator.
@@ -122,7 +122,7 @@ public extension FormatRule {
 
                         // Preserve the formatting as-is if the identifier is manually excluded
                         if let identifierAfterDot = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: rhsStartIndex),
-                           formatter.options.preservedSymbols.contains(formatter.tokens[identifierAfterDot].string)
+                           formatter.options.preservedPropertyTypes.contains(formatter.tokens[identifierAfterDot].string)
                         {
                             hasInvalidConditionalBranch = true
                         }
@@ -176,7 +176,7 @@ public extension FormatRule {
 
                 // Preserve any types that have been manually excluded.
                 // Preserve any `Void` types and tuples, since they're special and don't support things like `.init`
-                guard !(formatter.options.preservedSymbols + ["Void"]).contains(rhsType.name),
+                guard !(formatter.options.preservedPropertyTypes + ["Void"]).contains(rhsType.name),
                       !rhsType.name.hasPrefix("(")
                 else { return }
 
@@ -184,7 +184,7 @@ public extension FormatRule {
                 // so that the init call stays valid after we move the type to the LHS.
                 if formatter.tokens[indexAfterType] == .startOfScope("(") {
                     // Preserve the existing format if `init` is manually excluded
-                    if formatter.options.preservedSymbols.contains("init") {
+                    if formatter.options.preservedPropertyTypes.contains("init") {
                         return
                     }
 
@@ -202,7 +202,7 @@ public extension FormatRule {
 
                     // Preserve the formatting as-is if the identifier is manually excluded.
                     // Don't convert `let foo = Foo.self` to `let foo: Foo = .self`, since `.self` returns the metatype
-                    let symbolsToExclude = formatter.options.preservedSymbols + ["self"]
+                    let symbolsToExclude = formatter.options.preservedPropertyTypes + ["self"]
                     if let indexAfterDot = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: indexAfterType),
                        symbolsToExclude.contains(formatter.tokens[indexAfterDot].string)
                     { return }

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -16,7 +16,7 @@ public extension FormatRule {
         // swiftformat:sort:end comments.
         """,
         options: ["sortedpatterns"],
-        sharedOptions: ["linebreaks", "organizetypes", "structthreshold", "classthreshold", "enumthreshold", "extensionlength"]
+        sharedOptions: ["linebreaks", "organizetypes", "structthreshold", "classthreshold", "enumthreshold", "extensionthreshold"]
     ) { formatter in
         formatter.forEachToken(
             where: {

--- a/Sources/Rules/WrapAttributes.swift
+++ b/Sources/Rules/WrapAttributes.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let wrapAttributes = FormatRule(
         help: "Wrap @attributes onto a separate line, or keep them on the same line.",
-        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattrs", "computedvarattrs", "complexattrs", "noncomplexattrs"],
+        options: ["funcattributes", "typeattributes", "varattributes", "storedvarattributes", "computedvarattributes", "complexattributes", "noncomplexattributes"],
         sharedOptions: ["linebreaks", "maxwidth"]
     ) { formatter in
         formatter.forEach(.attribute) { i, _ in

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		08CC3AD52D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
 		08CC3AD62D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
 		08CC3AD82D656259005BFABE /* SwiftTestingTestCaseNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD72D656257005BFABE /* SwiftTestingTestCaseNamesTests.swift */; };
+		2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
+		2E26108F2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
 		2E2BAB8C2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8D2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8E2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
@@ -2324,6 +2326,7 @@
 				2E2BAD792C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
 				2E2BAD412C57F6DD00590239 /* MarkTypes.swift in Sources */,
 				2E2BAC092C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
 				2E2BAC0D2C57F6DD00590239 /* Indent.swift in Sources */,
 				015D3A562995A0340065B2D9 /* AboutViewController.swift in Sources */,
 				2E2BACAD2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
@@ -2477,6 +2480,7 @@
 				2E2BAD7A2C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
 				2E2BAD422C57F6DD00590239 /* MarkTypes.swift in Sources */,
 				2E2BAC0A2C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E26108F2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
 				2E2BAC0E2C57F6DD00590239 /* Indent.swift in Sources */,
 				01045A9F2119D30D00D2BE3D /* Inference.swift in Sources */,
 				2E2BACAE2C57F6DD00590239 /* RedundantLetError.swift in Sources */,

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -78,6 +78,14 @@
 		08CC3AD82D656259005BFABE /* SwiftTestingTestCaseNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD72D656257005BFABE /* SwiftTestingTestCaseNamesTests.swift */; };
 		2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
 		2E26108F2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
+		2E2611C82DD94FE900FFFE09 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
+		2E2611C92DD94FE900FFFE09 /* XMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */; };
+		2E2611CA2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */; };
+		2E2611CB2DD94FE900FFFE09 /* Reporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39D2999FCC8001C2C0E /* Reporter.swift */; };
+		2E2611CC2DD94FE900FFFE09 /* Reporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39D2999FCC8001C2C0E /* Reporter.swift */; };
+		2E2611CD2DD94FE900FFFE09 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
+		2E2611CE2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */; };
+		2E2611CF2DD94FE900FFFE09 /* XMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */; };
 		2E2BAB8C2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8D2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8E2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
@@ -2326,6 +2334,10 @@
 				2E2BAD792C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
 				2E2BAD412C57F6DD00590239 /* MarkTypes.swift in Sources */,
 				2E2BAC092C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
+				2E2611C82DD94FE900FFFE09 /* JSONReporter.swift in Sources */,
+				2E2611C92DD94FE900FFFE09 /* XMLReporter.swift in Sources */,
+				2E2611CA2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */,
+				2E2611CB2DD94FE900FFFE09 /* Reporter.swift in Sources */,
 				2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
 				2E2BAC0D2C57F6DD00590239 /* Indent.swift in Sources */,
 				015D3A562995A0340065B2D9 /* AboutViewController.swift in Sources */,
@@ -2524,6 +2536,10 @@
 				2E2BAC122C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				015243E42B04B0A700F65221 /* Singularize.swift in Sources */,
 				2E2BAD562C57F6DD00590239 /* TrailingCommas.swift in Sources */,
+				2E2611CC2DD94FE900FFFE09 /* Reporter.swift in Sources */,
+				2E2611CD2DD94FE900FFFE09 /* JSONReporter.swift in Sources */,
+				2E2611CE2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */,
+				2E2611CF2DD94FE900FFFE09 /* XMLReporter.swift in Sources */,
 				2E2BAD022C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */,
 				2E2BAD662C57F6DD00590239 /* SpaceAroundParens.swift in Sources */,
 				2E2BAC422C57F6DD00590239 /* DuplicateImports.swift in Sources */,

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -315,17 +315,6 @@ class CommandLineTests: XCTestCase {
         }
     }
 
-    func testHelpLineLength() {
-        CLI.print = { message, _ in
-            for line in message.components(separatedBy: "\n") {
-                // TODO: Consider removing this limit entirely
-                XCTAssertLessThanOrEqual(line.count, 160, line)
-            }
-        }
-        printHelp(as: .content)
-        printOptions(as: .content)
-    }
-
     func testHelpOptionsImplemented() {
         CLI.print = { message, _ in
             if message.hasPrefix("--") {
@@ -352,6 +341,54 @@ class CommandLineTests: XCTestCase {
         printHelp(as: .content)
         printOptions(as: .content)
         XCTAssert(arguments.isEmpty, "\(arguments.joined(separator: ",")) not listed in help")
+    }
+
+    func testHelpOptionFormatting() {
+        let shortOption = OptionDescriptor(
+            argumentName: "option",
+            displayName: "option",
+            help: "Short option description",
+            keyPath: \.fragment,
+            trueValues: [],
+            falseValues: []
+        )
+
+        let mediumOption = OptionDescriptor(
+            argumentName: "optionmedium",
+            displayName: "optionmedium",
+            help: "Option with a medium name and description length",
+            keyPath: \.fragment,
+            trueValues: [],
+            falseValues: []
+        )
+
+        let longOption = OptionDescriptor(
+            argumentName: "optionwithlongername",
+            displayName: "optionwithlongername",
+            help: """
+            This is a longer option with a name over the original 16 character limit, \
+            and a help text over the original 80 character limit.
+            """,
+            keyPath: \.fragment,
+            trueValues: [],
+            falseValues: []
+        )
+
+        CLI.print = { output, _ in
+            guard !output.isEmpty else { return }
+            XCTAssertEqual(output, """
+            --option           Short option description
+            --option           Short option description
+            --optionmedium     Option with a medium name and description length
+            --optionmedium     Option with a medium name and description length
+            --optionwithlongername
+                               This is a longer option with a name over the original 16 character limit, and a help text over the original 80 character limit.
+            --optionwithlongername
+                               This is a longer option with a name over the original 16 character limit, and a help text over the original 80 character limit.
+            """)
+        }
+
+        printOptions([shortOption, shortOption, mediumOption, mediumOption, longOption, longOption], as: .content)
     }
 
     // MARK: cache

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -246,16 +246,6 @@ class MetadataTests: XCTestCase {
         }
     }
 
-    func testArgumentNamesAreValidLength() {
-        let arguments = Set(commandLineArguments).subtracting(deprecatedArguments)
-        for argument in arguments {
-            XCTAssert(
-                argument.count <= Options.maxArgumentNameLength,
-                "\"\(argument)\" (length=\(argument.count)) longer than maximum allowed argument name length \(Options.maxArgumentNameLength)"
-            )
-        }
-    }
-
     func testArgumentNamesAreLowercase() {
         let arguments = Set(commandLineArguments).subtracting(deprecatedArguments)
         for argument in arguments {

--- a/Tests/Rules/PropertyTypesTests.swift
+++ b/Tests/Rules/PropertyTypesTests.swift
@@ -460,7 +460,7 @@ class PropertyTypesTests: XCTestCase {
         }
         """
 
-        let options = FormatOptions(propertyTypes: .inferLocalsOnly, preservedSymbols: ["Foo", "Baaz", "quux"])
+        let options = FormatOptions(propertyTypes: .inferLocalsOnly, preservedPropertyTypes: ["Foo", "Baaz", "quux"])
         testFormatting(for: input, output, rule: .propertyTypes, options: options)
     }
 
@@ -493,7 +493,7 @@ class PropertyTypesTests: XCTestCase {
         }
         """
 
-        let options = FormatOptions(propertyTypes: .inferLocalsOnly, preservedSymbols: ["init"])
+        let options = FormatOptions(propertyTypes: .inferLocalsOnly, preservedPropertyTypes: ["init"])
         testFormatting(for: input, output, rule: .propertyTypes, options: options, exclude: [.redundantInit])
     }
 


### PR DESCRIPTION
This PR removes the 16 character limit for option names and the 80 character limit for option descriptions.

This was originally to keep the help text output under 80 characters wide. Instead, this PR updates the help text formatting to use the style used by `swift --help`:

 - For short option names, the description is output on the same line.
 - For long option names, the description is output with indentation on the following line.

For example:

```
--option           Short option description
--option           Short option description
--optionmedium     Option with a medium name and description length
--optionmedium     Option with a medium name and description length
--optionwithlongername
                   This is a longer option with a name over the original 16 character limit, and a help text over the original 80 character limit.
--optionwithlongername
                   This is a longer option with a name over the original 16 character limit, and a help text over the original 80 character limit.
```

To take advantage of this, this PR also renames some existing options that felt a little unnatural due to the previous 16 character limit.

For comparison, here's the output of `swift --help`:

<details>

```
USAGE: swift

OPTIONS:
  -access-notes-path <value>
                          Specify YAML file to override attributes on Swift declarations in this module
  -allow-non-resilient-access
                          Ensures all contents are generated besides exportable decls in the binary module, so non-resilient access can be allowed
  -allowable-client <vers>
                          Module names that are allowed to import this module
  -assert-config <value>  Specify the assert_configuration replacement. Possible values are Debug, Release, Unchecked, DisableReplacement.
  -build-id <build-id>    Specify the build ID argument passed to the linker
  -cache-compile-job      Enable compiler caching
  -cache-disable-replay   Skip loading the compilation result from cache
  -cas-path <path>        Path to CAS
  -cas-plugin-option <name>=<option>
                          Option pass to CAS Plugin
  -cas-plugin-path <path> Path to CAS Plugin
  -clang-build-session-file <value>
                          Use the last modification time of <file> as the underlying Clang build session timestamp
  -clang-scanner-module-cache-path <value>
                          Specifies the Clang dependency scanner module cache path
  -clang-target <value>   Separately set the target we should use for internal Clang instance
  -color-diagnostics      Print diagnostics in color
  -compiler-assertions    Enable internal self-checks while compiling
  -continue-building-after-errors
                          Continue building, even after errors are encountered
  -coverage-prefix-map <prefix=replacement>
                          Remap source paths in coverage info
  -cxx-interoperability-mode=<value>
                          Enables C++ interoperability; pass 'default' to enable or 'off' to disable
  -debug-info-format=<value>
                          Specify the debug info format type to either 'dwarf' or 'codeview'
  -debug-info-store-invocation
                          Emit the compiler invocation in the debug info.
  -debug-prefix-map <prefix=replacement>
                          Remap source paths in debug info
  -diagnostic-style <style>
                          The formatting style used when printing diagnostics ('swift' or 'llvm')
  -disable-actor-data-race-checks
                          Disable runtime checks for actor data races
  -disable-autolinking-runtime-compatibility-concurrency
                          Do not use autolinking for the concurrency runtime compatibility library
  -disable-autolinking-runtime-compatibility-dynamic-replacements
                          Do not use autolinking for the dynamic replacement runtime compatibility library
  -disable-autolinking-runtime-compatibility
                          Do not use autolinking for runtime compatibility libraries
  -disable-clang-target   Disable a separately specified target triple for Clang instance to use
  -disable-dynamic-actor-isolation
                          Disable dynamic actor isolation checks
  -disable-experimental-feature <value>
                          Disable an experimental feature
  -disable-incremental-imports
                          Disable cross-module incremental build metadata and driver scheduling for Swift modules
  -disable-only-one-dependency-file
                          Disables incremental build optimization that only produces one dependencies file
  -disable-sandbox        Disable using the sandbox when executing subprocesses
  -disable-upcoming-feature <value>
                          Disable a feature that will be introduced in an upcoming language version
  -disallow-use-new-driver
                          Disable using new swift-driver
  -dwarf-version=<version>
                          DWARF debug info version to produce if requested
  -D <value>              Marks a conditional compilation flag as true
  -embed-tbd-for-module <value>
                          Embed symbols from the module in the emitted tbd file
  -emit-module-dependencies-path <path>
                          Emit a discovered dependencies file for the emit-module task to <path>
  -emit-module-serialize-diagnostics-path <path>
                          Emit a serialized diagnostics file for the emit-module task to <path>
  -enable-actor-data-race-checks
                          Emit runtime checks for actor data races
  -enable-autolinking-runtime-compatibility-bytecode-layouts
                          Enable autolinking for the bytecode layouts runtime compatibility library
  -enable-bare-slash-regex
                          Enable the use of forward slash regular-expression literal syntax
  -enable-builtin-module  Enables the explicit import of the Builtin module
  -enable-experimental-additive-arithmetic-derivation
                          Enable experimental 'AdditiveArithmetic' derived conformances
  -enable-experimental-concise-pound-file
                          Enable experimental concise '#file' identifier
  -enable-experimental-feature <value>
                          Enable an experimental feature
  -enable-experimental-forward-mode-differentiation
                          Enable experimental forward mode differentiation
  -enable-incremental-imports
                          Enable cross-module incremental build metadata and driver scheduling for Swift modules
  -enable-library-evolution
                          Build the module to allow binary-compatible library evolution
  -enable-only-one-dependency-file
                          Enables incremental build optimization that only produces one dependencies file
  -enable-upcoming-feature <value>
                          Enable a feature that will be introduced in an upcoming language version
  -enforce-exclusivity=<enforcement>
                          Enforce law of exclusivity
  -experimental-allow-non-resilient-access
                          Deprecated; use -allow-non-resilient-access instead
  -experimental-package-bypass-resilience
                          Deprecated; has no effect
  -experimental-package-cmo
                          Deprecated; use -package-cmo instead
  -explain-module-dependency-detailed <value>
                          Emit remarks describing every possible dependency path that explains why compilation may depend on a module with a given name.
  -explain-module-dependency <value>
                          Emit remark describing why compilation may depend on a module with a given name.
  -explicit-auto-linking  Instead of linker-load directives, have the driver specify all link dependencies on the linker invocation. Requires '-explicit-module-build'.
  -export-as <value>      Module name to use when referenced in clients module interfaces
  -external-plugin-path <path>#<plugin-server-path>
                          Add directory to the plugin search path with a plugin server executable
  -e <value>              Executes a line of code provided on the command line
  -file-compilation-dir <path>
                          The compilation directory to embed in the debug info. Coverage mapping is not supported yet.
  -file-prefix-map <prefix=replacement>
                          Remap source paths in debug, coverage, and index info
  -framework <value>      Specifies a framework which should be linked against
  -Fsystem <value>        Add directory to system framework search path
  -F <value>              Add directory to framework search path
  -gdwarf-types           Emit full DWARF type info.
  -gline-tables-only      Emit minimal debug info for backtraces only
  -gnone                  Don't emit debug info
  -g                      Emit debug info. This is the preferred setting for debugging with LLDB.
  -help                   Display available options
  -in-process-plugin-server-path <value>
                          Path to dynamic library plugin server
  -index-ignore-clang-modules
                          Avoid indexing clang modules (pcms)
  -index-include-locals   Include local definitions/references in the produced index data.
  -index-store-path <path>
                          Store indexing data to <path>
  -index-unit-output-path <path>
                          Use <path> as the output path in the produced index data.
  -I <value>              Add directory to the import search path
  -j <n>                  Number of commands to execute in parallel
  -libc <value>           libc runtime library to use
  -link-objc-runtime      Deprecated
  -load-plugin-executable <path>#<module-names>
                          Path to a compiler plugin executable and a comma-separated list of module names where the macro types are declared
  -load-plugin-library <path>
                          Path to a dynamic library containing compiler plugins such as macros
  -load-resolved-plugin <library-path>#<executable-path>#<module-names>
                          Path to resolved plugin configuration and a comma-separated list of module names where the macro types are declared. Library path and exectuable path can be empty if not used
  -locale <locale-code>   Choose a language for diagnostic messages
  -localization-path <path>
                          Path to localized diagnostic messages directory
  -L <value>              Add directory to library link search path
  -l <value>              Specifies a library which should be linked against
  -module-abi-name <value>
                          ABI name to use for the contents of this module
  -module-alias <alias_name=real_name>
                          If a source file imports or references module <alias_name>, the <real_name> is used for the contents of the file
  -module-cache-path <value>
                          Specifies the module cache path
  -module-link-name <value>
                          Library to link against when using this module
  -module-name <value>    Name of the module to build
  -no-color-diagnostics   Do not print diagnostics in color
  -no-warnings-as-errors  Treat warnings as warnings
  -nostdimport            Don't search the standard library import path for modules
  -num-threads <n>        Enable multi-threading and specify number of threads
  -Onone                  Compile without any optimization
  -Osize                  Compile with optimizations and target small code size
  -Ounchecked             Compile with optimizations and remove runtime safety checks
  -O                      Compile with optimizations
  -package-cmo            Enable optimization to perform defalut CMO within a package boundary
  -package-name <value>   Name of the package the module belongs to
  -plugin-path <value>    Add directory to the plugin search path
  -prefix-serialized-debugging-options
                          Apply debug prefix mappings to serialized debug info in Swiftmodule files
  -pretty-print           Pretty-print the output JSON
  -print-educational-notes
                          Include educational notes in printed diagnostic output, if available
  -print-target-info      Print target information for the given target <triple>, such as x86_64-apple-macos10.9
  -project-name <value>   Name of the project this module to build belongs to
  -public-module-name <value>
                          Public facing module name to use in diagnostics and documentation
  -Rcache-compile-job     Show remarks for compiler caching
  -Rcross-import          Emit a remark if a cross-import of a module is triggered.
  -remove-runtime-asserts Remove runtime safety checks.
  -Rindexing-system-module
                          Emit a remark when indexing a system module
  -Rmacro-loading         Emit remarks about loaded macro implementations
  -Rmodule-api-import     Emit remarks about the import bridging in each element composing the API
  -Rmodule-loading        Emit remarks about loaded module
  -Rmodule-recovery       Emit remarks about contextual inconsistencies in loaded modules
  -Rmodule-serialization  Emit remarks about module serialization
  -Rpass-missed=<value>   Report missed transformations by optimization passes whose name matches the given POSIX regular expression
  -Rpass=<value>          Report performed transformations by optimization passes whose name matches the given POSIX regular expression
  -Rskip-explicit-interface-build
                          Emit a remark if an explicit module interface invocation has an early exit because the expected output is up-to-date
  -runtime-compatibility-version <value>
                          Link compatibility library for Swift runtime version, or 'none'
  -save-optimization-record-passes <regex>
                          Only include passes which match a specified regular expression in the generated optimization record (by default, include all passes)
  -save-optimization-record-path <value>
                          Specify the file name of any generated optimization record
  -save-optimization-record=<format>
                          Generate an optimization record file in a specific format (default: YAML)
  -save-optimization-record
                          Generate a YAML optimization record file
  -scanner-prefix-map-sdk <path>
                          Remap paths within SDK reported by dependency scanner
  -scanner-prefix-map-toolchain <path>
                          Remap paths within toolchain directory reported by dependency scanner
  -scanner-prefix-map <prefix=replacement>
                          Remap paths reported by dependency scanner
  -sdk <sdk>              Compile against <sdk>
  -serialize-diagnostics-path <path>
                          Emit a serialized diagnostics file to <path>
  -static-executable      Statically link the executable
  -static-stdlib          Statically link the Swift standard library
  -strict-concurrency=<value>
                          Specify the how strict concurrency checking will be. The value may be 'minimal' (most 'Sendable' checking is disabled), 'targeted' ('Sendable' checking is enabled in code that uses the concurrency model, or 'complete' ('Sendable' and other checking is enabled for all code in the module)
  -suppress-remarks       Suppress all remarks
  -suppress-warnings      Suppress all warnings
  -swift-isa-ptrauth-mode <mode>
                          Mode for staging isa/super signing. Supported modes are LegacyAndStrip, NewAndStrip and NewAndAuth.
  -swift-ptrauth-mode <mode>
                          Mode for staging pointer authentication. Supported modes are LegacyAndStrip, NewAndStrip and NewAndAuth.
  -swift-version <vers>   Interpret input according to a specific Swift language version number
  -sysroot <sysroot>      Native Platform sysroot
  -target-cpu <value>     Generate code for a particular CPU variant
  -target-min-inlining-version <value>
                          Require inlinable code with no '@available' attribute to back-deploy to this version of the '-target' OS
  -target-variant <value> Generate 'zippered' code for macCatalyst that can run on the specified variant target triple in addition to the main -target triple
  -target <triple>        Generate code for the given target <triple>, such as x86_64-apple-macos10.9
  -use-ld=<value>         Specifies the flavor of the linker to be used
  -user-module-version <vers>
                          Module version specified from Swift module authors
  -validate-clang-modules-once
                          Don't verify input files for Clang modules if the module has been successfully validated or loaded during this build session
  -version                Print version information and exit
  -vfsoverlay <value>     Add directory to VFS overlay file
  -visualc-tools-root <root>
                          VisualC++ Tools Root
  -visualc-tools-version <version>
                          VisualC++ ToolSet Version
  -v                      Show commands to run and use verbose output
  -warn-concurrency       Warn about code that is unsafe according to the Swift Concurrency model and will become ill-formed in a future language version
  -warn-implicit-overrides
                          Warn about implicit overrides of protocol members
  -warnings-as-errors     Treat warnings as errors
  -windows-sdk-root <root>
                          Windows SDK Root
  -windows-sdk-version <version>
                          Windows SDK Version
  -working-directory <path>
                          Resolve file paths relative to the specified directory
  -Xcc <arg>              Pass <arg> to the C/C++/Objective-C compiler
  -Xlinker <value>        Specifies an option which should be passed to the linker
```

</details>

And here's `swiftformat --options` after this change:

<details>

```
--acronyms         Acronyms to auto-capitalize. Defaults to "ID,URL,UUID"
--allman           Use allman indentation style: "true" or "false" (default)
--anonymousforeach Convert anonymous forEach closures to for loops: "convert" (default) or "ignore"
--assetliterals    Color/image literal width. "actual-width" or "visual-width"
--asynccapturing   List of functions with async @autoclosure arguments
--beforemarks      Declarations placed before first mark (e.g. typealias,struct)
--binarygrouping   Binary grouping,threshold (default: 4,8) or "none", "ignore"
--callsiteparen    Closing paren at call sites: "balanced" or "same-line"
--categorymark     Template for category mark comments. Defaults to "MARK: %c"
--classthreshold   Minimum line count to organize class body. Defaults to 0
--closingparen     Closing paren position: "balanced" (default) or "same-line"
--closurevoid      Closure void returns: "remove" (default) or "preserve"
--commas           Commas in collection literals: "always" (default) or "inline"
--complexattributes
                   Complex @attributes: "preserve", "prev-line", or "same-line"
--computedvarattributes
                   Computed var @attribs: "preserve", "prev-line", "same-line"
--conditionalassignment
                   Use if/switch expressions for conditional assignment: "after-property" (default) or "always"
--dateformat       "system" (default), "iso", "dmy", "mdy" or custom
--decimalgrouping  Decimal grouping,threshold (default: 3,6) or "none", "ignore"
--doccomments      Convert standard comments to doc comments: "before-declarations" (default) or "preserve"
--elseposition     Placement of else/catch: "same-line" (default) or "next-line"
--emptybraces      Empty braces: "no-space" (default), "spaced" or "linebreak"
--enumnamespaces   Change type to enum: "always" (default) or "structs-only"
--enumthreshold    Minimum line count to organize enum body. Defaults to 0
--equatablemacro   For example: "@Equatable,EquatableMacroLib"
--exponentcase     Case of 'e' in numbers: "lowercase" or "uppercase" (default)
--exponentgrouping Group exponent digits: "enabled" or "disabled" (default)
--extensionacl     Place ACL "on-extension" (default) or "on-declarations"
--extensionmark    Mark for standalone extensions. Defaults to "MARK: - %t + %c"
--extensionthreshold
                   Minimum line count to organize extension body. Defaults to 0
--filemacro        File macro to prefer: "#file" (default) or "#fileID".
--fractiongrouping Group digits after '.': "enabled" or "disabled" (default)
--funcattributes   Function @attributes: "preserve", "prev-line", or "same-line"
--generictypes     Semicolon-delimited list of generic types and type parameters. For example: "LinkedList<Element>;StateStore<State, Action>"
--groupblanklines  Require a blank line after each subgroup. Default: true
--groupedextension Mark for extension grouped with extended type. ("MARK: %c")
--guardelse        Guard else: "same-line", "next-line" or "auto" (default)
--header           Header comments: "strip", "ignore", or the text you wish use
--hexgrouping      Hex grouping,threshold (default: 4,8) or "none", "ignore"
--hexliteralcase   Casing for hex literals: "uppercase" (default) or "lowercase"
--ifdef            #if indenting: "indent" (default), "no-indent" or "outdent"
--importgrouping   "testable-first/last", "alpha" (default) or "length"
--indent           Number of spaces to indent, or "tab" to use tabs
--indentcase       Indent cases inside a switch: "true" or "false" (default)
--indentstrings    Indent multiline strings: "false" (default) or "true"
--inferredtypes    "exclude-cond-exprs" (default) or "always"
--initcodernil     Replace fatalError with nil in unavailable init?(coder:)
--lifecycle        Names of additional Lifecycle methods (e.g. viewDidLoad)
--lineaftermarks   Insert blank line after "MARK:": "true" (default) or "false"
--linebetweenguards
                   Insert line between guards: "true" or "false" (default)
--linebreaks       Linebreak character to use: "cr", "crlf" or "lf" (default)
--markcategories   Insert MARK comments between categories (true by default)
--markextensions   Mark extensions "always" (default), "never", "if-not-empty"
--marktypes        Mark types "always" (default), "never", "if-not-empty"
--maxwidth         Maximum length of a line before wrapping. defaults to "none"
--modifierorder    Comma-delimited list of modifiers in preferred order
--nevertrailing    List of functions that should never use trailing closures
--nilinit          "remove" (default) redundant nil or "insert" missing nil
--noncomplexattributes
                   List of @attributes to exclude from --complexattributes options
--nospaceoperators Comma-delimited list of operators without surrounding space
--nowrapoperators  Comma-delimited list of operators that shouldn't be wrapped
--octalgrouping    Octal grouping,threshold (default: 4,8) or "none", "ignore"
--operatorfunc     Operator funcs: "spaced" (default), "no-space", or "preserve"
--organizationmode Organize declarations by "visibility" (default) or "type"
--organizetypes    Declarations to organize (default: class,actor,struct,enum)
--patternlet       let/var placement in patterns: "hoist" (default) or "inline"
--preserveacronyms List of symbols to be ignored by the acyronyms rule
--preservedecls    Comma separated list of declaration names to exclude
--preservedpropertytypes
                   Comma-delimited list of symbols to be ignored and preserved as-is by the propertyTypes rule
--propertytypes    "inferred", "explicit", or "infer-locals-only" (default)
--ranges           Range spaces: "spaced" (default) or "no-space", or "preserve"
--self             Explicit self: "insert", "remove" (default) or "init-only"
--selfrequired     Comma-delimited list of functions with @autoclosure arguments
--semicolons       Allow semicolons: "never" or "inline" (default)
--shortoptionals   Use ? for optionals "always" or "except-properties" (default)
--singlelineforeach
                   Convert single-line forEach closures to for loop: "convert", "ignore" (default)
--smarttabs        Align code independently of tab width. defaults to "enabled"
--someany          Use some Any types: "true" (default) or "false"
--sortedpatterns   List of patterns to sort alphabetically without :sort mark.
--sortswiftuiproperties
                   Sort SwiftUI props: "none", "alphabetize", "first-appearance-sort"
--storedvarattributes
                   Stored var @attribs: "preserve", "prev-line", or "same-line"
--stripunusedargs  "closure-only", "unnamed-only" or "always" (default)
--structthreshold  Minimum line count to organize struct body. Defaults to 0
--tabwidth         The width of a tab character. Defaults to "unspecified"
--throwcapturing   List of functions with throwing @autoclosure arguments
--timezone         "system" (default) or a valid identifier/abbreviation
--trailingclosures Comma-delimited list of functions that use trailing closures
--trimwhitespace   Trim trailing space: "always" (default) or "nonblank-lines"
--typeattributes   Type @attributes: "preserve", "prev-line", or "same-line"
--typeblanklines   "remove" (default) or "preserve" blank lines from types
--typedelimiter    "space-after" (default), "spaced" or "no-space"
--typemark         Template for type mark comments. Defaults to "MARK: - %t"
--typemarks        Marks for declaration type groups (classMethod:Baaz,..)
--typeorder        Order for declaration type groups inside declaration
--visibilitymarks  Marks for visibility groups (public:Public Fields,..)
--visibilityorder  Order for visibility groups inside declaration
--voidtype         How void types are represented: "void" (default) or "tuple"
--wraparguments    Wrap all arguments: "before-first", "after-first", "preserve"
--wrapcollections  Wrap array/dict: "before-first", "after-first", "preserve"
--wrapconditions   Wrap conditions: "before-first", "after-first", "preserve"
--wrapeffects      Wrap effects: "if-multiline", "never", "preserve"
--wrapenumcases    Wrap enum cases: "always" (default) or "with-values"
--wrapparameters   Wrap func params: "before-first", "after-first", "preserve"
--wrapreturntype   Wrap return type: "if-multiline", "preserve", "never"
--wrapstringinterpolation
                   Wrap string interpolation: "default" (wrap if needed), "preserve"
--wrapternary      Wrap ternary operators: "default" (wrap if needed), "before-operators"
--wraptypealiases  Wrap typealiases: "before-first", "after-first", "preserve"
--xcodeindentation Match Xcode indenting: "enabled" or "disabled" (default)
--xctestsymbols    Comma-delimited list of symbols that depend on XCTest
--yodaswap         Swap yoda values: "always" (default) or "literals-only"
```

</details>

What do you think @nicklockwood?