### PR TITLE
Update `trailingCommas` to support `@escaping` / `@Sendable` closures, protocol primary associated types

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -637,6 +637,12 @@ extension Formatter {
         }
     }
 
+    /// Whether or not the index is the start of a valid closure type
+    func isStartOfClosureType(at i: Int) -> Bool {
+        guard let type = parseType(at: i) else { return false }
+        return index(of: .operator("->", .infix), in: Range(type.range)) != nil
+    }
+
     func isInClosureArguments(at i: Int) -> Bool {
         var i = i
         while let token = token(at: i) {

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -649,6 +649,35 @@ class TrailingCommasTests: XCTestCase {
             bar: String,
             quux: String // trailing comma not supported
         )
+
+        let closure: @Sendable (
+            String,
+            String // trailing comma not supported
+        ) -> (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+
+        let closure: (
+            String,
+            String // trailing comma not supported
+        ) async -> (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+
+        let closure: (
+            String,
+            String // trailing comma not supported
+        ) async throws -> (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+
+        func foo(_: @escaping (
+            String,
+            String // trailing comma not supported
+        ) -> Void) {}
         """
 
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
@@ -1085,6 +1114,11 @@ class TrailingCommasTests: XCTestCase {
         extension Dictionary<
             String,
             Any
+        > {}
+
+        protocol MyProtocolWithAssociatedTypes<
+            Foo,
+            Bar
         > {}
         """
 


### PR DESCRIPTION
This PR fixes more Swift 6.1 edge cases with the `trailingCommas` rule:
 - It was mistaking `@escaping` and `@Sendable` closures for an attribute with arguments in parenthesis rather than a closure type
 - It thought that trailing commas were supported in `protocol` primary associated type lists, even though this is unexpectedly not supported in Swift 6.1

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2061.