### PR TITLE
Support adding and testing new rules without using Xcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - 13
-          - latest
+          - 15
         xcode:
-          - latest-stable
+          - 16.3
     runs-on: macos-${{ matrix.macos }}
     steps:
       - name: Select Xcode version
@@ -91,9 +90,9 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - 13
+          - 15
         xcode:
-          - latest-stable
+          - 16.3
     runs-on: macos-${{ matrix.macos }}
     steps:
       - name: Select Xcode version
@@ -110,9 +109,9 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - 13
+          - 15
         xcode:
-          - latest-stable
+          - 16.3
     runs-on: macos-${{ matrix.macos }}
     steps:
       - name: Select Xcode version
@@ -129,9 +128,9 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - 13
+          - 15
         xcode:
-          - latest-stable
+          - 16.3
     runs-on: macos-${{ matrix.macos }}
     steps:
       - name: Select Xcode version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,18 @@ $ ./Scripts/test_rule.sh indent
 $ ./Scripts/test_rule.sh wrap
 ```
 
+## Tips
+
+* Use existing helpers in `ParsingHelpers.swift` or `FormattingHelpers.swift` where possible. There are existing parsing helpers for many parts of the Swift grammar, like: 
+  * Types (`parseType(at:)`) 
+  * Declarations (`parseDeclarations()`)
+  * Expressions (`parseExpressionRange(startingAt:)`)
+  * Properties (`parsePropertyDeclaration(atIntroducerIndex:)`)
+  * Functions (`parseFunctionDeclaration(keywordIndex:)`)
+  
+* Define helpers in extensions on `Formatter` at the bottom of the Rule file. These should be `internal` to improve discoverability. Helpers used by multiple rules should be moved to `ParsingHelpers`.
+  * Before writing new parsing helpers, consider checking if any existing rule has parsing helpers that could be reused.
+
 ## Prerelease builds
 
 If you contribute a new rule or option, it would be published in the following major version release. To start using the new rule or option right away in your own project, you could use a prerelease build of the `develop` branch. More information is available [here](https://github.com/nicklockwood/SwiftFormat#prerelease-builds).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,14 @@ Tests are run automatically on all pull requests, branches and tags. These are t
 
 There is a separate Performance Tests scheme that you should run manually if your code changes are likely to affect performance.
 
+Test cases for individual rules can be ran via the command line using the `./Scripts/test_rule.sh` script. For example:
+
+```sh
+$ ./Scripts/test_rule.sh blankLinesAtStartOfScope
+$ ./Scripts/test_rule.sh indent
+$ ./Scripts/test_rule.sh wrap
+```
+
 ## Prerelease builds
 
 If you contribute a new rule or option, it would be published in the following major version release. To start using the new rule or option right away in your own project, you could use a prerelease build of the `develop` branch. More information is available [here](https://github.com/nicklockwood/SwiftFormat#prerelease-builds).

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Running all SwiftFormat tests"
+echo "To test a single rule, use './Scripts/test_rule.sh'"
+
+WORKSPACE_PATH="SwiftFormat.xcodeproj/project.xcworkspace"
+XCODE_SCHEME="SwiftFormat (Framework)"
+
+CMD="xcodebuild test -workspace \"${WORKSPACE_PATH}\" -scheme \"${XCODE_SCHEME}\""
+
+eval $CMD
+exit $?

--- a/Scripts/test_rule.sh
+++ b/Scripts/test_rule.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Script for testing individual SwiftFormat rules.
+# $ ./Script/test_rule.sh blankLinesAtStartOfScope
+
+# Argument validation
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <RuleName>" >&2
+    exit 1
+fi
+
+rule_name="$1"
+
+# Capitalize the first letter
+first_char_upper=$(echo ${rule_name:0:1} | tr '[:lower:]' '[:upper:]')
+rest_of_name="${rule_name:1}"
+class_name_stem="${first_char_upper}${rest_of_name}"
+
+# Append "Tests"
+TEST_CLASS_NAME="${class_name_stem}Tests"
+
+# Validate test file existence
+TEST_FILE_PATH="Tests/Rules/${TEST_CLASS_NAME}.swift"
+if [ ! -f "$TEST_FILE_PATH" ]; then
+    echo "Error: Test file ${TEST_FILE_PATH} not found." >&2
+    exit 2
+fi
+
+echo "Testing ${rule_name} rule..."
+
+WORKSPACE_PATH="SwiftFormat.xcodeproj/project.xcworkspace"
+XCODE_SCHEME="SwiftFormat (Framework)"
+XCODE_TARGET="SwiftFormatTests"
+
+CMD="xcodebuild test -workspace \"${WORKSPACE_PATH}\" -scheme \"${XCODE_SCHEME}\" -only-testing:${XCODE_TARGET}/${TEST_CLASS_NAME}"
+
+eval $CMD
+exit $?

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -17,7 +17,6 @@
 		01045A9F2119D30D00D2BE3D /* Inference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01045A90211988F100D2BE3D /* Inference.swift */; };
 		01045AA0211A1EE300D2BE3D /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01045A982119979400D2BE3D /* Arguments.swift */; };
 		011A53EB21FFAA4200DD9268 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011A53E921FFAA3A00DD9268 /* VersionTests.swift */; };
-		012242DA2CD355B000B96EF8 /* EmptyExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012242D92CD355B000B96EF8 /* EmptyExtensionsTests.swift */; };
 		01426E4E23AA29B100E7D871 /* ParsingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01426E4D23AA29B100E7D871 /* ParsingHelpersTests.swift */; };
 		0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0142C76F23C3FB6D005D5832 /* LintFileCommand.swift */; };
 		0142F06F1D72FE10007D66CC /* SwiftFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0142F06E1D72FE10007D66CC /* SwiftFormatTests.swift */; };
@@ -66,16 +65,6 @@
 		01F3DF8D1DB9FD3F00454944 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F3DF8B1DB9FD3F00454944 /* Options.swift */; };
 		01F3DF8E1DB9FD3F00454944 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F3DF8B1DB9FD3F00454944 /* Options.swift */; };
 		01F3DF901DBA003E00454944 /* InferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F3DF8F1DBA003E00454944 /* InferenceTests.swift */; };
-		082D644B2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */; };
-		082D644C2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */; };
-		082D644D2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */; };
-		082D644E2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */; };
-		082D64502CA471F30072DA14 /* RedundantEquatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082D644F2CA471F00072DA14 /* RedundantEquatableTests.swift */; };
-		08CC3AD32D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
-		08CC3AD42D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
-		08CC3AD52D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
-		08CC3AD62D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */; };
-		08CC3AD82D656259005BFABE /* SwiftTestingTestCaseNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CC3AD72D656257005BFABE /* SwiftTestingTestCaseNamesTests.swift */; };
 		2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
 		2E26108F2DD92CB400FFFE09 /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F17E811E25870700DCD359 /* CommandLine.swift */; };
 		2E2611C82DD94FE900FFFE09 /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
@@ -90,568 +79,7 @@
 		2E2BAB8D2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8E2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
 		2E2BAB8F2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */; };
-		2E2BABFF2C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */; };
-		2E2BAC002C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */; };
-		2E2BAC012C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */; };
-		2E2BAC022C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */; };
-		2E2BAC032C57F6DD00590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */; };
-		2E2BAC042C57F6DD00590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */; };
-		2E2BAC052C57F6DD00590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */; };
-		2E2BAC062C57F6DD00590239 /* RedundantBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */; };
-		2E2BAC072C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */; };
-		2E2BAC082C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */; };
-		2E2BAC092C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */; };
-		2E2BAC0A2C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */; };
-		2E2BAC0B2C57F6DD00590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB942C57F6DD00590239 /* Indent.swift */; };
-		2E2BAC0C2C57F6DD00590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB942C57F6DD00590239 /* Indent.swift */; };
-		2E2BAC0D2C57F6DD00590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB942C57F6DD00590239 /* Indent.swift */; };
-		2E2BAC0E2C57F6DD00590239 /* Indent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB942C57F6DD00590239 /* Indent.swift */; };
-		2E2BAC0F2C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */; };
-		2E2BAC102C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */; };
-		2E2BAC112C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */; };
-		2E2BAC122C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */; };
-		2E2BAC132C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */; };
-		2E2BAC142C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */; };
-		2E2BAC152C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */; };
-		2E2BAC162C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */; };
-		2E2BAC172C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */; };
-		2E2BAC182C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */; };
-		2E2BAC192C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */; };
-		2E2BAC1A2C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */; };
-		2E2BAC1B2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */; };
-		2E2BAC1C2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */; };
-		2E2BAC1D2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */; };
-		2E2BAC1E2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */; };
-		2E2BAC1F2C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */; };
-		2E2BAC202C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */; };
-		2E2BAC212C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */; };
-		2E2BAC222C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */; };
-		2E2BAC232C57F6DD00590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */; };
-		2E2BAC242C57F6DD00590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */; };
-		2E2BAC252C57F6DD00590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */; };
-		2E2BAC262C57F6DD00590239 /* RedundantInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */; };
-		2E2BAC272C57F6DD00590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */; };
-		2E2BAC282C57F6DD00590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */; };
-		2E2BAC292C57F6DD00590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */; };
-		2E2BAC2A2C57F6DD00590239 /* RedundantNilInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */; };
-		2E2BAC2B2C57F6DD00590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9C2C57F6DD00590239 /* Todos.swift */; };
-		2E2BAC2C2C57F6DD00590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9C2C57F6DD00590239 /* Todos.swift */; };
-		2E2BAC2D2C57F6DD00590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9C2C57F6DD00590239 /* Todos.swift */; };
-		2E2BAC2E2C57F6DD00590239 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9C2C57F6DD00590239 /* Todos.swift */; };
-		2E2BAC2F2C57F6DD00590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */; };
-		2E2BAC302C57F6DD00590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */; };
-		2E2BAC312C57F6DD00590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */; };
-		2E2BAC322C57F6DD00590239 /* SpaceInsideParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */; };
-		2E2BAC332C57F6DD00590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */; };
-		2E2BAC342C57F6DD00590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */; };
-		2E2BAC352C57F6DD00590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */; };
-		2E2BAC362C57F6DD00590239 /* Semicolons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */; };
-		2E2BAC372C57F6DD00590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */; };
-		2E2BAC382C57F6DD00590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */; };
-		2E2BAC392C57F6DD00590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */; };
-		2E2BAC3A2C57F6DD00590239 /* HoistPatternLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */; };
-		2E2BAC3B2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */; };
-		2E2BAC3C2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */; };
-		2E2BAC3D2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */; };
-		2E2BAC3E2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */; };
-		2E2BAC3F2C57F6DD00590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */; };
-		2E2BAC402C57F6DD00590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */; };
-		2E2BAC412C57F6DD00590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */; };
-		2E2BAC422C57F6DD00590239 /* DuplicateImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */; };
-		2E2BAC432C57F6DD00590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA22C57F6DD00590239 /* RedundantGet.swift */; };
-		2E2BAC442C57F6DD00590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA22C57F6DD00590239 /* RedundantGet.swift */; };
-		2E2BAC452C57F6DD00590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA22C57F6DD00590239 /* RedundantGet.swift */; };
-		2E2BAC462C57F6DD00590239 /* RedundantGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA22C57F6DD00590239 /* RedundantGet.swift */; };
-		2E2BAC472C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */; };
-		2E2BAC482C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */; };
-		2E2BAC492C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */; };
-		2E2BAC4A2C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */; };
-		2E2BAC4B2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */; };
-		2E2BAC4C2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */; };
-		2E2BAC4D2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */; };
-		2E2BAC4E2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */; };
-		2E2BAC4F2C57F6DD00590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA52C57F6DD00590239 /* SortImports.swift */; };
-		2E2BAC502C57F6DD00590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA52C57F6DD00590239 /* SortImports.swift */; };
-		2E2BAC512C57F6DD00590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA52C57F6DD00590239 /* SortImports.swift */; };
-		2E2BAC522C57F6DD00590239 /* SortImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA52C57F6DD00590239 /* SortImports.swift */; };
-		2E2BAC532C57F6DD00590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA62C57F6DD00590239 /* SortedImports.swift */; };
-		2E2BAC542C57F6DD00590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA62C57F6DD00590239 /* SortedImports.swift */; };
-		2E2BAC552C57F6DD00590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA62C57F6DD00590239 /* SortedImports.swift */; };
-		2E2BAC562C57F6DD00590239 /* SortedImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA62C57F6DD00590239 /* SortedImports.swift */; };
-		2E2BAC572C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */; };
-		2E2BAC582C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */; };
-		2E2BAC592C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */; };
-		2E2BAC5A2C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */; };
-		2E2BAC5B2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */; };
-		2E2BAC5C2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */; };
-		2E2BAC5D2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */; };
-		2E2BAC5E2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */; };
-		2E2BAC5F2C57F6DD00590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA92C57F6DD00590239 /* BlockComments.swift */; };
-		2E2BAC602C57F6DD00590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA92C57F6DD00590239 /* BlockComments.swift */; };
-		2E2BAC612C57F6DD00590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA92C57F6DD00590239 /* BlockComments.swift */; };
-		2E2BAC622C57F6DD00590239 /* BlockComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABA92C57F6DD00590239 /* BlockComments.swift */; };
-		2E2BAC632C57F6DD00590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */; };
-		2E2BAC642C57F6DD00590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */; };
-		2E2BAC652C57F6DD00590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */; };
-		2E2BAC662C57F6DD00590239 /* StrongOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */; };
-		2E2BAC672C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */; };
-		2E2BAC682C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */; };
-		2E2BAC692C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */; };
-		2E2BAC6A2C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */; };
-		2E2BAC6B2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */; };
-		2E2BAC6C2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */; };
-		2E2BAC6D2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */; };
-		2E2BAC6E2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */; };
-		2E2BAC6F2C57F6DD00590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */; };
-		2E2BAC702C57F6DD00590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */; };
-		2E2BAC712C57F6DD00590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */; };
-		2E2BAC722C57F6DD00590239 /* AssertionFailures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */; };
-		2E2BAC732C57F6DD00590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */; };
-		2E2BAC742C57F6DD00590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */; };
-		2E2BAC752C57F6DD00590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */; };
-		2E2BAC762C57F6DD00590239 /* EmptyBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */; };
-		2E2BAC772C57F6DD00590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */; };
-		2E2BAC782C57F6DD00590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */; };
-		2E2BAC792C57F6DD00590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */; };
-		2E2BAC7A2C57F6DD00590239 /* SpaceAroundComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */; };
-		2E2BAC7B2C57F6DD00590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB02C57F6DD00590239 /* RedundantParens.swift */; };
-		2E2BAC7C2C57F6DD00590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB02C57F6DD00590239 /* RedundantParens.swift */; };
-		2E2BAC7D2C57F6DD00590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB02C57F6DD00590239 /* RedundantParens.swift */; };
-		2E2BAC7E2C57F6DD00590239 /* RedundantParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB02C57F6DD00590239 /* RedundantParens.swift */; };
-		2E2BAC7F2C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */; };
-		2E2BAC802C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */; };
-		2E2BAC812C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */; };
-		2E2BAC822C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */; };
-		2E2BAC832C57F6DD00590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB22C57F6DD00590239 /* Linebreaks.swift */; };
-		2E2BAC842C57F6DD00590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB22C57F6DD00590239 /* Linebreaks.swift */; };
-		2E2BAC852C57F6DD00590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB22C57F6DD00590239 /* Linebreaks.swift */; };
-		2E2BAC862C57F6DD00590239 /* Linebreaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB22C57F6DD00590239 /* Linebreaks.swift */; };
-		2E2BAC872C57F6DD00590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */; };
-		2E2BAC882C57F6DD00590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */; };
-		2E2BAC892C57F6DD00590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */; };
-		2E2BAC8A2C57F6DD00590239 /* LeadingDelimiters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */; };
-		2E2BAC8B2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */; };
-		2E2BAC8C2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */; };
-		2E2BAC8D2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */; };
-		2E2BAC8E2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */; };
-		2E2BAC8F2C57F6DD00590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB52C57F6DD00590239 /* RedundantLet.swift */; };
-		2E2BAC902C57F6DD00590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB52C57F6DD00590239 /* RedundantLet.swift */; };
-		2E2BAC912C57F6DD00590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB52C57F6DD00590239 /* RedundantLet.swift */; };
-		2E2BAC922C57F6DD00590239 /* RedundantLet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB52C57F6DD00590239 /* RedundantLet.swift */; };
-		2E2BAC932C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */; };
-		2E2BAC942C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */; };
-		2E2BAC952C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */; };
-		2E2BAC962C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */; };
-		2E2BAC972C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */; };
-		2E2BAC982C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */; };
-		2E2BAC992C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */; };
-		2E2BAC9A2C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */; };
-		2E2BAC9B2C57F6DD00590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB82C57F6DD00590239 /* RedundantInit.swift */; };
-		2E2BAC9C2C57F6DD00590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB82C57F6DD00590239 /* RedundantInit.swift */; };
-		2E2BAC9D2C57F6DD00590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB82C57F6DD00590239 /* RedundantInit.swift */; };
-		2E2BAC9E2C57F6DD00590239 /* RedundantInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB82C57F6DD00590239 /* RedundantInit.swift */; };
-		2E2BAC9F2C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */; };
-		2E2BACA02C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */; };
-		2E2BACA12C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */; };
-		2E2BACA22C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */; };
-		2E2BACA32C57F6DD00590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBA2C57F6DD00590239 /* Void.swift */; };
-		2E2BACA42C57F6DD00590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBA2C57F6DD00590239 /* Void.swift */; };
-		2E2BACA52C57F6DD00590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBA2C57F6DD00590239 /* Void.swift */; };
-		2E2BACA62C57F6DD00590239 /* Void.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBA2C57F6DD00590239 /* Void.swift */; };
-		2E2BACA72C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */; };
-		2E2BACA82C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */; };
-		2E2BACA92C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */; };
-		2E2BACAA2C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */; };
-		2E2BACAB2C57F6DD00590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */; };
-		2E2BACAC2C57F6DD00590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */; };
-		2E2BACAD2C57F6DD00590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */; };
-		2E2BACAE2C57F6DD00590239 /* RedundantLetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */; };
-		2E2BACAF2C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */; };
-		2E2BACB02C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */; };
-		2E2BACB12C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */; };
-		2E2BACB22C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */; };
-		2E2BACB32C57F6DD00590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */; };
-		2E2BACB42C57F6DD00590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */; };
-		2E2BACB52C57F6DD00590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */; };
-		2E2BACB62C57F6DD00590239 /* RedundantClosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */; };
-		2E2BACB72C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */; };
-		2E2BACB82C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */; };
-		2E2BACB92C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */; };
-		2E2BACBA2C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */; };
-		2E2BACBB2C57F6DD00590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC02C57F6DD00590239 /* FileHeader.swift */; };
-		2E2BACBC2C57F6DD00590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC02C57F6DD00590239 /* FileHeader.swift */; };
-		2E2BACBD2C57F6DD00590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC02C57F6DD00590239 /* FileHeader.swift */; };
-		2E2BACBE2C57F6DD00590239 /* FileHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC02C57F6DD00590239 /* FileHeader.swift */; };
-		2E2BACBF2C57F6DD00590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC12C57F6DD00590239 /* TypeSugar.swift */; };
-		2E2BACC02C57F6DD00590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC12C57F6DD00590239 /* TypeSugar.swift */; };
-		2E2BACC12C57F6DD00590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC12C57F6DD00590239 /* TypeSugar.swift */; };
-		2E2BACC22C57F6DD00590239 /* TypeSugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC12C57F6DD00590239 /* TypeSugar.swift */; };
-		2E2BACC32C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */; };
-		2E2BACC42C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */; };
-		2E2BACC52C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */; };
-		2E2BACC62C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */; };
-		2E2BACC72C57F6DD00590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */; };
-		2E2BACC82C57F6DD00590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */; };
-		2E2BACC92C57F6DD00590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */; };
-		2E2BACCA2C57F6DD00590239 /* HeaderFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */; };
-		2E2BACCB2C57F6DD00590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC42C57F6DD00590239 /* IsEmpty.swift */; };
-		2E2BACCC2C57F6DD00590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC42C57F6DD00590239 /* IsEmpty.swift */; };
-		2E2BACCD2C57F6DD00590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC42C57F6DD00590239 /* IsEmpty.swift */; };
-		2E2BACCE2C57F6DD00590239 /* IsEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC42C57F6DD00590239 /* IsEmpty.swift */; };
-		2E2BACCF2C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */; };
-		2E2BACD02C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */; };
-		2E2BACD12C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */; };
-		2E2BACD22C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */; };
-		2E2BACD32C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */; };
-		2E2BACD42C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */; };
-		2E2BACD52C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */; };
-		2E2BACD62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */; };
-		2E2BACD72C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */; };
-		2E2BACD82C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */; };
-		2E2BACD92C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */; };
-		2E2BACDA2C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */; };
-		2E2BACDB2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */; };
-		2E2BACDC2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */; };
-		2E2BACDD2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */; };
-		2E2BACDE2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */; };
-		2E2BACDF2C57F6DD00590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */; };
-		2E2BACE02C57F6DD00590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */; };
-		2E2BACE12C57F6DD00590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */; };
-		2E2BACE22C57F6DD00590239 /* RedundantReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */; };
-		2E2BACE32C57F6DD00590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */; };
-		2E2BACE42C57F6DD00590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */; };
-		2E2BACE52C57F6DD00590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */; };
-		2E2BACE62C57F6DD00590239 /* GenericExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */; };
-		2E2BACE72C57F6DD00590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */; };
-		2E2BACE82C57F6DD00590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */; };
-		2E2BACE92C57F6DD00590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */; };
-		2E2BACEA2C57F6DD00590239 /* TrailingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */; };
-		2E2BACEB2C57F6DD00590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */; };
-		2E2BACEC2C57F6DD00590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */; };
-		2E2BACED2C57F6DD00590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */; };
-		2E2BACEE2C57F6DD00590239 /* RedundantObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */; };
-		2E2BACEF2C57F6DD00590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */; };
-		2E2BACF02C57F6DD00590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */; };
-		2E2BACF12C57F6DD00590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */; };
-		2E2BACF22C57F6DD00590239 /* ConditionalAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */; };
-		2E2BACF32C57F6DD00590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */; };
-		2E2BACF42C57F6DD00590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */; };
-		2E2BACF52C57F6DD00590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */; };
-		2E2BACF62C57F6DD00590239 /* PreferForLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */; };
-		2E2BACF72C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */; };
-		2E2BACF82C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */; };
-		2E2BACF92C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */; };
-		2E2BACFA2C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */; };
-		2E2BACFB2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */; };
-		2E2BACFC2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */; };
-		2E2BACFD2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */; };
-		2E2BACFE2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */; };
-		2E2BACFF2C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */; };
-		2E2BAD002C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */; };
-		2E2BAD012C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */; };
-		2E2BAD022C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */; };
-		2E2BAD032C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */; };
-		2E2BAD042C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */; };
-		2E2BAD052C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */; };
-		2E2BAD062C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */; };
-		2E2BAD072C57F6DD00590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */; };
-		2E2BAD082C57F6DD00590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */; };
-		2E2BAD092C57F6DD00590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */; };
-		2E2BAD0A2C57F6DD00590239 /* RedundantPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */; };
-		2E2BAD0B2C57F6DD00590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */; };
-		2E2BAD0C2C57F6DD00590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */; };
-		2E2BAD0D2C57F6DD00590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */; };
-		2E2BAD0E2C57F6DD00590239 /* ApplicationMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */; };
-		2E2BAD0F2C57F6DD00590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */; };
-		2E2BAD102C57F6DD00590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */; };
-		2E2BAD112C57F6DD00590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */; };
-		2E2BAD122C57F6DD00590239 /* RedundantProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */; };
-		2E2BAD132C57F6DD00590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD62C57F6DD00590239 /* Wrap.swift */; };
-		2E2BAD142C57F6DD00590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD62C57F6DD00590239 /* Wrap.swift */; };
-		2E2BAD152C57F6DD00590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD62C57F6DD00590239 /* Wrap.swift */; };
-		2E2BAD162C57F6DD00590239 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD62C57F6DD00590239 /* Wrap.swift */; };
-		2E2BAD172C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */; };
-		2E2BAD182C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */; };
-		2E2BAD192C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */; };
-		2E2BAD1A2C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */; };
-		2E2BAD1B2C57F6DD00590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */; };
-		2E2BAD1C2C57F6DD00590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */; };
-		2E2BAD1D2C57F6DD00590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */; };
-		2E2BAD1E2C57F6DD00590239 /* ModifierOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */; };
-		2E2BAD1F2C57F6DD00590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */; };
-		2E2BAD202C57F6DD00590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */; };
-		2E2BAD212C57F6DD00590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */; };
-		2E2BAD222C57F6DD00590239 /* EnumNamespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */; };
-		2E2BAD232C57F6DD00590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */; };
-		2E2BAD242C57F6DD00590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */; };
-		2E2BAD252C57F6DD00590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */; };
-		2E2BAD262C57F6DD00590239 /* RedundantSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */; };
-		2E2BAD272C57F6DD00590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */; };
-		2E2BAD282C57F6DD00590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */; };
-		2E2BAD292C57F6DD00590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */; };
-		2E2BAD2A2C57F6DD00590239 /* PreferKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */; };
-		2E2BAD2B2C57F6DD00590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */; };
-		2E2BAD2C2C57F6DD00590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */; };
-		2E2BAD2D2C57F6DD00590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */; };
-		2E2BAD2E2C57F6DD00590239 /* WrapEnumCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */; };
-		2E2BAD2F2C57F6DD00590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */; };
-		2E2BAD302C57F6DD00590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */; };
-		2E2BAD312C57F6DD00590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */; };
-		2E2BAD322C57F6DD00590239 /* WrapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */; };
-		2E2BAD332C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */; };
-		2E2BAD342C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */; };
-		2E2BAD352C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */; };
-		2E2BAD362C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */; };
-		2E2BAD372C57F6DD00590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */; };
-		2E2BAD382C57F6DD00590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */; };
-		2E2BAD392C57F6DD00590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */; };
-		2E2BAD3A2C57F6DD00590239 /* WrapSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */; };
-		2E2BAD3B2C57F6DD00590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE02C57F6DD00590239 /* Braces.swift */; };
-		2E2BAD3C2C57F6DD00590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE02C57F6DD00590239 /* Braces.swift */; };
-		2E2BAD3D2C57F6DD00590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE02C57F6DD00590239 /* Braces.swift */; };
-		2E2BAD3E2C57F6DD00590239 /* Braces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE02C57F6DD00590239 /* Braces.swift */; };
-		2E2BAD3F2C57F6DD00590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE12C57F6DD00590239 /* MarkTypes.swift */; };
-		2E2BAD402C57F6DD00590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE12C57F6DD00590239 /* MarkTypes.swift */; };
-		2E2BAD412C57F6DD00590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE12C57F6DD00590239 /* MarkTypes.swift */; };
-		2E2BAD422C57F6DD00590239 /* MarkTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE12C57F6DD00590239 /* MarkTypes.swift */; };
-		2E2BAD432C57F6DD00590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE22C57F6DD00590239 /* AndOperator.swift */; };
-		2E2BAD442C57F6DD00590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE22C57F6DD00590239 /* AndOperator.swift */; };
-		2E2BAD452C57F6DD00590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE22C57F6DD00590239 /* AndOperator.swift */; };
-		2E2BAD462C57F6DD00590239 /* AndOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE22C57F6DD00590239 /* AndOperator.swift */; };
-		2E2BAD472C57F6DD00590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */; };
-		2E2BAD482C57F6DD00590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */; };
-		2E2BAD492C57F6DD00590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */; };
-		2E2BAD4A2C57F6DD00590239 /* WrapLoopBodies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */; };
-		2E2BAD4B2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */; };
-		2E2BAD4C2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */; };
-		2E2BAD4D2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */; };
-		2E2BAD4E2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */; };
-		2E2BAD4F2C57F6DD00590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */; };
-		2E2BAD502C57F6DD00590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */; };
-		2E2BAD512C57F6DD00590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */; };
-		2E2BAD522C57F6DD00590239 /* RedundantRawValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */; };
-		2E2BAD532C57F6DD00590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */; };
-		2E2BAD542C57F6DD00590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */; };
-		2E2BAD552C57F6DD00590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */; };
-		2E2BAD562C57F6DD00590239 /* TrailingCommas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */; };
-		2E2BAD572C57F6DD00590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */; };
-		2E2BAD582C57F6DD00590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */; };
-		2E2BAD592C57F6DD00590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */; };
-		2E2BAD5A2C57F6DD00590239 /* StrongifiedSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */; };
-		2E2BAD5B2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */; };
-		2E2BAD5C2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */; };
-		2E2BAD5D2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */; };
-		2E2BAD5E2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */; };
-		2E2BAD5F2C57F6DD00590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */; };
-		2E2BAD602C57F6DD00590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */; };
-		2E2BAD612C57F6DD00590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */; };
-		2E2BAD622C57F6DD00590239 /* RedundantBackticks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */; };
-		2E2BAD632C57F6DD00590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */; };
-		2E2BAD642C57F6DD00590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */; };
-		2E2BAD652C57F6DD00590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */; };
-		2E2BAD662C57F6DD00590239 /* SpaceAroundParens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */; };
-		2E2BAD672C57F6DD00590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */; };
-		2E2BAD682C57F6DD00590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */; };
-		2E2BAD692C57F6DD00590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */; };
-		2E2BAD6A2C57F6DD00590239 /* HoistAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */; };
-		2E2BAD6B2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */; };
-		2E2BAD6C2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */; };
-		2E2BAD6D2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */; };
-		2E2BAD6E2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */; };
-		2E2BAD6F2C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */; };
-		2E2BAD702C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */; };
-		2E2BAD712C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */; };
-		2E2BAD722C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */; };
-		2E2BAD732C57F6DD00590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */; };
-		2E2BAD742C57F6DD00590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */; };
-		2E2BAD752C57F6DD00590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */; };
-		2E2BAD762C57F6DD00590239 /* TrailingClosures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */; };
-		2E2BAD772C57F6DD00590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */; };
-		2E2BAD782C57F6DD00590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */; };
-		2E2BAD792C57F6DD00590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */; };
-		2E2BAD7A2C57F6DD00590239 /* SortedSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */; };
-		2E2BAD7B2C57F6DD00590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF02C57F6DD00590239 /* Acronyms.swift */; };
-		2E2BAD7C2C57F6DD00590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF02C57F6DD00590239 /* Acronyms.swift */; };
-		2E2BAD7D2C57F6DD00590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF02C57F6DD00590239 /* Acronyms.swift */; };
-		2E2BAD7E2C57F6DD00590239 /* Acronyms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF02C57F6DD00590239 /* Acronyms.swift */; };
-		2E2BAD7F2C57F6DD00590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */; };
-		2E2BAD802C57F6DD00590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */; };
-		2E2BAD812C57F6DD00590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */; };
-		2E2BAD822C57F6DD00590239 /* SortTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */; };
-		2E2BAD832C57F6DD00590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF22C57F6DD00590239 /* DocComments.swift */; };
-		2E2BAD842C57F6DD00590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF22C57F6DD00590239 /* DocComments.swift */; };
-		2E2BAD852C57F6DD00590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF22C57F6DD00590239 /* DocComments.swift */; };
-		2E2BAD862C57F6DD00590239 /* DocComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF22C57F6DD00590239 /* DocComments.swift */; };
-		2E2BAD872C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */; };
-		2E2BAD882C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */; };
-		2E2BAD892C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */; };
-		2E2BAD8A2C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */; };
-		2E2BAD8B2C57F6DD00590239 /* PropertyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */; };
-		2E2BAD8C2C57F6DD00590239 /* PropertyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */; };
-		2E2BAD8D2C57F6DD00590239 /* PropertyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */; };
-		2E2BAD8E2C57F6DD00590239 /* PropertyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */; };
-		2E2BAD8F2C57F6DD00590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF52C57F6DD00590239 /* HoistTry.swift */; };
-		2E2BAD902C57F6DD00590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF52C57F6DD00590239 /* HoistTry.swift */; };
-		2E2BAD912C57F6DD00590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF52C57F6DD00590239 /* HoistTry.swift */; };
-		2E2BAD922C57F6DD00590239 /* HoistTry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF52C57F6DD00590239 /* HoistTry.swift */; };
-		2E2BAD932C57F6DD00590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */; };
-		2E2BAD942C57F6DD00590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */; };
-		2E2BAD952C57F6DD00590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */; };
-		2E2BAD962C57F6DD00590239 /* NumberFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */; };
-		2E2BAD972C57F6DD00590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF72C57F6DD00590239 /* WrapArguments.swift */; };
-		2E2BAD982C57F6DD00590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF72C57F6DD00590239 /* WrapArguments.swift */; };
-		2E2BAD992C57F6DD00590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF72C57F6DD00590239 /* WrapArguments.swift */; };
-		2E2BAD9A2C57F6DD00590239 /* WrapArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF72C57F6DD00590239 /* WrapArguments.swift */; };
-		2E2BAD9B2C57F6DD00590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF82C57F6DD00590239 /* Specifiers.swift */; };
-		2E2BAD9C2C57F6DD00590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF82C57F6DD00590239 /* Specifiers.swift */; };
-		2E2BAD9D2C57F6DD00590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF82C57F6DD00590239 /* Specifiers.swift */; };
-		2E2BAD9E2C57F6DD00590239 /* Specifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF82C57F6DD00590239 /* Specifiers.swift */; };
-		2E2BAD9F2C57F6DD00590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF92C57F6DD00590239 /* YodaConditions.swift */; };
-		2E2BADA02C57F6DD00590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF92C57F6DD00590239 /* YodaConditions.swift */; };
-		2E2BADA12C57F6DD00590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF92C57F6DD00590239 /* YodaConditions.swift */; };
-		2E2BADA22C57F6DD00590239 /* YodaConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABF92C57F6DD00590239 /* YodaConditions.swift */; };
-		2E2BADA32C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */; };
-		2E2BADA42C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */; };
-		2E2BADA52C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */; };
-		2E2BADA62C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */; };
-		2E2BADA72C57F6DD00590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */; };
-		2E2BADA82C57F6DD00590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */; };
-		2E2BADA92C57F6DD00590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */; };
-		2E2BADAA2C57F6DD00590239 /* UnusedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */; };
-		2E2BADAB2C57F6DD00590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */; };
-		2E2BADAC2C57F6DD00590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */; };
-		2E2BADAD2C57F6DD00590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */; };
-		2E2BADAE2C57F6DD00590239 /* SortSwitchCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */; };
-		2E2BADAF2C57F6DD00590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFD2C57F6DD00590239 /* RedundantType.swift */; };
-		2E2BADB02C57F6DD00590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFD2C57F6DD00590239 /* RedundantType.swift */; };
-		2E2BADB12C57F6DD00590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFD2C57F6DD00590239 /* RedundantType.swift */; };
-		2E2BADB22C57F6DD00590239 /* RedundantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFD2C57F6DD00590239 /* RedundantType.swift */; };
-		2E2BADB32C57F6DD00590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */; };
-		2E2BADB42C57F6DD00590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */; };
-		2E2BADB52C57F6DD00590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */; };
-		2E2BADB62C57F6DD00590239 /* SortDeclarations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */; };
-		2E723EF32D45592B00D1B389 /* PreferSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E723EF22D45592B00D1B389 /* PreferSwiftTestingTests.swift */; };
-		2E723EF62D455B2A00D1B389 /* PreferSwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */; };
-		2E723EF72D455B2B00D1B389 /* PreferSwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */; };
-		2E723EF92D455B2C00D1B389 /* PreferSwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */; };
-		2E723EFA2D455B2C00D1B389 /* PreferSwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */; };
 		2E7D30A42A7940C500C32174 /* Singularize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7D30A32A7940C500C32174 /* Singularize.swift */; };
-		2E8DE6F82C57FEB30032BF25 /* RedundantClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE68D2C57FEB30032BF25 /* RedundantClosureTests.swift */; };
-		2E8DE6F92C57FEB30032BF25 /* BlankLinesBetweenChainedFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE68E2C57FEB30032BF25 /* BlankLinesBetweenChainedFunctionsTests.swift */; };
-		2E8DE6FA2C57FEB30032BF25 /* SpaceAroundGenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE68F2C57FEB30032BF25 /* SpaceAroundGenericsTests.swift */; };
-		2E8DE6FB2C57FEB30032BF25 /* BlankLinesAroundMarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6902C57FEB30032BF25 /* BlankLinesAroundMarkTests.swift */; };
-		2E8DE6FC2C57FEB30032BF25 /* WrapArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6912C57FEB30032BF25 /* WrapArgumentsTests.swift */; };
-		2E8DE6FD2C57FEB30032BF25 /* RedundantSelfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6922C57FEB30032BF25 /* RedundantSelfTests.swift */; };
-		2E8DE6FE2C57FEB30032BF25 /* BlankLinesBetweenScopesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6932C57FEB30032BF25 /* BlankLinesBetweenScopesTests.swift */; };
-		2E8DE6FF2C57FEB30032BF25 /* DuplicateImportsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6942C57FEB30032BF25 /* DuplicateImportsTests.swift */; };
-		2E8DE7002C57FEB30032BF25 /* TodosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6952C57FEB30032BF25 /* TodosTests.swift */; };
-		2E8DE7012C57FEB30032BF25 /* FileHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6962C57FEB30032BF25 /* FileHeaderTests.swift */; };
-		2E8DE7022C57FEB30032BF25 /* EnumNamespacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6972C57FEB30032BF25 /* EnumNamespacesTests.swift */; };
-		2E8DE7032C57FEB30032BF25 /* PreferForLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6982C57FEB30032BF25 /* PreferForLoopTests.swift */; };
-		2E8DE7042C57FEB30032BF25 /* ExtensionAccessControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6992C57FEB30032BF25 /* ExtensionAccessControlTests.swift */; };
-		2E8DE7052C57FEB30032BF25 /* TrailingCommasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69A2C57FEB30032BF25 /* TrailingCommasTests.swift */; };
-		2E8DE7062C57FEB30032BF25 /* WrapLoopBodiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69B2C57FEB30032BF25 /* WrapLoopBodiesTests.swift */; };
-		2E8DE7072C57FEB30032BF25 /* StrongifiedSelfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69C2C57FEB30032BF25 /* StrongifiedSelfTests.swift */; };
-		2E8DE7082C57FEB30032BF25 /* RedundantPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69D2C57FEB30032BF25 /* RedundantPropertyTests.swift */; };
-		2E8DE7092C57FEB30032BF25 /* OpaqueGenericParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69E2C57FEB30032BF25 /* OpaqueGenericParametersTests.swift */; };
-		2E8DE70A2C57FEB30032BF25 /* SpaceInsideBracesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE69F2C57FEB30032BF25 /* SpaceInsideBracesTests.swift */; };
-		2E8DE70B2C57FEB30032BF25 /* ModifierOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A02C57FEB30032BF25 /* ModifierOrderTests.swift */; };
-		2E8DE70C2C57FEB30032BF25 /* WrapAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A12C57FEB30032BF25 /* WrapAttributesTests.swift */; };
-		2E8DE70D2C57FEB30032BF25 /* RedundantObjcTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A22C57FEB30032BF25 /* RedundantObjcTests.swift */; };
-		2E8DE70E2C57FEB30032BF25 /* HoistPatternLetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A32C57FEB30032BF25 /* HoistPatternLetTests.swift */; };
-		2E8DE70F2C57FEB30032BF25 /* WrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A42C57FEB30032BF25 /* WrapTests.swift */; };
-		2E8DE7102C57FEB30032BF25 /* SpaceInsideGenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A52C57FEB30032BF25 /* SpaceInsideGenericsTests.swift */; };
-		2E8DE7112C57FEB30032BF25 /* RedundantStaticSelfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A62C57FEB30032BF25 /* RedundantStaticSelfTests.swift */; };
-		2E8DE7122C57FEB30032BF25 /* BlankLinesAtEndOfScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A72C57FEB30032BF25 /* BlankLinesAtEndOfScopeTests.swift */; };
-		2E8DE7132C57FEB30032BF25 /* RedundantInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A82C57FEB30032BF25 /* RedundantInitTests.swift */; };
-		2E8DE7142C57FEB30032BF25 /* RedundantRawValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6A92C57FEB30032BF25 /* RedundantRawValuesTests.swift */; };
-		2E8DE7152C57FEB30032BF25 /* SortImportsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AA2C57FEB30032BF25 /* SortImportsTests.swift */; };
-		2E8DE7162C57FEB30032BF25 /* TrailingSpaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AB2C57FEB30032BF25 /* TrailingSpaceTests.swift */; };
-		2E8DE7172C57FEB30032BF25 /* YodaConditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AC2C57FEB30032BF25 /* YodaConditionsTests.swift */; };
-		2E8DE7182C57FEB30032BF25 /* ConsecutiveBlankLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AD2C57FEB30032BF25 /* ConsecutiveBlankLinesTests.swift */; };
-		2E8DE7192C57FEB30032BF25 /* UnusedArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AE2C57FEB30032BF25 /* UnusedArgumentsTests.swift */; };
-		2E8DE71A2C57FEB30032BF25 /* GenericExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6AF2C57FEB30032BF25 /* GenericExtensionsTests.swift */; };
-		2E8DE71B2C57FEB30032BF25 /* NumberFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B02C57FEB30032BF25 /* NumberFormattingTests.swift */; };
-		2E8DE71C2C57FEB30032BF25 /* RedundantTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B12C57FEB30032BF25 /* RedundantTypeTests.swift */; };
-		2E8DE71D2C57FEB30032BF25 /* TypeSugarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B22C57FEB30032BF25 /* TypeSugarTests.swift */; };
-		2E8DE71E2C57FEB30032BF25 /* SpaceAroundBracesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B32C57FEB30032BF25 /* SpaceAroundBracesTests.swift */; };
-		2E8DE71F2C57FEB30032BF25 /* SortTypealiasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B42C57FEB30032BF25 /* SortTypealiasesTests.swift */; };
-		2E8DE7202C57FEB30032BF25 /* SortSwitchCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B52C57FEB30032BF25 /* SortSwitchCasesTests.swift */; };
-		2E8DE7212C57FEB30032BF25 /* EmptyBracesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B62C57FEB30032BF25 /* EmptyBracesTests.swift */; };
-		2E8DE7222C57FEB30032BF25 /* SortDeclarationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B72C57FEB30032BF25 /* SortDeclarationsTests.swift */; };
-		2E8DE7232C57FEB30032BF25 /* BlockCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B82C57FEB30032BF25 /* BlockCommentsTests.swift */; };
-		2E8DE7242C57FEB30032BF25 /* StrongOutletsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6B92C57FEB30032BF25 /* StrongOutletsTests.swift */; };
-		2E8DE7252C57FEB30032BF25 /* BracesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BA2C57FEB30032BF25 /* BracesTests.swift */; };
-		2E8DE7262C57FEB30032BF25 /* AnyObjectProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BB2C57FEB30032BF25 /* AnyObjectProtocolTests.swift */; };
-		2E8DE7272C57FEB30032BF25 /* RedundantBreakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BC2C57FEB30032BF25 /* RedundantBreakTests.swift */; };
-		2E8DE7282C57FEB30032BF25 /* RedundantNilInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BD2C57FEB30032BF25 /* RedundantNilInitTests.swift */; };
-		2E8DE7292C57FEB30032BF25 /* RedundantParensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BE2C57FEB30032BF25 /* RedundantParensTests.swift */; };
-		2E8DE72A2C57FEB30032BF25 /* PreferKeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6BF2C57FEB30032BF25 /* PreferKeyPathTests.swift */; };
-		2E8DE72B2C57FEB30032BF25 /* SpaceAroundParensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C02C57FEB30032BF25 /* SpaceAroundParensTests.swift */; };
-		2E8DE72C2C57FEB30032BF25 /* RedundantLetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C12C57FEB30032BF25 /* RedundantLetTests.swift */; };
-		2E8DE72D2C57FEB30032BF25 /* VoidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C22C57FEB30032BF25 /* VoidTests.swift */; };
-		2E8DE72E2C57FEB30032BF25 /* IndentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C32C57FEB30032BF25 /* IndentTests.swift */; };
-		2E8DE72F2C57FEB30032BF25 /* RedundantBackticksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C42C57FEB30032BF25 /* RedundantBackticksTests.swift */; };
-		2E8DE7302C57FEB30032BF25 /* BlankLineAfterSwitchCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C52C57FEB30032BF25 /* BlankLineAfterSwitchCaseTests.swift */; };
-		2E8DE7312C57FEB30032BF25 /* HoistAwaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C62C57FEB30032BF25 /* HoistAwaitTests.swift */; };
-		2E8DE7322C57FEB30032BF25 /* RedundantLetErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C72C57FEB30032BF25 /* RedundantLetErrorTests.swift */; };
-		2E8DE7332C57FEB30032BF25 /* SpaceAroundCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C82C57FEB30032BF25 /* SpaceAroundCommentsTests.swift */; };
-		2E8DE7342C57FEB30032BF25 /* PropertyTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6C92C57FEB30032BF25 /* PropertyTypesTests.swift */; };
-		2E8DE7352C57FEB30032BF25 /* SpaceAroundOperatorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CA2C57FEB30032BF25 /* SpaceAroundOperatorsTests.swift */; };
-		2E8DE7362C57FEB30032BF25 /* SemicolonsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CB2C57FEB30032BF25 /* SemicolonsTests.swift */; };
-		2E8DE7372C57FEB30032BF25 /* RedundantPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CC2C57FEB30032BF25 /* RedundantPatternTests.swift */; };
-		2E8DE7382C57FEB30032BF25 /* WrapMultilineConditionalAssignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CD2C57FEB30032BF25 /* WrapMultilineConditionalAssignmentTests.swift */; };
-		2E8DE7392C57FEB30032BF25 /* RedundantInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CE2C57FEB30032BF25 /* RedundantInternalTests.swift */; };
-		2E8DE73A2C57FEB30032BF25 /* IsEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6CF2C57FEB30032BF25 /* IsEmptyTests.swift */; };
-		2E8DE73B2C57FEB30032BF25 /* AcronymsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D02C57FEB30032BF25 /* AcronymsTests.swift */; };
-		2E8DE73C2C57FEB30032BF25 /* ConsistentSwitchCaseSpacingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D12C57FEB30032BF25 /* ConsistentSwitchCaseSpacingTests.swift */; };
-		2E8DE73D2C57FEB30032BF25 /* UnusedPrivateDeclarationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D22C57FEB30032BF25 /* UnusedPrivateDeclarationsTests.swift */; };
-		2E8DE73E2C57FEB30032BF25 /* WrapEnumCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D32C57FEB30032BF25 /* WrapEnumCasesTests.swift */; };
-		2E8DE73F2C57FEB30032BF25 /* NoExplicitOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D42C57FEB30032BF25 /* NoExplicitOwnershipTests.swift */; };
-		2E8DE7402C57FEB30032BF25 /* HoistTryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D52C57FEB30032BF25 /* HoistTryTests.swift */; };
-		2E8DE7412C57FEB30032BF25 /* RedundantOptionalBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D62C57FEB30032BF25 /* RedundantOptionalBindingTests.swift */; };
-		2E8DE7422C57FEB30032BF25 /* ConsecutiveSpacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D72C57FEB30032BF25 /* ConsecutiveSpacesTests.swift */; };
-		2E8DE7432C57FEB30032BF25 /* SpaceAroundBracketsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D82C57FEB30032BF25 /* SpaceAroundBracketsTests.swift */; };
-		2E8DE7442C57FEB30032BF25 /* TrailingClosuresTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6D92C57FEB30032BF25 /* TrailingClosuresTests.swift */; };
-		2E8DE7452C57FEB30032BF25 /* WrapMultilineStatementBracesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DA2C57FEB30032BF25 /* WrapMultilineStatementBracesTests.swift */; };
-		2E8DE7462C57FEB30032BF25 /* LinebreakAtEndOfFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DB2C57FEB30032BF25 /* LinebreakAtEndOfFileTests.swift */; };
-		2E8DE7472C57FEB30032BF25 /* ConditionalAssignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DC2C57FEB30032BF25 /* ConditionalAssignmentTests.swift */; };
-		2E8DE7482C57FEB30032BF25 /* RedundantGetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DD2C57FEB30032BF25 /* RedundantGetTests.swift */; };
-		2E8DE7492C57FEB30032BF25 /* HeaderFileNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DE2C57FEB30032BF25 /* HeaderFileNameTests.swift */; };
-		2E8DE74A2C57FEB30032BF25 /* RedundantExtensionACLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6DF2C57FEB30032BF25 /* RedundantExtensionACLTests.swift */; };
-		2E8DE74B2C57FEB30032BF25 /* LeadingDelimitersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E02C57FEB30032BF25 /* LeadingDelimitersTests.swift */; };
-		2E8DE74C2C57FEB30032BF25 /* WrapConditionalBodiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E12C57FEB30032BF25 /* WrapConditionalBodiesTests.swift */; };
-		2E8DE74D2C57FEB30032BF25 /* OrganizeDeclarationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E22C57FEB30032BF25 /* OrganizeDeclarationsTests.swift */; };
-		2E8DE74F2C57FEB30032BF25 /* ElseOnSameLineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E42C57FEB30032BF25 /* ElseOnSameLineTests.swift */; };
-		2E8DE7502C57FEB30032BF25 /* RedundantReturnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E52C57FEB30032BF25 /* RedundantReturnTests.swift */; };
-		2E8DE7512C57FEB30032BF25 /* LinebreaksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E62C57FEB30032BF25 /* LinebreaksTests.swift */; };
-		2E8DE7522C57FEB30032BF25 /* MarkTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E72C57FEB30032BF25 /* MarkTypesTests.swift */; };
-		2E8DE7532C57FEB30032BF25 /* SpaceInsideParensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E82C57FEB30032BF25 /* SpaceInsideParensTests.swift */; };
-		2E8DE7542C57FEB30032BF25 /* AssertionFailuresTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6E92C57FEB30032BF25 /* AssertionFailuresTests.swift */; };
-		2E8DE7552C57FEB30032BF25 /* RedundantTypedThrowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6EA2C57FEB30032BF25 /* RedundantTypedThrowsTests.swift */; };
-		2E8DE7562C57FEB30032BF25 /* BlankLinesAtStartOfScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6EB2C57FEB30032BF25 /* BlankLinesAtStartOfScopeTests.swift */; };
-		2E8DE7572C57FEB30032BF25 /* ApplicationMainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6EC2C57FEB30032BF25 /* ApplicationMainTests.swift */; };
-		2E8DE7582C57FEB30032BF25 /* RedundantVoidReturnTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6ED2C57FEB30032BF25 /* RedundantVoidReturnTypeTests.swift */; };
-		2E8DE7592C57FEB30032BF25 /* BlankLinesBetweenImportsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6EE2C57FEB30032BF25 /* BlankLinesBetweenImportsTests.swift */; };
-		2E8DE75A2C57FEB30032BF25 /* SpaceInsideCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6EF2C57FEB30032BF25 /* SpaceInsideCommentsTests.swift */; };
-		2E8DE75B2C57FEB30032BF25 /* AndOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F02C57FEB30032BF25 /* AndOperatorTests.swift */; };
-		2E8DE75C2C57FEB30032BF25 /* WrapSwitchCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F12C57FEB30032BF25 /* WrapSwitchCasesTests.swift */; };
-		2E8DE75D2C57FEB30032BF25 /* SpaceInsideBracketsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F22C57FEB30032BF25 /* SpaceInsideBracketsTests.swift */; };
-		2E8DE75E2C57FEB30032BF25 /* DocCommentsBeforeModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F32C57FEB30032BF25 /* DocCommentsBeforeModifiersTests.swift */; };
-		2E8DE75F2C57FEB30032BF25 /* BlankLineAfterImportsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F42C57FEB30032BF25 /* BlankLineAfterImportsTests.swift */; };
-		2E8DE7602C57FEB30032BF25 /* InitCoderUnavailableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F52C57FEB30032BF25 /* InitCoderUnavailableTests.swift */; };
-		2E8DE7612C57FEB30032BF25 /* RedundantFileprivateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */; };
-		2E8DE7622C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */; };
-		2E9DE5062C95F9A1000FEDF8 /* FileMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */; };
-		2E9DE5072C95F9A1000FEDF8 /* FileMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */; };
-		2E9DE5082C95F9A1000FEDF8 /* FileMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */; };
-		2E9DE5092C95F9A1000FEDF8 /* FileMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */; };
-		2E9DE50F2C95FBB6000FEDF8 /* FileMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9DE50A2C95FB4F000FEDF8 /* FileMacroTests.swift */; };
-		2EA8C3702D04F51A00843B42 /* PreferCountWhere.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */; };
-		2EA8C3712D04F51A00843B42 /* PreferCountWhere.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */; };
-		2EA8C3722D04F51A00843B42 /* PreferCountWhere.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */; };
-		2EA8C3732D04F51A00843B42 /* PreferCountWhere.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */; };
-		2EA8C3752D05282600843B42 /* PreferCountWhereTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8C3742D05282600843B42 /* PreferCountWhereTests.swift */; };
 		2EDC9DDA2CCE9A7C0085DBE2 /* Declaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */; };
 		2EDC9DDB2CCE9A7C0085DBE2 /* Declaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */; };
 		2EDC9DDC2CCE9A7C0085DBE2 /* Declaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */; };
@@ -659,17 +87,12 @@
 		2EDC9DDF2CCE9BC70085DBE2 /* DeclarationV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DDE2CCE9BC70085DBE2 /* DeclarationV2Tests.swift */; };
 		2EF737522C5E881C00128F91 /* CodeOrganizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */; };
 		2EF737542C5E897800128F91 /* ProjectFilePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737532C5E897800128F91 /* ProjectFilePaths.swift */; };
-		2EF737562C5ED19600128F91 /* DocCommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737552C5ED19600128F91 /* DocCommentsTests.swift */; };
 		2EF8BF1B2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		2EF8BF1C2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		2EF8BF1D2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		2EF8BF1E2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		37D828AB24BF77DA0012FC0A /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; };
 		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		580496D52C584E8F004B7DBF /* EmptyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtensions.swift */; };
-		580496D62C584E8F004B7DBF /* EmptyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtensions.swift */; };
-		580496D72C584E8F004B7DBF /* EmptyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtensions.swift */; };
-		580496D82C584E8F004B7DBF /* EmptyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580496D42C584E8F004B7DBF /* EmptyExtensions.swift */; };
 		9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EAC41D5DB54A00A0A8E3 /* SwiftFormat.swift */; };
 		9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EABF1D5DB4F700A0A8E3 /* Tokenizer.swift */; };
 		9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
@@ -683,23 +106,8 @@
 		90C4B6EB1DA4B059009EB000 /* SwiftFormat.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 90C4B6DD1DA4B059009EB000 /* SwiftFormat.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AF71DA5EB4600EB4EA1 /* FormatFileCommand.swift */; };
 		90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */; };
-		9BDB4F1B2C94760000C93995 /* PrivateStateVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDB4F1A2C94760000C93995 /* PrivateStateVariablesTests.swift */; };
-		9BDB4F1E2C9477FF00C93995 /* PrivateStateVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */; };
-		9BDB4F1F2C94780000C93995 /* PrivateStateVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */; };
-		9BDB4F202C94780100C93995 /* PrivateStateVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */; };
-		9BDB4F212C94780200C93995 /* PrivateStateVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */; };
 		A3DF48252620E03600F45A5F /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
 		A3DF48262620E03600F45A5F /* JSONReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF48242620E03600F45A5F /* JSONReporter.swift */; };
-		A64BDD1B2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */; };
-		A64BDD1C2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */; };
-		A64BDD1D2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */; };
-		A64BDD1E2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */; };
-		A64BDD202D68641B008C9B8A /* WrapMultilineFunctionChainsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64BDD1F2D68641B008C9B8A /* WrapMultilineFunctionChainsTests.swift */; };
-		ABC11AF82CC082D300556471 /* EnvironmentEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC11AF72CC082D300556471 /* EnvironmentEntryTests.swift */; };
-		ABC4BA2C2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */; };
-		ABC4BA2D2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */; };
-		ABC4BA2E2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */; };
-		ABC4BA2F2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */; };
 		B9C4F55C2387FA3E0088DBEE /* SupportedContentUTIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C4F55B2387FA3E0088DBEE /* SupportedContentUTIs.swift */; };
 		C2FFD1822BD13C9E00774F55 /* XMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */; };
 		C2FFD1832BD13C9E00774F55 /* XMLReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */; };
@@ -735,11 +143,6 @@
 		E4FABAD6202FEF060065716E /* OptionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FABAD4202FEF060065716E /* OptionDescriptor.swift */; };
 		E4FABAD7202FEF060065716E /* OptionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FABAD4202FEF060065716E /* OptionDescriptor.swift */; };
 		E4FABAD8202FEF060065716E /* OptionDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FABAD4202FEF060065716E /* OptionDescriptor.swift */; };
-		EBA6E7022C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */; };
-		EBA6E7032C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */; };
-		EBA6E7042C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */; };
-		EBA6E7052C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */; };
-		EBA6E70B2C5B7E8400CBD360 /* BlankLinesAfterGuardStatementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA6E7062C5B7DC400CBD360 /* BlankLinesAfterGuardStatementsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -796,7 +199,6 @@
 		01045A982119979400D2BE3D /* Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		01045A9C2119A21000D2BE3D /* ArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentsTests.swift; sourceTree = "<group>"; };
 		011A53E921FFAA3A00DD9268 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
-		012242D92CD355B000B96EF8 /* EmptyExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyExtensionsTests.swift; sourceTree = "<group>"; };
 		01426E4D23AA29B100E7D871 /* ParsingHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingHelpersTests.swift; sourceTree = "<group>"; };
 		0142C76F23C3FB6D005D5832 /* LintFileCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintFileCommand.swift; sourceTree = "<group>"; };
 		0142F06E1D72FE10007D66CC /* SwiftFormatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftFormatTests.swift; sourceTree = "<group>"; };
@@ -829,242 +231,14 @@
 		01F17E841E258A4900DCD359 /* CommandLineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLineTests.swift; sourceTree = "<group>"; };
 		01F3DF8B1DB9FD3F00454944 /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		01F3DF8F1DBA003E00454944 /* InferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InferenceTests.swift; sourceTree = "<group>"; };
-		082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantEquatable.swift; sourceTree = "<group>"; };
-		082D644F2CA471F00072DA14 /* RedundantEquatableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedundantEquatableTests.swift; sourceTree = "<group>"; };
-		08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestingTestCaseNames.swift; sourceTree = "<group>"; };
-		08CC3AD72D656257005BFABE /* SwiftTestingTestCaseNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestingTestCaseNamesTests.swift; sourceTree = "<group>"; };
 		2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleRegistry.generated.swift; sourceTree = "<group>"; };
-		2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitCoderUnavailable.swift; sourceTree = "<group>"; };
-		2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBreak.swift; sourceTree = "<group>"; };
-		2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterSwitchCase.swift; sourceTree = "<group>"; };
-		2E2BAB942C57F6DD00590239 /* Indent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Indent.swift; sourceTree = "<group>"; };
-		2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineConditionalAssignment.swift; sourceTree = "<group>"; };
-		2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveSpaces.swift; sourceTree = "<group>"; };
-		2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsistentSwitchCaseSpacing.swift; sourceTree = "<group>"; };
-		2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantExtensionACL.swift; sourceTree = "<group>"; };
-		2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalBinding.swift; sourceTree = "<group>"; };
-		2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInternal.swift; sourceTree = "<group>"; };
-		2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilInit.swift; sourceTree = "<group>"; };
-		2E2BAB9C2C57F6DD00590239 /* Todos.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todos.swift; sourceTree = "<group>"; };
-		2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideParens.swift; sourceTree = "<group>"; };
-		2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semicolons.swift; sourceTree = "<group>"; };
-		2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistPatternLet.swift; sourceTree = "<group>"; };
-		2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElseOnSameLine.swift; sourceTree = "<group>"; };
-		2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImports.swift; sourceTree = "<group>"; };
-		2E2BABA22C57F6DD00590239 /* RedundantGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantGet.swift; sourceTree = "<group>"; };
-		2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundOperators.swift; sourceTree = "<group>"; };
-		2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAroundMark.swift; sourceTree = "<group>"; };
-		2E2BABA52C57F6DD00590239 /* SortImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortImports.swift; sourceTree = "<group>"; };
-		2E2BABA62C57F6DD00590239 /* SortedImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedImports.swift; sourceTree = "<group>"; };
-		2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenChainedFunctions.swift; sourceTree = "<group>"; };
-		2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantFileprivate.swift; sourceTree = "<group>"; };
-		2E2BABA92C57F6DD00590239 /* BlockComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockComments.swift; sourceTree = "<group>"; };
-		2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongOutlets.swift; sourceTree = "<group>"; };
-		2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinebreakAtEndOfFile.swift; sourceTree = "<group>"; };
-		2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideGenerics.swift; sourceTree = "<group>"; };
-		2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionFailures.swift; sourceTree = "<group>"; };
-		2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyBraces.swift; sourceTree = "<group>"; };
-		2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundComments.swift; sourceTree = "<group>"; };
-		2E2BABB02C57F6DD00590239 /* RedundantParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantParens.swift; sourceTree = "<group>"; };
-		2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundGenerics.swift; sourceTree = "<group>"; };
-		2E2BABB22C57F6DD00590239 /* Linebreaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linebreaks.swift; sourceTree = "<group>"; };
-		2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeadingDelimiters.swift; sourceTree = "<group>"; };
-		2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideComments.swift; sourceTree = "<group>"; };
-		2E2BABB52C57F6DD00590239 /* RedundantLet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLet.swift; sourceTree = "<group>"; };
-		2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocCommentsBeforeModifiers.swift; sourceTree = "<group>"; };
-		2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveBlankLines.swift; sourceTree = "<group>"; };
-		2E2BABB82C57F6DD00590239 /* RedundantInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInit.swift; sourceTree = "<group>"; };
-		2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExplicitOwnership.swift; sourceTree = "<group>"; };
-		2E2BABBA2C57F6DD00590239 /* Void.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Void.swift; sourceTree = "<group>"; };
-		2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSingleLineComments.swift; sourceTree = "<group>"; };
-		2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLetError.swift; sourceTree = "<group>"; };
-		2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenScopes.swift; sourceTree = "<group>"; };
-		2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantClosure.swift; sourceTree = "<group>"; };
-		2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizeDeclarations.swift; sourceTree = "<group>"; };
-		2E2BABC02C57F6DD00590239 /* FileHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeader.swift; sourceTree = "<group>"; };
-		2E2BABC12C57F6DD00590239 /* TypeSugar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeSugar.swift; sourceTree = "<group>"; };
-		2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBrackets.swift; sourceTree = "<group>"; };
-		2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFileName.swift; sourceTree = "<group>"; };
-		2E2BABC42C57F6DD00590239 /* IsEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsEmpty.swift; sourceTree = "<group>"; };
-		2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBrackets.swift; sourceTree = "<group>"; };
-		2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtEndOfScope.swift; sourceTree = "<group>"; };
-		2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionAccessControl.swift; sourceTree = "<group>"; };
-		2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBraces.swift; sourceTree = "<group>"; };
-		2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantReturn.swift; sourceTree = "<group>"; };
-		2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericExtensions.swift; sourceTree = "<group>"; };
-		2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingSpace.swift; sourceTree = "<group>"; };
-		2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjc.swift; sourceTree = "<group>"; };
-		2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalAssignment.swift; sourceTree = "<group>"; };
-		2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferForLoop.swift; sourceTree = "<group>"; };
-		2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStaticSelf.swift; sourceTree = "<group>"; };
-		2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenImports.swift; sourceTree = "<group>"; };
-		2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineStatementBraces.swift; sourceTree = "<group>"; };
-		2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBraces.swift; sourceTree = "<group>"; };
-		2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantPattern.swift; sourceTree = "<group>"; };
-		2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationMain.swift; sourceTree = "<group>"; };
-		2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantProperty.swift; sourceTree = "<group>"; };
-		2E2BABD62C57F6DD00590239 /* Wrap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrap.swift; sourceTree = "<group>"; };
-		2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterImports.swift; sourceTree = "<group>"; };
-		2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrder.swift; sourceTree = "<group>"; };
-		2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumNamespaces.swift; sourceTree = "<group>"; };
-		2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantSelf.swift; sourceTree = "<group>"; };
-		2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferKeyPath.swift; sourceTree = "<group>"; };
-		2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapEnumCases.swift; sourceTree = "<group>"; };
-		2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapAttributes.swift; sourceTree = "<group>"; };
-		2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapConditionalBodies.swift; sourceTree = "<group>"; };
-		2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSwitchCases.swift; sourceTree = "<group>"; };
-		2E2BABE02C57F6DD00590239 /* Braces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Braces.swift; sourceTree = "<group>"; };
-		2E2BABE12C57F6DD00590239 /* MarkTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkTypes.swift; sourceTree = "<group>"; };
-		2E2BABE22C57F6DD00590239 /* AndOperator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AndOperator.swift; sourceTree = "<group>"; };
-		2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapLoopBodies.swift; sourceTree = "<group>"; };
-		2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnType.swift; sourceTree = "<group>"; };
-		2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantRawValues.swift; sourceTree = "<group>"; };
-		2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommas.swift; sourceTree = "<group>"; };
-		2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongifiedSelf.swift; sourceTree = "<group>"; };
-		2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyObjectProtocol.swift; sourceTree = "<group>"; };
-		2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBackticks.swift; sourceTree = "<group>"; };
-		2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundParens.swift; sourceTree = "<group>"; };
-		2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistAwait.swift; sourceTree = "<group>"; };
-		2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtStartOfScope.swift; sourceTree = "<group>"; };
-		2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpaqueGenericParameters.swift; sourceTree = "<group>"; };
-		2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingClosures.swift; sourceTree = "<group>"; };
-		2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedSwitchCases.swift; sourceTree = "<group>"; };
-		2E2BABF02C57F6DD00590239 /* Acronyms.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Acronyms.swift; sourceTree = "<group>"; };
-		2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortTypealiases.swift; sourceTree = "<group>"; };
-		2E2BABF22C57F6DD00590239 /* DocComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocComments.swift; sourceTree = "<group>"; };
-		2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedPrivateDeclarations.swift; sourceTree = "<group>"; };
-		2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyTypes.swift; sourceTree = "<group>"; };
-		2E2BABF52C57F6DD00590239 /* HoistTry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistTry.swift; sourceTree = "<group>"; };
-		2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormatting.swift; sourceTree = "<group>"; };
-		2E2BABF72C57F6DD00590239 /* WrapArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapArguments.swift; sourceTree = "<group>"; };
-		2E2BABF82C57F6DD00590239 /* Specifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Specifiers.swift; sourceTree = "<group>"; };
-		2E2BABF92C57F6DD00590239 /* YodaConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YodaConditions.swift; sourceTree = "<group>"; };
-		2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantTypedThrows.swift; sourceTree = "<group>"; };
-		2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedArguments.swift; sourceTree = "<group>"; };
-		2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortSwitchCases.swift; sourceTree = "<group>"; };
-		2E2BABFD2C57F6DD00590239 /* RedundantType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantType.swift; sourceTree = "<group>"; };
-		2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDeclarations.swift; sourceTree = "<group>"; };
-		2E723EF22D45592B00D1B389 /* PreferSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferSwiftTestingTests.swift; sourceTree = "<group>"; };
-		2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferSwiftTesting.swift; sourceTree = "<group>"; };
 		2E7D30A32A7940C500C32174 /* Singularize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Singularize.swift; sourceTree = "<group>"; };
-		2E8DE68D2C57FEB30032BF25 /* RedundantClosureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantClosureTests.swift; sourceTree = "<group>"; };
-		2E8DE68E2C57FEB30032BF25 /* BlankLinesBetweenChainedFunctionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenChainedFunctionsTests.swift; sourceTree = "<group>"; };
-		2E8DE68F2C57FEB30032BF25 /* SpaceAroundGenericsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundGenericsTests.swift; sourceTree = "<group>"; };
-		2E8DE6902C57FEB30032BF25 /* BlankLinesAroundMarkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAroundMarkTests.swift; sourceTree = "<group>"; };
-		2E8DE6912C57FEB30032BF25 /* WrapArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapArgumentsTests.swift; sourceTree = "<group>"; };
-		2E8DE6922C57FEB30032BF25 /* RedundantSelfTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantSelfTests.swift; sourceTree = "<group>"; };
-		2E8DE6932C57FEB30032BF25 /* BlankLinesBetweenScopesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenScopesTests.swift; sourceTree = "<group>"; };
-		2E8DE6942C57FEB30032BF25 /* DuplicateImportsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuplicateImportsTests.swift; sourceTree = "<group>"; };
-		2E8DE6952C57FEB30032BF25 /* TodosTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodosTests.swift; sourceTree = "<group>"; };
-		2E8DE6962C57FEB30032BF25 /* FileHeaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileHeaderTests.swift; sourceTree = "<group>"; };
-		2E8DE6972C57FEB30032BF25 /* EnumNamespacesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumNamespacesTests.swift; sourceTree = "<group>"; };
-		2E8DE6982C57FEB30032BF25 /* PreferForLoopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferForLoopTests.swift; sourceTree = "<group>"; };
-		2E8DE6992C57FEB30032BF25 /* ExtensionAccessControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionAccessControlTests.swift; sourceTree = "<group>"; };
-		2E8DE69A2C57FEB30032BF25 /* TrailingCommasTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingCommasTests.swift; sourceTree = "<group>"; };
-		2E8DE69B2C57FEB30032BF25 /* WrapLoopBodiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapLoopBodiesTests.swift; sourceTree = "<group>"; };
-		2E8DE69C2C57FEB30032BF25 /* StrongifiedSelfTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongifiedSelfTests.swift; sourceTree = "<group>"; };
-		2E8DE69D2C57FEB30032BF25 /* RedundantPropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantPropertyTests.swift; sourceTree = "<group>"; };
-		2E8DE69E2C57FEB30032BF25 /* OpaqueGenericParametersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpaqueGenericParametersTests.swift; sourceTree = "<group>"; };
-		2E8DE69F2C57FEB30032BF25 /* SpaceInsideBracesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBracesTests.swift; sourceTree = "<group>"; };
-		2E8DE6A02C57FEB30032BF25 /* ModifierOrderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierOrderTests.swift; sourceTree = "<group>"; };
-		2E8DE6A12C57FEB30032BF25 /* WrapAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapAttributesTests.swift; sourceTree = "<group>"; };
-		2E8DE6A22C57FEB30032BF25 /* RedundantObjcTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantObjcTests.swift; sourceTree = "<group>"; };
-		2E8DE6A32C57FEB30032BF25 /* HoistPatternLetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistPatternLetTests.swift; sourceTree = "<group>"; };
-		2E8DE6A42C57FEB30032BF25 /* WrapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapTests.swift; sourceTree = "<group>"; };
-		2E8DE6A52C57FEB30032BF25 /* SpaceInsideGenericsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideGenericsTests.swift; sourceTree = "<group>"; };
-		2E8DE6A62C57FEB30032BF25 /* RedundantStaticSelfTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantStaticSelfTests.swift; sourceTree = "<group>"; };
-		2E8DE6A72C57FEB30032BF25 /* BlankLinesAtEndOfScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtEndOfScopeTests.swift; sourceTree = "<group>"; };
-		2E8DE6A82C57FEB30032BF25 /* RedundantInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInitTests.swift; sourceTree = "<group>"; };
-		2E8DE6A92C57FEB30032BF25 /* RedundantRawValuesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantRawValuesTests.swift; sourceTree = "<group>"; };
-		2E8DE6AA2C57FEB30032BF25 /* SortImportsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortImportsTests.swift; sourceTree = "<group>"; };
-		2E8DE6AB2C57FEB30032BF25 /* TrailingSpaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingSpaceTests.swift; sourceTree = "<group>"; };
-		2E8DE6AC2C57FEB30032BF25 /* YodaConditionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YodaConditionsTests.swift; sourceTree = "<group>"; };
-		2E8DE6AD2C57FEB30032BF25 /* ConsecutiveBlankLinesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveBlankLinesTests.swift; sourceTree = "<group>"; };
-		2E8DE6AE2C57FEB30032BF25 /* UnusedArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedArgumentsTests.swift; sourceTree = "<group>"; };
-		2E8DE6AF2C57FEB30032BF25 /* GenericExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericExtensionsTests.swift; sourceTree = "<group>"; };
-		2E8DE6B02C57FEB30032BF25 /* NumberFormattingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberFormattingTests.swift; sourceTree = "<group>"; };
-		2E8DE6B12C57FEB30032BF25 /* RedundantTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantTypeTests.swift; sourceTree = "<group>"; };
-		2E8DE6B22C57FEB30032BF25 /* TypeSugarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeSugarTests.swift; sourceTree = "<group>"; };
-		2E8DE6B32C57FEB30032BF25 /* SpaceAroundBracesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBracesTests.swift; sourceTree = "<group>"; };
-		2E8DE6B42C57FEB30032BF25 /* SortTypealiasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortTypealiasesTests.swift; sourceTree = "<group>"; };
-		2E8DE6B52C57FEB30032BF25 /* SortSwitchCasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortSwitchCasesTests.swift; sourceTree = "<group>"; };
-		2E8DE6B62C57FEB30032BF25 /* EmptyBracesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyBracesTests.swift; sourceTree = "<group>"; };
-		2E8DE6B72C57FEB30032BF25 /* SortDeclarationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDeclarationsTests.swift; sourceTree = "<group>"; };
-		2E8DE6B82C57FEB30032BF25 /* BlockCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockCommentsTests.swift; sourceTree = "<group>"; };
-		2E8DE6B92C57FEB30032BF25 /* StrongOutletsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrongOutletsTests.swift; sourceTree = "<group>"; };
-		2E8DE6BA2C57FEB30032BF25 /* BracesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BracesTests.swift; sourceTree = "<group>"; };
-		2E8DE6BB2C57FEB30032BF25 /* AnyObjectProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyObjectProtocolTests.swift; sourceTree = "<group>"; };
-		2E8DE6BC2C57FEB30032BF25 /* RedundantBreakTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBreakTests.swift; sourceTree = "<group>"; };
-		2E8DE6BD2C57FEB30032BF25 /* RedundantNilInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantNilInitTests.swift; sourceTree = "<group>"; };
-		2E8DE6BE2C57FEB30032BF25 /* RedundantParensTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantParensTests.swift; sourceTree = "<group>"; };
-		2E8DE6BF2C57FEB30032BF25 /* PreferKeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferKeyPathTests.swift; sourceTree = "<group>"; };
-		2E8DE6C02C57FEB30032BF25 /* SpaceAroundParensTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundParensTests.swift; sourceTree = "<group>"; };
-		2E8DE6C12C57FEB30032BF25 /* RedundantLetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLetTests.swift; sourceTree = "<group>"; };
-		2E8DE6C22C57FEB30032BF25 /* VoidTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidTests.swift; sourceTree = "<group>"; };
-		2E8DE6C32C57FEB30032BF25 /* IndentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndentTests.swift; sourceTree = "<group>"; };
-		2E8DE6C42C57FEB30032BF25 /* RedundantBackticksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantBackticksTests.swift; sourceTree = "<group>"; };
-		2E8DE6C52C57FEB30032BF25 /* BlankLineAfterSwitchCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterSwitchCaseTests.swift; sourceTree = "<group>"; };
-		2E8DE6C62C57FEB30032BF25 /* HoistAwaitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistAwaitTests.swift; sourceTree = "<group>"; };
-		2E8DE6C72C57FEB30032BF25 /* RedundantLetErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantLetErrorTests.swift; sourceTree = "<group>"; };
-		2E8DE6C82C57FEB30032BF25 /* SpaceAroundCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundCommentsTests.swift; sourceTree = "<group>"; };
-		2E8DE6C92C57FEB30032BF25 /* PropertyTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyTypesTests.swift; sourceTree = "<group>"; };
-		2E8DE6CA2C57FEB30032BF25 /* SpaceAroundOperatorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundOperatorsTests.swift; sourceTree = "<group>"; };
-		2E8DE6CB2C57FEB30032BF25 /* SemicolonsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemicolonsTests.swift; sourceTree = "<group>"; };
-		2E8DE6CC2C57FEB30032BF25 /* RedundantPatternTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantPatternTests.swift; sourceTree = "<group>"; };
-		2E8DE6CD2C57FEB30032BF25 /* WrapMultilineConditionalAssignmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineConditionalAssignmentTests.swift; sourceTree = "<group>"; };
-		2E8DE6CE2C57FEB30032BF25 /* RedundantInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantInternalTests.swift; sourceTree = "<group>"; };
-		2E8DE6CF2C57FEB30032BF25 /* IsEmptyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsEmptyTests.swift; sourceTree = "<group>"; };
-		2E8DE6D02C57FEB30032BF25 /* AcronymsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AcronymsTests.swift; sourceTree = "<group>"; };
-		2E8DE6D12C57FEB30032BF25 /* ConsistentSwitchCaseSpacingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsistentSwitchCaseSpacingTests.swift; sourceTree = "<group>"; };
-		2E8DE6D22C57FEB30032BF25 /* UnusedPrivateDeclarationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedPrivateDeclarationsTests.swift; sourceTree = "<group>"; };
-		2E8DE6D32C57FEB30032BF25 /* WrapEnumCasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapEnumCasesTests.swift; sourceTree = "<group>"; };
-		2E8DE6D42C57FEB30032BF25 /* NoExplicitOwnershipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoExplicitOwnershipTests.swift; sourceTree = "<group>"; };
-		2E8DE6D52C57FEB30032BF25 /* HoistTryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoistTryTests.swift; sourceTree = "<group>"; };
-		2E8DE6D62C57FEB30032BF25 /* RedundantOptionalBindingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantOptionalBindingTests.swift; sourceTree = "<group>"; };
-		2E8DE6D72C57FEB30032BF25 /* ConsecutiveSpacesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsecutiveSpacesTests.swift; sourceTree = "<group>"; };
-		2E8DE6D82C57FEB30032BF25 /* SpaceAroundBracketsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceAroundBracketsTests.swift; sourceTree = "<group>"; };
-		2E8DE6D92C57FEB30032BF25 /* TrailingClosuresTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingClosuresTests.swift; sourceTree = "<group>"; };
-		2E8DE6DA2C57FEB30032BF25 /* WrapMultilineStatementBracesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapMultilineStatementBracesTests.swift; sourceTree = "<group>"; };
-		2E8DE6DB2C57FEB30032BF25 /* LinebreakAtEndOfFileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinebreakAtEndOfFileTests.swift; sourceTree = "<group>"; };
-		2E8DE6DC2C57FEB30032BF25 /* ConditionalAssignmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalAssignmentTests.swift; sourceTree = "<group>"; };
-		2E8DE6DD2C57FEB30032BF25 /* RedundantGetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantGetTests.swift; sourceTree = "<group>"; };
-		2E8DE6DE2C57FEB30032BF25 /* HeaderFileNameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFileNameTests.swift; sourceTree = "<group>"; };
-		2E8DE6DF2C57FEB30032BF25 /* RedundantExtensionACLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantExtensionACLTests.swift; sourceTree = "<group>"; };
-		2E8DE6E02C57FEB30032BF25 /* LeadingDelimitersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeadingDelimitersTests.swift; sourceTree = "<group>"; };
-		2E8DE6E12C57FEB30032BF25 /* WrapConditionalBodiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapConditionalBodiesTests.swift; sourceTree = "<group>"; };
-		2E8DE6E22C57FEB30032BF25 /* OrganizeDeclarationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizeDeclarationsTests.swift; sourceTree = "<group>"; };
-		2E8DE6E42C57FEB30032BF25 /* ElseOnSameLineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElseOnSameLineTests.swift; sourceTree = "<group>"; };
-		2E8DE6E52C57FEB30032BF25 /* RedundantReturnTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantReturnTests.swift; sourceTree = "<group>"; };
-		2E8DE6E62C57FEB30032BF25 /* LinebreaksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinebreaksTests.swift; sourceTree = "<group>"; };
-		2E8DE6E72C57FEB30032BF25 /* MarkTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkTypesTests.swift; sourceTree = "<group>"; };
-		2E8DE6E82C57FEB30032BF25 /* SpaceInsideParensTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideParensTests.swift; sourceTree = "<group>"; };
-		2E8DE6E92C57FEB30032BF25 /* AssertionFailuresTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionFailuresTests.swift; sourceTree = "<group>"; };
-		2E8DE6EA2C57FEB30032BF25 /* RedundantTypedThrowsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantTypedThrowsTests.swift; sourceTree = "<group>"; };
-		2E8DE6EB2C57FEB30032BF25 /* BlankLinesAtStartOfScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesAtStartOfScopeTests.swift; sourceTree = "<group>"; };
-		2E8DE6EC2C57FEB30032BF25 /* ApplicationMainTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationMainTests.swift; sourceTree = "<group>"; };
-		2E8DE6ED2C57FEB30032BF25 /* RedundantVoidReturnTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantVoidReturnTypeTests.swift; sourceTree = "<group>"; };
-		2E8DE6EE2C57FEB30032BF25 /* BlankLinesBetweenImportsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLinesBetweenImportsTests.swift; sourceTree = "<group>"; };
-		2E8DE6EF2C57FEB30032BF25 /* SpaceInsideCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideCommentsTests.swift; sourceTree = "<group>"; };
-		2E8DE6F02C57FEB30032BF25 /* AndOperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AndOperatorTests.swift; sourceTree = "<group>"; };
-		2E8DE6F12C57FEB30032BF25 /* WrapSwitchCasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSwitchCasesTests.swift; sourceTree = "<group>"; };
-		2E8DE6F22C57FEB30032BF25 /* SpaceInsideBracketsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpaceInsideBracketsTests.swift; sourceTree = "<group>"; };
-		2E8DE6F32C57FEB30032BF25 /* DocCommentsBeforeModifiersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocCommentsBeforeModifiersTests.swift; sourceTree = "<group>"; };
-		2E8DE6F42C57FEB30032BF25 /* BlankLineAfterImportsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlankLineAfterImportsTests.swift; sourceTree = "<group>"; };
-		2E8DE6F52C57FEB30032BF25 /* InitCoderUnavailableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitCoderUnavailableTests.swift; sourceTree = "<group>"; };
-		2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedundantFileprivateTests.swift; sourceTree = "<group>"; };
-		2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapSingleLineCommentsTests.swift; sourceTree = "<group>"; };
-		2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMacro.swift; sourceTree = "<group>"; };
-		2E9DE50A2C95FB4F000FEDF8 /* FileMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMacroTests.swift; sourceTree = "<group>"; };
-		2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferCountWhere.swift; sourceTree = "<group>"; };
-		2EA8C3742D05282600843B42 /* PreferCountWhereTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferCountWhereTests.swift; sourceTree = "<group>"; };
 		2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Declaration.swift; sourceTree = "<group>"; };
 		2EDC9DDE2CCE9BC70085DBE2 /* DeclarationV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationV2Tests.swift; sourceTree = "<group>"; };
 		2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeOrganizationTests.swift; sourceTree = "<group>"; };
 		2EF737532C5E897800128F91 /* ProjectFilePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFilePaths.swift; sourceTree = "<group>"; };
-		2EF737552C5ED19600128F91 /* DocCommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocCommentsTests.swift; sourceTree = "<group>"; };
 		2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationType.swift; sourceTree = "<group>"; };
 		37D828AA24BF77DA0012FC0A /* XcodeKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XcodeKit.framework; path = Library/Frameworks/XcodeKit.framework; sourceTree = DEVELOPER_DIR; };
-		580496D42C584E8F004B7DBF /* EmptyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyExtensions.swift; sourceTree = "<group>"; };
 		90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftFormat for Xcode.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		90C4B6D01DA4B04A009EB000 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1079,13 +253,7 @@
 		90CB44D81DA4B56500F86C22 /* SwiftFormatter.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftFormatter.entitlements; sourceTree = "<group>"; };
 		90F16AF71DA5EB4600EB4EA1 /* FormatFileCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatFileCommand.swift; sourceTree = "<group>"; };
 		90F16AFA1DA5ED9A00EB4EA1 /* CommandErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandErrors.swift; sourceTree = "<group>"; };
-		9BDB4F1A2C94760000C93995 /* PrivateStateVariablesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateStateVariablesTests.swift; sourceTree = "<group>"; };
-		9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateStateVariables.swift; sourceTree = "<group>"; };
 		A3DF48242620E03600F45A5F /* JSONReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReporter.swift; sourceTree = "<group>"; };
-		A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapMultilineFunctionChains.swift; sourceTree = "<group>"; };
-		A64BDD1F2D68641B008C9B8A /* WrapMultilineFunctionChainsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapMultilineFunctionChainsTests.swift; sourceTree = "<group>"; };
-		ABC11AF72CC082D300556471 /* EnvironmentEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentEntryTests.swift; sourceTree = "<group>"; };
-		ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentEntry.swift; sourceTree = "<group>"; };
 		B9C4F55B2387FA3E0088DBEE /* SupportedContentUTIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedContentUTIs.swift; sourceTree = "<group>"; };
 		C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReporter.swift; sourceTree = "<group>"; };
 		D52F6A632A82E04600FE1448 /* GitFileInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitFileInfo.swift; sourceTree = "<group>"; };
@@ -1102,9 +270,12 @@
 		E4E4D3C82033F17C000D7CB1 /* EnumAssociable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumAssociable.swift; sourceTree = "<group>"; };
 		E4E4D3CD2033F1EF000D7CB1 /* EnumAssociableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumAssociableTests.swift; sourceTree = "<group>"; };
 		E4FABAD4202FEF060065716E /* OptionDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionDescriptor.swift; sourceTree = "<group>"; };
-		EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankLinesAfterGuardStatements.swift; sourceTree = "<group>"; };
-		EBA6E7062C5B7DC400CBD360 /* BlankLinesAfterGuardStatementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankLinesAfterGuardStatementsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		2E3A24EE2DDD621600407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Rules; sourceTree = "<group>"; };
+		2E3A27442DDD622800407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Rules; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		015AF2BF1DC6A538008F0A8C /* Frameworks */ = {
@@ -1206,7 +377,7 @@
 		01A0EAA61D5DB4CF00A0A8E3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				2E2BAB902C57F6DD00590239 /* Rules */,
+				2E3A24EE2DDD621600407419 /* Rules */,
 				2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */,
 				01F17E811E25870700DCD359 /* CommandLine.swift */,
 				E4E4D3C82033F17C000D7CB1 /* EnumAssociable.swift */,
@@ -1235,7 +406,7 @@
 		01A0EAB21D5DB4D000A0A8E3 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				2E8DE68C2C57FEB30032BF25 /* Rules */,
+				2E3A27442DDD622800407419 /* Rules */,
 				01045A9C2119A21000D2BE3D /* ArgumentsTests.swift */,
 				2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */,
 				01F17E841E258A4900DCD359 /* CommandLineTests.swift */,
@@ -1274,257 +445,6 @@
 				E4962DDF203F3CD500A02013 /* OptionsStore.swift */,
 			);
 			path = Shared;
-			sourceTree = "<group>";
-		};
-		2E2BAB902C57F6DD00590239 /* Rules */ = {
-			isa = PBXGroup;
-			children = (
-				2E2BABF02C57F6DD00590239 /* Acronyms.swift */,
-				2E2BABE22C57F6DD00590239 /* AndOperator.swift */,
-				2E2BABE82C57F6DD00590239 /* AnyObjectProtocol.swift */,
-				2E2BABD42C57F6DD00590239 /* ApplicationMain.swift */,
-				2E2BABAD2C57F6DD00590239 /* AssertionFailures.swift */,
-				2E2BABD72C57F6DD00590239 /* BlankLineAfterImports.swift */,
-				2E2BAB932C57F6DD00590239 /* BlankLineAfterSwitchCase.swift */,
-				EBA6E7012C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift */,
-				2E2BABA42C57F6DD00590239 /* BlankLinesAroundMark.swift */,
-				2E2BABC62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift */,
-				2E2BABEC2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift */,
-				2E2BABA72C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift */,
-				2E2BABD02C57F6DD00590239 /* BlankLinesBetweenImports.swift */,
-				2E2BABBD2C57F6DD00590239 /* BlankLinesBetweenScopes.swift */,
-				2E2BABA92C57F6DD00590239 /* BlockComments.swift */,
-				2E2BABE02C57F6DD00590239 /* Braces.swift */,
-				2E2BABCD2C57F6DD00590239 /* ConditionalAssignment.swift */,
-				2E2BABB72C57F6DD00590239 /* ConsecutiveBlankLines.swift */,
-				2E2BAB962C57F6DD00590239 /* ConsecutiveSpaces.swift */,
-				2E2BAB972C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift */,
-				2E2BABF22C57F6DD00590239 /* DocComments.swift */,
-				2E2BABB62C57F6DD00590239 /* DocCommentsBeforeModifiers.swift */,
-				2E2BABA12C57F6DD00590239 /* DuplicateImports.swift */,
-				2E2BABA02C57F6DD00590239 /* ElseOnSameLine.swift */,
-				2E2BABAE2C57F6DD00590239 /* EmptyBraces.swift */,
-				580496D42C584E8F004B7DBF /* EmptyExtensions.swift */,
-				2E2BABD92C57F6DD00590239 /* EnumNamespaces.swift */,
-				ABC4BA2B2CB9B094002C6874 /* EnvironmentEntry.swift */,
-				2E2BABC72C57F6DD00590239 /* ExtensionAccessControl.swift */,
-				2E2BABC02C57F6DD00590239 /* FileHeader.swift */,
-				2E9DE5052C95F9A1000FEDF8 /* FileMacro.swift */,
-				2E2BABCA2C57F6DD00590239 /* GenericExtensions.swift */,
-				2E2BABC32C57F6DD00590239 /* HeaderFileName.swift */,
-				2E2BABEB2C57F6DD00590239 /* HoistAwait.swift */,
-				2E2BAB9F2C57F6DD00590239 /* HoistPatternLet.swift */,
-				2E2BABF52C57F6DD00590239 /* HoistTry.swift */,
-				2E2BAB942C57F6DD00590239 /* Indent.swift */,
-				2E2BAB912C57F6DD00590239 /* InitCoderUnavailable.swift */,
-				2E2BABC42C57F6DD00590239 /* IsEmpty.swift */,
-				2E2BABB32C57F6DD00590239 /* LeadingDelimiters.swift */,
-				2E2BABAB2C57F6DD00590239 /* LinebreakAtEndOfFile.swift */,
-				2E2BABB22C57F6DD00590239 /* Linebreaks.swift */,
-				2E2BABE12C57F6DD00590239 /* MarkTypes.swift */,
-				2E2BABD82C57F6DD00590239 /* ModifierOrder.swift */,
-				2E2BABB92C57F6DD00590239 /* NoExplicitOwnership.swift */,
-				2E2BABF62C57F6DD00590239 /* NumberFormatting.swift */,
-				2E2BABED2C57F6DD00590239 /* OpaqueGenericParameters.swift */,
-				2E2BABBF2C57F6DD00590239 /* OrganizeDeclarations.swift */,
-				2EA8C36F2D04F51A00843B42 /* PreferCountWhere.swift */,
-				2E2BABCE2C57F6DD00590239 /* PreferForLoop.swift */,
-				2E2BABDB2C57F6DD00590239 /* PreferKeyPath.swift */,
-				2E723EF42D455B2600D1B389 /* PreferSwiftTesting.swift */,
-				9BDB4F1C2C94773600C93995 /* PrivateStateVariables.swift */,
-				2E2BABF42C57F6DD00590239 /* PropertyTypes.swift */,
-				2E2BABE92C57F6DD00590239 /* RedundantBackticks.swift */,
-				2E2BAB922C57F6DD00590239 /* RedundantBreak.swift */,
-				2E2BABBE2C57F6DD00590239 /* RedundantClosure.swift */,
-				082D644A2CA4719B0072DA14 /* RedundantEquatable.swift */,
-				2E2BAB982C57F6DD00590239 /* RedundantExtensionACL.swift */,
-				2E2BABA82C57F6DD00590239 /* RedundantFileprivate.swift */,
-				2E2BABA22C57F6DD00590239 /* RedundantGet.swift */,
-				2E2BABB82C57F6DD00590239 /* RedundantInit.swift */,
-				2E2BAB9A2C57F6DD00590239 /* RedundantInternal.swift */,
-				2E2BABB52C57F6DD00590239 /* RedundantLet.swift */,
-				2E2BABBC2C57F6DD00590239 /* RedundantLetError.swift */,
-				2E2BAB9B2C57F6DD00590239 /* RedundantNilInit.swift */,
-				2E2BABCC2C57F6DD00590239 /* RedundantObjc.swift */,
-				2E2BAB992C57F6DD00590239 /* RedundantOptionalBinding.swift */,
-				2E2BABB02C57F6DD00590239 /* RedundantParens.swift */,
-				2E2BABD32C57F6DD00590239 /* RedundantPattern.swift */,
-				2E2BABD52C57F6DD00590239 /* RedundantProperty.swift */,
-				2E2BABE52C57F6DD00590239 /* RedundantRawValues.swift */,
-				2E2BABC92C57F6DD00590239 /* RedundantReturn.swift */,
-				2E2BABDA2C57F6DD00590239 /* RedundantSelf.swift */,
-				2E2BABCF2C57F6DD00590239 /* RedundantStaticSelf.swift */,
-				2E2BABFD2C57F6DD00590239 /* RedundantType.swift */,
-				2E2BABFA2C57F6DD00590239 /* RedundantTypedThrows.swift */,
-				2E2BABE42C57F6DD00590239 /* RedundantVoidReturnType.swift */,
-				2E2BAB9E2C57F6DD00590239 /* Semicolons.swift */,
-				2E2BABFE2C57F6DD00590239 /* SortDeclarations.swift */,
-				2E2BABA62C57F6DD00590239 /* SortedImports.swift */,
-				2E2BABEF2C57F6DD00590239 /* SortedSwitchCases.swift */,
-				2E2BABA52C57F6DD00590239 /* SortImports.swift */,
-				2E2BABFC2C57F6DD00590239 /* SortSwitchCases.swift */,
-				2E2BABF12C57F6DD00590239 /* SortTypealiases.swift */,
-				2E2BABC82C57F6DD00590239 /* SpaceAroundBraces.swift */,
-				2E2BABC52C57F6DD00590239 /* SpaceAroundBrackets.swift */,
-				2E2BABAF2C57F6DD00590239 /* SpaceAroundComments.swift */,
-				2E2BABB12C57F6DD00590239 /* SpaceAroundGenerics.swift */,
-				2E2BABA32C57F6DD00590239 /* SpaceAroundOperators.swift */,
-				2E2BABEA2C57F6DD00590239 /* SpaceAroundParens.swift */,
-				2E2BABD22C57F6DD00590239 /* SpaceInsideBraces.swift */,
-				2E2BABC22C57F6DD00590239 /* SpaceInsideBrackets.swift */,
-				2E2BABB42C57F6DD00590239 /* SpaceInsideComments.swift */,
-				2E2BABAC2C57F6DD00590239 /* SpaceInsideGenerics.swift */,
-				2E2BAB9D2C57F6DD00590239 /* SpaceInsideParens.swift */,
-				2E2BABF82C57F6DD00590239 /* Specifiers.swift */,
-				2E2BABE72C57F6DD00590239 /* StrongifiedSelf.swift */,
-				2E2BABAA2C57F6DD00590239 /* StrongOutlets.swift */,
-				08CC3AD22D655C48005BFABE /* SwiftTestingTestCaseNames.swift */,
-				2E2BAB9C2C57F6DD00590239 /* Todos.swift */,
-				2E2BABEE2C57F6DD00590239 /* TrailingClosures.swift */,
-				2E2BABE62C57F6DD00590239 /* TrailingCommas.swift */,
-				2E2BABCB2C57F6DD00590239 /* TrailingSpace.swift */,
-				2E2BABC12C57F6DD00590239 /* TypeSugar.swift */,
-				2E2BABFB2C57F6DD00590239 /* UnusedArguments.swift */,
-				2E2BABF32C57F6DD00590239 /* UnusedPrivateDeclarations.swift */,
-				2E2BABBA2C57F6DD00590239 /* Void.swift */,
-				2E2BABD62C57F6DD00590239 /* Wrap.swift */,
-				2E2BABF72C57F6DD00590239 /* WrapArguments.swift */,
-				2E2BABDD2C57F6DD00590239 /* WrapAttributes.swift */,
-				2E2BABDE2C57F6DD00590239 /* WrapConditionalBodies.swift */,
-				2E2BABDC2C57F6DD00590239 /* WrapEnumCases.swift */,
-				2E2BABE32C57F6DD00590239 /* WrapLoopBodies.swift */,
-				2E2BAB952C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift */,
-				A64BDD1A2D68640F008C9B8A /* WrapMultilineFunctionChains.swift */,
-				2E2BABD12C57F6DD00590239 /* WrapMultilineStatementBraces.swift */,
-				2E2BABBB2C57F6DD00590239 /* WrapSingleLineComments.swift */,
-				2E2BABDF2C57F6DD00590239 /* WrapSwitchCases.swift */,
-				2E2BABF92C57F6DD00590239 /* YodaConditions.swift */,
-			);
-			path = Rules;
-			sourceTree = "<group>";
-		};
-		2E8DE68C2C57FEB30032BF25 /* Rules */ = {
-			isa = PBXGroup;
-			children = (
-				2E8DE6D02C57FEB30032BF25 /* AcronymsTests.swift */,
-				2E8DE6F02C57FEB30032BF25 /* AndOperatorTests.swift */,
-				2E8DE6BB2C57FEB30032BF25 /* AnyObjectProtocolTests.swift */,
-				2E8DE6EC2C57FEB30032BF25 /* ApplicationMainTests.swift */,
-				2E8DE6E92C57FEB30032BF25 /* AssertionFailuresTests.swift */,
-				2E8DE6F42C57FEB30032BF25 /* BlankLineAfterImportsTests.swift */,
-				2E8DE6C52C57FEB30032BF25 /* BlankLineAfterSwitchCaseTests.swift */,
-				EBA6E7062C5B7DC400CBD360 /* BlankLinesAfterGuardStatementsTests.swift */,
-				2E8DE6902C57FEB30032BF25 /* BlankLinesAroundMarkTests.swift */,
-				2E8DE6A72C57FEB30032BF25 /* BlankLinesAtEndOfScopeTests.swift */,
-				2E8DE6EB2C57FEB30032BF25 /* BlankLinesAtStartOfScopeTests.swift */,
-				2E8DE68E2C57FEB30032BF25 /* BlankLinesBetweenChainedFunctionsTests.swift */,
-				2E8DE6EE2C57FEB30032BF25 /* BlankLinesBetweenImportsTests.swift */,
-				2E8DE6932C57FEB30032BF25 /* BlankLinesBetweenScopesTests.swift */,
-				2E8DE6B82C57FEB30032BF25 /* BlockCommentsTests.swift */,
-				2E8DE6BA2C57FEB30032BF25 /* BracesTests.swift */,
-				2E8DE6DC2C57FEB30032BF25 /* ConditionalAssignmentTests.swift */,
-				2E8DE6AD2C57FEB30032BF25 /* ConsecutiveBlankLinesTests.swift */,
-				2E8DE6D72C57FEB30032BF25 /* ConsecutiveSpacesTests.swift */,
-				2E8DE6D12C57FEB30032BF25 /* ConsistentSwitchCaseSpacingTests.swift */,
-				2E8DE6F32C57FEB30032BF25 /* DocCommentsBeforeModifiersTests.swift */,
-				2EF737552C5ED19600128F91 /* DocCommentsTests.swift */,
-				2E8DE6942C57FEB30032BF25 /* DuplicateImportsTests.swift */,
-				2E8DE6E42C57FEB30032BF25 /* ElseOnSameLineTests.swift */,
-				2E8DE6B62C57FEB30032BF25 /* EmptyBracesTests.swift */,
-				012242D92CD355B000B96EF8 /* EmptyExtensionsTests.swift */,
-				2E8DE6972C57FEB30032BF25 /* EnumNamespacesTests.swift */,
-				ABC11AF72CC082D300556471 /* EnvironmentEntryTests.swift */,
-				2E8DE6992C57FEB30032BF25 /* ExtensionAccessControlTests.swift */,
-				2E8DE6962C57FEB30032BF25 /* FileHeaderTests.swift */,
-				2E9DE50A2C95FB4F000FEDF8 /* FileMacroTests.swift */,
-				2E8DE6AF2C57FEB30032BF25 /* GenericExtensionsTests.swift */,
-				2E8DE6DE2C57FEB30032BF25 /* HeaderFileNameTests.swift */,
-				2E8DE6C62C57FEB30032BF25 /* HoistAwaitTests.swift */,
-				2E8DE6A32C57FEB30032BF25 /* HoistPatternLetTests.swift */,
-				2E8DE6D52C57FEB30032BF25 /* HoistTryTests.swift */,
-				2E8DE6C32C57FEB30032BF25 /* IndentTests.swift */,
-				2E8DE6F52C57FEB30032BF25 /* InitCoderUnavailableTests.swift */,
-				2E8DE6CF2C57FEB30032BF25 /* IsEmptyTests.swift */,
-				2E8DE6E02C57FEB30032BF25 /* LeadingDelimitersTests.swift */,
-				2E8DE6DB2C57FEB30032BF25 /* LinebreakAtEndOfFileTests.swift */,
-				2E8DE6E62C57FEB30032BF25 /* LinebreaksTests.swift */,
-				2E8DE6E72C57FEB30032BF25 /* MarkTypesTests.swift */,
-				2E8DE6A02C57FEB30032BF25 /* ModifierOrderTests.swift */,
-				2E8DE6D42C57FEB30032BF25 /* NoExplicitOwnershipTests.swift */,
-				2E8DE6B02C57FEB30032BF25 /* NumberFormattingTests.swift */,
-				2E8DE69E2C57FEB30032BF25 /* OpaqueGenericParametersTests.swift */,
-				2E8DE6E22C57FEB30032BF25 /* OrganizeDeclarationsTests.swift */,
-				2EA8C3742D05282600843B42 /* PreferCountWhereTests.swift */,
-				2E8DE6982C57FEB30032BF25 /* PreferForLoopTests.swift */,
-				2E8DE6BF2C57FEB30032BF25 /* PreferKeyPathTests.swift */,
-				2E723EF22D45592B00D1B389 /* PreferSwiftTestingTests.swift */,
-				9BDB4F1A2C94760000C93995 /* PrivateStateVariablesTests.swift */,
-				2E8DE6C92C57FEB30032BF25 /* PropertyTypesTests.swift */,
-				2E8DE6C42C57FEB30032BF25 /* RedundantBackticksTests.swift */,
-				2E8DE6BC2C57FEB30032BF25 /* RedundantBreakTests.swift */,
-				2E8DE68D2C57FEB30032BF25 /* RedundantClosureTests.swift */,
-				082D644F2CA471F00072DA14 /* RedundantEquatableTests.swift */,
-				2E8DE6DF2C57FEB30032BF25 /* RedundantExtensionACLTests.swift */,
-				2E8DE6F62C57FEB30032BF25 /* RedundantFileprivateTests.swift */,
-				2E8DE6DD2C57FEB30032BF25 /* RedundantGetTests.swift */,
-				2E8DE6A82C57FEB30032BF25 /* RedundantInitTests.swift */,
-				2E8DE6CE2C57FEB30032BF25 /* RedundantInternalTests.swift */,
-				2E8DE6C72C57FEB30032BF25 /* RedundantLetErrorTests.swift */,
-				2E8DE6C12C57FEB30032BF25 /* RedundantLetTests.swift */,
-				2E8DE6BD2C57FEB30032BF25 /* RedundantNilInitTests.swift */,
-				2E8DE6A22C57FEB30032BF25 /* RedundantObjcTests.swift */,
-				2E8DE6D62C57FEB30032BF25 /* RedundantOptionalBindingTests.swift */,
-				2E8DE6BE2C57FEB30032BF25 /* RedundantParensTests.swift */,
-				2E8DE6CC2C57FEB30032BF25 /* RedundantPatternTests.swift */,
-				2E8DE69D2C57FEB30032BF25 /* RedundantPropertyTests.swift */,
-				2E8DE6A92C57FEB30032BF25 /* RedundantRawValuesTests.swift */,
-				2E8DE6E52C57FEB30032BF25 /* RedundantReturnTests.swift */,
-				2E8DE6922C57FEB30032BF25 /* RedundantSelfTests.swift */,
-				2E8DE6A62C57FEB30032BF25 /* RedundantStaticSelfTests.swift */,
-				2E8DE6EA2C57FEB30032BF25 /* RedundantTypedThrowsTests.swift */,
-				2E8DE6B12C57FEB30032BF25 /* RedundantTypeTests.swift */,
-				2E8DE6ED2C57FEB30032BF25 /* RedundantVoidReturnTypeTests.swift */,
-				2E8DE6CB2C57FEB30032BF25 /* SemicolonsTests.swift */,
-				2E8DE6B72C57FEB30032BF25 /* SortDeclarationsTests.swift */,
-				2E8DE6AA2C57FEB30032BF25 /* SortImportsTests.swift */,
-				2E8DE6B52C57FEB30032BF25 /* SortSwitchCasesTests.swift */,
-				2E8DE6B42C57FEB30032BF25 /* SortTypealiasesTests.swift */,
-				2E8DE6B32C57FEB30032BF25 /* SpaceAroundBracesTests.swift */,
-				2E8DE6D82C57FEB30032BF25 /* SpaceAroundBracketsTests.swift */,
-				2E8DE6C82C57FEB30032BF25 /* SpaceAroundCommentsTests.swift */,
-				2E8DE68F2C57FEB30032BF25 /* SpaceAroundGenericsTests.swift */,
-				2E8DE6CA2C57FEB30032BF25 /* SpaceAroundOperatorsTests.swift */,
-				2E8DE6C02C57FEB30032BF25 /* SpaceAroundParensTests.swift */,
-				2E8DE69F2C57FEB30032BF25 /* SpaceInsideBracesTests.swift */,
-				2E8DE6F22C57FEB30032BF25 /* SpaceInsideBracketsTests.swift */,
-				2E8DE6EF2C57FEB30032BF25 /* SpaceInsideCommentsTests.swift */,
-				2E8DE6A52C57FEB30032BF25 /* SpaceInsideGenericsTests.swift */,
-				2E8DE6E82C57FEB30032BF25 /* SpaceInsideParensTests.swift */,
-				2E8DE69C2C57FEB30032BF25 /* StrongifiedSelfTests.swift */,
-				2E8DE6B92C57FEB30032BF25 /* StrongOutletsTests.swift */,
-				08CC3AD72D656257005BFABE /* SwiftTestingTestCaseNamesTests.swift */,
-				2E8DE6952C57FEB30032BF25 /* TodosTests.swift */,
-				2E8DE6D92C57FEB30032BF25 /* TrailingClosuresTests.swift */,
-				2E8DE69A2C57FEB30032BF25 /* TrailingCommasTests.swift */,
-				2E8DE6AB2C57FEB30032BF25 /* TrailingSpaceTests.swift */,
-				2E8DE6B22C57FEB30032BF25 /* TypeSugarTests.swift */,
-				2E8DE6AE2C57FEB30032BF25 /* UnusedArgumentsTests.swift */,
-				2E8DE6D22C57FEB30032BF25 /* UnusedPrivateDeclarationsTests.swift */,
-				2E8DE6C22C57FEB30032BF25 /* VoidTests.swift */,
-				2E8DE6912C57FEB30032BF25 /* WrapArgumentsTests.swift */,
-				2E8DE6A12C57FEB30032BF25 /* WrapAttributesTests.swift */,
-				2E8DE6E12C57FEB30032BF25 /* WrapConditionalBodiesTests.swift */,
-				2E8DE6D32C57FEB30032BF25 /* WrapEnumCasesTests.swift */,
-				2E8DE69B2C57FEB30032BF25 /* WrapLoopBodiesTests.swift */,
-				2E8DE6CD2C57FEB30032BF25 /* WrapMultilineConditionalAssignmentTests.swift */,
-				A64BDD1F2D68641B008C9B8A /* WrapMultilineFunctionChainsTests.swift */,
-				2E8DE6DA2C57FEB30032BF25 /* WrapMultilineStatementBracesTests.swift */,
-				2E8DE6F72C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift */,
-				2E8DE6F12C57FEB30032BF25 /* WrapSwitchCasesTests.swift */,
-				2E8DE6A42C57FEB30032BF25 /* WrapTests.swift */,
-				2E8DE6AC2C57FEB30032BF25 /* YodaConditionsTests.swift */,
-			);
-			path = Rules;
 			sourceTree = "<group>";
 		};
 		9016DEFD1DA5042E008A4E36 /* Resources */ = {
@@ -1666,6 +586,9 @@
 			);
 			dependencies = (
 			);
+			fileSystemSynchronizedGroups = (
+				2E3A24EE2DDD621600407419 /* Rules */,
+			);
 			name = SwiftFormat;
 			packageProductDependencies = (
 			);
@@ -1686,6 +609,9 @@
 			dependencies = (
 				01A0EAB11D5DB4D000A0A8E3 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				2E3A27442DDD622800407419 /* Rules */,
+			);
 			name = SwiftFormatTests;
 			productName = SwiftFormatTests;
 			productReference = 01A0EAAE1D5DB4D000A0A8E3 /* SwiftFormatTests.xctest */;
@@ -1701,6 +627,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				2E3A24EE2DDD621600407419 /* Rules */,
 			);
 			name = CommandLineTool;
 			productName = CommandLineTool;
@@ -1721,6 +650,9 @@
 			dependencies = (
 				90C4B6EA1DA4B059009EB000 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				2E3A24EE2DDD621600407419 /* Rules */,
+			);
 			name = "SwiftFormat for Xcode";
 			productName = "SwiftFormat for Xcode";
 			productReference = 90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */;
@@ -1738,6 +670,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				2E3A24EE2DDD621600407419 /* Rules */,
 			);
 			name = "Editor Extension";
 			productName = "Swift Formatter";
@@ -1880,148 +815,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E2BAD9B2C57F6DD00590239 /* Specifiers.swift in Sources */,
 				D52F6A642A82E04600FE1448 /* GitFileInfo.swift in Sources */,
-				2E2BACEB2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
-				2E2BAC572C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2BACAB2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
-				2E2BADA72C57F6DD00590239 /* UnusedArguments.swift in Sources */,
-				08CC3AD32D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */,
-				2E2BACCB2C57F6DD00590239 /* IsEmpty.swift in Sources */,
-				2E2BAD0B2C57F6DD00590239 /* ApplicationMain.swift in Sources */,
-				2E2BAD572C57F6DD00590239 /* StrongifiedSelf.swift in Sources */,
-				2E2BAC032C57F6DD00590239 /* RedundantBreak.swift in Sources */,
-				2E2BAC432C57F6DD00590239 /* RedundantGet.swift in Sources */,
 				01045A992119979400D2BE3D /* Arguments.swift in Sources */,
 				01567D2F225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
-				2E2BACB32C57F6DD00590239 /* RedundantClosure.swift in Sources */,
-				2E2BAD032C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
-				2E2BAC7B2C57F6DD00590239 /* RedundantParens.swift in Sources */,
-				2E2BAC1B2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
 				DD9AD39E2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */,
-				2E2BAC5F2C57F6DD00590239 /* BlockComments.swift in Sources */,
 				01045A91211988F100D2BE3D /* Inference.swift in Sources */,
-				2E2BAC4F2C57F6DD00590239 /* SortImports.swift in Sources */,
-				2E2BAC632C57F6DD00590239 /* StrongOutlets.swift in Sources */,
-				2E2BAC532C57F6DD00590239 /* SortedImports.swift in Sources */,
-				2E2BADAF2C57F6DD00590239 /* RedundantType.swift in Sources */,
-				2E2BAD7B2C57F6DD00590239 /* Acronyms.swift in Sources */,
 				DD9AD3A32999FCC8001C2C0E /* Reporter.swift in Sources */,
-				2E2BAC8F2C57F6DD00590239 /* RedundantLet.swift in Sources */,
 				E4FABAD5202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2BAD8F2C57F6DD00590239 /* HoistTry.swift in Sources */,
-				2E2BAC732C57F6DD00590239 /* EmptyBraces.swift in Sources */,
-				2E2BAD6F2C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */,
-				2E2BACD32C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */,
-				2E2BACF72C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */,
-				2E2BAC4B2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */,
-				2E2BAC372C57F6DD00590239 /* HoistPatternLet.swift in Sources */,
-				2E2BAD672C57F6DD00590239 /* HoistAwait.swift in Sources */,
-				2E2BAD832C57F6DD00590239 /* DocComments.swift in Sources */,
-				082D644E2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */,
-				2E2BAC2B2C57F6DD00590239 /* Todos.swift in Sources */,
-				2E2BAC6F2C57F6DD00590239 /* AssertionFailures.swift in Sources */,
-				2E2BAD5B2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */,
-				580496D52C584E8F004B7DBF /* EmptyExtensions.swift in Sources */,
-				2E2BAC072C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
-				2E2BADA32C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */,
-				2E2BAD4B2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */,
-				2E2BAC332C57F6DD00590239 /* Semicolons.swift in Sources */,
-				2EA8C3702D04F51A00843B42 /* PreferCountWhere.swift in Sources */,
-				2E2BAC0B2C57F6DD00590239 /* Indent.swift in Sources */,
-				2E2BACC32C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */,
 				2EDC9DDA2CCE9A7C0085DBE2 /* Declaration.swift in Sources */,
-				2E2BACF32C57F6DD00590239 /* PreferForLoop.swift in Sources */,
-				2E2BAC172C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
-				2E2BACE32C57F6DD00590239 /* GenericExtensions.swift in Sources */,
 				01BBD85921DAA2A000457380 /* Globs.swift in Sources */,
 				01D3B28624E9C9C700888DE0 /* FormattingHelpers.swift in Sources */,
-				2E2BAD532C57F6DD00590239 /* TrailingCommas.swift in Sources */,
-				2E2BAD5F2C57F6DD00590239 /* RedundantBackticks.swift in Sources */,
-				A64BDD1B2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */,
-				2E2BAC272C57F6DD00590239 /* RedundantNilInit.swift in Sources */,
-				2E2BACDB2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */,
-				2E2BAC772C57F6DD00590239 /* SpaceAroundComments.swift in Sources */,
-				2E2BAD8B2C57F6DD00590239 /* PropertyTypes.swift in Sources */,
-				2E2BAD3F2C57F6DD00590239 /* MarkTypes.swift in Sources */,
-				2E2BAC972C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */,
-				2E2BAC132C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */,
-				2E2BAD0F2C57F6DD00590239 /* RedundantProperty.swift in Sources */,
-				2E2BACFF2C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */,
 				E4E4D3C92033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2BAC472C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */,
-				2E2BAD2F2C57F6DD00590239 /* WrapAttributes.swift in Sources */,
-				2E2BAC932C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */,
 				A3DF48252620E03600F45A5F /* JSONReporter.swift in Sources */,
-				EBA6E7022C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */,
 				01A0EAC11D5DB4F700A0A8E3 /* FormatRule.swift in Sources */,
-				2E2BAC9F2C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */,
-				2E2BACA72C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */,
-				2E2BACC72C57F6DD00590239 /* HeaderFileName.swift in Sources */,
-				2E2BACD72C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */,
-				2E2BAC7F2C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */,
-				2E2BAC5B2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */,
-				2E2BACBB2C57F6DD00590239 /* FileHeader.swift in Sources */,
-				2E2BAD972C57F6DD00590239 /* WrapArguments.swift in Sources */,
-				2E2BAD272C57F6DD00590239 /* PreferKeyPath.swift in Sources */,
-				2E2BAC6B2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */,
-				2E2BACCF2C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
-				2E2BAC9B2C57F6DD00590239 /* RedundantInit.swift in Sources */,
-				2E2BAC3B2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */,
 				01A0EAC51D5DB54A00A0A8E3 /* SwiftFormat.swift in Sources */,
-				2E2BAC232C57F6DD00590239 /* RedundantInternal.swift in Sources */,
-				2E2BAC872C57F6DD00590239 /* LeadingDelimiters.swift in Sources */,
-				2E2BAC8B2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */,
-				2E2BAC672C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
-				2E2BACFB2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */,
-				2E2BAD2B2C57F6DD00590239 /* WrapEnumCases.swift in Sources */,
-				2E2BAD872C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */,
-				2E2BAD1B2C57F6DD00590239 /* ModifierOrder.swift in Sources */,
 				C2FFD1822BD13C9E00774F55 /* XMLReporter.swift in Sources */,
-				2E2BAD632C57F6DD00590239 /* SpaceAroundParens.swift in Sources */,
 				2E7D30A42A7940C500C32174 /* Singularize.swift in Sources */,
-				2E2BADB32C57F6DD00590239 /* SortDeclarations.swift in Sources */,
-				2E2BACAF2C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */,
 				2E2BAB8C2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
 				01B3987D1D763493009ADE61 /* Formatter.swift in Sources */,
-				2E2BAD932C57F6DD00590239 /* NumberFormatting.swift in Sources */,
 				2EF8BF1B2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */,
 				01F17E821E25870700DCD359 /* CommandLine.swift in Sources */,
-				2E2BAD7F2C57F6DD00590239 /* SortTypealiases.swift in Sources */,
-				2E2BAD772C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
-				2E2BACA32C57F6DD00590239 /* Void.swift in Sources */,
-				2E2BAD9F2C57F6DD00590239 /* YodaConditions.swift in Sources */,
-				2E2BAD3B2C57F6DD00590239 /* Braces.swift in Sources */,
-				2E2BABFF2C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */,
-				2E2BACB72C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */,
-				2E723EF62D455B2A00D1B389 /* PreferSwiftTesting.swift in Sources */,
-				2E2BAD132C57F6DD00590239 /* Wrap.swift in Sources */,
-				2E2BACDF2C57F6DD00590239 /* RedundantReturn.swift in Sources */,
-				2E2BAC0F2C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
-				2E2BAD072C57F6DD00590239 /* RedundantPattern.swift in Sources */,
-				2E2BACE72C57F6DD00590239 /* TrailingSpace.swift in Sources */,
-				2E9DE5062C95F9A1000FEDF8 /* FileMacro.swift in Sources */,
-				2E2BACEF2C57F6DD00590239 /* ConditionalAssignment.swift in Sources */,
-				9BDB4F1E2C9477FF00C93995 /* PrivateStateVariables.swift in Sources */,
-				2E2BAD172C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */,
-				2E2BAD332C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */,
-				2E2BAC2F2C57F6DD00590239 /* SpaceInsideParens.swift in Sources */,
-				2E2BADAB2C57F6DD00590239 /* SortSwitchCases.swift in Sources */,
-				2E2BAC832C57F6DD00590239 /* Linebreaks.swift in Sources */,
-				2E2BAC3F2C57F6DD00590239 /* DuplicateImports.swift in Sources */,
-				2E2BAC1F2C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
-				ABC4BA2F2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */,
-				2E2BACBF2C57F6DD00590239 /* TypeSugar.swift in Sources */,
-				2E2BAD372C57F6DD00590239 /* WrapSwitchCases.swift in Sources */,
-				2E2BAD472C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
-				2E2BAD432C57F6DD00590239 /* AndOperator.swift in Sources */,
-				2E2BAD4F2C57F6DD00590239 /* RedundantRawValues.swift in Sources */,
-				2E2BAD1F2C57F6DD00590239 /* EnumNamespaces.swift in Sources */,
-				2E2BAD232C57F6DD00590239 /* RedundantSelf.swift in Sources */,
 				01F3DF8C1DB9FD3F00454944 /* Options.swift in Sources */,
-				2E2BAD6B2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */,
 				01A0EAC21D5DB4F700A0A8E3 /* Tokenizer.swift in Sources */,
-				2E2BAD732C57F6DD00590239 /* TrailingClosures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2029,142 +844,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E9DE50F2C95FBB6000FEDF8 /* FileMacroTests.swift in Sources */,
-				2E8DE74A2C57FEB30032BF25 /* RedundantExtensionACLTests.swift in Sources */,
 				01A0EAB41D5DB4D000A0A8E3 /* XCTestCase+testFormatting.swift in Sources */,
-				2E8DE7602C57FEB30032BF25 /* InitCoderUnavailableTests.swift in Sources */,
-				2E8DE75C2C57FEB30032BF25 /* WrapSwitchCasesTests.swift in Sources */,
-				012242DA2CD355B000B96EF8 /* EmptyExtensionsTests.swift in Sources */,
-				2E8DE71B2C57FEB30032BF25 /* NumberFormattingTests.swift in Sources */,
-				2E8DE74C2C57FEB30032BF25 /* WrapConditionalBodiesTests.swift in Sources */,
-				EBA6E70B2C5B7E8400CBD360 /* BlankLinesAfterGuardStatementsTests.swift in Sources */,
-				2E8DE7332C57FEB30032BF25 /* SpaceAroundCommentsTests.swift in Sources */,
-				2E723EF32D45592B00D1B389 /* PreferSwiftTestingTests.swift in Sources */,
-				2E8DE7342C57FEB30032BF25 /* PropertyTypesTests.swift in Sources */,
-				2E8DE7162C57FEB30032BF25 /* TrailingSpaceTests.swift in Sources */,
-				2E8DE7472C57FEB30032BF25 /* ConditionalAssignmentTests.swift in Sources */,
 				01F17E851E258A4900DCD359 /* CommandLineTests.swift in Sources */,
-				2E8DE7082C57FEB30032BF25 /* RedundantPropertyTests.swift in Sources */,
 				01426E4E23AA29B100E7D871 /* ParsingHelpersTests.swift in Sources */,
-				2E8DE70A2C57FEB30032BF25 /* SpaceInsideBracesTests.swift in Sources */,
-				2E8DE7442C57FEB30032BF25 /* TrailingClosuresTests.swift in Sources */,
-				2E8DE7402C57FEB30032BF25 /* HoistTryTests.swift in Sources */,
-				2E8DE7062C57FEB30032BF25 /* WrapLoopBodiesTests.swift in Sources */,
-				2E8DE6F92C57FEB30032BF25 /* BlankLinesBetweenChainedFunctionsTests.swift in Sources */,
-				2E8DE7382C57FEB30032BF25 /* WrapMultilineConditionalAssignmentTests.swift in Sources */,
-				2E8DE74F2C57FEB30032BF25 /* ElseOnSameLineTests.swift in Sources */,
-				2E8DE6FD2C57FEB30032BF25 /* RedundantSelfTests.swift in Sources */,
 				018E82751D62E730008CA0F8 /* TokenizerTests.swift in Sources */,
-				2E8DE74D2C57FEB30032BF25 /* OrganizeDeclarationsTests.swift in Sources */,
-				2EF737562C5ED19600128F91 /* DocCommentsTests.swift in Sources */,
-				2E8DE71E2C57FEB30032BF25 /* SpaceAroundBracesTests.swift in Sources */,
-				2E8DE73C2C57FEB30032BF25 /* ConsistentSwitchCaseSpacingTests.swift in Sources */,
-				2E8DE75B2C57FEB30032BF25 /* AndOperatorTests.swift in Sources */,
-				2E8DE71C2C57FEB30032BF25 /* RedundantTypeTests.swift in Sources */,
-				2E8DE7492C57FEB30032BF25 /* HeaderFileNameTests.swift in Sources */,
-				2E8DE7172C57FEB30032BF25 /* YodaConditionsTests.swift in Sources */,
-				2E8DE7152C57FEB30032BF25 /* SortImportsTests.swift in Sources */,
-				2E8DE7302C57FEB30032BF25 /* BlankLineAfterSwitchCaseTests.swift in Sources */,
 				011A53EB21FFAA4200DD9268 /* VersionTests.swift in Sources */,
-				2E8DE72E2C57FEB30032BF25 /* IndentTests.swift in Sources */,
-				2E8DE7532C57FEB30032BF25 /* SpaceInsideParensTests.swift in Sources */,
-				2E8DE7462C57FEB30032BF25 /* LinebreakAtEndOfFileTests.swift in Sources */,
 				01BBD85E21DAA30700457380 /* GlobsTests.swift in Sources */,
-				2E8DE7542C57FEB30032BF25 /* AssertionFailuresTests.swift in Sources */,
 				01B3987B1D763424009ADE61 /* FormatterTests.swift in Sources */,
-				2E8DE7502C57FEB30032BF25 /* RedundantReturnTests.swift in Sources */,
-				2E8DE7052C57FEB30032BF25 /* TrailingCommasTests.swift in Sources */,
-				2E8DE7362C57FEB30032BF25 /* SemicolonsTests.swift in Sources */,
-				2E8DE7272C57FEB30032BF25 /* RedundantBreakTests.swift in Sources */,
-				2E8DE7232C57FEB30032BF25 /* BlockCommentsTests.swift in Sources */,
-				2E8DE75A2C57FEB30032BF25 /* SpaceInsideCommentsTests.swift in Sources */,
 				2EF737542C5E897800128F91 /* ProjectFilePaths.swift in Sources */,
-				2E8DE75D2C57FEB30032BF25 /* SpaceInsideBracketsTests.swift in Sources */,
-				2E8DE72D2C57FEB30032BF25 /* VoidTests.swift in Sources */,
-				2E8DE72B2C57FEB30032BF25 /* SpaceAroundParensTests.swift in Sources */,
-				2E8DE73F2C57FEB30032BF25 /* NoExplicitOwnershipTests.swift in Sources */,
 				01C4D3292BB518D400BDF1AF /* ZRegressionTests.swift in Sources */,
-				2E8DE7092C57FEB30032BF25 /* OpaqueGenericParametersTests.swift in Sources */,
 				2EF737522C5E881C00128F91 /* CodeOrganizationTests.swift in Sources */,
-				2E8DE7202C57FEB30032BF25 /* SortSwitchCasesTests.swift in Sources */,
-				2E8DE7452C57FEB30032BF25 /* WrapMultilineStatementBracesTests.swift in Sources */,
-				2E8DE7242C57FEB30032BF25 /* StrongOutletsTests.swift in Sources */,
-				2E8DE7292C57FEB30032BF25 /* RedundantParensTests.swift in Sources */,
 				0142F06F1D72FE10007D66CC /* SwiftFormatTests.swift in Sources */,
-				2E8DE7432C57FEB30032BF25 /* SpaceAroundBracketsTests.swift in Sources */,
-				2E8DE7612C57FEB30032BF25 /* RedundantFileprivateTests.swift in Sources */,
-				ABC11AF82CC082D300556471 /* EnvironmentEntryTests.swift in Sources */,
-				2E8DE6F82C57FEB30032BF25 /* RedundantClosureTests.swift in Sources */,
-				2E8DE7562C57FEB30032BF25 /* BlankLinesAtStartOfScopeTests.swift in Sources */,
-				2E8DE75F2C57FEB30032BF25 /* BlankLineAfterImportsTests.swift in Sources */,
-				2E8DE7182C57FEB30032BF25 /* ConsecutiveBlankLinesTests.swift in Sources */,
-				2E8DE7192C57FEB30032BF25 /* UnusedArgumentsTests.swift in Sources */,
-				2E8DE7022C57FEB30032BF25 /* EnumNamespacesTests.swift in Sources */,
-				2E8DE7572C57FEB30032BF25 /* ApplicationMainTests.swift in Sources */,
-				2E8DE7102C57FEB30032BF25 /* SpaceInsideGenericsTests.swift in Sources */,
-				2E8DE70C2C57FEB30032BF25 /* WrapAttributesTests.swift in Sources */,
-				2E8DE73D2C57FEB30032BF25 /* UnusedPrivateDeclarationsTests.swift in Sources */,
-				2E8DE71D2C57FEB30032BF25 /* TypeSugarTests.swift in Sources */,
-				2E8DE73E2C57FEB30032BF25 /* WrapEnumCasesTests.swift in Sources */,
 				E4E4D3CE2033F1EF000D7CB1 /* EnumAssociableTests.swift in Sources */,
 				2EDC9DDF2CCE9BC70085DBE2 /* DeclarationV2Tests.swift in Sources */,
-				2E8DE73B2C57FEB30032BF25 /* AcronymsTests.swift in Sources */,
 				E43EF47C202FF47C00E523BD /* OptionDescriptorTests.swift in Sources */,
-				2E8DE71F2C57FEB30032BF25 /* SortTypealiasesTests.swift in Sources */,
-				2E8DE7012C57FEB30032BF25 /* FileHeaderTests.swift in Sources */,
-				2E8DE7322C57FEB30032BF25 /* RedundantLetErrorTests.swift in Sources */,
 				01045A9E2119A37F00D2BE3D /* ArgumentsTests.swift in Sources */,
-				2E8DE71A2C57FEB30032BF25 /* GenericExtensionsTests.swift in Sources */,
-				2E8DE7372C57FEB30032BF25 /* RedundantPatternTests.swift in Sources */,
-				2E8DE7622C57FEB30032BF25 /* WrapSingleLineCommentsTests.swift in Sources */,
-				2E8DE72A2C57FEB30032BF25 /* PreferKeyPathTests.swift in Sources */,
-				2E8DE7592C57FEB30032BF25 /* BlankLinesBetweenImportsTests.swift in Sources */,
-				2E8DE7392C57FEB30032BF25 /* RedundantInternalTests.swift in Sources */,
-				2E8DE70B2C57FEB30032BF25 /* ModifierOrderTests.swift in Sources */,
-				2E8DE7422C57FEB30032BF25 /* ConsecutiveSpacesTests.swift in Sources */,
-				2E8DE7312C57FEB30032BF25 /* HoistAwaitTests.swift in Sources */,
-				2E8DE7132C57FEB30032BF25 /* RedundantInitTests.swift in Sources */,
-				082D64502CA471F30072DA14 /* RedundantEquatableTests.swift in Sources */,
-				2E8DE7142C57FEB30032BF25 /* RedundantRawValuesTests.swift in Sources */,
-				2E8DE7262C57FEB30032BF25 /* AnyObjectProtocolTests.swift in Sources */,
-				2E8DE70F2C57FEB30032BF25 /* WrapTests.swift in Sources */,
-				2E8DE7032C57FEB30032BF25 /* PreferForLoopTests.swift in Sources */,
-				2E8DE6FC2C57FEB30032BF25 /* WrapArgumentsTests.swift in Sources */,
-				2E8DE70D2C57FEB30032BF25 /* RedundantObjcTests.swift in Sources */,
-				2E8DE7212C57FEB30032BF25 /* EmptyBracesTests.swift in Sources */,
-				2E8DE7072C57FEB30032BF25 /* StrongifiedSelfTests.swift in Sources */,
-				2E8DE73A2C57FEB30032BF25 /* IsEmptyTests.swift in Sources */,
 				01BEC5772236E1A700D0DD83 /* MetadataTests.swift in Sources */,
-				2E8DE6FB2C57FEB30032BF25 /* BlankLinesAroundMarkTests.swift in Sources */,
-				2E8DE7582C57FEB30032BF25 /* RedundantVoidReturnTypeTests.swift in Sources */,
-				2E8DE7352C57FEB30032BF25 /* SpaceAroundOperatorsTests.swift in Sources */,
-				9BDB4F1B2C94760000C93995 /* PrivateStateVariablesTests.swift in Sources */,
-				2E8DE7412C57FEB30032BF25 /* RedundantOptionalBindingTests.swift in Sources */,
-				2E8DE7512C57FEB30032BF25 /* LinebreaksTests.swift in Sources */,
 				01F3DF901DBA003E00454944 /* InferenceTests.swift in Sources */,
-				2E8DE7482C57FEB30032BF25 /* RedundantGetTests.swift in Sources */,
-				2E8DE72F2C57FEB30032BF25 /* RedundantBackticksTests.swift in Sources */,
-				2E8DE6FE2C57FEB30032BF25 /* BlankLinesBetweenScopesTests.swift in Sources */,
-				2E8DE7002C57FEB30032BF25 /* TodosTests.swift in Sources */,
-				2E8DE7282C57FEB30032BF25 /* RedundantNilInitTests.swift in Sources */,
-				2E8DE6FA2C57FEB30032BF25 /* SpaceAroundGenericsTests.swift in Sources */,
-				2E8DE7222C57FEB30032BF25 /* SortDeclarationsTests.swift in Sources */,
-				2E8DE7122C57FEB30032BF25 /* BlankLinesAtEndOfScopeTests.swift in Sources */,
-				2E8DE7252C57FEB30032BF25 /* BracesTests.swift in Sources */,
-				A64BDD202D68641B008C9B8A /* WrapMultilineFunctionChainsTests.swift in Sources */,
-				08CC3AD82D656259005BFABE /* SwiftTestingTestCaseNamesTests.swift in Sources */,
-				2E8DE74B2C57FEB30032BF25 /* LeadingDelimitersTests.swift in Sources */,
-				2E8DE7552C57FEB30032BF25 /* RedundantTypedThrowsTests.swift in Sources */,
-				2EA8C3752D05282600843B42 /* PreferCountWhereTests.swift in Sources */,
 				015CE8B12B448CCE00924504 /* SingularizeTests.swift in Sources */,
-				2E8DE7042C57FEB30032BF25 /* ExtensionAccessControlTests.swift in Sources */,
 				015F83FB2BF1448D0060A07E /* ReporterTests.swift in Sources */,
-				2E8DE70E2C57FEB30032BF25 /* HoistPatternLetTests.swift in Sources */,
-				2E8DE7522C57FEB30032BF25 /* MarkTypesTests.swift in Sources */,
-				2E8DE75E2C57FEB30032BF25 /* DocCommentsBeforeModifiersTests.swift in Sources */,
-				2E8DE6FF2C57FEB30032BF25 /* DuplicateImportsTests.swift in Sources */,
-				2E8DE7112C57FEB30032BF25 /* RedundantStaticSelfTests.swift in Sources */,
-				2E8DE72C2C57FEB30032BF25 /* RedundantLetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2172,149 +870,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				082D644C2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */,
 				01A0EAD51D5DC08A00A0A8E3 /* FormatRule.swift in Sources */,
-				2E2BAC6C2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */,
-				2E2BAD2C2C57F6DD00590239 /* WrapEnumCases.swift in Sources */,
 				01A0EAD61D5DC08A00A0A8E3 /* Tokenizer.swift in Sources */,
-				2E2BACC82C57F6DD00590239 /* HeaderFileName.swift in Sources */,
-				2E2BACA42C57F6DD00590239 /* Void.swift in Sources */,
-				2E2BACF42C57F6DD00590239 /* PreferForLoop.swift in Sources */,
-				2E2BACE42C57F6DD00590239 /* GenericExtensions.swift in Sources */,
-				2E2BAC942C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */,
 				2EF8BF1C2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */,
-				2E2BACDC2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */,
-				2E2BAD942C57F6DD00590239 /* NumberFormatting.swift in Sources */,
-				2E2BAD442C57F6DD00590239 /* AndOperator.swift in Sources */,
-				2E2BAC502C57F6DD00590239 /* SortImports.swift in Sources */,
-				2E2BAD702C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */,
-				2E2BAC7C2C57F6DD00590239 /* RedundantParens.swift in Sources */,
-				2E2BAC002C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */,
-				2E2BAC242C57F6DD00590239 /* RedundantInternal.swift in Sources */,
-				2E2BAC1C2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
-				2E2BADB42C57F6DD00590239 /* SortDeclarations.swift in Sources */,
-				2E2BAC642C57F6DD00590239 /* StrongOutlets.swift in Sources */,
 				01567D30225B2BFD00B22D41 /* ParsingHelpers.swift in Sources */,
 				01B3987F1D7634A0009ADE61 /* Formatter.swift in Sources */,
-				2E2BAD802C57F6DD00590239 /* SortTypealiases.swift in Sources */,
-				2E2BADA02C57F6DD00590239 /* YodaConditions.swift in Sources */,
-				2E2BACA82C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */,
-				ABC4BA2E2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */,
-				2E2BAC742C57F6DD00590239 /* EmptyBraces.swift in Sources */,
-				2E2BAD242C57F6DD00590239 /* RedundantSelf.swift in Sources */,
-				2E2BAC282C57F6DD00590239 /* RedundantNilInit.swift in Sources */,
 				01A0EAD41D5DC08A00A0A8E3 /* SwiftFormat.swift in Sources */,
-				2E2BADAC2C57F6DD00590239 /* SortSwitchCases.swift in Sources */,
-				2E2BAD882C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */,
-				2E2BAD642C57F6DD00590239 /* SpaceAroundParens.swift in Sources */,
 				DD9AD39F2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */,
-				2E2BAC402C57F6DD00590239 /* DuplicateImports.swift in Sources */,
-				2E2BAD782C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
-				2E2BAD4C2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */,
 				E4E4D3CA2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
 				01BBD85A21DAA2A600457380 /* Globs.swift in Sources */,
-				2E2BACBC2C57F6DD00590239 /* FileHeader.swift in Sources */,
-				2E2BAC582C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
-				2E2BADA42C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */,
-				2E2BAC0C2C57F6DD00590239 /* Indent.swift in Sources */,
-				2E2BAD7C2C57F6DD00590239 /* Acronyms.swift in Sources */,
-				2E2BAD842C57F6DD00590239 /* DocComments.swift in Sources */,
-				2E2BACF02C57F6DD00590239 /* ConditionalAssignment.swift in Sources */,
-				2E2BAC2C2C57F6DD00590239 /* Todos.swift in Sources */,
 				2EDC9DDB2CCE9A7C0085DBE2 /* Declaration.swift in Sources */,
 				01045A92211988F100D2BE3D /* Inference.swift in Sources */,
-				2E2BACB02C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */,
-				2E2BAC902C57F6DD00590239 /* RedundantLet.swift in Sources */,
-				2E2BAC982C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */,
-				2E2BAD602C57F6DD00590239 /* RedundantBackticks.swift in Sources */,
-				2E2BAC482C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */,
-				2E2BACE82C57F6DD00590239 /* TrailingSpace.swift in Sources */,
-				2E2BADA82C57F6DD00590239 /* UnusedArguments.swift in Sources */,
-				2E2BACF82C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */,
-				2E2BAC442C57F6DD00590239 /* RedundantGet.swift in Sources */,
 				01F3DF8D1DB9FD3F00454944 /* Options.swift in Sources */,
-				08CC3AD62D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */,
 				E4FABAD6202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2BACCC2C57F6DD00590239 /* IsEmpty.swift in Sources */,
-				A64BDD1C2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */,
 				D52F6A652A82E04600FE1448 /* GitFileInfo.swift in Sources */,
-				2E2BAD382C57F6DD00590239 /* WrapSwitchCases.swift in Sources */,
-				2E2BAC882C57F6DD00590239 /* LeadingDelimiters.swift in Sources */,
-				2E2BAD142C57F6DD00590239 /* Wrap.swift in Sources */,
-				2E2BAD682C57F6DD00590239 /* HoistAwait.swift in Sources */,
-				2E2BAC842C57F6DD00590239 /* Linebreaks.swift in Sources */,
-				2E2BAD182C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */,
-				2E2BAD402C57F6DD00590239 /* MarkTypes.swift in Sources */,
 				A3DF48262620E03600F45A5F /* JSONReporter.swift in Sources */,
-				2E2BACD02C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
-				2E2BAD582C57F6DD00590239 /* StrongifiedSelf.swift in Sources */,
-				2E2BAD302C57F6DD00590239 /* WrapAttributes.swift in Sources */,
-				2E2BAD902C57F6DD00590239 /* HoistTry.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
-				2E2BACB42C57F6DD00590239 /* RedundantClosure.swift in Sources */,
-				2E2BAD542C57F6DD00590239 /* TrailingCommas.swift in Sources */,
-				2E2BAC042C57F6DD00590239 /* RedundantBreak.swift in Sources */,
-				2E2BAD002C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */,
-				2E2BACB82C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */,
-				2E2BACC42C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */,
-				2E2BAD3C2C57F6DD00590239 /* Braces.swift in Sources */,
 				015243E22B04B0A600F65221 /* Singularize.swift in Sources */,
-				2E2BAC3C2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */,
-				2E2BAD9C2C57F6DD00590239 /* Specifiers.swift in Sources */,
-				2E2BAD742C57F6DD00590239 /* TrailingClosures.swift in Sources */,
-				2E2BAC4C2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */,
-				EBA6E7032C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */,
-				2E2BAC602C57F6DD00590239 /* BlockComments.swift in Sources */,
-				2E2BAD0C2C57F6DD00590239 /* ApplicationMain.swift in Sources */,
-				2E2BAD102C57F6DD00590239 /* RedundantProperty.swift in Sources */,
-				2E2BAC9C2C57F6DD00590239 /* RedundantInit.swift in Sources */,
 				C2FFD1832BD13C9E00774F55 /* XMLReporter.swift in Sources */,
-				2E2BAC5C2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */,
-				2E2BACD82C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */,
-				2E2BAC382C57F6DD00590239 /* HoistPatternLet.swift in Sources */,
-				2E2BAD202C57F6DD00590239 /* EnumNamespaces.swift in Sources */,
-				2E2BAD282C57F6DD00590239 /* PreferKeyPath.swift in Sources */,
-				2E2BAD5C2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */,
-				2E2BAC082C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
-				2E2BAC802C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */,
-				2E2BAC182C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
 				01A0EACD1D5DB5F500A0A8E3 /* main.swift in Sources */,
-				2E2BACA02C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */,
-				2E2BACFC2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */,
 				2E2BAB8D2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
-				2E2BAC782C57F6DD00590239 /* SpaceAroundComments.swift in Sources */,
-				2E2BAC682C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
-				2E2BAC8C2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */,
-				2E2BAC102C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
-				2EA8C3712D04F51A00843B42 /* PreferCountWhere.swift in Sources */,
-				2E2BACC02C57F6DD00590239 /* TypeSugar.swift in Sources */,
-				2E2BACEC2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
-				2E2BACE02C57F6DD00590239 /* RedundantReturn.swift in Sources */,
-				2E2BAC142C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */,
-				2E2BAC702C57F6DD00590239 /* AssertionFailures.swift in Sources */,
-				2E2BAD342C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */,
 				DD9AD3A42999FCC8001C2C0E /* Reporter.swift in Sources */,
-				2E2BAD1C2C57F6DD00590239 /* ModifierOrder.swift in Sources */,
-				2E2BAD982C57F6DD00590239 /* WrapArguments.swift in Sources */,
-				2E2BAC342C57F6DD00590239 /* Semicolons.swift in Sources */,
-				2E2BAD502C57F6DD00590239 /* RedundantRawValues.swift in Sources */,
-				2E2BACAC2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
 				01045A9A2119979400D2BE3D /* Arguments.swift in Sources */,
-				2E723EF72D455B2B00D1B389 /* PreferSwiftTesting.swift in Sources */,
-				580496D62C584E8F004B7DBF /* EmptyExtensions.swift in Sources */,
-				2E9DE5072C95F9A1000FEDF8 /* FileMacro.swift in Sources */,
-				2E2BAD482C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
-				2E2BAD082C57F6DD00590239 /* RedundantPattern.swift in Sources */,
-				2E2BAD042C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
-				2E2BADB02C57F6DD00590239 /* RedundantType.swift in Sources */,
-				2E2BACD42C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */,
-				2E2BAC542C57F6DD00590239 /* SortedImports.swift in Sources */,
-				9BDB4F1F2C94780000C93995 /* PrivateStateVariables.swift in Sources */,
-				2E2BAD8C2C57F6DD00590239 /* PropertyTypes.swift in Sources */,
-				2E2BAC202C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
-				2E2BAD6C2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */,
-				2E2BAC302C57F6DD00590239 /* SpaceInsideParens.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2322,157 +900,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E2BAD6D2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */,
-				2E2BAC252C57F6DD00590239 /* RedundantInternal.swift in Sources */,
-				2E2BADB52C57F6DD00590239 /* SortDeclarations.swift in Sources */,
-				2E2BACB92C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */,
-				2E2BAD7D2C57F6DD00590239 /* Acronyms.swift in Sources */,
-				2E2BAD752C57F6DD00590239 /* TrailingClosures.swift in Sources */,
-				2E2BADAD2C57F6DD00590239 /* SortSwitchCases.swift in Sources */,
 				E4083191202C049200CAF11D /* SwiftFormat.swift in Sources */,
 				E4FABAD7202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2BAD792C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
-				2E2BAD412C57F6DD00590239 /* MarkTypes.swift in Sources */,
-				2E2BAC092C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
 				2E2611C82DD94FE900FFFE09 /* JSONReporter.swift in Sources */,
 				2E2611C92DD94FE900FFFE09 /* XMLReporter.swift in Sources */,
 				2E2611CA2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */,
 				2E2611CB2DD94FE900FFFE09 /* Reporter.swift in Sources */,
 				2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
-				2E2BAC0D2C57F6DD00590239 /* Indent.swift in Sources */,
 				015D3A562995A0340065B2D9 /* AboutViewController.swift in Sources */,
-				2E2BACAD2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
-				2E2BACB12C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */,
-				2E2BAD092C57F6DD00590239 /* RedundantPattern.swift in Sources */,
 				E41CB5C52027700100C1BEDE /* FreeTextTableCellView.swift in Sources */,
-				2E2BAD992C57F6DD00590239 /* WrapArguments.swift in Sources */,
-				2E2BAC852C57F6DD00590239 /* Linebreaks.swift in Sources */,
-				2E2BACE52C57F6DD00590239 /* GenericExtensions.swift in Sources */,
-				2E2BAC652C57F6DD00590239 /* StrongOutlets.swift in Sources */,
 				E4872125201D980D0014845E /* BinarySelectionTableCellView.swift in Sources */,
-				2E2BAD392C57F6DD00590239 /* WrapSwitchCases.swift in Sources */,
-				2E2BAC392C57F6DD00590239 /* HoistPatternLet.swift in Sources */,
-				2E2BADA52C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */,
-				2E2BACC12C57F6DD00590239 /* TypeSugar.swift in Sources */,
-				2E2BACA12C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */,
-				2E2BACD92C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */,
-				2E2BAC792C57F6DD00590239 /* SpaceAroundComments.swift in Sources */,
-				2E2BAC3D2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */,
-				2E2BAC612C57F6DD00590239 /* BlockComments.swift in Sources */,
-				2E2BACC52C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */,
-				2E2BAC8D2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */,
-				2E2BACA92C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */,
-				2E2BAC452C57F6DD00590239 /* RedundantGet.swift in Sources */,
-				2E2BAD212C57F6DD00590239 /* EnumNamespaces.swift in Sources */,
-				2E2BACED2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
-				2E2BAC692C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				E487211D201D885A0014845E /* RulesViewController.swift in Sources */,
-				2E723EF92D455B2C00D1B389 /* PreferSwiftTesting.swift in Sources */,
-				2E9DE5082C95F9A1000FEDF8 /* FileMacro.swift in Sources */,
-				2E2BAC212C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
 				01045A9B2119979400D2BE3D /* Arguments.swift in Sources */,
-				2E2BAC712C57F6DD00590239 /* AssertionFailures.swift in Sources */,
 				E4872114201D3B8C0014845E /* Tokenizer.swift in Sources */,
-				2E2BAD612C57F6DD00590239 /* RedundantBackticks.swift in Sources */,
-				2E2BAC752C57F6DD00590239 /* EmptyBraces.swift in Sources */,
-				ABC4BA2C2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */,
-				2E2BACF92C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */,
-				A64BDD1D2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */,
-				2E2BAC512C57F6DD00590239 /* SortImports.swift in Sources */,
-				2E2BAC112C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				015243E32B04B0A600F65221 /* Singularize.swift in Sources */,
-				2E2BAD552C57F6DD00590239 /* TrailingCommas.swift in Sources */,
-				2E2BAD012C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */,
-				2E2BAD652C57F6DD00590239 /* SpaceAroundParens.swift in Sources */,
-				2E2BAC412C57F6DD00590239 /* DuplicateImports.swift in Sources */,
-				2E2BADA12C57F6DD00590239 /* YodaConditions.swift in Sources */,
-				2E2BAD8D2C57F6DD00590239 /* PropertyTypes.swift in Sources */,
 				E4872112201D3B860014845E /* FormatRule.swift in Sources */,
 				2E2BAB8E2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
-				2E2BAC892C57F6DD00590239 /* LeadingDelimiters.swift in Sources */,
-				2E2BACD52C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */,
-				2E2BACA52C57F6DD00590239 /* Void.swift in Sources */,
-				2E2BAC492C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */,
-				2E2BAC812C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */,
-				2E2BAD052C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
-				2E2BAD892C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */,
 				E4962DE0203F3CD500A02013 /* OptionsStore.swift in Sources */,
-				2E2BAD2D2C57F6DD00590239 /* WrapEnumCases.swift in Sources */,
-				2E2BACDD2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */,
-				2E2BAD692C57F6DD00590239 /* HoistAwait.swift in Sources */,
-				2E2BAD192C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */,
-				2E2BAC052C57F6DD00590239 /* RedundantBreak.swift in Sources */,
-				2E2BAC192C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
-				2E2BAC7D2C57F6DD00590239 /* RedundantParens.swift in Sources */,
-				2E2BAC592C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
 				E4872113201D3B890014845E /* Formatter.swift in Sources */,
 				E4E4D3CB2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2BAC992C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */,
-				2E2BACE92C57F6DD00590239 /* TrailingSpace.swift in Sources */,
-				2E2BAC4D2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */,
-				2E2BAC6D2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */,
-				2E2BAD592C57F6DD00590239 /* StrongifiedSelf.swift in Sources */,
-				2E2BAD912C57F6DD00590239 /* HoistTry.swift in Sources */,
-				2E2BADA92C57F6DD00590239 /* UnusedArguments.swift in Sources */,
-				2E2BAD452C57F6DD00590239 /* AndOperator.swift in Sources */,
-				08CC3AD52D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */,
-				2E2BAC312C57F6DD00590239 /* SpaceInsideParens.swift in Sources */,
 				2EF8BF1D2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */,
-				2E2BAD5D2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */,
-				2E2BAD492C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
-				2E2BACF52C57F6DD00590239 /* PreferForLoop.swift in Sources */,
-				9BDB4F202C94780100C93995 /* PrivateStateVariables.swift in Sources */,
-				2E2BACCD2C57F6DD00590239 /* IsEmpty.swift in Sources */,
-				2E2BAD3D2C57F6DD00590239 /* Braces.swift in Sources */,
-				2E2BAD712C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */,
-				EBA6E7042C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */,
-				2E2BAC9D2C57F6DD00590239 /* RedundantInit.swift in Sources */,
-				2E2BACB52C57F6DD00590239 /* RedundantClosure.swift in Sources */,
 				2EDC9DDC2CCE9A7C0085DBE2 /* Declaration.swift in Sources */,
-				2E2BAD0D2C57F6DD00590239 /* ApplicationMain.swift in Sources */,
-				2E2BAC2D2C57F6DD00590239 /* Todos.swift in Sources */,
-				2E2BAD852C57F6DD00590239 /* DocComments.swift in Sources */,
-				2E2BAC292C57F6DD00590239 /* RedundantNilInit.swift in Sources */,
-				2E2BADB12C57F6DD00590239 /* RedundantType.swift in Sources */,
 				01BBD85B21DAA2A700457380 /* Globs.swift in Sources */,
-				2E2BAD112C57F6DD00590239 /* RedundantProperty.swift in Sources */,
 				01A8320824EC7F7700A9D0EB /* FormattingHelpers.swift in Sources */,
-				2EA8C3722D04F51A00843B42 /* PreferCountWhere.swift in Sources */,
-				082D644B2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */,
-				2E2BACFD2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */,
-				2E2BACF12C57F6DD00590239 /* ConditionalAssignment.swift in Sources */,
-				2E2BAD4D2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */,
 				01045A93211988F100D2BE3D /* Inference.swift in Sources */,
 				E41CB5C32026CACD00C1BEDE /* ListSelectionTableCellView.swift in Sources */,
-				2E2BAC912C57F6DD00590239 /* RedundantLet.swift in Sources */,
-				2E2BAD292C57F6DD00590239 /* PreferKeyPath.swift in Sources */,
 				E4872129201E3DD50014845E /* RulesStore.swift in Sources */,
-				2E2BAC152C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */,
-				2E2BACBD2C57F6DD00590239 /* FileHeader.swift in Sources */,
 				E41CB5BF2025761D00C1BEDE /* UserSelection.swift in Sources */,
-				2E2BAC952C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */,
-				2E2BAC1D2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
-				2E2BACD12C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
-				2E2BAD312C57F6DD00590239 /* WrapAttributes.swift in Sources */,
-				580496D72C584E8F004B7DBF /* EmptyExtensions.swift in Sources */,
-				2E2BAD9D2C57F6DD00590239 /* Specifiers.swift in Sources */,
 				E4872111201D3B830014845E /* Options.swift in Sources */,
-				2E2BACC92C57F6DD00590239 /* HeaderFileName.swift in Sources */,
-				2E2BAD252C57F6DD00590239 /* RedundantSelf.swift in Sources */,
 				01A95BD3225BEDE400744931 /* ParsingHelpers.swift in Sources */,
-				2E2BACE12C57F6DD00590239 /* RedundantReturn.swift in Sources */,
 				D52F6A662A82E04600FE1448 /* GitFileInfo.swift in Sources */,
-				2E2BAD952C57F6DD00590239 /* NumberFormatting.swift in Sources */,
-				2E2BAD812C57F6DD00590239 /* SortTypealiases.swift in Sources */,
 				90C4B6CD1DA4B04A009EB000 /* AppDelegate.swift in Sources */,
-				2E2BAC552C57F6DD00590239 /* SortedImports.swift in Sources */,
-				2E2BAD352C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */,
-				2E2BAC012C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */,
-				2E2BAC352C57F6DD00590239 /* Semicolons.swift in Sources */,
-				2E2BAD512C57F6DD00590239 /* RedundantRawValues.swift in Sources */,
-				2E2BAC5D2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */,
-				2E2BAD152C57F6DD00590239 /* Wrap.swift in Sources */,
-				2E2BAD1D2C57F6DD00590239 /* ModifierOrder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2480,157 +938,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E2BAD6E2C57F6DD00590239 /* BlankLinesAtStartOfScope.swift in Sources */,
-				2E2BAC262C57F6DD00590239 /* RedundantInternal.swift in Sources */,
-				2E2BADB62C57F6DD00590239 /* SortDeclarations.swift in Sources */,
-				2E2BACBA2C57F6DD00590239 /* OrganizeDeclarations.swift in Sources */,
-				2E2BAD7E2C57F6DD00590239 /* Acronyms.swift in Sources */,
-				2E2BAD762C57F6DD00590239 /* TrailingClosures.swift in Sources */,
-				2E2BADAE2C57F6DD00590239 /* SortSwitchCases.swift in Sources */,
 				01045AA0211A1EE300D2BE3D /* Arguments.swift in Sources */,
 				01BBD85C21DAA2A700457380 /* Globs.swift in Sources */,
-				2E2BAD7A2C57F6DD00590239 /* SortedSwitchCases.swift in Sources */,
-				2E2BAD422C57F6DD00590239 /* MarkTypes.swift in Sources */,
-				2E2BAC0A2C57F6DD00590239 /* BlankLineAfterSwitchCase.swift in Sources */,
 				2E26108F2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
-				2E2BAC0E2C57F6DD00590239 /* Indent.swift in Sources */,
 				01045A9F2119D30D00D2BE3D /* Inference.swift in Sources */,
-				2E2BACAE2C57F6DD00590239 /* RedundantLetError.swift in Sources */,
-				2E2BACB22C57F6DD00590239 /* BlankLinesBetweenScopes.swift in Sources */,
-				2E2BAD0A2C57F6DD00590239 /* RedundantPattern.swift in Sources */,
 				01A95BD2225BEDE300744931 /* ParsingHelpers.swift in Sources */,
-				2E2BAD9A2C57F6DD00590239 /* WrapArguments.swift in Sources */,
-				2E2BAC862C57F6DD00590239 /* Linebreaks.swift in Sources */,
-				2E2BACE62C57F6DD00590239 /* GenericExtensions.swift in Sources */,
-				2E2BAC662C57F6DD00590239 /* StrongOutlets.swift in Sources */,
 				90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */,
-				2E2BAD3A2C57F6DD00590239 /* WrapSwitchCases.swift in Sources */,
-				2E2BAC3A2C57F6DD00590239 /* HoistPatternLet.swift in Sources */,
-				2E2BADA62C57F6DD00590239 /* RedundantTypedThrows.swift in Sources */,
-				2E2BACC22C57F6DD00590239 /* TypeSugar.swift in Sources */,
-				2E2BACA22C57F6DD00590239 /* NoExplicitOwnership.swift in Sources */,
-				2E2BACDA2C57F6DD00590239 /* ExtensionAccessControl.swift in Sources */,
-				2E2BAC7A2C57F6DD00590239 /* SpaceAroundComments.swift in Sources */,
-				2E2BAC3E2C57F6DD00590239 /* ElseOnSameLine.swift in Sources */,
-				2E2BAC622C57F6DD00590239 /* BlockComments.swift in Sources */,
-				2E2BACC62C57F6DD00590239 /* SpaceInsideBrackets.swift in Sources */,
-				2E2BAC8E2C57F6DD00590239 /* SpaceInsideComments.swift in Sources */,
-				2E2BACAA2C57F6DD00590239 /* WrapSingleLineComments.swift in Sources */,
-				2E2BAC462C57F6DD00590239 /* RedundantGet.swift in Sources */,
-				2E2BAD222C57F6DD00590239 /* EnumNamespaces.swift in Sources */,
-				2E2BACEE2C57F6DD00590239 /* RedundantObjc.swift in Sources */,
-				2E2BAC6A2C57F6DD00590239 /* LinebreakAtEndOfFile.swift in Sources */,
 				0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */,
-				2E723EFA2D455B2C00D1B389 /* PreferSwiftTesting.swift in Sources */,
-				2E9DE5092C95F9A1000FEDF8 /* FileMacro.swift in Sources */,
-				2E2BAC222C57F6DD00590239 /* RedundantOptionalBinding.swift in Sources */,
 				E4E4D3CC2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
-				2E2BAC722C57F6DD00590239 /* AssertionFailures.swift in Sources */,
 				E4FABAD8202FEF060065716E /* OptionDescriptor.swift in Sources */,
-				2E2BAD622C57F6DD00590239 /* RedundantBackticks.swift in Sources */,
-				2E2BAC762C57F6DD00590239 /* EmptyBraces.swift in Sources */,
-				ABC4BA2D2CB9B094002C6874 /* EnvironmentEntry.swift in Sources */,
-				2E2BACFA2C57F6DD00590239 /* RedundantStaticSelf.swift in Sources */,
-				A64BDD1E2D68640F008C9B8A /* WrapMultilineFunctionChains.swift in Sources */,
-				2E2BAC522C57F6DD00590239 /* SortImports.swift in Sources */,
-				2E2BAC122C57F6DD00590239 /* WrapMultilineConditionalAssignment.swift in Sources */,
 				015243E42B04B0A700F65221 /* Singularize.swift in Sources */,
-				2E2BAD562C57F6DD00590239 /* TrailingCommas.swift in Sources */,
 				2E2611CC2DD94FE900FFFE09 /* Reporter.swift in Sources */,
 				2E2611CD2DD94FE900FFFE09 /* JSONReporter.swift in Sources */,
 				2E2611CE2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */,
 				2E2611CF2DD94FE900FFFE09 /* XMLReporter.swift in Sources */,
-				2E2BAD022C57F6DD00590239 /* WrapMultilineStatementBraces.swift in Sources */,
-				2E2BAD662C57F6DD00590239 /* SpaceAroundParens.swift in Sources */,
-				2E2BAC422C57F6DD00590239 /* DuplicateImports.swift in Sources */,
-				2E2BADA22C57F6DD00590239 /* YodaConditions.swift in Sources */,
-				2E2BAD8E2C57F6DD00590239 /* PropertyTypes.swift in Sources */,
 				9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */,
 				2E2BAB8F2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
-				2E2BAC8A2C57F6DD00590239 /* LeadingDelimiters.swift in Sources */,
-				2E2BACD62C57F6DD00590239 /* BlankLinesAtEndOfScope.swift in Sources */,
-				2E2BACA62C57F6DD00590239 /* Void.swift in Sources */,
-				2E2BAC4A2C57F6DD00590239 /* SpaceAroundOperators.swift in Sources */,
-				2E2BAC822C57F6DD00590239 /* SpaceAroundGenerics.swift in Sources */,
-				2E2BAD062C57F6DD00590239 /* SpaceInsideBraces.swift in Sources */,
-				2E2BAD8A2C57F6DD00590239 /* UnusedPrivateDeclarations.swift in Sources */,
 				90F16AFB1DA5ED9A00EB4EA1 /* CommandErrors.swift in Sources */,
-				2E2BAD2E2C57F6DD00590239 /* WrapEnumCases.swift in Sources */,
-				2E2BACDE2C57F6DD00590239 /* SpaceAroundBraces.swift in Sources */,
 				01A8320924EC7F7800A9D0EB /* FormattingHelpers.swift in Sources */,
-				2E2BAD6A2C57F6DD00590239 /* HoistAwait.swift in Sources */,
-				2E2BAD1A2C57F6DD00590239 /* BlankLineAfterImports.swift in Sources */,
-				2E2BAC062C57F6DD00590239 /* RedundantBreak.swift in Sources */,
-				2E2BAC1A2C57F6DD00590239 /* ConsistentSwitchCaseSpacing.swift in Sources */,
-				2E2BAC7E2C57F6DD00590239 /* RedundantParens.swift in Sources */,
-				2E2BAC5A2C57F6DD00590239 /* BlankLinesBetweenChainedFunctions.swift in Sources */,
 				018541CF1DBA0F17000F82E3 /* XCSourceTextBuffer+SwiftFormat.swift in Sources */,
 				E4962DE1203F3CD500A02013 /* OptionsStore.swift in Sources */,
-				2E2BAC9A2C57F6DD00590239 /* ConsecutiveBlankLines.swift in Sources */,
-				2E2BACEA2C57F6DD00590239 /* TrailingSpace.swift in Sources */,
-				2E2BAC4E2C57F6DD00590239 /* BlankLinesAroundMark.swift in Sources */,
-				2E2BAC6E2C57F6DD00590239 /* SpaceInsideGenerics.swift in Sources */,
-				2E2BAD5A2C57F6DD00590239 /* StrongifiedSelf.swift in Sources */,
-				2E2BAD922C57F6DD00590239 /* HoistTry.swift in Sources */,
-				2E2BADAA2C57F6DD00590239 /* UnusedArguments.swift in Sources */,
-				08CC3AD42D655C56005BFABE /* SwiftTestingTestCaseNames.swift in Sources */,
-				2E2BAD462C57F6DD00590239 /* AndOperator.swift in Sources */,
 				2EF8BF1E2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */,
-				2E2BAC322C57F6DD00590239 /* SpaceInsideParens.swift in Sources */,
-				2E2BAD5E2C57F6DD00590239 /* AnyObjectProtocol.swift in Sources */,
-				2E2BAD4A2C57F6DD00590239 /* WrapLoopBodies.swift in Sources */,
-				9BDB4F212C94780200C93995 /* PrivateStateVariables.swift in Sources */,
-				2E2BACF62C57F6DD00590239 /* PreferForLoop.swift in Sources */,
-				2E2BACCE2C57F6DD00590239 /* IsEmpty.swift in Sources */,
-				2E2BAD3E2C57F6DD00590239 /* Braces.swift in Sources */,
-				2E2BAD722C57F6DD00590239 /* OpaqueGenericParameters.swift in Sources */,
-				EBA6E7052C5B7D4800CBD360 /* BlankLinesAfterGuardStatements.swift in Sources */,
-				2E2BAC9E2C57F6DD00590239 /* RedundantInit.swift in Sources */,
 				2EDC9DDD2CCE9A7C0085DBE2 /* Declaration.swift in Sources */,
-				2E2BACB62C57F6DD00590239 /* RedundantClosure.swift in Sources */,
-				2E2BAD0E2C57F6DD00590239 /* ApplicationMain.swift in Sources */,
-				2E2BAC2E2C57F6DD00590239 /* Todos.swift in Sources */,
-				2E2BAD862C57F6DD00590239 /* DocComments.swift in Sources */,
-				2E2BAC2A2C57F6DD00590239 /* RedundantNilInit.swift in Sources */,
-				2E2BADB22C57F6DD00590239 /* RedundantType.swift in Sources */,
 				9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */,
-				2E2BAD122C57F6DD00590239 /* RedundantProperty.swift in Sources */,
-				2EA8C3732D04F51A00843B42 /* PreferCountWhere.swift in Sources */,
-				082D644D2CA4719E0072DA14 /* RedundantEquatable.swift in Sources */,
 				E487212A201E3DD50014845E /* RulesStore.swift in Sources */,
-				2E2BACFE2C57F6DD00590239 /* BlankLinesBetweenImports.swift in Sources */,
-				2E2BACF22C57F6DD00590239 /* ConditionalAssignment.swift in Sources */,
-				2E2BAD4E2C57F6DD00590239 /* RedundantVoidReturnType.swift in Sources */,
 				01F3DF8E1DB9FD3F00454944 /* Options.swift in Sources */,
 				9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */,
-				2E2BAC922C57F6DD00590239 /* RedundantLet.swift in Sources */,
-				2E2BAD2A2C57F6DD00590239 /* PreferKeyPath.swift in Sources */,
 				B9C4F55C2387FA3E0088DBEE /* SupportedContentUTIs.swift in Sources */,
-				2E2BAC162C57F6DD00590239 /* ConsecutiveSpaces.swift in Sources */,
-				2E2BACBE2C57F6DD00590239 /* FileHeader.swift in Sources */,
 				90C4B6E71DA4B059009EB000 /* FormatSelectionCommand.swift in Sources */,
-				2E2BAC962C57F6DD00590239 /* DocCommentsBeforeModifiers.swift in Sources */,
-				2E2BAC1E2C57F6DD00590239 /* RedundantExtensionACL.swift in Sources */,
-				2E2BACD22C57F6DD00590239 /* SpaceAroundBrackets.swift in Sources */,
-				2E2BAD322C57F6DD00590239 /* WrapAttributes.swift in Sources */,
-				580496D82C584E8F004B7DBF /* EmptyExtensions.swift in Sources */,
-				2E2BAD9E2C57F6DD00590239 /* Specifiers.swift in Sources */,
 				90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */,
-				2E2BACCA2C57F6DD00590239 /* HeaderFileName.swift in Sources */,
-				2E2BAD262C57F6DD00590239 /* RedundantSelf.swift in Sources */,
-				2E2BACE22C57F6DD00590239 /* RedundantReturn.swift in Sources */,
 				D52F6A672A82E04600FE1448 /* GitFileInfo.swift in Sources */,
-				2E2BAD962C57F6DD00590239 /* NumberFormatting.swift in Sources */,
-				2E2BAD822C57F6DD00590239 /* SortTypealiases.swift in Sources */,
 				9028F7861DA4B435009FE5B4 /* FormatRule.swift in Sources */,
-				2E2BAC562C57F6DD00590239 /* SortedImports.swift in Sources */,
-				2E2BAD362C57F6DD00590239 /* WrapConditionalBodies.swift in Sources */,
-				2E2BAC022C57F6DD00590239 /* InitCoderUnavailable.swift in Sources */,
-				2E2BAC362C57F6DD00590239 /* Semicolons.swift in Sources */,
-				2E2BAD522C57F6DD00590239 /* RedundantRawValues.swift in Sources */,
-				2E2BAC5E2C57F6DD00590239 /* RedundantFileprivate.swift in Sources */,
-				2E2BAD162C57F6DD00590239 /* Wrap.swift in Sources */,
-				2E2BAD1E2C57F6DD00590239 /* ModifierOrder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -273,8 +273,8 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2E3A24EE2DDD621600407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Rules; sourceTree = "<group>"; };
-		2E3A27442DDD622800407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Rules; sourceTree = "<group>"; };
+		2E3A24EE2DDD621600407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); name = Rules; path = Sources/Rules; sourceTree = SOURCE_ROOT; };
+		2E3A27442DDD622800407419 /* Rules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); name = Rules; path = Tests/Rules; sourceTree = SOURCE_ROOT; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -718,7 +718,7 @@
 				};
 			};
 			buildConfigurationList = 01A0EA9E1D5DB4CF00A0A8E3 /* Build configuration list for PBXProject "SwiftFormat" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (


### PR DESCRIPTION
This PR updates the project to support adding and testing new rules without using Xcode, by:
 1. Updating the `Rules` folders in the Xcode project from groups to folder references. This make it so you can add new rules just by creating files on disk without having to modify the Xcode project.
 2. Adding a `./Scripts/test_rule.sh` script for running the tests for an individual rule (e.g. `./Scripts/test_rule.sh blankLinesAtStartOfScope`).