### PR TITLE
Add support for formatting code blocks in markdown files

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -455,6 +455,12 @@ func argumentsFor(_ options: Options, excludingDefaults: Bool = false) -> [Strin
             }
             arguments.remove("minversion")
         }
+        do {
+            if !excludingDefaults || fileOptions.markdownFormattingMode != nil {
+                args["markdownfiles"] = fileOptions.markdownFormattingMode?.rawValue ?? "ignore"
+            }
+            arguments.remove("markdownfiles")
+        }
         assert(arguments.isEmpty)
     }
     if let formatOptions = options.formatOptions {
@@ -582,6 +588,24 @@ func fileOptionsFor(_ args: [String: String], in directory: String) throws -> Fi
         }
         options.minVersion = minVersion
     }
+    try processOption("markdownfiles", in: args, from: &arguments) {
+        containsFileOption = true
+        switch $0.lowercased() {
+        case "ignore":
+            break
+        case MarkdownFormattingMode.lenient.rawValue:
+            options.supportedFileExtensions.append("md")
+            options.markdownFormattingMode = .lenient
+        case MarkdownFormattingMode.strict.rawValue:
+            options.supportedFileExtensions.append("md")
+            options.markdownFormattingMode = .strict
+        default:
+            throw FormatError.options("""
+            Valid options for --markdownfiles are 'ignore' (default), \
+            'format-lenient', or 'format-strict'.
+            """)
+        }
+    }
     assert(arguments.isEmpty, "\(arguments.joined(separator: ","))")
     return containsFileOption ? options : nil
 }
@@ -638,6 +662,7 @@ let fileArguments = [
     "exclude",
     "unexclude",
     "minversion",
+    "markdownfiles",
 ]
 
 let rulesArguments = [

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -532,8 +532,8 @@ private func processOption(_ key: String,
 }
 
 /// Parse rule names from arguments
-public func rulesFor(_ args: [String: String], lint: Bool) throws -> Set<String> {
-    var rules = allRules
+public func rulesFor(_ args: [String: String], lint: Bool, initial: Set<String>? = nil) throws -> Set<String> {
+    var rules = initial ?? allRules
     rules = try args["rules"].map {
         try Set(parseRules($0))
     } ?? rules.subtracting(FormatRules.disabledByDefault.map(\.name))
@@ -614,17 +614,32 @@ func fileOptionsFor(_ args: [String: String], in directory: String) throws -> Fi
 /// Returns nil if the arguments dictionary does not contain any formatting arguments
 public func formatOptionsFor(_ args: [String: String]) throws -> FormatOptions? {
     var options = FormatOptions.default
-    var arguments = Set(formattingArguments)
+    let containsFormatOption = try applyFormatOptions(from: args, to: &options)
+    return containsFormatOption ? options : nil
+}
 
+public func applyFormatOptions(from args: [String: String], to formatOptions: inout FormatOptions) throws -> Bool {
+    var arguments = Set(formattingArguments)
     var containsFormatOption = false
     for option in Descriptors.all {
         try processOption(option.argumentName, in: args, from: &arguments) {
             containsFormatOption = true
-            try option.toOptions($0, &options)
+            try option.toOptions($0, &formatOptions)
         }
     }
     assert(arguments.isEmpty, "\(arguments.joined(separator: ","))")
-    return containsFormatOption ? options : nil
+    return containsFormatOption
+}
+
+/// Applies additional arguments to the given `Options` struct
+func applyArguments(_ args: [String: String], lint: Bool, to options: inout Options) throws {
+    options.rules = try rulesFor(args, lint: lint, initial: options.rules)
+
+    var formatOptions = options.formatOptions ?? .default
+    let containsFormatOption = try applyFormatOptions(from: args, to: &formatOptions)
+    if containsFormatOption {
+        options.formatOptions = formatOptions
+    }
 }
 
 /// Get deprecation warnings from a set of arguments

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -802,11 +802,31 @@ extension String {
     }
 }
 
-private extension Collection<Token> where Index == Int {
+extension Collection<Token> {
     /// Ranges of lines within this array of tokens
-    var lineRanges: [ClosedRange<Int>] {
-        var lineRanges: [ClosedRange<Int>] = []
-        var currentLine: ClosedRange<Int>?
+    var lineRanges: [ClosedRange<Index>] {
+        lineRanges(isLinebreak: \.isLinebreak)
+    }
+
+    /// All of the lines within this array of tokens
+    var lines: [SubSequence] {
+        lineRanges.map { lineRange in
+            self[lineRange]
+        }
+    }
+}
+
+extension String {
+    /// Ranges of lines within this string
+    var lineRanges: [ClosedRange<Index>] {
+        lineRanges(isLinebreak: { $0 == "\n" })
+    }
+}
+
+private extension Collection {
+    func lineRanges(isLinebreak: (Element) -> Bool) -> [ClosedRange<Index>] {
+        var lineRanges: [ClosedRange<Index>] = []
+        var currentLine: ClosedRange<Index>?
 
         for (index, token) in zip(indices, self) {
             if currentLine == nil {
@@ -815,7 +835,7 @@ private extension Collection<Token> where Index == Int {
                 currentLine = currentLine!.lowerBound ... index
             }
 
-            if token.isLinebreak {
+            if isLinebreak(token) {
                 lineRanges.append(currentLine!)
                 currentLine = nil
             }
@@ -826,13 +846,6 @@ private extension Collection<Token> where Index == Int {
         }
 
         return lineRanges
-    }
-
-    /// All of the lines within this array of tokens
-    var lines: [SubSequence] {
-        lineRanges.map { lineRange in
-            self[lineRange]
-        }
     }
 }
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -1047,6 +1047,13 @@ public struct FormatOptions: CustomStringConvertible {
     }
 }
 
+public enum MarkdownFormattingMode: String {
+    /// Errors in markdown code blocks are ignored
+    case lenient = "format-lenient"
+    /// Errors in markdown code blocks are emitted
+    case strict = "format-strict"
+}
+
 /// File enumeration options
 public struct FileOptions {
     public var followSymlinks: Bool
@@ -1054,6 +1061,7 @@ public struct FileOptions {
     public var excludedGlobs: [Glob]
     public var unexcludedGlobs: [Glob]
     public var minVersion: Version
+    public var markdownFormattingMode: MarkdownFormattingMode?
 
     public static let `default` = FileOptions()
 
@@ -1061,13 +1069,15 @@ public struct FileOptions {
                 supportedFileExtensions: [String] = ["swift"],
                 excludedGlobs: [Glob] = [],
                 unexcludedGlobs: [Glob] = [],
-                minVersion: Version = .undefined)
+                minVersion: Version = .undefined,
+                markdownFormattingMode: MarkdownFormattingMode? = nil)
     {
         self.followSymlinks = followSymlinks
         self.supportedFileExtensions = supportedFileExtensions
         self.excludedGlobs = excludedGlobs
         self.unexcludedGlobs = unexcludedGlobs
         self.minVersion = minVersion
+        self.markdownFormattingMode = markdownFormattingMode
     }
 
     public func shouldSkipFile(_ inputURL: URL) -> Bool {

--- a/Sources/Rules/ExtensionAccessControl.swift
+++ b/Sources/Rules/ExtensionAccessControl.swift
@@ -13,8 +13,6 @@ public extension FormatRule {
         help: "Configure the placement of an extension's access control keyword.",
         options: ["extensionacl"]
     ) { formatter in
-        guard !formatter.options.fragment else { return }
-
         let declarations = formatter.parseDeclarations()
         declarations.forEachRecursiveDeclaration { declaration in
             guard let extensionDeclaration = declaration.asTypeDeclaration,

--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -663,7 +663,7 @@ public extension FormatRule {
                         ) ?? index
                     }
                     let lastToken = formatter.tokens[lastIndex]
-                    if formatter.options.fragment, lastToken == .delimiter(",") {
+                    if formatter.options.fragment, lastToken == .delimiter(","), formatter.startOfScope(at: i) == nil {
                         break // Can't reliably indent
                     }
                     if lastIndex == formatter.startOfLine(at: lastIndex, excludingIndent: true) {

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -23,8 +23,6 @@ public extension FormatRule {
         ],
         sharedOptions: ["sortedpatterns", "lineaftermarks", "linebreaks"]
     ) { formatter in
-        guard !formatter.options.fragment else { return }
-
         formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
             // Organize the body of type declarations
             guard let typeDeclaration = declaration.asTypeDeclaration else { return }

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -448,9 +448,9 @@ public func newOffset(for offset: SourceOffset, in tokens: [Token], tabWidth: In
 }
 
 /// Process parsing errors
-public func parsingError(for tokens: [Token], options: FormatOptions) -> FormatError? {
+public func parsingError(for tokens: [Token], options: FormatOptions, allowErrorsInFragments: Bool = true) -> FormatError? {
     guard let index = tokens.firstIndex(where: {
-        guard options.fragment || !$0.isError else { return true }
+        guard (options.fragment && allowErrorsInFragments) || !$0.isError else { return true }
         guard !options.ignoreConflictMarkers, case let .operator(string, _) = $0 else { return false }
         return string.hasPrefix("<<<<<") || string.hasPrefix("=====") || string.hasPrefix(">>>>>")
     }) else {

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -755,12 +755,12 @@ class CommandLineTests: XCTestCase {
             ) -> Foo { ... }
             ```
 
-            ```swift --indent 2
-            func foo(
-            bar: Bar,
-            baaz: Baaz
-            ) -> Foo { ... }
-            ```
+              ```swift --indent 2
+              func foo(
+              bar: Bar,
+              baaz: Baaz
+              ) -> Foo { ... }
+              ```
 
             ```swift --disable indent
             print( "foo" )
@@ -814,12 +814,12 @@ class CommandLineTests: XCTestCase {
             ) -> Foo { ... }
             ```
 
-            ```swift --indent 2
-            func foo(
-              bar: Bar,
-              baaz: Baaz
-            ) -> Foo { ... }
-            ```
+              ```swift --indent 2
+              func foo(
+                bar: Bar,
+                baaz: Baaz
+              ) -> Foo { ... }
+              ```
 
             ```swift --disable indent
             print("foo")
@@ -845,6 +845,13 @@ class CommandLineTests: XCTestCase {
                 func bar() {}
             }
             ```
+
+            ```swift
+            --markdownfiles format-lenient ignores blocks that can't be parsed:
+            print("Foo
+            ```
+
+            Thanks for reading!
             """)
         }
     }

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -755,10 +755,30 @@ class CommandLineTests: XCTestCase {
             ) -> Foo { ... }
             ```
 
-            ```swift
-            print("foo")
-              print("bar")
-                print("baaz")
+            ```swift --indent 2
+            func foo(
+            bar: Bar,
+            baaz: Baaz
+            ) -> Foo { ... }
+            ```
+
+            ```swift --disable indent
+            print( "foo" )
+              print( "bar" )
+                print( "baaz" )
+            ```
+
+            ```swift --disable spaceInsideParens
+            print( "foo" )
+              print( "bar" )
+                print( "baaz" )
+            ```
+
+            ```swift --enable organizeDeclarations
+            class Foo {
+                init() {}
+                func bar() {}
+            }
             ```
 
             ```swift
@@ -774,6 +794,9 @@ class CommandLineTests: XCTestCase {
                 url.path,
                 "--markdownfiles", "format-lenient",
                 "--rules", "indent",
+                "--rules", "braces",
+                "--rules", "spaceInsideParens",
+                "--rules", "linebreakAtEndOfFile",
             ], in: "")
 
             let updatedReadme = try String(contentsOf: url, encoding: .utf8)
@@ -791,18 +814,37 @@ class CommandLineTests: XCTestCase {
             ) -> Foo { ... }
             ```
 
-            ```swift
+            ```swift --indent 2
+            func foo(
+              bar: Bar,
+              baaz: Baaz
+            ) -> Foo { ... }
+            ```
+
+            ```swift --disable indent
             print("foo")
-            print("bar")
-            print("baaz")
+              print("bar")
+                print("baaz")
             ```
 
-            ```swift
-            --markdownfiles format-lenient ignores blocks that can't be parsed:
-            print("Foo
+            ```swift --disable spaceInsideParens
+            print( "foo" )
+            print( "bar" )
+            print( "baaz" )
             ```
 
-            Thanks for reading!
+            ```swift --enable organizeDeclarations
+            class Foo {
+
+                // MARK: Lifecycle
+
+                init() {}
+
+                // MARK: Internal
+
+                func bar() {}
+            }
+            ```
             """)
         }
     }
@@ -824,6 +866,11 @@ class CommandLineTests: XCTestCase {
 
             ```swift
             --markdownfiles format-strict fails if there are parsing errors:
+            print("Foo
+            ```
+
+            ```swift no-format
+            This block is ignored
             print("Foo
             ```
 

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2820,12 +2820,12 @@ class ParsingHelpersTests: XCTestCase {
 
         and:
 
-        ```swift no-format
-        class Foo {
-            public init() {}
-            public func bar() {}
-        }
-        ```
+          ```swift no-format
+          class Foo {
+              public init() {}
+              public func bar() {}
+          }
+          ```
 
         This sample code even has a multi-line string in it:
 
@@ -2833,6 +2833,11 @@ class ParsingHelpersTests: XCTestCase {
         let codeBlock = """
           ```swift
           print("foo")
+          ```
+
+          ```diff
+          - print("foo")
+          + print("bar")
           ```
           """
         ```
@@ -2855,10 +2860,10 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(
             codeBlocks[1].text,
             #"""
-            class Foo {
-                public init() {}
-                public func bar() {}
-            }
+              class Foo {
+                  public init() {}
+                  public func bar() {}
+              }
             """#
         )
 
@@ -2870,6 +2875,11 @@ class ParsingHelpersTests: XCTestCase {
             let codeBlock = """
               ```swift
               print("foo")
+              ```
+
+              ```diff
+              - print("foo")
+              + print("bar")
               ```
               """
             """#

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2820,7 +2820,7 @@ class ParsingHelpersTests: XCTestCase {
 
         and:
 
-        ```swift
+        ```swift no-format
         class Foo {
             public init() {}
             public func bar() {}
@@ -2829,7 +2829,7 @@ class ParsingHelpersTests: XCTestCase {
 
         This sample code even has a multi-line string in it:
 
-        ```swift
+        ```swift --indentstrings true
         let codeBlock = """
           ```swift
           print("foo")
@@ -2862,6 +2862,8 @@ class ParsingHelpersTests: XCTestCase {
             """#
         )
 
+        XCTAssertEqual(codeBlocks[1].options, "no-format")
+
         XCTAssertEqual(
             codeBlocks[2].text,
             #"""
@@ -2872,5 +2874,7 @@ class ParsingHelpersTests: XCTestCase {
               """
             """#
         )
+
+        XCTAssertEqual(codeBlocks[2].options, "--indentstrings true")
     }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2804,4 +2804,73 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(secondInit.whereClauseRange, nil)
         XCTAssertEqual(formatter.tokens[secondInit.bodyRange!].string, "{ return nil }")
     }
+
+    func testParseMarkdownFile() {
+        let input = #"""
+        # Sample README
+
+        This is a nice project with lots of cool APIs to know about, including:
+
+        ```swift
+        func foo(
+            bar: Bar
+            baaz: Baaz
+        ) -> Foo {}
+        ```
+
+        and:
+
+        ```swift
+        class Foo {
+            public init() {}
+            public func bar() {}
+        }
+        ```
+
+        This sample code even has a multi-line string in it:
+
+        ```swift
+        let codeBlock = """
+          ```swift
+          print("foo")
+          ```
+          """
+        ```
+
+        Try it out!
+        """#
+
+        let codeBlocks = parseSwiftCodeBlocks(fromMarkdown: input)
+
+        XCTAssertEqual(
+            codeBlocks[0].text,
+            #"""
+            func foo(
+                bar: Bar
+                baaz: Baaz
+            ) -> Foo {}
+            """#
+        )
+
+        XCTAssertEqual(
+            codeBlocks[1].text,
+            #"""
+            class Foo {
+                public init() {}
+                public func bar() {}
+            }
+            """#
+        )
+
+        XCTAssertEqual(
+            codeBlocks[2].text,
+            #"""
+            let codeBlock = """
+              ```swift
+              print("foo")
+              ```
+              """
+            """#
+        )
+    }
 }


### PR DESCRIPTION
This PR adds support for formatting code blocks in markdown files. You can pass in either:
 - `--markdownfiles format-strict`, to require that all markdown code blocks parse and format successfully
 - `--markdownfiles format-lenient`, to only format code blocks that parse and format without encountering errors

It also supports providing additional SwiftFormat options in the code block header, including `no-format` to have the block not be formatted or parsed at all.

For example, this markdown input:

> ### Sample README
> 
> This is a nice project with lots of cool APIs to know about, including:
> 
> ```swift
> func foo(
> bar: Bar,
> baaz: Baaz
> ) -> Foo { ... }
> ```
> 
>   Uses `--indent 2`:
>   ```swift --indent 2
>   func foo(
>   bar: Bar,
>   baaz: Baaz
>   ) -> Foo { ... }
>   ```
> 
>   Uses `--disable indent`:
> ```swift --disable indent
> print( "foo" )
>   print( "bar" )
>     print( "baaz" )
> ```
> 
> Uses `--disable spaceInsideParence`:
> ```swift --disable spaceInsideParens
> print( "foo" )
>   print( "bar" )
>     print( "baaz" )
> ```
> 
> Uses `--enable organizeDeclarations`:
> ```swift --enable organizeDeclarations
> class Foo {
>     init() {}
>     func bar() {}
> }
> ```
> 
> ```swift
> --markdownfiles format-lenient ignores blocks that can't be parsed:
> print("Foo
> ```
> 
> Thanks for reading!

is reformatted to:

> ### Sample README
> 
> This is a nice project with lots of cool APIs to know about, including:
> 
> ```swift
> func foo(
>     bar: Bar,
>     baaz: Baaz
> ) -> Foo { ... }
> ```
> 
>   Uses `--indent 2`:
>   ```swift --indent 2
>   func foo(
>     bar: Bar,
>     baaz: Baaz
>   ) -> Foo { ... }
>   ```
>
>   Uses `--disable indent`: 
> ```swift --disable indent
> print("foo")
>   print("bar")
>     print("baaz")
> ```
> 
> Uses `--disable spaceInsideParence`:
> ```swift --disable spaceInsideParens
> print( "foo" )
> print( "bar" )
> print( "baaz" )
> ```
> 
> Uses `--enable organizeDeclarations`:
> ```swift --enable organizeDeclarations
> class Foo {
> 
>     // MARK: Lifecycle
> 
>     init() {}
> 
>     // MARK: Internal
> 
>     func bar() {}
> }
> ```
> 
> ```swift
> --markdownfiles format-lenient ignores blocks that can't be parsed:
> print("Foo
> ```
> 
> Thanks for reading!