### PR TITLE
Add job to validate that PR base branch is `develop`

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,0 +1,16 @@
+name: "validate"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-base:
+    name: "Pull request base is 'develop'"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR base is not 'develop'
+        if: github.event.pull_request.base.ref != 'develop'
+        run: |
+          echo "❌ Pull request must target the 'develop' branch. Current base: '${{ github.event.pull_request.base.ref }}'"
+          exit 1


### PR DESCRIPTION
This PR adds a GitHub actions job to validate that a PR's base branch is `develop`.

For example, on a PR targeting `main`:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/b5b721a3-17a4-4bae-b0c0-d270950a5fff" />

and a PR targeting `develop`:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/ae1f50f8-4da3-49ec-9d45-a3024d037de1" />
