### PR TITLE
Fix Swift 6.1 trailing comma support for closure / tuple typealiases

### DIFF
--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -61,9 +61,17 @@ public extension FormatRule {
                    let startOfScope = formatter.startOfScope(at: i),
                    let tokenBeforeStartOfScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: startOfScope)
                 {
-                    // `= (...)`, `{ (...) }`, `return (...)` etc are always tuple values
-                    let tokensPreceedingValuesNotTypes: Set<Token> = [.operator("=", .infix), .startOfScope("{"), .keyword("return"), .keyword("throw"), .keyword("switch"), .endOfScope("case")]
+                    // `{ (...) }`, `return (...)` etc are always tuple values
+                    // (except in the case of a typealias, where the rhs is a type)
+                    let tokensPreceedingValuesNotTypes: Set<Token> = [.startOfScope("{"), .keyword("return"), .keyword("throw"), .keyword("switch"), .endOfScope("case")]
                     if tokensPreceedingValuesNotTypes.contains(formatter.tokens[tokenBeforeStartOfScope]) {
+                        trailingCommaSupported = true
+                    }
+
+                    // `= (...)` is a tuple value, unless this is a typealias.
+                    if formatter.tokens[tokenBeforeStartOfScope] == .operator("=", .infix),
+                       formatter.lastSignificantKeyword(at: tokenBeforeStartOfScope) != "typealias"
+                    {
                         trailingCommaSupported = true
                     }
 

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -447,15 +447,25 @@ class TrailingCommasTests: XCTestCase {
 
     func testTrailingCommasAddedToTuple() {
         let input = """
-        let foo = (
+        var foo = (
             bar: 0,
             baz: 1
         )
+
+        foo = (
+            bar: 1,
+            baz: 2
+        )
         """
         let output = """
-        let foo = (
+        var foo = (
             bar: 0,
             baz: 1,
+        )
+
+        foo = (
+            bar: 1,
+            baz: 2,
         )
         """
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
@@ -693,6 +703,34 @@ class TrailingCommasTests: XCTestCase {
                 _ error: LocationServiceError?
             ) -> Void
         )?) {}
+        """
+
+        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasPreservedInClosureTupleTypealiasesInSwift6_1() {
+        let input = """
+        public typealias StringToInt = (
+            String
+        ) -> Int
+
+        enum Toster {
+            public typealias StringToInt = ((
+                String
+            ) -> Int)?
+        }
+
+        public typealias Tuple = (
+            foo: String,
+            bar: Int
+        )
+
+        public typealias OptionalTuple = (
+            foo: String,
+            bar: Int,
+            baaz: Bool
+        )?
         """
 
         let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")


### PR DESCRIPTION
This PR fixes Swift 6.1 trailing support for closure / tuple typealiases. We were mistaking these types for expressions (where trailing commas are allowed in 6.1) since they were on the RHS of an `=` assignment.

Fixes #2071.