### PR TITLE
Add new rule to keep declaration modifiers on same line

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -34,6 +34,7 @@
 * [linebreakAtEndOfFile](#linebreakAtEndOfFile)
 * [linebreaks](#linebreaks)
 * [modifierOrder](#modifierOrder)
+* [modifiersOnSameLine](#modifiersOnSameLine)
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferCountWhere](#preferCountWhere)
@@ -1499,6 +1500,33 @@ Option | Description
 
 **NOTE:** If the `--modifierorder` option isn't set, the default order will be:
 `override`, `private`, `fileprivate`, `internal`, `package`, `public`, `open`, `private(set)`, `fileprivate(set)`, `internal(set)`, `package(set)`, `public(set)`, `open(set)`, `final`, `dynamic`, `optional`, `required`, `convenience`, `indirect`, `isolated`, `nonisolated`, `nonisolated(unsafe)`, `lazy`, `weak`, `unowned`, `static`, `class`, `borrowing`, `consuming`, `mutating`, `nonmutating`, `prefix`, `infix`, `postfix`
+
+</details>
+<br/>
+
+## modifiersOnSameLine
+
+Ensure that all modifiers are on the same line as the declaration keyword.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- @MainActor
+- public
+- private(set)
+- var foo: Foo
+
++ @MainActor
++ public private(set) var foo: Foo
+```
+
+```diff
+- nonisolated
+- func bar() {}
+
++ nonisolated func bar() {}
+```
 
 </details>
 <br/>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -53,6 +53,7 @@ let ruleRegistry: [String: FormatRule] = [
     "linebreaks": .linebreaks,
     "markTypes": .markTypes,
     "modifierOrder": .modifierOrder,
+    "modifiersOnSameLine": .modifiersOnSameLine,
     "noExplicitOwnership": .noExplicitOwnership,
     "numberFormatting": .numberFormatting,
     "opaqueGenericParameters": .opaqueGenericParameters,

--- a/Sources/Rules/ModifiersOnSameLine.swift
+++ b/Sources/Rules/ModifiersOnSameLine.swift
@@ -1,0 +1,80 @@
+//
+//  ModifiersOnSameLine.swift
+//  SwiftFormat
+//
+//  Created by cal_stephens on 5/29/25.
+//  Copyright © 2025 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Ensure all modifiers are on the same line as the declaration keyword
+    static let modifiersOnSameLine = FormatRule(
+        help: "Ensure that all modifiers are on the same line as the declaration keyword."
+    ) { formatter in
+        formatter.forEachToken { i, token in
+            // Check if this is a declaration keyword
+            guard token.isDeclarationTypeKeyword else { return }
+
+            // Find the start of modifiers (excluding attributes)
+            let modifierStart = formatter.startOfModifiers(at: i, includingAttributes: false)
+
+            // If there are no modifiers before the declaration, nothing to do
+            guard modifierStart < i else { return }
+
+            // Check if modifiers and declaration are already on the same line
+            if formatter.onSameLine(modifierStart, i) {
+                return
+            }
+
+            // Check if there are any comments between modifiers and declaration
+            // If there are, we should preserve the existing formatting
+            var hasComment = false
+            for index in modifierStart ..< i {
+                if formatter.tokens[index].isComment {
+                    hasComment = true
+                    break
+                }
+            }
+
+            if hasComment {
+                return
+            }
+
+            // Unwrap all lines between modifiers and the declaration
+            var currentIndex = i
+            while currentIndex > modifierStart {
+                guard let prevIndex = formatter.index(of: .nonSpaceOrLinebreak, before: currentIndex) else {
+                    break
+                }
+
+                // If there's a linebreak between previous and current token, unwrap it
+                if formatter.tokens[prevIndex + 1 ..< currentIndex].contains(where: \.isLinebreak) {
+                    _ = formatter.unwrapLine(before: currentIndex, preservingComments: true)
+                }
+
+                currentIndex = prevIndex
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - @MainActor
+        - public
+        - private(set)
+        - var foo: Foo
+
+        + @MainActor
+        + public private(set) var foo: Foo
+        ```
+
+        ```diff
+        - nonisolated
+        - func bar() {}
+
+        + nonisolated func bar() {}
+        ```
+        """
+    }
+}

--- a/Tests/Rules/DocCommentsBeforeModifiersTests.swift
+++ b/Tests/Rules/DocCommentsBeforeModifiersTests.swift
@@ -95,7 +95,7 @@ class DocCommentsBeforeModifiersTests: XCTestCase {
         func bar() {}
         """
 
-        testFormatting(for: input, output, rule: .docCommentsBeforeModifiers)
+        testFormatting(for: input, output, rule: .docCommentsBeforeModifiers, exclude: [.modifiersOnSameLine])
     }
 
     func testUpdatesCommentsAfterMark() {

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -190,7 +190,7 @@ class IndentTests: XCTestCase {
 
     func testNoIndentWrappedModifiersForProtocol() {
         let input = "@objc\nprivate\nprotocol Foo {}"
-        testFormatting(for: input, rule: .indent)
+        testFormatting(for: input, rule: .indent, exclude: [.modifiersOnSameLine])
     }
 
     // indent braces

--- a/Tests/Rules/ModifiersOnSameLineTests.swift
+++ b/Tests/Rules/ModifiersOnSameLineTests.swift
@@ -1,0 +1,174 @@
+//
+//  ModifiersOnSameLineTests.swift
+//  SwiftFormatTests
+//
+//  Created by cal_stephens on 5/29/25.
+//  Copyright © 2025 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class ModifiersOnSameLineTests: XCTestCase {
+    // MARK: - modifiersOnSameLine
+
+    func testModifiersOnSeparateLinesAreCombined() {
+        let input = """
+        public
+        private(set)
+        var foo: Foo
+        """
+        let output = """
+        public private(set) var foo: Foo
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testSingleModifierOnSeparateLineIsCombined() {
+        let input = """
+        public
+        var foo: Foo
+        """
+        let output = """
+        public var foo: Foo
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testNonisolatedModifierOnSeparateLineIsCombined() {
+        let input = """
+        nonisolated
+        func bar() {}
+        """
+        let output = """
+        nonisolated func bar() {}
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testMultipleModifiersOnMultipleLinesAreCombined() {
+        let input = """
+        class Container {
+            public
+            static
+            final
+            var foo: String = ""
+        }
+        """
+        let output = """
+        class Container {
+            public static final var foo: String = ""
+        }
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine, exclude: [.modifierOrder])
+    }
+
+    func testAttributesCanRemainOnSeparateLines() {
+        let input = """
+        @MainActor
+        public var foo: Foo
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testAttributesOnSeparateLinesWithModifiersOnSeparateLines() {
+        let input = """
+        @MainActor
+        public
+        private(set)
+        var foo: Foo
+        """
+        let output = """
+        @MainActor
+        public private(set) var foo: Foo
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testMultipleAttributesCanRemainOnSeparateLines() {
+        let input = """
+        @MainActor
+        @Published
+        public var foo: Foo
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testModifiersAlreadyOnSameLineAreNotChanged() {
+        let input = """
+        public private(set) var foo: Foo
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testCommentsArePreserved() {
+        let input = """
+        public
+        // This is private setter
+        private(set)
+        var foo: Foo
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine, exclude: [.docComments, .docCommentsBeforeModifiers])
+    }
+
+    func testDeclarationWithoutModifiersIsNotChanged() {
+        let input = """
+        var foo: Foo
+        func bar() {}
+        class Baz {}
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testOnlyAttributesWithoutModifiers() {
+        let input = """
+        @MainActor
+        var foo: Foo
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testModifiersInStructDeclaration() {
+        let input = """
+        public
+        struct MyStruct {
+            private
+            var value: Int
+        }
+        """
+        let output = """
+        public struct MyStruct {
+            private var value: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testModifiersInProtocolDeclaration() {
+        let input = """
+        public
+        protocol MyProtocol {
+            static
+            func someMethod()
+        }
+        """
+        let output = """
+        public protocol MyProtocol {
+            static func someMethod()
+        }
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testModifiersWithComplexAccessControl() {
+        let input = """
+        public
+        private(set)
+        var complexProperty: String
+        """
+        let output = """
+        public private(set) var complexProperty: String
+        """
+        testFormatting(for: input, output, rule: .modifiersOnSameLine, exclude: [.redundantInternal, .redundantFileprivate, .modifierOrder])
+    }
+}


### PR DESCRIPTION
This PR adds a new rule to keep a declaration's modifiers all on the same line:

```diff
- @MainActor
- public
- private(set)
- var foo: Foo

+ @MainActor
+ public private(set) var foo: Foo
```

```diff
- nonisolated
- func bar() {}

+ nonisolated func bar() {}
```