### PR TITLE
Prefer throwing tests to using `try!`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -79,7 +79,6 @@
 * [strongOutlets](#strongOutlets)
 * [strongifiedSelf](#strongifiedSelf)
 * [swiftTestingTestCaseNames](#swiftTestingTestCaseNames)
-* [throwingTests](#throwingTests)
 * [todos](#todos)
 * [trailingClosures](#trailingClosures)
 * [trailingCommas](#trailingCommas)
@@ -115,6 +114,7 @@
 * [redundantEquatable](#redundantEquatable)
 * [redundantProperty](#redundantProperty)
 * [sortSwitchCases](#sortSwitchCases)
+* [throwingTests](#throwingTests)
 * [unusedPrivateDeclarations](#unusedPrivateDeclarations)
 * [wrapConditionalBodies](#wrapConditionalBodies)
 * [wrapEnumCases](#wrapEnumCases)
@@ -3084,15 +3084,25 @@ Write tests that use `throws` instead of using `try!`.
 <summary>Examples</summary>
 
 ```diff
-import Testing
+    import Testing
 
-struct MyFeatureTests {
-- @Test func doSomething() {
-+ @Test func doSomething() throws {
-     - try! MyFeature().doSomething()
-     + try MyFeature().doSomething()
-  }
-}
+    struct MyFeatureTests {
+-       @Test func doSomething() {
++       @Test func doSomething() throws {
+-           try! MyFeature().doSomething()
++           try MyFeature().doSomething()
+      }
+    }
+
+    import XCTeset
+
+    class MyFeatureTests: XCTestCase {
+-       func test_doSomething() {
++       func test_doSomething() throws {
+-           try! MyFeature().doSomething()
++           try MyFeature().doSomething()
+      }
+    }
 
 </details>
 <br/>

--- a/Rules.md
+++ b/Rules.md
@@ -79,6 +79,7 @@
 * [strongOutlets](#strongOutlets)
 * [strongifiedSelf](#strongifiedSelf)
 * [swiftTestingTestCaseNames](#swiftTestingTestCaseNames)
+* [throwingTests](#throwingTests)
 * [todos](#todos)
 * [trailingClosures](#trailingClosures)
 * [trailingCommas](#trailingCommas)
@@ -3071,6 +3072,27 @@ In Swift Testing, don't prefix @Test methods with 'test'.
       }
   }
 ```
+
+</details>
+<br/>
+
+## throwingTests
+
+Write tests that use `throws` instead of using `try!`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+import Testing
+
+struct MyFeatureTests {
+- @Test func doSomething() {
++ @Test func doSomething() throws {
+     - try! MyFeature().doSomething()
+     + try MyFeature().doSomething()
+    }
+}
 
 </details>
 <br/>

--- a/Rules.md
+++ b/Rules.md
@@ -3091,7 +3091,7 @@ struct MyFeatureTests {
 + @Test func doSomething() throws {
      - try! MyFeature().doSomething()
      + try MyFeature().doSomething()
-    }
+  }
 }
 
 </details>

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -525,7 +525,7 @@ extension Formatter {
         }
     }
 
-    /// Whether or not this index the start of scope of a closure literal, eg `{` but not some other type of scope. 
+    /// Whether or not this index the start of scope of a closure literal, eg `{` but not some other type of scope.
     func isStartOfClosure(at i: Int) -> Bool {
         guard token(at: i) == .startOfScope("{") else {
             return false

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -513,6 +513,19 @@ extension Formatter {
         return index(of: .operator("->", .infix), in: startIndex + 1 ..< endIndex)
     }
 
+    /// Recursively searches to the start of scopes until we either no longer find a scope or we know we are in a closure.
+    func isInClosure(at index: Int) -> Bool {
+        guard let startOfScopeIndex = startOfScope(at: index) else {
+            return false
+        }
+        if isStartOfClosure(at: startOfScopeIndex) {
+            return true
+        } else {
+            return isInClosure(at: startOfScopeIndex)
+        }
+    }
+
+    /// Whether or not this index the start of scope of a closure literal, eg `{` but not some other type of scope. 
     func isStartOfClosure(at i: Int) -> Bool {
         guard token(at: i) == .startOfScope("{") else {
             return false

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -109,6 +109,7 @@ let ruleRegistry: [String: FormatRule] = [
     "strongOutlets": .strongOutlets,
     "strongifiedSelf": .strongifiedSelf,
     "swiftTestingTestCaseNames": .swiftTestingTestCaseNames,
+    "throwingTests": .throwingTests,
     "todos": .todos,
     "trailingClosures": .trailingClosures,
     "trailingCommas": .trailingCommas,

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -10,7 +10,8 @@ enum TestingFramework {
 
 public extension FormatRule {
     static let throwingTests = FormatRule(
-        help: "Write tests that use `throws` instead of using `try!`."
+        help: "Write tests that use `throws` instead of using `try!`.",
+        disabledByDefault: true
     ) { formatter in
         let testFramework: TestingFramework? = if formatter.hasImport("Testing") {
             .Testing

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -7,12 +7,14 @@ public extension FormatRule {
     static let throwingTests = FormatRule(
         help: "Write tests that use `throws` instead of using `try!`."
     ) { formatter in
-        guard formatter.hasImport("Testing") else { return }
+        guard formatter.hasImport("Testing") || formatter.hasImport("XCTest") else { return }
 
         formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
-            guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") else { return }
             guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)
             else { return }
+
+            guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test")
+                || functionDecl.name?.starts(with: "test") == true else { return }
 
             guard let bodyRange = functionDecl.bodyRange else { return }
 
@@ -55,7 +57,7 @@ public extension FormatRule {
         + @Test func doSomething() throws {
              - try! MyFeature().doSomething()
              + try MyFeature().doSomething()
-            }
+          }
         }
         """
     }

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -50,15 +50,25 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        import Testing
+            import Testing
 
-        struct MyFeatureTests {
-        - @Test func doSomething() {
-        + @Test func doSomething() throws {
-             - try! MyFeature().doSomething()
-             + try MyFeature().doSomething()
-          }
-        }
+            struct MyFeatureTests {
+        -       @Test func doSomething() {
+        +       @Test func doSomething() throws {
+        -           try! MyFeature().doSomething()
+        +           try MyFeature().doSomething()
+              }
+            }
+            
+            import XCTeset
+
+            class MyFeatureTests: XCTestCase {
+        -       func test_doSomething() {
+        +       func test_doSomething() throws {
+        -           try! MyFeature().doSomething()
+        +           try MyFeature().doSomething()
+              }
+            }
         """
     }
 }

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -13,14 +13,15 @@ public extension FormatRule {
         help: "Write tests that use `throws` instead of using `try!`.",
         disabledByDefault: true
     ) { formatter in
-        let testFramework: TestingFramework? = if formatter.hasImport("Testing") {
-            .Testing
+        let testFramework: TestingFramework
+
+        if formatter.hasImport("Testing") {
+            testFramework = .Testing
         } else if formatter.hasImport("XCTest") {
-            .XCTest
+            testFramework = .XCTest
         } else {
-            nil
+            return
         }
-        guard let testFramework else { return }
 
         formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
             guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public extension FormatRule {
     static let throwingTests = FormatRule(
-        help: "Write tests that use `throws` instead of using `try!`"
+        help: "Write tests that use `throws` instead of using `try!`."
     ) { formatter in
         guard formatter.hasImport("Testing") else { return }
 

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -1,0 +1,62 @@
+// Created by Andy Bartholomew on 5/30/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+public extension FormatRule {
+    static let throwingTests = FormatRule(
+        help: "Write tests that use `throws` instead of using `try!`"
+    ) { formatter in
+        guard formatter.hasImport("Testing") else { return }
+
+        formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
+            guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") else { return }
+            guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)
+            else { return }
+
+            guard let bodyRange = functionDecl.bodyRange else { return }
+
+            // Find all `try!` and remove the `!`
+            var foundAnyTryExclamationMarks = false
+            for index in bodyRange.reversed() {
+                guard formatter.tokens[index] == .keyword("try") else { continue }
+                guard let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index)
+                else { return }
+                let nextToken = formatter.tokens[nextTokenIndex]
+                if nextToken != .operator("!", .postfix) { continue }
+
+                // Only remove the `!` if we are not within a closure, where it's not safe to just remove the `!` and make our function throw.
+                if formatter.isInClosure(at: index) { return }
+
+                formatter.removeToken(at: nextTokenIndex)
+                foundAnyTryExclamationMarks = true
+            }
+
+            // If we found any `!`s, add a `throws` if it doesn't already exist.
+            guard foundAnyTryExclamationMarks else { return }
+
+            if functionDecl.effects.contains("throws") { return }
+
+            // If there are effects, just add it to the end of the effects range.
+            if let effectsRange = functionDecl.effectsRange {
+                formatter.insert([.keyword("throws"), .space(" ")], at: effectsRange.upperBound)
+            } else {
+                // If there are no effects, add after the arguments.
+                formatter.insert([.space(" "), .keyword("throws")], at: functionDecl.argumentsRange.upperBound + 1)
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        import Testing
+
+        struct MyFeatureTests {
+        - @Test func doSomething() {
+        + @Test func doSomething() throws {
+             - try! MyFeature().doSomething()
+             + try MyFeature().doSomething()
+            }
+        }
+        """
+    }
+}

--- a/Tests/CodeOrganizationTests.swift
+++ b/Tests/CodeOrganizationTests.swift
@@ -147,7 +147,7 @@ class CodeOrganizationTests: XCTestCase {
         for testFile in allRuleTestFiles {
             let testFileName = testFile.lastPathComponent
             let expectedTestClassName = testFileName.replacingOccurrences(of: ".swift", with: "")
-            let titleCaseRuleName = expectedTestClassName.replacingOccurrences(of: "Tests", with: "")
+            let titleCaseRuleName = expectedTestClassName.hasSuffix("Tests") ? String(expectedTestClassName.dropLast(5)) : expectedTestClassName
             let ruleName = titleCaseRuleName.first!.lowercased() + titleCaseRuleName.dropFirst()
 
             XCTAssert(allRuleNames.contains(ruleName), """

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -294,15 +294,15 @@ class MetadataTests: XCTestCase {
 
     // MARK: releases
 
-    func testLatestVersionInChangelog() {
-        let changelog = try! String(contentsOf: changeLogURL, encoding: .utf8)
+    func testLatestVersionInChangelog() throws {
+        let changelog = try String(contentsOf: changeLogURL, encoding: .utf8)
         XCTAssertTrue(changelog.contains("[\(SwiftFormat.version)]"), "CHANGELOG.md does not mention latest release")
         XCTAssertTrue(changelog.contains("(https://github.com/nicklockwood/SwiftFormat/releases/tag/\(SwiftFormat.version))"),
                       "CHANGELOG.md does not include correct link for latest release")
     }
 
-    func testLatestVersionInPodspec() {
-        let podspec = try! String(contentsOf: podspecURL, encoding: .utf8)
+    func testLatestVersionInPodspec() throws {
+        let podspec = try String(contentsOf: podspecURL, encoding: .utf8)
         XCTAssertTrue(podspec.contains("\"version\": \"\(SwiftFormat.version)\""), "Podspec version does not match latest release")
         XCTAssertTrue(podspec.contains("\"tag\": \"\(SwiftFormat.version)\""), "Podspec tag does not match latest release")
     }

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -191,7 +191,7 @@ final class PreferSwiftTestingTests: XCTestCase {
                 #expect(!(foo() == bar()), "foo is not equal to bar")
                 #expect(!Foo(hasBar: foo == bar).isValid)
                 #expect(try !foo)
-                #expect(try !(foo.bar.baz()))
+                #expect(!(try! foo.bar.baz()))
                 #expect(!(foo is Bar))
                 #expect(foo == nil)
                 #expect(foo == nil, "foo is nil")
@@ -232,7 +232,7 @@ final class PreferSwiftTestingTests: XCTestCase {
         """
 
         let options = FormatOptions(swiftVersion: "6.0")
-        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .wrapArguments, .indent, .redundantParens, .hoistTry], options: options)
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .wrapArguments, .indent, .redundantParens, .hoistTry], options: options, exclude: [.throwingTests])
     }
 
     func testConvertsMultilineXCTestHelpers() {

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -191,7 +191,7 @@ final class PreferSwiftTestingTests: XCTestCase {
                 #expect(!(foo() == bar()), "foo is not equal to bar")
                 #expect(!Foo(hasBar: foo == bar).isValid)
                 #expect(try !foo)
-                #expect(!(try! foo.bar.baz()))
+                #expect(try !(foo.bar.baz()))
                 #expect(!(foo is Bar))
                 #expect(foo == nil)
                 #expect(foo == nil, "foo is nil")

--- a/Tests/Rules/ThrowingTestsTests.swift
+++ b/Tests/Rules/ThrowingTestsTests.swift
@@ -1,0 +1,130 @@
+// Created by Andy Bartholomew on 5/30/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import XCTest
+
+final class ThrowingTestsTests: XCTestCase {
+    func testTestCaseIsUpdated() throws {
+        let input = """
+        import Testing
+
+        @Test func something() {
+            try! somethingThatThrows()
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() throws {
+            try somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testTestCaseIsUpdated_for_async_test() throws {
+        let input = """
+        import Testing
+
+        @Test func something() async {
+            try! somethingThatThrows()
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() throws async {
+            try somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testTestCaseIsUpdated_for_already_throws() throws {
+        let input = """
+        import Testing
+
+        @Test func something() throws {
+            try! somethingThatThrows()
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() throws {
+            try somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testTestCaseIsUpdated_for_multiple_try_exclamationMarks() throws {
+        let input = """
+        import Testing
+
+        @Test func something() {
+            try! somethingThatThrows()
+            try! somethingThatThrows()
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() throws {
+            try somethingThatThrows()
+            try somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testTestCaseIsNotUpdated_for_try_exclamationMark_in_closoure() throws {
+        let input = """
+        import Testing
+
+        @Test func something() {
+            someFunction {
+                try! somethingThatThrows()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .throwingTests)
+    }
+
+    func testTestCaseIsUpdated_for_try_exclamationMark_in_if_statement() throws {
+        let input = """
+        import Testing
+
+        @Test func something() {
+            if condition {
+                try! somethingThatThrows()
+            }
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() throws {
+            if condition {
+                try somethingThatThrows()
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testCaseIsNotUpdated_for_try_exclamationMark_in_closure_inside_if_statement() throws {
+        let input = """
+        import Testing
+
+        @Test func something() {
+            doSomething {
+                if condition {
+                    try! somethingThatThrows()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .throwingTests)
+    }
+}

--- a/Tests/Rules/ThrowingTestsTests.swift
+++ b/Tests/Rules/ThrowingTestsTests.swift
@@ -22,6 +22,23 @@ final class ThrowingTestsTests: XCTestCase {
         testFormatting(for: input, output, rule: .throwingTests)
     }
 
+    func test_nonTestCaseFunction_IsNotUpdated_for_Testing() throws {
+        let input = """
+        import Testing
+
+        func something() {
+            try! somethingThatThrows()
+        }
+
+        /// Testing test cases must be annotated with @Test, otherwise they are not test cases.
+        /// This naming is not good style but we don't want to accidentally apply XCTest logic.
+        func test_something() {
+            try! somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, rule: .throwingTests)
+    }
+
     func testTestCaseIsUpdated_for_XCTest() throws {
         let input = """
         import XCTest
@@ -42,6 +59,19 @@ final class ThrowingTestsTests: XCTestCase {
         }
         """
         testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func test_nonTestCaseFunction_IsNotUpdated_for_XCTest() throws {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func something() {
+                try! somethingThatThrows()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .throwingTests)
     }
 
     func testTestCaseIsUpdated_for_async_test() throws {

--- a/Tests/Rules/ThrowingTestsTests.swift
+++ b/Tests/Rules/ThrowingTestsTests.swift
@@ -4,7 +4,7 @@
 import XCTest
 
 final class ThrowingTestsTests: XCTestCase {
-    func testTestCaseIsUpdated() throws {
+    func testTestCaseIsUpdated_for_Testing() throws {
         let input = """
         import Testing
 
@@ -17,6 +17,28 @@ final class ThrowingTestsTests: XCTestCase {
 
         @Test func something() throws {
             try somethingThatThrows()
+        }
+        """
+        testFormatting(for: input, output, rule: .throwingTests)
+    }
+
+    func testTestCaseIsUpdated_for_XCTest() throws {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                try! somethingThatThrows()
+            }
+        }
+        """
+        let output = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() throws {
+                try somethingThatThrows()
+            }
         }
         """
         testFormatting(for: input, output, rule: .throwingTests)


### PR DESCRIPTION
`try!` is always bad. In Unit tests, we can just make the test function `throws` and automatically remove them. 

This is a draft until I also implement the XCTest version