### PR TITLE
Fix edge cases in `modifiersOnSameLine` rule

### DIFF
--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -118,8 +118,9 @@ extension Declaration {
 
     /// The start index of this declaration's modifiers,
     /// which represents the first non-space / non-comment token in the declaration.
-    var startOfModifiersIndex: Int {
-        formatter.startOfModifiers(at: keywordIndex, includingAttributes: true)
+    func startOfModifiersIndex(includingAttributes: Bool) -> Int {
+        let startOfModifiers = formatter.startOfModifiers(at: keywordIndex, includingAttributes: includingAttributes)
+        return max(startOfModifiers, range.lowerBound)
     }
 
     /// The modifiers before this declaration's keyword, including any attributes.

--- a/Sources/Rules/RedundantEquatable.swift
+++ b/Sources/Rules/RedundantEquatable.swift
@@ -80,7 +80,7 @@ public extension FormatRule {
                 // Add the `@Equatable` macro
                 formatter.insert(
                     [.keyword(macro), .space(" ")],
-                    at: equatableType.typeDeclaration.startOfModifiersIndex
+                    at: equatableType.typeDeclaration.startOfModifiersIndex(includingAttributes: true)
                 )
 
                 // Import the module that defines the `@Equatable` macro if needed

--- a/Tests/Rules/ModifiersOnSameLineTests.swift
+++ b/Tests/Rules/ModifiersOnSameLineTests.swift
@@ -169,6 +169,23 @@ class ModifiersOnSameLineTests: XCTestCase {
         let output = """
         public private(set) var complexProperty: String
         """
-        testFormatting(for: input, output, rule: .modifiersOnSameLine, exclude: [.redundantInternal, .redundantFileprivate, .modifierOrder])
+        testFormatting(for: input, output, rule: .modifiersOnSameLine)
+    }
+
+    func testDoesNotConfusePropertyIdentifierWithModifier() {
+        let input = """
+        @Environment(\\.rowPaddingOverride) private var override
+        private var resolvedRowPadding: AdaptiveEdgeInsets
+        """
+        testFormatting(for: input, rule: .modifiersOnSameLine)
+    }
+
+    func testDoesNotUnwrapWhenLineWouldExceedMaxWidth() {
+        let input = """
+        public private(set)
+        var propertyWithAReallyLongNameExceedingWidth: T
+        """
+        let options = FormatOptions(maxWidth: 50)
+        testFormatting(for: input, rule: .modifiersOnSameLine, options: options)
     }
 }


### PR DESCRIPTION
This PR fixes some edge case in the new `modifiersOnSameLine` rule:

1. Don't unwrap if it would cause the `maxWidth` to be exceeded
2. Avoid confusing identifiers in previous declarations with modifiers, like in:

```swift
@Environment(\.rowPaddingOverride) private var override
private var resolvedRowPadding: AdaptiveEdgeInsets

// This was being unwrapped to:
@Environment(\.rowPaddingOverride) private var override private var resolvedRowPadding: AdaptiveEdgeInsets
```