### PR TITLE
Update `redundantPublic` rule to handle extensions of internal types

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2422,9 +2422,9 @@ Remove redundant public access control from declarations in internal types.
 +     func baz() {}
   }
 
-  internal class Example {
--     public var value: Int
-+     var value: Int
+  extension Foo {
+-     public func quux() {}
++     func quux() {}
   }
 ```
 

--- a/Snapshots/Consumer/Sources/Consumer.swift
+++ b/Snapshots/Consumer/Sources/Consumer.swift
@@ -642,22 +642,22 @@ private extension Consumer {
 
 extension Consumer.Location: CustomStringConvertible {
     /// Human-readable description of the location
-    public var description: String {
+    var description: String {
         return "\(offset.line):\(offset.column)"
     }
 
     /// Equatable implementation
-    public static func == (lhs: Consumer.Location, rhs: Consumer.Location) -> Bool {
+    static func == (lhs: Consumer.Location, rhs: Consumer.Location) -> Bool {
         return lhs.range == rhs.range
     }
 
     /// Convenience constructor, used by compiled parsers
-    public static func at(_ range: Range<String.Index>, in source: String.UnicodeScalarView) -> Consumer.Location {
+    static func at(_ range: Range<String.Index>, in source: String.UnicodeScalarView) -> Consumer.Location {
         return Consumer.Location(source: source, range: range)
     }
 
     /// Convenience constructor, used for testing
-    public static func at(_ range: CountableRange<Int>) -> Consumer.Location {
+    static func at(_ range: CountableRange<Int>) -> Consumer.Location {
         let source = String(repeating: " ", count: range.upperBound).unicodeScalars
         let range = source.index(source.startIndex, offsetBy: range.lowerBound) ..< source.endIndex
         return Consumer.Location(source: source, range: range)
@@ -748,7 +748,7 @@ private extension Consumer.Charset {
 
 extension Consumer.Match: CustomStringConvertible {
     /// Lisp-like description of the AST
-    public var description: String {
+    var description: String {
         func _description(_ match: Consumer.Match, _ indent: String) -> String {
             switch match {
             case let .token(string, _):
@@ -813,7 +813,7 @@ private extension Consumer.Match {
 
 extension Consumer.Error: CustomStringConvertible {
     /// Human-readable error description
-    public var description: String {
+    var description: String {
         var token = ""
         if var remaining = remaining, let first = remaining.first {
             let whitespace = " \t\n\r".unicodeScalars

--- a/Snapshots/Issues/697.swift
+++ b/Snapshots/Issues/697.swift
@@ -738,81 +738,81 @@ extension _FirestoreDecoder: SingleValueDecodingContainer {
     }
   }
 
-  public func decodeNil() -> Bool {
+  func decodeNil() -> Bool {
     return storage.topContainer is NSNull
   }
 
-  public func decode(_: Bool.Type) throws -> Bool {
+  func decode(_: Bool.Type) throws -> Bool {
     try expectNonNull(Bool.self)
     return try unbox(storage.topContainer, as: Bool.self)!
   }
 
-  public func decode(_: Int.Type) throws -> Int {
+  func decode(_: Int.Type) throws -> Int {
     try expectNonNull(Int.self)
     return try unbox(storage.topContainer, as: Int.self)!
   }
 
-  public func decode(_: Int8.Type) throws -> Int8 {
+  func decode(_: Int8.Type) throws -> Int8 {
     try expectNonNull(Int8.self)
     return try unbox(storage.topContainer, as: Int8.self)!
   }
 
-  public func decode(_: Int16.Type) throws -> Int16 {
+  func decode(_: Int16.Type) throws -> Int16 {
     try expectNonNull(Int16.self)
     return try unbox(storage.topContainer, as: Int16.self)!
   }
 
-  public func decode(_: Int32.Type) throws -> Int32 {
+  func decode(_: Int32.Type) throws -> Int32 {
     try expectNonNull(Int32.self)
     return try unbox(storage.topContainer, as: Int32.self)!
   }
 
-  public func decode(_: Int64.Type) throws -> Int64 {
+  func decode(_: Int64.Type) throws -> Int64 {
     try expectNonNull(Int64.self)
     return try unbox(storage.topContainer, as: Int64.self)!
   }
 
-  public func decode(_: UInt.Type) throws -> UInt {
+  func decode(_: UInt.Type) throws -> UInt {
     try expectNonNull(UInt.self)
     return try unbox(storage.topContainer, as: UInt.self)!
   }
 
-  public func decode(_: UInt8.Type) throws -> UInt8 {
+  func decode(_: UInt8.Type) throws -> UInt8 {
     try expectNonNull(UInt8.self)
     return try unbox(storage.topContainer, as: UInt8.self)!
   }
 
-  public func decode(_: UInt16.Type) throws -> UInt16 {
+  func decode(_: UInt16.Type) throws -> UInt16 {
     try expectNonNull(UInt16.self)
     return try unbox(storage.topContainer, as: UInt16.self)!
   }
 
-  public func decode(_: UInt32.Type) throws -> UInt32 {
+  func decode(_: UInt32.Type) throws -> UInt32 {
     try expectNonNull(UInt32.self)
     return try unbox(storage.topContainer, as: UInt32.self)!
   }
 
-  public func decode(_: UInt64.Type) throws -> UInt64 {
+  func decode(_: UInt64.Type) throws -> UInt64 {
     try expectNonNull(UInt64.self)
     return try unbox(storage.topContainer, as: UInt64.self)!
   }
 
-  public func decode(_: Float.Type) throws -> Float {
+  func decode(_: Float.Type) throws -> Float {
     try expectNonNull(Float.self)
     return try unbox(storage.topContainer, as: Float.self)!
   }
 
-  public func decode(_: Double.Type) throws -> Double {
+  func decode(_: Double.Type) throws -> Double {
     try expectNonNull(Double.self)
     return try unbox(storage.topContainer, as: Double.self)!
   }
 
-  public func decode(_: String.Type) throws -> String {
+  func decode(_: String.Type) throws -> String {
     try expectNonNull(String.self)
     return try unbox(storage.topContainer, as: String.self)!
   }
 
-  public func decode<T: Decodable>(_: T.Type) throws -> T {
+  func decode<T: Decodable>(_: T.Type) throws -> T {
     try expectNonNull(T.self)
     return try unbox(storage.topContainer, as: T.self)!
   }

--- a/Snapshots/Layout/Layout/RuntimeType.swift
+++ b/Snapshots/Layout/Layout/RuntimeType.swift
@@ -24,11 +24,11 @@ public class RuntimeType: NSObject {
         case options(Any.Type, [String: Any])
         case array(RuntimeType)
 
-        public static func == (lhs: Kind, rhs: Kind) -> Bool {
+        static func == (lhs: Kind, rhs: Kind) -> Bool {
             return lhs.description == rhs.description
         }
 
-        public var description: String {
+        var description: String {
             switch self {
             case let .any(type),
                  let .options(type, _):
@@ -50,7 +50,7 @@ public class RuntimeType: NSObject {
         case available
         case unavailable(reason: String?)
 
-        public static func == (lhs: Availability, rhs: Availability) -> Bool {
+        static func == (lhs: Availability, rhs: Availability) -> Bool {
             switch (lhs, rhs) {
             case (.available, .available):
                 return true

--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -166,6 +166,16 @@ extension Declaration {
         return parent.parentDeclarations + [parent]
     }
 
+    /// The type that contains this declaration, or `nil` if this is a top-level declaration.
+    /// The closest `parent` that is not a conditional compilation declaration.
+    var parentType: TypeDeclaration? {
+        if let parentType = parent?.asTypeDeclaration {
+            return parentType
+        } else {
+            return parent?.parentType
+        }
+    }
+
     /// The `CustomDebugStringConvertible` representation of this declaration
     var debugDescription: String {
         guard isValid else {

--- a/Tests/Rules/ExtensionAccessControlTests.swift
+++ b/Tests/Rules/ExtensionAccessControlTests.swift
@@ -443,7 +443,7 @@ class ExtensionAccessControlTests: XCTestCase {
             public func bar() {}
         }
         """
-        testFormatting(for: input, rule: .extensionAccessControl)
+        testFormatting(for: input, rule: .extensionAccessControl, exclude: [.redundantPublic])
     }
 
     func testExtensionAccessControlRuleTerminatesInFileWithConditionalCompilation() {

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -2565,7 +2565,7 @@ class OrganizeDeclarationsTests: XCTestCase {
 
     func testSortDeclarationsSortsExtensionBody() {
         let input = """
-        enum Namespace {}
+        public enum Namespace {}
 
         // swiftformat:sort
         extension Namespace {
@@ -2576,7 +2576,7 @@ class OrganizeDeclarationsTests: XCTestCase {
         """
 
         let output = """
-        enum Namespace {}
+        public enum Namespace {}
 
         // swiftformat:sort
         extension Namespace {
@@ -2595,7 +2595,7 @@ class OrganizeDeclarationsTests: XCTestCase {
 
     func testOrganizeDeclarationsSortsExtensionBody() {
         let input = """
-        enum Namespace {}
+        public enum Namespace {}
 
         // swiftformat:sort
         extension Namespace {
@@ -2606,7 +2606,7 @@ class OrganizeDeclarationsTests: XCTestCase {
         """
 
         let output = """
-        enum Namespace {}
+        public enum Namespace {}
 
         // swiftformat:sort
         extension Namespace {

--- a/Tests/Rules/SortDeclarationsTests.swift
+++ b/Tests/Rules/SortDeclarationsTests.swift
@@ -253,7 +253,7 @@ class SortDeclarationsTests: XCTestCase {
         """
 
         let options = FormatOptions(alphabeticallySortedDeclarationPatterns: ["Namespace"])
-        testFormatting(for: input, [output], rules: [.sortDeclarations, .blankLinesBetweenScopes], options: options)
+        testFormatting(for: input, [output], rules: [.sortDeclarations, .blankLinesBetweenScopes], options: options, exclude: [.redundantPublic])
     }
 
     func testSortDeclarationsWontSortByNamePatternInComment() {
@@ -270,7 +270,7 @@ class SortDeclarationsTests: XCTestCase {
         """
 
         let options = FormatOptions(alphabeticallySortedDeclarationPatterns: ["Constants"])
-        testFormatting(for: input, rules: [.sortDeclarations, .blankLinesBetweenScopes], options: options)
+        testFormatting(for: input, rules: [.sortDeclarations, .blankLinesBetweenScopes], options: options, exclude: [.redundantPublic])
     }
 
     func testSortDeclarationsUsesLocalizedCompare() {


### PR DESCRIPTION
This PR updates the `redundantPublic` rule to handle removing the `public` keyword from declarations in extensions of internal types. Of course we can only detect this case if the extension and extended type are defined in the same file.

```diff
  struct Foo {
    let bar: Bar
  }

  extension Foo {
-     public func quux() {}
+     func quux() {}
  }
```