### PR TITLE
Improve performance of `docComments` rule

### DIFF
--- a/Tests/Rules/DocCommentsBeforeModifiersTests.swift
+++ b/Tests/Rules/DocCommentsBeforeModifiersTests.swift
@@ -158,7 +158,7 @@ class DocCommentsBeforeModifiersTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .docCommentsBeforeModifiers,
-                       exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .redundantPublic])
+                       exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .redundantPublic, .docComments])
     }
 
     func testPreservesCommentOnSameLineAsAttribute() {


### PR DESCRIPTION
The `docComments` rule will occasionally time out when processing very long comments. We found a file with 900+ lines of commented-out code where `docComments` was consistently taking 15-20 seconds to run.

We were previously doing a lot of repeated work at each comment index, so we can improve performance by avoiding that. Now the long file can be formatted / linted in ~0.1-0.2s.