### PR TITLE
Fix bug where trailing comments would be converted to doc comments

### DIFF
--- a/Tests/Rules/DocCommentsTests.swift
+++ b/Tests/Rules/DocCommentsTests.swift
@@ -576,4 +576,32 @@ class DocCommentsTests: XCTestCase {
         """
         testFormatting(for: input, rule: .docComments)
     }
+
+    func testCommentsTrailingDeclarationPreservedAsRegularComment() {
+        let input = """
+        // Comment
+        let foo: Foo // Foo
+        let bar: Bar // Bar
+        """
+
+        testFormatting(for: input, rule: .docComments)
+    }
+
+    func testDocCommentsTrailingDeclarationConvertedToRegularComment() {
+        let input = """
+        // Comment
+        let foo: Foo /// Foo
+        let foo: bar /// Bar
+
+        """
+
+        let output = """
+        // Comment
+        let foo: Foo // Foo
+        let foo: bar // Bar
+
+        """
+
+        testFormatting(for: input, output, rule: .docComments)
+    }
 }


### PR DESCRIPTION
I noticed a new issue where trailing comments were being converted to doc comments:

```diff
  // Comment
- let foo: Foo // Foo
+ let foo: Foo /// Foo
  let bar: Bar // Bar
```

This PR fixes the issue