### PR TITLE
Add support for opting-out of Swift 6.1 trailing comma support.

### DIFF
--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -77,7 +77,7 @@ class PerformanceTests: XCTestCase {
             spaceAroundOperatorDeclarations: .remove,
             useVoid: false,
             indentCase: true,
-            trailingCommas: false,
+            trailingCommas: .never,
             indentComments: false,
             truncateBlankLines: false,
             allmanBraces: true,

--- a/Rules.md
+++ b/Rules.md
@@ -3211,7 +3211,7 @@ Add or remove trailing commas in comma-separated lists.
 
 Option | Description
 --- | ---
-`--commas` | Trailing commas: "always" (default), "never", or "collections-only"
+`--trailingcommas` | Trailing commas: "always" (default), "never", or "collections-only"
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -3211,7 +3211,7 @@ Add or remove trailing commas in comma-separated lists.
 
 Option | Description
 --- | ---
-`--commas` | Commas in collection literals: "always" (default) or "inline"
+`--commas` | Trailing commas: "always" (default), "never", or "collections-only"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2675,7 +2675,7 @@ extension Formatter {
                         switch prevToken {
                         case .identifier, .number, .endOfScope,
                              .operator where ![
-                                 .operator("=", .infix), .operator(".", .prefix)
+                                 .operator("=", .infix), .operator(".", .prefix),
                              ].contains(prevToken):
                             isAssignment = false
                             lastKeyword = ""

--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -235,7 +235,7 @@ private struct Inference {
                 noTrailing += 1
             }
         }
-        options.trailingCommas = (trailing >= noTrailing)
+        options.trailingCommas = (trailing >= noTrailing) ? .always : .never
     }
 
     let truncateBlankLines = OptionInferrer { formatter, options in

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -516,8 +516,8 @@ struct _Descriptors {
         falseValues: ["false"]
     )
     let trailingCommas = OptionDescriptor(
-        argumentName: "commas",
-        displayName: "Commas",
+        argumentName: "trailingcommas",
+        displayName: "Trailing commas",
         help: "Trailing commas: \"always\" (default), \"never\", or \"collections-only\"",
         keyPath: \.trailingCommas,
         altOptions: [

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -518,10 +518,13 @@ struct _Descriptors {
     let trailingCommas = OptionDescriptor(
         argumentName: "commas",
         displayName: "Commas",
-        help: "Commas in collection literals: \"always\" (default) or \"inline\"",
+        help: "Trailing commas: \"always\" (default), \"never\", or \"collections-only\"",
         keyPath: \.trailingCommas,
-        trueValues: ["always", "true"],
-        falseValues: ["inline", "false"]
+        altOptions: [
+            "inline": .never,
+            "false": .never,
+            "true": .always,
+        ]
     )
     let truncateBlankLines = OptionDescriptor(
         argumentName: "trimwhitespace",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -519,12 +519,7 @@ struct _Descriptors {
         argumentName: "trailingcommas",
         displayName: "Trailing commas",
         help: "Trailing commas: \"always\" (default), \"never\", or \"collections-only\"",
-        keyPath: \.trailingCommas,
-        altOptions: [
-            "inline": .never,
-            "false": .never,
-            "true": .always,
-        ]
+        keyPath: \.trailingCommas
     )
     let truncateBlankLines = OptionDescriptor(
         argumentName: "trimwhitespace",
@@ -1365,6 +1360,18 @@ struct _Descriptors {
         help: "Property @attributes: \"preserve\", \"prev-line\", or \"same-line\"",
         deprecationMessage: "Use with `--storedvarattributes` or `--computedvarattributes` instead.",
         keyPath: \.varAttributes
+    )
+    let commas = OptionDescriptor(
+        argumentName: "commas",
+        displayName: "Trailing commas",
+        help: "deprecated",
+        deprecationMessage: "Use '--trailingcommas' instead",
+        keyPath: \.trailingCommas,
+        altOptions: [
+            "inline": .never,
+            "false": .never,
+            "true": .always,
+        ]
     )
 
     // MARK: - RENAMED

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -178,6 +178,12 @@ public enum ClosureVoidReturn: String, CaseIterable {
     case preserve
 }
 
+public enum TrailingCommas: String, CaseIterable {
+    case never
+    case always
+    case collectionsOnly = "collections-only"
+}
+
 /// Whether to insert, remove, or preserve spaces around operators
 public enum OperatorSpacingMode: String, CaseIterable {
     case insert = "spaced"
@@ -644,7 +650,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var spaceAroundOperatorDeclarations: OperatorSpacingMode
     public var useVoid: Bool
     public var indentCase: Bool
-    public var trailingCommas: Bool
+    public var trailingCommas: TrailingCommas
     public var truncateBlankLines: Bool
     public var insertBlankLines: Bool
     public var removeBlankLines: Bool
@@ -775,7 +781,7 @@ public struct FormatOptions: CustomStringConvertible {
                 spaceAroundOperatorDeclarations: OperatorSpacingMode = .insert,
                 useVoid: Bool = true,
                 indentCase: Bool = false,
-                trailingCommas: Bool = true,
+                trailingCommas: TrailingCommas = .always,
                 indentComments: Bool = true,
                 truncateBlankLines: Bool = true,
                 insertBlankLines: Bool = true,

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -327,7 +327,7 @@ extension Formatter {
                 }
                 switch tokens[prevIndex] {
                 case .identifier, .endOfScope(")"), .endOfScope("]"),
-                     .operator("?", _), .operator("!", _),
+                     .operator("?", .postfix), .operator("!", .postfix),
                      .endOfScope where token.isStringDelimiter:
                     if tokens[prevIndex + 1 ..< index].contains(where: \.isLinebreak) {
                         break

--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -582,7 +582,7 @@ public extension FormatRule {
                             }
                             if !lastToken.isEndOfScope || lastToken == .endOfScope("case") ||
                                 formatter.options.xcodeIndentation, ![
-                                    .endOfScope("}"), .endOfScope(")")
+                                    .endOfScope("}"), .endOfScope(")"),
                                 ].contains(lastToken)
                             {
                                 indent += formatter.options.indent

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension FormatRule {
     static let trailingCommas = FormatRule(
         help: "Add or remove trailing commas in comma-separated lists.",
-        options: ["commas"]
+        options: ["trailingcommas"]
     ) { formatter in
         formatter.forEachToken { i, token in
             switch token {

--- a/Tests/InferenceTests.swift
+++ b/Tests/InferenceTests.swift
@@ -149,13 +149,13 @@ class InferenceTests: XCTestCase {
     func testInferTrailingCommas() {
         let input = "let foo = [\nbar,\n]\n let baz = [\nquux\n]"
         let options = inferFormatOptions(from: tokenize(input))
-        XCTAssertTrue(options.trailingCommas)
+        XCTAssertEqual(options.trailingCommas, .always)
     }
 
     func testInferNoTrailingCommas() {
         let input = "let foo = [\nbar\n]\n let baz = [\nquux\n]"
         let options = inferFormatOptions(from: tokenize(input))
-        XCTAssertFalse(options.trailingCommas)
+        XCTAssertEqual(options.trailingCommas, .never)
     }
 
     // MARK: truncateBlankLines

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -22,6 +22,13 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
+    func testCommaAddedToLastItemCollectionsOnly() {
+        let input = "[\n    foo,\n    bar\n]"
+        let output = "[\n    foo,\n    bar,\n]"
+        let options = FormatOptions(trailingCommas: .collectionsOnly)
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
     func testCommaAddedToDictionary() {
         let input = "[\n    foo: bar\n]"
         let output = "[\n    foo: bar,\n]"
@@ -262,14 +269,14 @@ class TrailingCommasTests: XCTestCase {
 
     func testCommaNotAddedToLastItem() {
         let input = "[\n    foo,\n    bar\n]"
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
     func testCommaRemovedFromLastItem() {
         let input = "[\n    foo,\n    bar,\n]"
         let output = "[\n    foo,\n    bar\n]"
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -284,7 +291,7 @@ class TrailingCommasTests: XCTestCase {
             bar _: Int,
         ) {}
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -294,7 +301,7 @@ class TrailingCommasTests: XCTestCase {
             bar _: Int
         ) {}
         """
-        let options = FormatOptions(trailingCommas: true)
+        let options = FormatOptions(trailingCommas: .always)
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -309,7 +316,7 @@ class TrailingCommasTests: XCTestCase {
             bar _: Int
         ) {}
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -326,7 +333,7 @@ class TrailingCommasTests: XCTestCase {
             baaz _: Int)
         {}
         """
-        let options = FormatOptions(trailingCommas: false, closingParenPosition: .sameLine)
+        let options = FormatOptions(trailingCommas: .never, closingParenPosition: .sameLine)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -343,7 +350,7 @@ class TrailingCommasTests: XCTestCase {
             baaz _: Int)
         {}
         """
-        let options = FormatOptions(trailingCommas: true, closingParenPosition: .sameLine)
+        let options = FormatOptions(trailingCommas: .always, closingParenPosition: .sameLine)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -358,7 +365,7 @@ class TrailingCommasTests: XCTestCase {
             bar _: Int,
         ) {}
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -373,7 +380,7 @@ class TrailingCommasTests: XCTestCase {
             bar _: Int
         ) {}
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -392,7 +399,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -411,7 +418,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -426,7 +433,7 @@ class TrailingCommasTests: XCTestCase {
             1,
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -441,7 +448,7 @@ class TrailingCommasTests: XCTestCase {
             1
         )
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -468,7 +475,7 @@ class TrailingCommasTests: XCTestCase {
             baz: 2,
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -503,7 +510,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn])
     }
 
@@ -527,7 +534,7 @@ class TrailingCommasTests: XCTestCase {
             ),
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn])
     }
 
@@ -542,7 +549,7 @@ class TrailingCommasTests: XCTestCase {
             0,
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantParens])
     }
 
@@ -559,7 +566,7 @@ class TrailingCommasTests: XCTestCase {
             1,
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -576,7 +583,7 @@ class TrailingCommasTests: XCTestCase {
             baz: 1
         )
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -590,7 +597,7 @@ class TrailingCommasTests: XCTestCase {
         )
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -609,7 +616,7 @@ class TrailingCommasTests: XCTestCase {
         )]]()
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.propertyTypes])
     }
 
@@ -628,7 +635,7 @@ class TrailingCommasTests: XCTestCase {
         )>()
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
     }
 
@@ -644,7 +651,7 @@ class TrailingCommasTests: XCTestCase {
         ) {}
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -690,7 +697,7 @@ class TrailingCommasTests: XCTestCase {
         ) -> Void) {}
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -705,7 +712,7 @@ class TrailingCommasTests: XCTestCase {
         )?) {}
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -733,7 +740,7 @@ class TrailingCommasTests: XCTestCase {
         )?
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -760,7 +767,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -787,7 +794,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -814,7 +821,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -841,7 +848,7 @@ class TrailingCommasTests: XCTestCase {
             )
         }
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -878,7 +885,7 @@ class TrailingCommasTests: XCTestCase {
         default: break
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -889,7 +896,7 @@ class TrailingCommasTests: XCTestCase {
             baz: Int
         )
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -912,7 +919,7 @@ class TrailingCommasTests: XCTestCase {
         ): break
         }
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -929,7 +936,7 @@ class TrailingCommasTests: XCTestCase {
             bar
         ) = (0, 1)
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -939,7 +946,7 @@ class TrailingCommasTests: XCTestCase {
 
         )
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, rule: .trailingCommas,
                        options: options, exclude: [
                            .blankLinesAtEndOfScope,
@@ -964,7 +971,7 @@ class TrailingCommasTests: XCTestCase {
         )
         \"""
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -983,7 +990,7 @@ class TrailingCommasTests: XCTestCase {
         )
         struct Qux {}
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1028,7 +1035,7 @@ class TrailingCommasTests: XCTestCase {
         extension CoreFoundation.CGFloat: Swift.SignedNumeric {}
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
@@ -1047,7 +1054,7 @@ class TrailingCommasTests: XCTestCase {
         )
         struct Qux {}
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1064,7 +1071,7 @@ class TrailingCommasTests: XCTestCase {
             "baz",
         )
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1081,7 +1088,7 @@ class TrailingCommasTests: XCTestCase {
             "baz"
         )
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1120,7 +1127,7 @@ class TrailingCommasTests: XCTestCase {
             T2,
         >() -> (T1, T2) {}
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1160,7 +1167,7 @@ class TrailingCommasTests: XCTestCase {
         > {}
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.emptyExtensions, .typeSugar])
     }
 
@@ -1179,7 +1186,7 @@ class TrailingCommasTests: XCTestCase {
             T3
         > {}
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1190,7 +1197,7 @@ class TrailingCommasTests: XCTestCase {
         let output = """
         struct S<T1, T2, T3> {}
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1209,7 +1216,7 @@ class TrailingCommasTests: XCTestCase {
         ] in
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1228,7 +1235,7 @@ class TrailingCommasTests: XCTestCase {
         ] in
         }
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1243,7 +1250,7 @@ class TrailingCommasTests: XCTestCase {
             print(capturedValue1, capturedValue2)
         }
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1260,7 +1267,24 @@ class TrailingCommasTests: XCTestCase {
             y,
         ]
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemoveFromSubscriptWhenCollectionsOnly() {
+        let input = """
+        let value = m[
+            x,
+            y,
+        ]
+        """
+        let output = """
+        let value = m[
+            x,
+            y
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .collectionsOnly, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1277,7 +1301,7 @@ class TrailingCommasTests: XCTestCase {
             y
         ]
         """
-        let options = FormatOptions(trailingCommas: false)
+        let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1288,7 +1312,7 @@ class TrailingCommasTests: XCTestCase {
         let output = """
         let value = m[x, y]
         """
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
@@ -1315,7 +1339,38 @@ class TrailingCommasTests: XCTestCase {
         }
         """
 
-        let options = FormatOptions(trailingCommas: true, swiftVersion: "6.1")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testCollectionsOnlyAddsCollectionCommasAndRemovesNonCollectionCommas() {
+        let input = """
+        let array = [
+            1,
+            2
+        ]
+
+        func foo(
+            a: Int,
+            b: Int,
+        ) {
+            print(a, b)
+        }
+        """
+        let output = """
+        let array = [
+            1,
+            2,
+        ]
+
+        func foo(
+            a: Int,
+            b: Int
+        ) {
+            print(a, b)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .collectionsOnly, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -1373,4 +1373,16 @@ class TrailingCommasTests: XCTestCase {
         let options = FormatOptions(trailingCommas: .collectionsOnly, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
+
+    func testSingleLineArrayWithMultipleElements() {
+        let input = """
+        for file in files where
+            file != "build" && !file.hasPrefix(".") && ![
+                ".build", ".app", ".framework", ".xcodeproj", ".xcassets",
+            ].contains(where: { file.hasSuffix($0) }) {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always)
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
 }

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -1209,7 +1209,7 @@ class WrapArgumentsTests: XCTestCase {
     func testNoDoubleSpaceAddedToWrappedArray() {
         let input = "[ foo,\n    bar ]"
         let output = "[\n    foo,\n    bar\n]"
-        let options = FormatOptions(trailingCommas: false, wrapCollections: .beforeFirst)
+        let options = FormatOptions(trailingCommas: .never, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .spaceInsideBrackets],
                        options: options)
     }
@@ -1217,7 +1217,7 @@ class WrapArgumentsTests: XCTestCase {
     func testTrailingCommasAddedToWrappedArray() {
         let input = "[foo,\n    bar]"
         let output = "[\n    foo,\n    bar,\n]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1225,7 +1225,7 @@ class WrapArgumentsTests: XCTestCase {
     func testTrailingCommasAddedToWrappedNestedDictionary() {
         let input = "[foo: [bar: baz,\n    bar2: baz2]]"
         let output = "[foo: [\n    bar: baz,\n    bar2: baz2,\n]]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1233,7 +1233,7 @@ class WrapArgumentsTests: XCTestCase {
     func testTrailingCommasAddedToSingleLineNestedDictionary() {
         let input = "[\n    foo: [bar: baz, bar2: baz2]]"
         let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1241,7 +1241,7 @@ class WrapArgumentsTests: XCTestCase {
     func testTrailingCommasAddedToWrappedNestedDictionaries() {
         let input = "[foo: [bar: baz,\n    bar2: baz2],\n    foo2: [bar: baz,\n    bar2: baz2]]"
         let output = "[\n    foo: [\n        bar: baz,\n        bar2: baz2,\n    ],\n    foo2: [\n        bar: baz,\n        bar2: baz2,\n    ],\n]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .beforeFirst)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1311,7 +1311,7 @@ class WrapArgumentsTests: XCTestCase {
     func testNoBeforeFirstPreservedAndTrailingCommaIgnoredInMultilineNestedDictionary() {
         let input = "[foo: [bar: baz,\n    bar2: baz2]]"
         let output = "[foo: [bar: baz,\n       bar2: baz2]]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .preserve)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1319,7 +1319,7 @@ class WrapArgumentsTests: XCTestCase {
     func testBeforeFirstPreservedAndTrailingCommaAddedInSingleLineNestedDictionary() {
         let input = "[\n    foo: [bar: baz, bar2: baz2]]"
         let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .preserve)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
@@ -1327,7 +1327,7 @@ class WrapArgumentsTests: XCTestCase {
     func testBeforeFirstPreservedAndTrailingCommaAddedInSingleLineNestedDictionaryWithOneNestedItem() {
         let input = "[\n    foo: [bar: baz]]"
         let output = "[\n    foo: [bar: baz],\n]"
-        let options = FormatOptions(trailingCommas: true, wrapCollections: .preserve)
+        let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }


### PR DESCRIPTION
Hello!

I've taken a crack at a fix for https://github.com/nicklockwood/SwiftFormat/issues/2053 and added a new `commas` rule option: `collections`, to supplement the existing `inline` and `always` options.

Not sure I love the implementation currently as it starts conflating language level support with rule configuration and I'm curious to hear if y'all have any thoughts. (It seems to work but it may be difficult to extend further to additional options in the future)

- Is this generally something y'all would be open to supporting?
- Any suggestions on the testing strategy? My current approach was to add a second assert within each 6.1 specific test that ensures that `collections` "undoes" `always` to avoid duplicating lots of string literals.