### PR TITLE
Update `void` rule to convert `()` to `Void` in typealiases

### DIFF
--- a/Sources/Rules/Void.swift
+++ b/Sources/Rules/Void.swift
@@ -86,6 +86,15 @@ public extension FormatRule {
                 !hasLocalVoid
             {
                 formatter.replaceTokens(in: i ... endIndex, with: .identifier("Void"))
+            } else if prevToken == .operator("=", .infix),
+                      let equalIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i),
+                      let prevPrevToken = formatter.last(.nonSpaceOrCommentOrLinebreak, before: equalIndex),
+                      prevPrevToken.isIdentifier,
+                      formatter.lastSignificantKeyword(at: i) == "typealias",
+                      !hasLocalVoid
+            {
+                // Handle typealias cases like: typealias Dependencies = ()
+                formatter.replaceTokens(in: i ... endIndex, with: .identifier("Void"))
             }
             // TODO: other cases
         }

--- a/Tests/Rules/VoidTests.swift
+++ b/Tests/Rules/VoidTests.swift
@@ -258,4 +258,10 @@ class VoidTests: XCTestCase {
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, output, rule: .void, options: options)
     }
+
+    func testTypealiasEmptyTupleConvertedToVoid() {
+        let input = "public typealias Dependencies = ()"
+        let output = "public typealias Dependencies = Void"
+        testFormatting(for: input, output, rule: .void)
+    }
 }


### PR DESCRIPTION
This PR update the `void` rule to convert `()` to `Void` in typealiases, since `()` represents a type in this case.