### PR TITLE
Fix issue where `trailingCommas` rule ignored function declarations with return type

### DIFF
--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -282,14 +282,24 @@ class TrailingCommasTests: XCTestCase {
 
     func testTrailingCommasAddedToFunctionParameters() {
         let input = """
-        func foo(
-            bar _: Int
-        ) {}
+        struct Foo {
+            func foo(
+                bar: Int,
+                baaz: Int
+            ) -> Int {
+                bar + baaz
+            }
+        }
         """
         let output = """
-        func foo(
-            bar _: Int,
-        ) {}
+        struct Foo {
+            func foo(
+                bar: Int,
+                baaz: Int,
+            ) -> Int {
+                bar + baaz
+            }
+        }
         """
         let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options)


### PR DESCRIPTION
This fixes an issue where the `trailingCommas` rule ignored function declarations with a return type, due to confusing the `(...) -> Type` syntax for a closure type where trailing commas are not allowed in Swift 6.1