### PR TITLE
Add missing code tag to Rules documentation 

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3315,6 +3315,7 @@ Swift 6.1 and later:
 -     Quux
 +     Quux,
   > {}
+```
 
 </details>
 <br/>

--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -171,6 +171,7 @@ public extension FormatRule {
         -     Quux
         +     Quux,
           > {}
+        ```
         """
     }
 }


### PR DESCRIPTION
Rules doc missed a code closing tag