### PR TITLE
Fix issue where `try! [...]` was confused for subscript in `trailingCommas` rule Swift 6.1 support

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -325,9 +325,12 @@ extension Formatter {
                 if tokens[prevIndex].isAttribute {
                     prevIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex) ?? prevIndex
                 }
+                let tokenBeforePrevIndex = lastToken(before: prevIndex, where: \.isNonSpaceOrCommentOrLinebreak)
+
                 switch tokens[prevIndex] {
                 case .identifier, .endOfScope(")"), .endOfScope("]"),
-                     .operator("?", .postfix), .operator("!", .postfix),
+                     .operator("?", .postfix) where tokenBeforePrevIndex != .keyword("try"),
+                     .operator("!", .postfix) where tokenBeforePrevIndex != .keyword("try"),
                      .endOfScope where token.isStringDelimiter:
                     if tokens[prevIndex + 1 ..< index].contains(where: \.isLinebreak) {
                         break

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -396,6 +396,7 @@ public extension Token {
     var isSpaceOrLinebreak: Bool { isSpace || isLinebreak }
     var isSpaceOrComment: Bool { isSpace || isComment }
     var isSpaceOrCommentOrLinebreak: Bool { isSpaceOrComment || isLinebreak }
+    var isNonSpaceOrCommentOrLinebreak: Bool { !isSpaceOrCommentOrLinebreak }
     var isCommentOrLinebreak: Bool { isComment || isLinebreak }
 
     var isSwitchCaseOrDefault: Bool {

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -1384,12 +1384,27 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
-    func testSingleLineArrayWithMultipleElements() {
+    func testSingleLineArrayWithMultipleElementsFollowingNotOperator() {
         let input = """
         for file in files where
             file != "build" && !file.hasPrefix(".") && ![
                 ".build", ".app", ".framework", ".xcodeproj", ".xcassets",
             ].contains(where: { file.hasSuffix($0) }) {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always)
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testSingleLineArrayWithMultipleElementsFollowingForceTry() {
+        let input = """
+        let foo = try! [
+            ".build", ".app", ".framework", ".xcodeproj", ".xcassets",
+        ].throwingOperation()
+
+        let bar = try? [
+            ".build", ".app", ".framework", ".xcodeproj", ".xcassets",
+        ].throwingOperation()
         """
 
         let options = FormatOptions(trailingCommas: .always)


### PR DESCRIPTION
This PR fixes an issue where `try! [...]` would be confused for a subscript, causing the `trailingCommas` rule to think a trailing commas was not allowed in this position.