### PR TITLE
Support multiple `--config` files

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -35,7 +35,9 @@ extension Options {
     init(_ args: [String: String], in directory: String) throws {
         fileOptions = try fileOptionsFor(args, in: directory)
         formatOptions = try formatOptionsFor(args)
-        configURL = args["config"].map { expandPath($0, in: directory) }
+        configURLs = args["config"].map {
+            parseCommaDelimitedList($0).map { expandPath($0, in: directory) }
+        }
         let lint = args.keys.contains("lint")
         self.lint = lint
         rules = try rulesFor(args, lint: lint)
@@ -48,7 +50,7 @@ extension Options {
         if let fileInfo = formatOptions?.fileInfo {
             newOptions.formatOptions?.fileInfo = fileInfo
         }
-        newOptions.configURL = configURL
+        newOptions.configURLs = configURLs
         self = newOptions
     }
 }
@@ -187,7 +189,7 @@ func preprocessArguments(_ args: [String], _ names: [String]) throws -> [String:
         }
         if let existing = namedArgs[name], !existing.isEmpty,
            // TODO: find a more general way to represent merge-able options
-           ["exclude", "unexclude", "disable", "enable", "lintonly", "rules"].contains(name) ||
+           ["exclude", "unexclude", "disable", "enable", "lintonly", "rules", "config"].contains(name) ||
            Descriptors.all.contains(where: {
                $0.argumentName == name && $0.isSetType
            })

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -1115,27 +1115,27 @@ public struct Options {
     public var fileOptions: FileOptions?
     public var formatOptions: FormatOptions?
     public var rules: Set<String>?
-    public var configURL: URL?
+    public var configURLs: [URL]?
     public var lint: Bool
 
     public static let `default` = Options(
         fileOptions: .default,
         formatOptions: .default,
         rules: defaultRules,
-        configURL: nil,
+        configURLs: nil,
         lint: false
     )
 
     public init(fileOptions: FileOptions? = nil,
                 formatOptions: FormatOptions? = nil,
                 rules: Set<String>? = nil,
-                configURL: URL? = nil,
+                configURLs: [URL]? = nil,
                 lint: Bool = false)
     {
         self.fileOptions = fileOptions
         self.formatOptions = formatOptions
         self.rules = rules
-        self.configURL = configURL
+        self.configURLs = configURLs
         self.lint = lint
     }
 

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -322,8 +322,9 @@ private func processDirectory(_ inputURL: URL, with options: inout Options, logg
     let manager = FileManager.default
     let configFile = inputURL.appendingPathComponent(swiftFormatConfigurationFile)
     if manager.fileExists(atPath: configFile.path) {
-        if let configURL = options.configURL {
-            if configURL.standardizedFileURL != configFile.standardizedFileURL {
+        if let configURLs = options.configURLs {
+            let standardizedConfigFile = configFile.standardizedFileURL
+            if !configURLs.contains(where: { $0.standardizedFileURL == standardizedConfigFile }) {
                 logger?("Ignoring config file at \(configFile.path)")
             }
         } else {


### PR DESCRIPTION
This PR updates the `--config` option to support multiple config files. For example, you could have a base `A.swiftformat` file, and a separate `B.swiftformat` with overrides. Now `--config A.swiftformat --config B.swiftformat` handles this use case.

I actually always thought this was how it worked! I was trying to use this locally and found out that it didn't actually work this way. Seems like a nice enhancement for flexibility.