### PR TITLE
Add Redundant struct Member wise Init rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -50,6 +50,7 @@
 * [redundantInternal](#redundantInternal)
 * [redundantLet](#redundantLet)
 * [redundantLetError](#redundantLetError)
+* [redundantMemberwiseInit](#redundantMemberwiseInit)
 * [redundantNilInit](#redundantNilInit)
 * [redundantObjc](#redundantObjc)
 * [redundantOptionalBinding](#redundantOptionalBinding)
@@ -2314,6 +2315,28 @@ Remove redundant `let error` from `catch` clause.
 ```diff
 - do { ... } catch let error { log(error) }
 + do { ... } catch { log(error) }
+```
+
+</details>
+<br/>
+
+## redundantMemberwiseInit
+
+Remove explicit internal memberwise initializers that are redundant.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+struct Person {
+    var name: String
+    var age: Int
+
+-   init(name: String, age: Int) {
+-       self.name = name
+-       self.age = age
+-   }
+}
 ```
 
 </details>

--- a/Snapshots/Layout/Layout/Utilities.swift
+++ b/Snapshots/Layout/Layout/Utilities.swift
@@ -117,16 +117,10 @@ extension UIEdgeInsets {
 
 struct IntOptionSet: OptionSet {
     let rawValue: Int
-    init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
 }
 
 struct UIntOptionSet: OptionSet {
     let rawValue: UInt
-    init(rawValue: UInt) {
-        self.rawValue = rawValue
-    }
 }
 
 #if !swift(>=3.4)

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -76,6 +76,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantInternal": .redundantInternal,
     "redundantLet": .redundantLet,
     "redundantLetError": .redundantLetError,
+    "redundantMemberwiseInit": .redundantMemberwiseInit,
     "redundantNilInit": .redundantNilInit,
     "redundantObjc": .redundantObjc,
     "redundantOptionalBinding": .redundantOptionalBinding,

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -1,0 +1,185 @@
+//
+//  RedundantMemberwiseInit.swift
+//  SwiftFormat
+//
+//  Created by Miguel Jimenez on 6/17/25.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Remove redundant explicit memberwise initializers from structs
+    static let redundantMemberwiseInit = FormatRule(
+        help: "Remove explicit internal memberwise initializers that are redundant.",
+        orderAfter: [.redundantInit]
+    ) { formatter in
+        formatter.forEach(.keyword("struct")) { structIndex, _ in
+            guard let structBraceIndex = formatter.index(of: .startOfScope("{"), after: structIndex),
+                  let structEndIndex = formatter.endOfScope(at: structBraceIndex)
+            else { return }
+
+            // Collect stored properties
+            var storedProperties: [(name: String, type: String)] = []
+
+            var searchIndex = structBraceIndex + 1
+            while let varOrLetIndex = formatter.index(of: .keyword, after: searchIndex - 1, if: {
+                ["var", "let"].contains($0.string)
+            }), varOrLetIndex < structEndIndex {
+                guard let property = formatter.parsePropertyDeclaration(atIntroducerIndex: varOrLetIndex),
+                      let typeInfo = property.type,
+                      property.body == nil, // Only stored properties
+                      !formatter.modifiersForDeclaration(at: varOrLetIndex, contains: { _, modifier in
+                          ["static", "private", "fileprivate", "public", "open"].contains(modifier)
+                      })
+                else {
+                    searchIndex = varOrLetIndex + 1
+                    continue
+                }
+
+                storedProperties.append((name: property.identifier, type: typeInfo.name))
+                searchIndex = property.range.upperBound + 1
+            }
+
+            guard !storedProperties.isEmpty else { return }
+
+            // Find redundant memberwise inits
+            searchIndex = structBraceIndex + 1
+            while let initIndex = formatter.index(of: .keyword("init"), after: searchIndex - 1),
+                  initIndex < structEndIndex
+            {
+                // Skip if has explicit access modifier
+                guard !formatter.modifiersForDeclaration(at: initIndex, contains: { _, modifier in
+                    ["private", "fileprivate", "public", "open"].contains(modifier)
+                }) else {
+                    searchIndex = initIndex + 1
+                    continue
+                }
+
+                guard let openParenIndex = formatter.index(of: .startOfScope("("), after: initIndex),
+                      let closeParenIndex = formatter.endOfScope(at: openParenIndex),
+                      let initBodyIndex = formatter.index(of: .startOfScope("{"), after: closeParenIndex),
+                      let initBodyEndIndex = formatter.endOfScope(at: initBodyIndex)
+                else {
+                    searchIndex = initIndex + 1
+                    continue
+                }
+
+                // Parse parameters
+                var parameters: [(name: String, type: String)] = []
+                var paramIndex = openParenIndex + 1
+
+                while let nextParamIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: paramIndex - 1),
+                      nextParamIndex < closeParenIndex,
+                      let paramToken = formatter.token(at: nextParamIndex),
+                      paramToken.isIdentifier
+                {
+                    guard let colonIndex = formatter.index(of: .delimiter(":"), after: nextParamIndex),
+                          colonIndex < closeParenIndex,
+                          let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
+                          let typeInfo = formatter.parseType(at: typeStartIndex)
+                    else {
+                        paramIndex = nextParamIndex + 1
+                        continue
+                    }
+
+                    parameters.append((name: paramToken.string, type: typeInfo.name))
+
+                    if let commaIndex = formatter.index(of: .delimiter(","), after: typeInfo.range.upperBound),
+                       commaIndex < closeParenIndex
+                    {
+                        paramIndex = commaIndex + 1
+                    } else {
+                        break
+                    }
+                }
+
+                // Check if parameters match stored properties
+                guard parameters.count == storedProperties.count,
+                      zip(parameters, storedProperties).allSatisfy({ $0.name == $1.name && $0.type == $1.type })
+                else {
+                    searchIndex = initIndex + 1
+                    continue
+                }
+
+                // Check if body only contains memberwise assignments
+                var isRedundant = true
+                var bodyIndex = initBodyIndex + 1
+                var assignmentCount = 0
+
+                while let nextToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: bodyIndex - 1),
+                      nextToken < initBodyEndIndex
+                {
+                    let token = formatter.tokens[nextToken]
+
+                    if token == .identifier("self") {
+                        guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken, if: {
+                            $0.isOperator(".")
+                        }),
+                            let propIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                            let propToken = formatter.token(at: propIndex),
+                            propToken.isIdentifier,
+                            let equalsIndex = formatter.index(of: .operator("=", .infix), after: propIndex),
+                            let valueIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                            let valueToken = formatter.token(at: valueIndex),
+                            valueToken.isIdentifier,
+                            propToken.string == valueToken.string,
+                            storedProperties.contains(where: { $0.name == propToken.string })
+                        else {
+                            isRedundant = false
+                            break
+                        }
+
+                        assignmentCount += 1
+                        bodyIndex = valueIndex + 1
+                    } else {
+                        isRedundant = false
+                        break
+                    }
+                }
+
+                // Remove redundant init if all assignments match
+                if isRedundant, assignmentCount == storedProperties.count {
+                    let startRemovalIndex = formatter.startOfModifiers(at: initIndex, includingAttributes: false)
+                    let endRemovalIndex = initBodyEndIndex
+
+                    // Find the range including preceding and trailing whitespace
+                    var actualStartIndex = startRemovalIndex
+                    var actualEndIndex = endRemovalIndex
+
+                    // Include preceding spaces and blank line
+                    while let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isSpace {
+                        actualStartIndex -= 1
+                    }
+                    if let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isLinebreak {
+                        actualStartIndex -= 1
+                    }
+
+                    // Include trailing newlines and any orphaned indentation
+                    while let next = formatter.token(at: actualEndIndex + 1), next.isSpaceOrLinebreak {
+                        actualEndIndex += 1
+                    }
+
+                    formatter.removeTokens(in: actualStartIndex ... actualEndIndex)
+                    return
+                }
+
+                searchIndex = initIndex + 1
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        struct Person {
+            var name: String
+            var age: Int
+
+        -   init(name: String, age: Int) {
+        -       self.name = name
+        -       self.age = age
+        -   }
+        }
+        ```
+        """
+    }
+}

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Helper function to get the access level of a declaration
-private func getAccessLevel(for declaration: Declaration, in _: Formatter) -> String {
+private func getAccessLevel(for declaration: Declaration) -> String {
     let modifiers = declaration.modifiers
 
     // Check for explicit access modifiers
@@ -91,14 +91,14 @@ public extension FormatRule {
             guard case let .type(structDeclaration) = declaration.kind else { continue }
 
             // Get the struct's access level
-            let structAccessLevel = getAccessLevel(for: declaration, in: formatter)
+            let structAccessLevel = getAccessLevel(for: declaration)
 
             // Check if there are any private properties (which would make synthesized init private)
             var hasPrivateStoredProperties = false
             for childDeclaration in structDeclaration.body {
                 guard ["var", "let"].contains(childDeclaration.keyword) else { continue }
 
-                let propertyAccessLevel = getAccessLevel(for: childDeclaration, in: formatter)
+                let propertyAccessLevel = getAccessLevel(for: childDeclaration)
                 if propertyAccessLevel == "private" || propertyAccessLevel == "fileprivate" {
                     hasPrivateStoredProperties = true
                     break
@@ -151,7 +151,7 @@ public extension FormatRule {
             // Find init declarations in the struct body
             for initDeclaration in structDeclaration.body where initDeclaration.keyword == "init" {
                 // Get the init's access level
-                let initAccessLevel = getAccessLevel(for: initDeclaration, in: formatter)
+                let initAccessLevel = getAccessLevel(for: initDeclaration)
 
                 // Don't remove if struct is public but init is internal
                 // (compiler won't generate public memberwise init)

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -275,14 +275,14 @@ public extension FormatRule {
     }
 }
 
-private extension Declaration {
+extension Declaration {
     /// Helper function to get the access level of a declaration
     func accessLevel() -> Visibility {
         visibility() ?? .internal
     }
 }
 
-private extension Formatter {
+extension Formatter {
     /// Helper function to check if a stored property has a default value
     func hasDefaultValue(propertyName: String, in structDeclaration: TypeDeclaration) -> Bool {
         for childDeclaration in structDeclaration.body {

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -14,108 +14,87 @@ public extension FormatRule {
         help: "Remove explicit internal memberwise initializers that are redundant.",
         orderAfter: [.redundantInit]
     ) { formatter in
-        formatter.forEach(.keyword("struct")) { structIndex, _ in
-            guard let structBraceIndex = formatter.index(of: .startOfScope("{"), after: structIndex),
-                  let structEndIndex = formatter.endOfScope(at: structBraceIndex)
-            else { return }
-
-            // Collect stored properties
-            var storedProperties: [(name: String, type: String)] = []
-
-            var searchIndex = structBraceIndex + 1
-            while let varOrLetIndex = formatter.index(of: .keyword, after: searchIndex - 1, if: {
-                ["var", "let"].contains($0.string)
-            }), varOrLetIndex < structEndIndex {
-                guard let property = formatter.parsePropertyDeclaration(atIntroducerIndex: varOrLetIndex),
+        // Parse all struct declarations
+        let allDeclarations = formatter.parseDeclarations()
+        
+        for declaration in allDeclarations where declaration.keyword == "struct" {
+            guard case let .type(structDeclaration) = declaration.kind else { continue }
+            
+            // Collect stored properties from the struct body
+            let storedProperties = structDeclaration.body.compactMap { childDeclaration -> (name: String, type: String)? in
+                guard ["var", "let"].contains(childDeclaration.keyword),
+                      let property = formatter.parsePropertyDeclaration(atIntroducerIndex: childDeclaration.keywordIndex),
                       let typeInfo = property.type,
-                      property.body == nil, // Only stored properties
-                      !formatter.modifiersForDeclaration(at: varOrLetIndex, contains: { _, modifier in
+                      property.body == nil, // Only stored properties (no computed properties or observers)
+                      !formatter.modifiersForDeclaration(at: childDeclaration.keywordIndex, contains: { _, modifier in
                           ["static", "private", "fileprivate", "public", "open"].contains(modifier)
                       })
-                else {
-                    searchIndex = varOrLetIndex + 1
-                    continue
-                }
-
-                storedProperties.append((name: property.identifier, type: typeInfo.name))
-                searchIndex = property.range.upperBound + 1
-            }
-
-            guard !storedProperties.isEmpty else { return }
-
-            // Find redundant memberwise inits
-            searchIndex = structBraceIndex + 1
-            while let initIndex = formatter.index(of: .keyword("init"), after: searchIndex - 1),
-                  initIndex < structEndIndex
-            {
-                // Skip if has explicit access modifier
-                guard !formatter.modifiersForDeclaration(at: initIndex, contains: { _, modifier in
-                    ["private", "fileprivate", "public", "open"].contains(modifier)
-                }) else {
-                    searchIndex = initIndex + 1
-                    continue
-                }
-
-                guard let openParenIndex = formatter.index(of: .startOfScope("("), after: initIndex),
-                      let closeParenIndex = formatter.endOfScope(at: openParenIndex),
-                      let initBodyIndex = formatter.index(of: .startOfScope("{"), after: closeParenIndex),
-                      let initBodyEndIndex = formatter.endOfScope(at: initBodyIndex)
-                else {
-                    searchIndex = initIndex + 1
-                    continue
-                }
-
-                // Parse parameters
-                var parameters: [(name: String, type: String)] = []
-                var paramIndex = openParenIndex + 1
-
-                while let nextParamIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: paramIndex - 1),
-                      nextParamIndex < closeParenIndex,
-                      let paramToken = formatter.token(at: nextParamIndex),
-                      paramToken.isIdentifier
-                {
-                    guard let colonIndex = formatter.index(of: .delimiter(":"), after: nextParamIndex),
-                          colonIndex < closeParenIndex,
-                          let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
-                          let typeInfo = formatter.parseType(at: typeStartIndex)
-                    else {
-                        paramIndex = nextParamIndex + 1
-                        continue
+                else { return nil }
+                
+                // Additional check: ensure no property observers (didSet, willSet)
+                let propertyEnd = childDeclaration.range.upperBound
+                var checkIndex = childDeclaration.keywordIndex + 1
+                while checkIndex <= propertyEnd {
+                    if let token = formatter.token(at: checkIndex) {
+                        if token == .identifier("didSet") || token == .identifier("willSet") {
+                            return nil // Has property observers, not a simple stored property
+                        }
                     }
-
-                    parameters.append((name: paramToken.string, type: typeInfo.name))
-
-                    if let commaIndex = formatter.index(of: .delimiter(","), after: typeInfo.range.upperBound),
-                       commaIndex < closeParenIndex
-                    {
-                        paramIndex = commaIndex + 1
-                    } else {
+                    checkIndex += 1
+                }
+                
+                return (name: property.identifier, type: typeInfo.name)
+            }
+            
+            guard !storedProperties.isEmpty else { continue }
+            
+            // Find init declarations in the struct body
+            for initDeclaration in structDeclaration.body where initDeclaration.keyword == "init" {
+                // Skip if has explicit access modifier
+                guard !formatter.modifiersForDeclaration(at: initDeclaration.keywordIndex, contains: { _, modifier in
+                    ["private", "fileprivate", "public", "open"].contains(modifier)
+                }) else { continue }
+                
+                // Parse the init function using the parseFunctionDeclaration helper
+                guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: initDeclaration.keywordIndex),
+                      let bodyRange = functionDecl.bodyRange
+                else { continue }
+                
+                // Check if parameters match stored properties exactly
+                let parameters = functionDecl.arguments.compactMap { arg -> (name: String, type: String)? in
+                    guard let name = arg.internalLabel else { return nil }
+                    return (name: name, type: arg.type)
+                }
+                guard parameters.count == storedProperties.count,
+                      zip(parameters, storedProperties).allSatisfy({ $0.name == $1.name && $0.type == $1.type })
+                else { continue }
+                
+                // Check if body only contains memberwise assignments
+                let bodyStart = bodyRange.lowerBound + 1
+                let bodyEnd = bodyRange.upperBound
+                var isRedundant = true
+                var bodyIndex = bodyStart
+                var assignmentCount = 0
+                
+                // Check for any comments in the body first - if present, don't remove
+                for tokenIndex in bodyStart..<bodyEnd {
+                    let token = formatter.tokens[tokenIndex]
+                    if token.isComment {
+                        isRedundant = false
                         break
                     }
                 }
-
-                // Check if parameters match stored properties
-                guard parameters.count == storedProperties.count,
-                      zip(parameters, storedProperties).allSatisfy({ $0.name == $1.name && $0.type == $1.type })
-                else {
-                    searchIndex = initIndex + 1
-                    continue
-                }
-
-                // Check if body only contains memberwise assignments
-                var isRedundant = true
-                var bodyIndex = initBodyIndex + 1
-                var assignmentCount = 0
-
-                while let nextToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: bodyIndex - 1),
-                      nextToken < initBodyEndIndex
-                {
-                    let token = formatter.tokens[nextToken]
-
-                    if token == .identifier("self") {
-                        guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken, if: {
-                            $0.isOperator(".")
-                        }),
+                
+                if isRedundant {
+                    while let nextToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: bodyIndex - 1),
+                          nextToken < bodyEnd {
+                        
+                        let token = formatter.tokens[nextToken]
+                        
+                        if token == .identifier("self") {
+                            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken, if: {
+                                $0.isOperator(".")
+                            }),
                             let propIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
                             let propToken = formatter.token(at: propIndex),
                             propToken.isIdentifier,
@@ -125,28 +104,29 @@ public extension FormatRule {
                             valueToken.isIdentifier,
                             propToken.string == valueToken.string,
                             storedProperties.contains(where: { $0.name == propToken.string })
-                        else {
+                            else {
+                                isRedundant = false
+                                break
+                            }
+                            
+                            assignmentCount += 1
+                            bodyIndex = valueIndex + 1
+                        } else {
                             isRedundant = false
                             break
                         }
-
-                        assignmentCount += 1
-                        bodyIndex = valueIndex + 1
-                    } else {
-                        isRedundant = false
-                        break
                     }
                 }
-
+                
                 // Remove redundant init if all assignments match
-                if isRedundant, assignmentCount == storedProperties.count {
-                    let startRemovalIndex = formatter.startOfModifiers(at: initIndex, includingAttributes: false)
-                    let endRemovalIndex = initBodyEndIndex
-
+                if isRedundant && assignmentCount == storedProperties.count {
+                    let startRemovalIndex = formatter.startOfModifiers(at: initDeclaration.keywordIndex, includingAttributes: false)
+                    let endRemovalIndex = bodyRange.upperBound
+                    
                     // Find the range including preceding and trailing whitespace
                     var actualStartIndex = startRemovalIndex
                     var actualEndIndex = endRemovalIndex
-
+                    
                     // Include preceding spaces and blank line
                     while let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isSpace {
                         actualStartIndex -= 1
@@ -154,17 +134,15 @@ public extension FormatRule {
                     if let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isLinebreak {
                         actualStartIndex -= 1
                     }
-
+                    
                     // Include trailing newlines and any orphaned indentation
                     while let next = formatter.token(at: actualEndIndex + 1), next.isSpaceOrLinebreak {
                         actualEndIndex += 1
                     }
-
-                    formatter.removeTokens(in: actualStartIndex ... actualEndIndex)
+                    
+                    formatter.removeTokens(in: actualStartIndex...actualEndIndex)
                     return
                 }
-
-                searchIndex = initIndex + 1
             }
         }
     } examples: {

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -9,47 +9,72 @@
 import Foundation
 
 /// Helper function to get the access level of a declaration
-private func getAccessLevel(for declaration: Declaration, in formatter: Formatter) -> String {
+private func getAccessLevel(for declaration: Declaration, in _: Formatter) -> String {
     let modifiers = declaration.modifiers
-    
+
     // Check for explicit access modifiers
     for modifier in ["open", "public", "package", "internal", "fileprivate", "private"] {
         if modifiers.contains(modifier) {
             return modifier
         }
     }
-    
+
     // Default to internal if no explicit access modifier
     return "internal"
+}
+
+/// Helper function to check if a stored property has a default value
+private func hasDefaultValue(propertyName: String, in structDeclaration: TypeDeclaration, formatter: Formatter) -> Bool {
+    for childDeclaration in structDeclaration.body {
+        guard ["var", "let"].contains(childDeclaration.keyword),
+              let property = formatter.parsePropertyDeclaration(atIntroducerIndex: childDeclaration.keywordIndex),
+              property.identifier == propertyName
+        else { continue }
+
+        // Look for '=' token after the property declaration to indicate default value
+        let propertyEnd = childDeclaration.range.upperBound
+        var checkIndex = childDeclaration.keywordIndex + 1
+
+        while checkIndex <= propertyEnd {
+            if let token = formatter.token(at: checkIndex) {
+                if token == .operator("=", .infix) {
+                    return true // Found default value assignment
+                }
+            }
+            checkIndex += 1
+        }
+    }
+    return false
 }
 
 /// Helper function to check if a function argument has a default value
 private func checkForDefaultValue(arg: Formatter.FunctionArgument, in formatter: Formatter) -> Bool {
     // Start searching after the internal label index
     let searchIndex = arg.internalLabelIndex + 1
-    
+
     // Find the colon
     guard let colonIndex = formatter.index(of: .delimiter(":"), after: searchIndex - 1) else {
         return false
     }
-    
+
     // Find the end of the type after the colon
     guard let typeStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex) else {
-        return false  
+        return false
     }
-    
+
     // Parse the type to find its end
     guard let typeInfo = formatter.parseType(at: typeStartIndex) else {
         return false
     }
     let typeEndIndex = typeInfo.range.upperBound
-    
+
     // Look for '=' token after the type
     if let equalsIndex = formatter.index(of: .operator("=", .infix), after: typeEndIndex),
-       formatter.index(of: .nonSpaceOrCommentOrLinebreak, in: typeEndIndex + 1 ..< equalsIndex) == nil {
+       formatter.index(of: .nonSpaceOrCommentOrLinebreak, in: typeEndIndex + 1 ..< equalsIndex) == nil
+    {
         return true
     }
-    
+
     return false
 }
 
@@ -61,17 +86,28 @@ public extension FormatRule {
     ) { formatter in
         // Parse all struct declarations
         let allDeclarations = formatter.parseDeclarations()
-        
+
         for declaration in allDeclarations where declaration.keyword == "struct" {
             guard case let .type(structDeclaration) = declaration.kind else { continue }
-            
+
             // Get the struct's access level
             let structAccessLevel = getAccessLevel(for: declaration, in: formatter)
-            
-            // Collect stored properties from the struct body and check access levels
-            var storedProperties = [(name: String, type: String)]()
+
+            // Check if there are any private properties (which would make synthesized init private)
             var hasPrivateStoredProperties = false
-            
+            for childDeclaration in structDeclaration.body {
+                guard ["var", "let"].contains(childDeclaration.keyword) else { continue }
+
+                let propertyAccessLevel = getAccessLevel(for: childDeclaration, in: formatter)
+                if propertyAccessLevel == "private" || propertyAccessLevel == "fileprivate" {
+                    hasPrivateStoredProperties = true
+                    break
+                }
+            }
+
+            // Collect stored properties from the struct body
+            var storedProperties = [(name: String, type: String)]()
+
             for childDeclaration in structDeclaration.body {
                 guard ["var", "let"].contains(childDeclaration.keyword),
                       let property = formatter.parsePropertyDeclaration(atIntroducerIndex: childDeclaration.keywordIndex),
@@ -81,7 +117,7 @@ public extension FormatRule {
                           ["static"].contains(modifier) // Only exclude static properties
                       })
                 else { continue }
-                
+
                 // Additional check: ensure no property observers (didSet, willSet)
                 let propertyEnd = childDeclaration.range.upperBound
                 var checkIndex = childDeclaration.keywordIndex + 1
@@ -95,48 +131,42 @@ public extension FormatRule {
                     }
                     checkIndex += 1
                 }
-                
+
                 if hasObservers {
                     continue // Skip properties with observers
                 }
-                
-                // Check if this property is private or fileprivate
-                let propertyAccessLevel = getAccessLevel(for: childDeclaration, in: formatter)
-                if propertyAccessLevel == "private" || propertyAccessLevel == "fileprivate" {
-                    hasPrivateStoredProperties = true
-                }
-                
+
                 storedProperties.append((name: property.identifier, type: typeInfo.name))
             }
-            
+
             guard !storedProperties.isEmpty else { continue }
-            
+
             // Find all init declarations in the struct body
             let allInitDeclarations = structDeclaration.body.filter { $0.keyword == "init" }
-            
+
             // If there are multiple inits, don't remove any memberwise init
             // as the compiler won't synthesize it
             guard allInitDeclarations.count == 1 else { continue }
-            
+
             // Find init declarations in the struct body
             for initDeclaration in structDeclaration.body where initDeclaration.keyword == "init" {
                 // Get the init's access level
                 let initAccessLevel = getAccessLevel(for: initDeclaration, in: formatter)
-                
+
                 // Don't remove if struct is public but init is internal
                 // (compiler won't generate public memberwise init)
-                if structAccessLevel == "public" && initAccessLevel == "internal" {
+                if structAccessLevel == "public", initAccessLevel == "internal" {
                     continue
                 }
-                
+
                 // Handle private property access level implications
                 if hasPrivateStoredProperties {
-                    // If the init is internal or public but private properties would make 
-                    // the synthesized init private, don't remove
-                    if initAccessLevel == "internal" || initAccessLevel == "public" {
+                    // If there are ANY private properties, the synthesized init will be private
+                    // Don't remove the explicit init if it's more accessible than private
+                    if initAccessLevel != "private" {
                         continue
                     }
-                    // If both the current init and synthesized init would be private, 
+                    // If both the current init and synthesized init would be private,
                     // it's safe to remove (no access level change)
                 } else {
                     // No private properties, so synthesized init would match struct access level
@@ -145,25 +175,85 @@ public extension FormatRule {
                         continue
                     }
                 }
-                
+
+                // Check if the init has documentation comments
+                var hasDocumentation = false
+
+                // Start from the init keyword and look backwards
+                let initKeywordIndex = initDeclaration.keywordIndex
+                var checkIndex = initKeywordIndex - 1
+
+                // Look backwards from the init keyword to find documentation comments
+                while checkIndex >= 0 {
+                    let token = formatter.tokens[checkIndex]
+
+                    if token.isComment {
+                        let commentText = token.string
+
+                        // Check if it's documentation comment (/// or /** */)
+                        if commentText.hasPrefix("///") || commentText.hasPrefix("/**") {
+                            hasDocumentation = true
+                            break
+                        }
+
+                        // Also check for the case where SwiftFormat splits /// into separate tokens
+                        // Look for // followed by / (indicating the third slash for ///)
+                        if commentText == "//", checkIndex + 1 < formatter.tokens.count {
+                            let nextToken = formatter.tokens[checkIndex + 1]
+                            // Must be exactly "/" (the third slash) followed by content, not just any / content
+                            // For ///, SwiftFormat splits it as "//" + "/ content"
+                            if nextToken.isComment, nextToken.string.hasPrefix("/ ") {
+                                // This is /// split as // + / content (note the space after /)
+                                hasDocumentation = true
+                                break
+                            }
+                        }
+
+                        // Also check for block comments that start with /**
+                        if commentText.contains("/**") {
+                            hasDocumentation = true
+                            break
+                        }
+
+                        // Check for split block comment pattern: /* followed by *
+                        if commentText == "/*", checkIndex + 1 < formatter.tokens.count {
+                            let nextToken = formatter.tokens[checkIndex + 1]
+                            if nextToken.isComment, nextToken.string == "*" {
+                                hasDocumentation = true
+                                break
+                            }
+                        }
+                    } else if !token.isSpaceOrLinebreak {
+                        // Hit non-whitespace, non-comment token, stop looking
+                        break
+                    }
+
+                    checkIndex -= 1
+                }
+
+                // Don't remove init if it has documentation
+                if hasDocumentation {
+                    continue
+                }
+
                 // Parse the init function using the parseFunctionDeclaration helper
                 guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: initDeclaration.keywordIndex),
                       let bodyRange = functionDecl.bodyRange
                 else { continue }
-                
+
                 // Check if parameters match stored properties exactly
                 let parameters = functionDecl.arguments.compactMap { arg -> (name: String, type: String, externalLabel: String?, hasDefaultValue: Bool)? in
                     guard let name = arg.internalLabel else { return nil }
-                    
+
                     // Check for default value by looking for '=' after the type
                     let hasDefaultValue = checkForDefaultValue(arg: arg, in: formatter)
-                    
+
                     return (name: name, type: arg.type, externalLabel: arg.externalLabel, hasDefaultValue: hasDefaultValue)
                 }
-                
+
                 // Don't remove if any parameter has a default value
-                guard !parameters.contains(where: { $0.hasDefaultValue }) else { continue }
-                
+                guard !parameters.contains(where: \.hasDefaultValue) else { continue }
+
                 // Don't remove if any parameter has different external and internal labels
                 // This includes cases where external label is explicitly different or uses underscore
                 guard !parameters.contains(where: { param in
@@ -171,51 +261,58 @@ public extension FormatRule {
                     // If externalLabel exists and is different from internal name, it's also different
                     param.externalLabel == nil || (param.externalLabel != nil && param.externalLabel != param.name)
                 }) else { continue }
-                
-                guard parameters.count == storedProperties.count,
-                      zip(parameters, storedProperties).allSatisfy({ $0.name == $1.name && $0.type == $1.type })
+
+                // Only consider properties that don't have default values for memberwise init comparison
+                // Properties with default values are optional in memberwise init
+                let propertiesWithoutDefaults = storedProperties.filter { prop in
+                    // Check if this stored property has a default value
+                    !hasDefaultValue(propertyName: prop.name, in: structDeclaration, formatter: formatter)
+                }
+
+                guard parameters.count == propertiesWithoutDefaults.count,
+                      zip(parameters, propertiesWithoutDefaults).allSatisfy({ $0.name == $1.name && $0.type == $1.type })
                 else { continue }
-                
+
                 // Check if body only contains memberwise assignments
                 let bodyStart = bodyRange.lowerBound + 1
                 let bodyEnd = bodyRange.upperBound
                 var isRedundant = true
                 var bodyIndex = bodyStart
                 var assignmentCount = 0
-                
+
                 // Check for any comments in the body first - if present, don't remove
-                for tokenIndex in bodyStart..<bodyEnd {
+                for tokenIndex in bodyStart ..< bodyEnd {
                     let token = formatter.tokens[tokenIndex]
                     if token.isComment {
                         isRedundant = false
                         break
                     }
                 }
-                
+
                 if isRedundant {
                     while let nextToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: bodyIndex - 1),
-                          nextToken < bodyEnd {
-                        
+                          nextToken < bodyEnd
+                    {
                         let token = formatter.tokens[nextToken]
-                        
+
                         if token == .identifier("self") {
                             guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken, if: {
                                 $0.isOperator(".")
                             }),
-                            let propIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
-                            let propToken = formatter.token(at: propIndex),
-                            propToken.isIdentifier,
-                            let equalsIndex = formatter.index(of: .operator("=", .infix), after: propIndex),
-                            let valueIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
-                            let valueToken = formatter.token(at: valueIndex),
-                            valueToken.isIdentifier,
-                            propToken.string == valueToken.string,
-                            storedProperties.contains(where: { $0.name == propToken.string })
+                                let propIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                                let propToken = formatter.token(at: propIndex),
+                                propToken.isIdentifier,
+                                let equalsIndex = formatter.index(of: .operator("=", .infix), after: propIndex),
+                                let valueIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                                let valueToken = formatter.token(at: valueIndex),
+                                valueToken.isIdentifier,
+                                propToken.string == valueToken.string,
+                                propertiesWithoutDefaults.contains(where: { $0.name == propToken.string })
                             else {
                                 isRedundant = false
                                 break
                             }
-                            
+
                             assignmentCount += 1
                             bodyIndex = valueIndex + 1
                         } else {
@@ -224,17 +321,17 @@ public extension FormatRule {
                         }
                     }
                 }
-                
-                // Remove redundant init if all assignments match
-                if isRedundant && assignmentCount == storedProperties.count {
+
+                // Remove redundant init if all assignments match (only for properties without defaults)
+                if isRedundant, assignmentCount == propertiesWithoutDefaults.count {
                     // Use the declaration's range which includes leading comments
                     let startRemovalIndex = initDeclaration.range.lowerBound
                     let endRemovalIndex = bodyRange.upperBound
-                    
+
                     // Find the range including preceding and trailing whitespace
                     var actualStartIndex = startRemovalIndex
                     var actualEndIndex = endRemovalIndex
-                    
+
                     // Include preceding spaces and blank line
                     while let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isSpace {
                         actualStartIndex -= 1
@@ -242,13 +339,13 @@ public extension FormatRule {
                     if let prevToken = formatter.token(at: actualStartIndex - 1), prevToken.isLinebreak {
                         actualStartIndex -= 1
                     }
-                    
+
                     // Include trailing newlines and any orphaned indentation
                     while let next = formatter.token(at: actualEndIndex + 1), next.isSpaceOrLinebreak {
                         actualEndIndex += 1
                     }
-                    
-                    formatter.removeTokens(in: actualStartIndex...actualEndIndex)
+
+                    formatter.removeTokens(in: actualStartIndex ... actualEndIndex)
                     return
                 }
             }

--- a/Tests/Rules/BlankLinesBetweenScopesTests.swift
+++ b/Tests/Rules/BlankLinesBetweenScopesTests.swift
@@ -163,7 +163,7 @@ class BlankLinesBetweenScopesTests: XCTestCase {
             // sourcery:end
         }
         """
-        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.redundantPublic])
+        testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.redundantPublic, .redundantMemberwiseInit])
     }
 
     func testNoBlankLineBetweenChainedClosures() {

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -493,4 +493,81 @@ class RedundantMemberwiseInitTests: XCTestCase {
         """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesBetweenScopes])
     }
+
+    func testDontRemoveInitWithDefaultArguments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int = 0) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMultipleDefaultArguments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var city: String
+
+            init(name: String, age: Int = 0, city: String = "Unknown") {
+                self.name = name
+                self.age = age
+                self.city = city
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithDifferentExternalLabels() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(withName name: String, andAge age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMixedExternalLabels() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, withAge age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithUnderscoreExternalLabel() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(_ name: String, _ age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
 }

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -152,7 +152,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testDontRemovePublicInit() {
+    func testRemovePublicInitFromPublicStructDuplicate() {
         let input = """
         public struct Person {
             var name: String
@@ -164,7 +164,13 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+        let output = """
+        public struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
     }
 
     func testRemoveInitWithComputedProperties() {
@@ -565,6 +571,230 @@ class RedundantMemberwiseInitTests: XCTestCase {
             init(_ name: String, _ age: Int) {
                 self.name = name
                 self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInternalInitFromPublicStruct() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemovePublicInitFromPublicStruct() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+
+            public init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        public struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWhenMultipleInitsExist() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+
+            init(name: String) {
+                self.name = name
+                self.age = 0
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWhenThreeInitsExist() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+
+            init(name: String) {
+                self.name = name
+                self.age = 0
+            }
+
+            init() {
+                self.name = "Unknown"
+                self.age = 0
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInitWithAttributes() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            @inlinable
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveInitWithMultipleAttributes() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            @inlinable
+            @available(iOS 13.0, *)
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveInitWithAttributesAndComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            /// Initializes a person with name and age
+            @inlinable
+            internal init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithPrivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithFileprivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            fileprivate var secret: String
+
+            init(name: String, age: Int, secret: String) {
+                self.name = name
+                self.age = age
+                self.secret = secret
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemovePrivateInitWithPrivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            private init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemovePublicInitWithPrivateStoredProperty() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            public init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
             }
         }
         """

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -88,7 +88,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemoveInitWithAdditionalLogic() {
@@ -104,7 +104,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemoveInitWithDifferentParameterNames() {
@@ -119,7 +119,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemoveInitWithDifferentParameterTypes() {
@@ -134,7 +134,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemovePrivateInit() {
@@ -149,7 +149,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemovePublicInit() {
@@ -164,7 +164,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testRemoveInitWithComputedProperties() {
@@ -208,7 +208,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testRemoveInitWithStaticProperties() {
@@ -246,7 +246,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemoveInitWithPartialParameterMatch() {
@@ -263,7 +263,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontAffectClass() {
@@ -278,7 +278,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontAffectEnum() {
@@ -311,7 +311,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testRemoveRedundantInitWithComplexTypes() {
@@ -354,5 +354,143 @@ class RedundantMemberwiseInitTests: XCTestCase {
         }
         """
         testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithMethodCall() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.validate()
+            }
+            
+            func validate() {}
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMethodCallBefore() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                setupDefaults()
+                self.name = name
+                self.age = age
+            }
+            
+            func setupDefaults() {}
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithPrintStatement() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                print("Creating person: \\(name)")
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMultipleStatements() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                print("Person created")
+                NotificationCenter.default.post(name: .personCreated, object: nil)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithGuardStatement() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                guard age >= 0 else { fatalError("Invalid age") }
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesAfterGuardStatements, .wrapConditionalBodies])
+    }
+
+    func testDontRemoveInitWithComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                // Initialize properties
+                self.name = name
+                self.age = age
+                // Initialization complete
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithConditionalLogic() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                if age < 0 {
+                    self.age = 0
+                } else {
+                    self.age = age
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithPropertyObserver() {
+        let input = """
+        struct Person {
+            var name: String {
+                didSet { print("Name changed") }
+            }
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesBetweenScopes])
     }
 }

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -483,23 +483,6 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testDontRemoveInitWithPropertyObserver() {
-        let input = """
-        struct Person {
-            var name: String {
-                didSet { print("Name changed") }
-            }
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesBetweenScopes])
-    }
-
     func testDontRemoveInitWithDefaultArguments() {
         let input = """
         struct Person {
@@ -860,29 +843,6 @@ class RedundantMemberwiseInitTests: XCTestCase {
         }
         """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemovePrivateInitWhenPrivatePropertiesWithDefaultValues() {
-        let input = """
-        struct Person {
-            let name: String
-            let age: Int
-            private var id: String = "default"
-
-            private init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            let name: String
-            let age: Int
-            private var id: String = "default"
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
     }
 
     func testDontRemoveInitWithDocumentationComments() {

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -1,0 +1,358 @@
+//
+//  RedundantMemberwiseInitTests.swift
+//  SwiftFormatTests
+//
+//  Created by Miguel Jimenez on 6/17/25.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class RedundantMemberwiseInitTests: XCTestCase {
+    func testRemoveRedundantMemberwiseInit() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveRedundantMemberwiseInitWithLetProperties() {
+        let input = """
+        struct Point {
+            let x: Double
+            let y: Double
+
+            init(x: Double, y: Double) {
+                self.x = x
+                self.y = y
+            }
+        }
+        """
+        let output = """
+        struct Point {
+            let x: Double
+            let y: Double
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveRedundantMemberwiseInitMixedProperties() {
+        let input = """
+        struct User {
+            let id: Int
+            var name: String
+            var email: String
+
+            init(id: Int, name: String, email: String) {
+                self.id = id
+                self.name = name
+                self.email = email
+            }
+        }
+        """
+        let output = """
+        struct User {
+            let id: Int
+            var name: String
+            var email: String
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveCustomInit() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name.uppercased()
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithAdditionalLogic() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                print("Person created")
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithDifferentParameterNames() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(fullName: String, yearsOld: Int) {
+                self.name = fullName
+                self.age = yearsOld
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithDifferentParameterTypes() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Double) {
+                self.name = name
+                self.age = Int(age)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemovePrivateInit() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            private init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemovePublicInit() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+
+            public init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testRemoveInitWithComputedProperties() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool {
+                return age >= 18
+            }
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool {
+                return age >= 18
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithComputedPropertyInitialization() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.isAdult = age >= 18
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testRemoveInitWithStaticProperties() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            static var defaultAge = 0
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            static var defaultAge = 0
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithPrivateProperties() {
+        let input = """
+        struct Person {
+            private var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithPartialParameterMatch() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var city: String
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.city = "Unknown"
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontAffectClass() {
+        let input = """
+        class Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontAffectEnum() {
+        let input = """
+        enum Color {
+            case red
+            case blue
+
+            init() {
+                self = .red
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.trailingSpace])
+    }
+
+    func testHandleEmptyStruct() {
+        let input = """
+        struct Empty {
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.emptyBraces])
+    }
+
+    func testHandleStructWithOnlyComputedProperties() {
+        let input = """
+        struct Calculator {
+            var result: Int {
+                return 42
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testRemoveRedundantInitWithComplexTypes() {
+        let input = """
+        struct Container {
+            var items: [String]
+            var metadata: [String: Any]
+
+            init(items: [String], metadata: [String: Any]) {
+                self.items = items
+                self.metadata = metadata
+            }
+        }
+        """
+        let output = """
+        struct Container {
+            var items: [String]
+            var metadata: [String: Any]
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveRedundantInitWithOptionalTypes() {
+        let input = """
+        struct Person {
+            var name: String?
+            var age: Int?
+
+            init(name: String?, age: Int?) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String?
+            var age: Int?
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+}

--- a/Tests/Rules/RedundantPublicTests.swift
+++ b/Tests/Rules/RedundantPublicTests.swift
@@ -61,7 +61,7 @@ class RedundantPublicTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, [output], rules: [.redundantPublic])
+        testFormatting(for: input, [output], rules: [.redundantPublic], exclude: [.redundantMemberwiseInit])
     }
 
     func testDoesNotRemovePublicFromPublicType() {

--- a/debug_test.swift
+++ b/debug_test.swift
@@ -1,0 +1,4 @@
+struct Person {
+    var name: String
+    var age: Int
+}

--- a/debug_test.swift
+++ b/debug_test.swift
@@ -1,4 +1,0 @@
-struct Person {
-    var name: String
-    var age: Int
-}


### PR DESCRIPTION
This rule removes an explicit initializer from structs when the initializer can be syntetized by the compiler, therefore the init becomes redundant. 

```diff
struct Person {
    var name: String
    var age: Int

-   init(name: String, age: Int) {
-       self.name = name
-       self.age = age
-   }
}
```