### PR TITLE
Add support for SARIF output format.

### DIFF
--- a/Sources/Reporter.swift
+++ b/Sources/Reporter.swift
@@ -70,6 +70,7 @@ enum Reporters {
         JSONReporter.self,
         GithubActionsLogReporter.self,
         XMLReporter.self,
+        SARIFReporter.self,
     ]
 
     static var help: String {

--- a/Sources/SARIFReporter.swift
+++ b/Sources/SARIFReporter.swift
@@ -1,0 +1,191 @@
+//
+//  SARIFReporter.swift
+//  SwiftFormat
+//
+//  Created by Laurent Etiemble on 25/06/2025.
+//  Copyright 2025 Nick Lockwood and the SwiftFormat project authors
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/SwiftFormat
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+final class SARIFReporter: Reporter {
+    static let name: String = "sarif"
+    static let fileExtension: String? = "sarif"
+
+    private var changes: [Formatter.Change] = []
+
+    init(environment _: [String: String]) {}
+
+    func report(_ changes: [Formatter.Change]) {
+        self.changes.append(contentsOf: changes)
+    }
+
+    func write() throws -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            encoder.outputFormatting.insert(.sortedKeys)
+        }
+        let stripSlashes: Bool
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            stripSlashes = false
+            encoder.outputFormatting.insert(.withoutEscapingSlashes)
+        } else {
+            stripSlashes = true
+        }
+        let result = SARIFLog(changes)
+        var data = try encoder.encode(result)
+        if stripSlashes, let string = String(data: data, encoding: .utf8) {
+            data = Data(string.replacingOccurrences(of: "\\/", with: "/").utf8)
+        }
+        return data
+    }
+}
+
+/// Partial model for a SARIF log object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790728
+private struct SARIFLog: Encodable {
+    let version: String = "2.1.0"
+    let schema = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+    let runs: [Run]
+
+    init(_ changes: [Formatter.Change]) {
+        runs = [Run(changes)]
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case schema = "$schema"
+        case runs
+    }
+}
+
+/// Partial model for a SARIF run object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790734
+private struct Run: Encodable {
+    let tool: Tool
+    let results: [Result]
+
+    init(_ changes: [Formatter.Change]) {
+        tool = Tool()
+        results = changes.map(Result.init)
+    }
+}
+
+/// Partial model for a SARIF tool object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790779
+private struct Tool: Encodable {
+    let driver = ToolComponent()
+}
+
+/// Partial model for a SARIF toolComponent object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790783
+private struct ToolComponent: Encodable {
+    let name = "SwiftFormat"
+    let version = swiftFormatVersion
+    let informationUri = "https://github.com/nicklockwood/SwiftFormat"
+}
+
+/// Partial model for a SARIF result object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790888
+private struct Result: Encodable {
+    let ruleId: String
+    let level: Level
+    let message: Message
+    let locations: [Location]
+
+    init(_ change: Formatter.Change) {
+        ruleId = change.rule.name
+        level = .warning
+        message = Message(change)
+        locations = [Location(change)]
+    }
+}
+
+private enum Level: String, Encodable {
+    case none
+    case note
+    case warning
+    case error
+}
+
+/// Partial model for a SARIF message object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790709
+private struct Message: Encodable {
+    let text: String
+
+    init(_ change: Formatter.Change) {
+        text = change.help
+    }
+}
+
+/// Partial model for a SARIF location object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790920
+private struct Location: Encodable {
+    let physicalLocation: PhysicalLocation
+
+    init(_ change: Formatter.Change) {
+        physicalLocation = PhysicalLocation(change)
+    }
+}
+
+/// Partial model for a SARIF physicalLocation object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790928
+private struct PhysicalLocation: Encodable {
+    let artifactLocation: ArtifactLocation
+    let region: Region
+
+    init(_ change: Formatter.Change) {
+        artifactLocation = ArtifactLocation(change)
+        region = Region(change)
+    }
+}
+
+/// Partial model for a SARIF artifactLocation object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790677
+private struct ArtifactLocation: Encodable {
+    let uri: URL
+
+    init(_ change: Formatter.Change) {
+        uri = URL(fileURLWithPath: change.filePath ?? "/")
+    }
+}
+
+/// Partial model for a SARIF message object.
+/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790935
+private struct Region: Encodable {
+    let startLine: Int
+    let startColumn: Int
+    let endLine: Int
+    let endColumn: Int
+
+    init(_ change: Formatter.Change) {
+        startLine = change.line
+        startColumn = 1
+        endLine = change.line
+        endColumn = 2
+    }
+}

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -93,6 +93,10 @@
 		2EF8BF1E2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		37D828AB24BF77DA0012FC0A /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; };
 		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6E954FF32E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
+		6E954FF42E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
+		6E954FF52E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
+		6E954FF62E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
 		9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EAC41D5DB54A00A0A8E3 /* SwiftFormat.swift */; };
 		9028F7841DA4B435009FE5B4 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A0EABF1D5DB4F700A0A8E3 /* Tokenizer.swift */; };
 		9028F7851DA4B435009FE5B4 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3987C1D763493009ADE61 /* Formatter.swift */; };
@@ -239,6 +243,7 @@
 		2EF737532C5E897800128F91 /* ProjectFilePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFilePaths.swift; sourceTree = "<group>"; };
 		2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationType.swift; sourceTree = "<group>"; };
 		37D828AA24BF77DA0012FC0A /* XcodeKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XcodeKit.framework; path = Library/Frameworks/XcodeKit.framework; sourceTree = DEVELOPER_DIR; };
+		6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SARIFReporter.swift; sourceTree = "<group>"; };
 		90C4B6CA1DA4B04A009EB000 /* SwiftFormat for Xcode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftFormat for Xcode.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C4B6CC1DA4B04A009EB000 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		90C4B6D01DA4B04A009EB000 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -333,6 +338,7 @@
 				DD9AD39D2999FCC8001C2C0E /* Reporter.swift */,
 				DD9AD39C2999FCC8001C2C0E /* GithubActionsLogReporter.swift */,
 				A3DF48242620E03600F45A5F /* JSONReporter.swift */,
+				6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */,
 				C2FFD1812BD13C9E00774F55 /* XMLReporter.swift */,
 			);
 			name = Reporters;
@@ -830,6 +836,7 @@
 				01A0EAC11D5DB4F700A0A8E3 /* FormatRule.swift in Sources */,
 				01A0EAC51D5DB54A00A0A8E3 /* SwiftFormat.swift in Sources */,
 				C2FFD1822BD13C9E00774F55 /* XMLReporter.swift in Sources */,
+				6E954FF32E0DEACC004EE019 /* SARIFReporter.swift in Sources */,
 				2E7D30A42A7940C500C32174 /* Singularize.swift in Sources */,
 				2E2BAB8C2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
 				01B3987D1D763493009ADE61 /* Formatter.swift in Sources */,
@@ -888,6 +895,7 @@
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
 				015243E22B04B0A600F65221 /* Singularize.swift in Sources */,
+				6E954FF42E0DEACC004EE019 /* SARIFReporter.swift in Sources */,
 				C2FFD1832BD13C9E00774F55 /* XMLReporter.swift in Sources */,
 				01A0EACD1D5DB5F500A0A8E3 /* main.swift in Sources */,
 				2E2BAB8D2C57F6B600590239 /* RuleRegistry.generated.swift in Sources */,
@@ -926,6 +934,7 @@
 				01045A93211988F100D2BE3D /* Inference.swift in Sources */,
 				E41CB5C32026CACD00C1BEDE /* ListSelectionTableCellView.swift in Sources */,
 				E4872129201E3DD50014845E /* RulesStore.swift in Sources */,
+				6E954FF62E0DEACC004EE019 /* SARIFReporter.swift in Sources */,
 				E41CB5BF2025761D00C1BEDE /* UserSelection.swift in Sources */,
 				E4872111201D3B830014845E /* Options.swift in Sources */,
 				01A95BD3225BEDE400744931 /* ParsingHelpers.swift in Sources */,
@@ -964,6 +973,7 @@
 				E487212A201E3DD50014845E /* RulesStore.swift in Sources */,
 				01F3DF8E1DB9FD3F00454944 /* Options.swift in Sources */,
 				9028F7831DA4B435009FE5B4 /* SwiftFormat.swift in Sources */,
+				6E954FF52E0DEACC004EE019 /* SARIFReporter.swift in Sources */,
 				B9C4F55C2387FA3E0088DBEE /* SupportedContentUTIs.swift in Sources */,
 				90C4B6E71DA4B059009EB000 /* FormatSelectionCommand.swift in Sources */,
 				90F16AF81DA5EB4600EB4EA1 /* FormatFileCommand.swift in Sources */,


### PR DESCRIPTION
This PR add a new reporter that supports the SARIF format (https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790677).

I have added a partial object model for SARIF, just enough to produce a valid content.