### PR TITLE
Fix public struct handling in redundantMemberwiseInit rule

### DIFF
--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -12,7 +12,6 @@ public extension FormatRule {
     /// Remove redundant explicit memberwise initializers from structs
     static let redundantMemberwiseInit = FormatRule(
         help: "Remove explicit internal memberwise initializers that are redundant.",
-        disabledByDefault: true,
         orderAfter: [.redundantInit]
     ) { formatter in
         // Parse all struct declarations
@@ -62,9 +61,9 @@ public extension FormatRule {
                 // Get the init's access level
                 let initAccessLevel = initDeclaration.accessLevel()
 
-                // Don't remove if struct is public but init is internal
+                // Don't remove public inits from public structs
                 // (compiler won't generate public memberwise init)
-                if structAccessLevel == .public, initAccessLevel == .internal {
+                if structAccessLevel == .public, initAccessLevel == .public {
                     continue
                 }
 
@@ -306,6 +305,7 @@ extension Formatter {
                   property.identifier == propertyName,
                   property.value != nil
             else { continue }
+            return true
         }
         return false
     }

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -12,6 +12,7 @@ public extension FormatRule {
     /// Remove redundant explicit memberwise initializers from structs
     static let redundantMemberwiseInit = FormatRule(
         help: "Remove explicit internal memberwise initializers that are redundant.",
+        disabledByDefault: true,
         orderAfter: [.redundantInit]
     ) { formatter in
         // Parse all struct declarations

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -62,9 +62,9 @@ public extension FormatRule {
                 // Get the init's access level
                 let initAccessLevel = initDeclaration.accessLevel()
 
-                // Don't remove public inits from public structs
+                // Don't remove public or package inits
                 // (compiler won't generate public memberwise init)
-                if initAccessLevel == .public, initAccessLevel == .package {
+                if initAccessLevel == .public || initAccessLevel == .package {
                     continue
                 }
 

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -64,7 +64,7 @@ public extension FormatRule {
 
                 // Don't remove public inits from public structs
                 // (compiler won't generate public memberwise init)
-                if structAccessLevel == .public, initAccessLevel == .public {
+                if initAccessLevel == .public {
                     continue
                 }
 

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -64,7 +64,7 @@ public extension FormatRule {
 
                 // Don't remove public inits from public structs
                 // (compiler won't generate public memberwise init)
-                if initAccessLevel == .public {
+                if initAccessLevel == .public, initAccessLevel == .package {
                     continue
                 }
 

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -152,6 +152,415 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
+
+    func testRemoveInitWithComputedProperties() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool {
+                return age >= 18
+            }
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool {
+                return age >= 18
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithComputedPropertyInitialization() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var isAdult: Bool
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.isAdult = age >= 18
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInitWithStaticProperties() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            static var defaultAge = 0
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            static var defaultAge = 0
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+    }
+
+    func testDontRemoveInitWithPrivateProperties() {
+        let input = """
+        struct Person {
+            private var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithPartialParameterMatch() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var city: String
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.city = "Unknown"
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontAffectClass() {
+        let input = """
+        class Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontAffectEnum() {
+        let input = """
+        enum Color {
+            case red
+            case blue
+
+            init() {
+                self = .red
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.trailingSpace])
+    }
+
+    func testHandleEmptyStruct() {
+        let input = """
+        struct Empty {
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.emptyBraces])
+    }
+
+    func testHandleStructWithOnlyComputedProperties() {
+        let input = """
+        struct Calculator {
+            var result: Int {
+                return 42
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveRedundantInitWithComplexTypes() {
+        let input = """
+        struct Container {
+            var items: [String]
+            var metadata: [String: Any]
+
+            init(items: [String], metadata: [String: Any]) {
+                self.items = items
+                self.metadata = metadata
+            }
+        }
+        """
+        let output = """
+        struct Container {
+            var items: [String]
+            var metadata: [String: Any]
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveRedundantInitWithOptionalTypes() {
+        let input = """
+        struct Person {
+            var name: String?
+            var age: Int?
+
+            init(name: String?, age: Int?) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String?
+            var age: Int?
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithMethodCall() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                self.validate()
+            }
+
+            func validate() {}
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMethodCallBefore() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                setupDefaults()
+                self.name = name
+                self.age = age
+            }
+
+            func setupDefaults() {}
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithPrintStatement() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                print("Creating person: \\(name)")
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMultipleStatements() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+                print("Person created")
+                NotificationCenter.default.post(name: .personCreated, object: nil)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithGuardStatement() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                guard age >= 0 else { fatalError("Invalid age") }
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesAfterGuardStatements, .wrapConditionalBodies])
+    }
+
+    func testDontRemoveInitWithComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                // Initialize properties
+                self.name = name
+                self.age = age
+                // Initialization complete
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithConditionalLogic() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                if age < 0 {
+                    self.age = 0
+                } else {
+                    self.age = age
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithDefaultArguments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int = 0) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMultipleDefaultArguments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            var city: String
+
+            init(name: String, age: Int = 0, city: String = "Unknown") {
+                self.name = name
+                self.age = age
+                self.city = city
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithDifferentExternalLabels() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(withName name: String, andAge age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMixedExternalLabels() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, withAge age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithUnderscoreExternalLabel() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(_ name: String, _ age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInternalInitFromPublicStruct() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        public struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
     func testDontRemovePublicInitFromPublicStruct() {
         let input = """
         public struct Person {
@@ -167,25 +576,533 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testRemoveInternalInitFromPublicStruct() {
+    func testDontRemoveInitWhenMultipleInitsExist() {
         let input = """
-        public struct Person {
+        struct Person {
+            var name: String
+            var age: Int
+
             init(name: String, age: Int) {
                 self.name = name
                 self.age = age
             }
 
-            public let name: String
-            public let age: Int
+            init(name: String) {
+                self.name = name
+                self.age = 0
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWhenThreeInitsExist() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+
+            init(name: String) {
+                self.name = name
+                self.age = 0
+            }
+
+            init() {
+                self.name = "Unknown"
+                self.age = 0
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInitWithAttributes() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            @inlinable
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
         }
         """
         let output = """
-        public struct Person {
-            public let name: String
-            public let age: Int
+        struct Person {
+            var name: String
+            var age: Int
         }
         """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveInitWithMultipleAttributes() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            @inlinable
+            @available(iOS 13.0, *)
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testRemoveInitWithAttributesAndComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            /// Initializes a person with name and age
+            @inlinable
+            internal init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveInitWithPrivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithFileprivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            fileprivate var secret: String
+
+            init(name: String, age: Int, secret: String) {
+                self.name = name
+                self.age = age
+                self.secret = secret
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemovePrivateInitWithPrivateStoredProperty() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            private init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemovePublicInitWithPrivateStoredProperty() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+            private var id: String
+
+            public init(name: String, age: Int, id: String) {
+                self.name = name
+                self.age = age
+                self.id = id
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWhenPrivatePropertiesWithDefaultValues() {
+        let input = """
+        struct PayoutView {
+            let dataModel: String
+            private var style = DefaultStyle()
+
+            init(dataModel: String) {
+                self.dataModel = dataModel
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .propertyTypes])
+    }
+
+    func testDontRemoveInitWhenPrivatePropertiesHaveNoDefaultValues() {
+        let input = """
+        struct PayoutView {
+            let dataModel: String
+            private var shadowedStyle: ShadowedStyle
+
+            init(dataModel: String, shadowedStyle: ShadowedStyle) {
+                self.dataModel = dataModel
+                self.shadowedStyle = shadowedStyle
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWhenAllPropertiesInitialized() {
+        let input = """
+        struct Person {
+            let name: String
+            let age: Int
+            private var id: String = "default"
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWhenPrivatePropertiesWithDefaultsMakesSynthesizedInitPrivate() {
+        let input = """
+        struct Person {
+            let name: String
+            let age: Int
+            private var id: String = "default"
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithDocumentationComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            /// Creates a Person with the specified name and age
+            init(name: String, age: Int) {
+                self.name = name  
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveInitWithMultiLineDocumentationComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            /**
+             * Creates a Person with the specified name and age.
+             * - Parameter name: The person's full name
+             * - Parameter age: The person's age in years
+             */
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInitWithRegularComments() {
+        let input = """
+        struct Person {
+            var name: String
+            var age: Int
+
+            // This is just a regular comment
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            var name: String
+            var age: Int
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
+    }
+
+    func testDontRemoveRedundantPublicMemberwiseInitWithProperFormattingOfFirstProperty() {
+        let input = """
+        public struct CardViewAnimationState {
+            public init(
+            style: CardStyle,
+            backgroundColor: UIColor?
+            ) {
+            self.style = style
+            self.backgroundColor = backgroundColor
+            }
+
+            public let style: CardStyle
+            public let backgroundColor: UIColor?
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .wrapArguments])
+    }
+
+    func testDontRemoveRedundantMemberwiseInitWithComplexPublicStruct() {
+        let input = """
+        public struct Foo {
+
+          // MARK: Lifecycle
+
+          public init(
+            name: String,
+            value: Int,
+            isEnabled: Bool
+          ) {
+            self.name = name
+            self.value = value
+            self.isEnabled = isEnabled
+          }
+
+          // MARK: Public
+
+          public let name: String
+          public let value: Int
+          public let isEnabled: Bool
+        }
+
+        public struct Bar: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            id: String,
+            count: Int
+          ) {
+            self.id = id
+            self.count = count
+          }
+
+          // MARK: Public
+
+          public let id: String
+          public let count: Int
+        }
+
+        // MARK: - Baz
+
+        public struct Baz: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            title: String,
+            subtitle: String?,
+            data: [String]
+          ) {
+            self.title = title
+            self.subtitle = subtitle
+            self.data = data
+          }
+
+          // MARK: Public
+
+          public let title: String
+          public let subtitle: String?
+          public let data: [String]
+        }
+
+        // MARK: - Qux
+
+        public struct Qux: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            key: String,
+            value: String?
+          ) {
+            self.key = key
+            self.value = value
+          }
+
+          // MARK: Public
+
+          public let key: String
+          public let value: String?
+        }
+
+        // MARK: - Widget
+
+        public struct Widget: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            name: String,
+            color: String,
+            size: Int
+          ) {
+            self.name = name
+            self.color = color
+            self.size = size
+          }
+
+          // MARK: Public
+
+          public let name: String
+          public let color: String
+          public let size: Int
+        }
+
+        // MARK: - Item
+
+        public struct Item: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            identifier: String,
+            label: String
+          ) {
+            self.identifier = identifier
+            self.label = label
+          }
+
+          // MARK: Public
+
+          public let identifier: String
+          public let label: String
+        }
+
+        // MARK: - Component
+
+        public struct Component: Equatable {
+          public init(type: String, config: [String: Any]) {
+            self.type = type
+            self.config = config
+          }
+
+          public let type: String
+          public let config: [String: Any]
+        }
+
+        // MARK: - Element
+
+        public struct Element: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            tag: String,
+            attributes: [String]?,
+            content: String
+          ) {
+            self.tag = tag
+            self.attributes = attributes
+            self.content = content
+          }
+
+          // MARK: Public
+
+          public let tag: String
+          public let attributes: [String]?
+          public let content: String
+        }
+
+        // MARK: - Node
+
+        public struct Node: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(id: String, parent: String?, children: [String]) {
+            self.id = id
+            self.parent = parent
+            self.children = children
+          }
+
+          // MARK: Public
+
+          public let id: String
+          public let parent: String?
+          public let children: [String]
+        }
+
+        // MARK: - Record
+
+        public struct Record: Equatable {
+
+          // MARK: Lifecycle
+
+          public init(
+            timestamp: Double,
+            message: String
+          ) {
+            self.timestamp = timestamp
+            self.message = message
+          }
+
+          // MARK: Public
+
+          public let timestamp: Double
+          public let message: String
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.indent, .acronyms, .blankLinesAtStartOfScope, .redundantSelf, .trailingSpace, .wrapArguments])
     }
 
     func testRemoveInternalInitFromPublicStructWithInternalProperties() {
@@ -222,164 +1139,5 @@ class RedundantMemberwiseInitTests: XCTestCase {
         }
         """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithPrivateProperties() {
-        let input = """
-        struct Person {
-            private var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontAffectClass() {
-        let input = """
-        class Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontAffectEnum() {
-        let input = """
-        enum Color {
-            case red
-            case blue
-
-            init() {
-                self = .red
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.trailingSpace])
-    }
-
-    func testRemoveRedundantMemberwiseInitWithComplexStruct() {
-        let input = """
-        struct Foo {
-
-          // MARK: Lifecycle
-
-          init(
-            name: String,
-            value: Int,
-            isEnabled: Bool
-          ) {
-            self.name = name
-            self.value = value
-            self.isEnabled = isEnabled
-          }
-
-          // MARK: Public
-
-          let name: String
-          let value: Int
-          let isEnabled: Bool
-        }
-
-        struct Bar: Equatable {
-
-          // MARK: Lifecycle
-
-          init(
-            id: String,
-            count: Int
-          ) {
-            self.id = id
-            self.count = count
-          }
-
-          // MARK: Public
-
-          let id: String
-          let count: Int
-        }
-
-        // MARK: - Baz
-
-        struct Baz: Equatable {
-
-          // MARK: Lifecycle
-
-          init(
-            title: String,
-            subtitle: String?,
-            data: [String]
-          ) {
-            self.title = title
-            self.subtitle = subtitle
-            self.data = data
-          }
-
-          // MARK: Public
-
-          let title: String
-          let subtitle: String?
-          let data: [String]
-        }
-
-        // MARK: - Component
-
-        struct Component: Equatable {
-          init(type: String, config: [String: Any]) {
-            self.type = type
-            self.config = config
-          }
-
-          let type: String
-          let config: [String: Any]
-        }
-        """
-        let output = """
-        struct Foo {
-
-          // MARK: Public
-
-          let name: String
-          let value: Int
-          let isEnabled: Bool
-        }
-
-        struct Bar: Equatable {
-
-          // MARK: Public
-
-          let id: String
-          let count: Int
-        }
-
-        // MARK: - Baz
-
-        struct Baz: Equatable {
-
-          // MARK: Public
-
-          let title: String
-          let subtitle: String?
-          let data: [String]
-        }
-
-        // MARK: - Component
-
-        struct Component: Equatable {
-          let type: String
-          let config: [String: Any]
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.indent, .acronyms, .blankLinesAtStartOfScope])
     }
 }

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -901,13 +901,13 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .wrapArguments])
     }
 
-    func testDontRemoveRedundantMemberwiseInitWithComplexPublicStruct() {
+    func testRemoveRedundantMemberwiseInitWithComplexStruct() {
         let input = """
-        public struct Foo {
+        struct Foo {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             name: String,
             value: Int,
             isEnabled: Bool
@@ -919,16 +919,16 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let name: String
-          public let value: Int
-          public let isEnabled: Bool
+          let name: String
+          let value: Int
+          let isEnabled: Bool
         }
 
-        public struct Bar: Equatable {
+        struct Bar: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             id: String,
             count: Int
           ) {
@@ -938,17 +938,17 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let id: String
-          public let count: Int
+          let id: String
+          let count: Int
         }
 
         // MARK: - Baz
 
-        public struct Baz: Equatable {
+        struct Baz: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             title: String,
             subtitle: String?,
             data: [String]
@@ -960,18 +960,18 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let title: String
-          public let subtitle: String?
-          public let data: [String]
+          let title: String
+          let subtitle: String?
+          let data: [String]
         }
 
         // MARK: - Qux
 
-        public struct Qux: Equatable {
+        struct Qux: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             key: String,
             value: String?
           ) {
@@ -981,17 +981,17 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let key: String
-          public let value: String?
+          let key: String
+          let value: String?
         }
 
         // MARK: - Widget
 
-        public struct Widget: Equatable {
+        struct Widget: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             name: String,
             color: String,
             size: Int
@@ -1003,18 +1003,18 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let name: String
-          public let color: String
-          public let size: Int
+          let name: String
+          let color: String
+          let size: Int
         }
 
         // MARK: - Item
 
-        public struct Item: Equatable {
+        struct Item: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             identifier: String,
             label: String
           ) {
@@ -1024,29 +1024,29 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let identifier: String
-          public let label: String
+          let identifier: String
+          let label: String
         }
 
         // MARK: - Component
 
-        public struct Component: Equatable {
-          public init(type: String, config: [String: Any]) {
+        struct Component: Equatable {
+          init(type: String, config: [String: Any]) {
             self.type = type
             self.config = config
           }
 
-          public let type: String
-          public let config: [String: Any]
+          let type: String
+          let config: [String: Any]
         }
 
         // MARK: - Element
 
-        public struct Element: Equatable {
+        struct Element: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             tag: String,
             attributes: [String]?,
             content: String
@@ -1058,18 +1058,18 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let tag: String
-          public let attributes: [String]?
-          public let content: String
+          let tag: String
+          let attributes: [String]?
+          let content: String
         }
 
         // MARK: - Node
 
-        public struct Node: Equatable {
+        struct Node: Equatable {
 
           // MARK: Lifecycle
 
-          public init(id: String, parent: String?, children: [String]) {
+          init(id: String, parent: String?, children: [String]) {
             self.id = id
             self.parent = parent
             self.children = children
@@ -1077,18 +1077,18 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let id: String
-          public let parent: String?
-          public let children: [String]
+          let id: String
+          let parent: String?
+          let children: [String]
         }
 
         // MARK: - Record
 
-        public struct Record: Equatable {
+        struct Record: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             timestamp: Double,
             message: String
           ) {
@@ -1098,11 +1098,110 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let timestamp: Double
-          public let message: String
+          let timestamp: Double
+          let message: String
         }
         """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.indent, .acronyms, .blankLinesAtStartOfScope, .redundantSelf, .trailingSpace, .wrapArguments])
+        let output = """
+        struct Foo {
+
+          // MARK: Public
+
+          let name: String
+          let value: Int
+          let isEnabled: Bool
+        }
+
+        struct Bar: Equatable {
+
+          // MARK: Public
+
+          let id: String
+          let count: Int
+        }
+
+        // MARK: - Baz
+
+        struct Baz: Equatable {
+
+          // MARK: Public
+
+          let title: String
+          let subtitle: String?
+          let data: [String]
+        }
+
+        // MARK: - Qux
+
+        struct Qux: Equatable {
+
+          // MARK: Public
+
+          let key: String
+          let value: String?
+        }
+
+        // MARK: - Widget
+
+        struct Widget: Equatable {
+
+          // MARK: Public
+
+          let name: String
+          let color: String
+          let size: Int
+        }
+
+        // MARK: - Item
+
+        struct Item: Equatable {
+
+          // MARK: Public
+
+          let identifier: String
+          let label: String
+        }
+
+        // MARK: - Component
+
+        struct Component: Equatable {
+          let type: String
+          let config: [String: Any]
+        }
+
+        // MARK: - Element
+
+        struct Element: Equatable {
+
+          // MARK: Public
+
+          let tag: String
+          let attributes: [String]?
+          let content: String
+        }
+
+        // MARK: - Node
+
+        struct Node: Equatable {
+
+          // MARK: Public
+
+          let id: String
+          let parent: String?
+          let children: [String]
+        }
+
+        // MARK: - Record
+
+        struct Record: Equatable {
+
+          // MARK: Public
+
+          let timestamp: Double
+          let message: String
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.indent, .acronyms, .blankLinesAtStartOfScope])
     }
 
     func testRemoveInternalInitFromPublicStructWithInternalProperties() {

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -152,7 +152,6 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-
     func testRemoveInitWithComputedProperties() {
         let input = """
         struct Person {
@@ -776,6 +775,41 @@ class RedundantMemberwiseInitTests: XCTestCase {
         }
         """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .propertyTypes])
+    }
+
+    func testDontRemoveInitWhenPropertyHasDefaultValueButInitTakesBothRequiredAndOptional() {
+        let input = """
+        struct Person {
+            let name: String
+            var age: Int = 25
+
+            init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInitWhenPropertyHasDefaultValueAndInitMatchesCompilerGenerated() {
+        let input = """
+        struct Person {
+            let name: String
+            var age: Int = 25
+
+            init(name: String) {
+                self.name = name
+            }
+        }
+        """
+        let output = """
+        struct Person {
+            let name: String
+            var age: Int = 25
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
     }
 
     func testDontRemoveInitWhenPrivatePropertiesHaveNoDefaultValues() {

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -152,7 +152,7 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testRemovePublicInitFromPublicStructDuplicate() {
+    func testDontRemovePublicInitFromPublicStruct() {
         let input = """
         public struct Person {
             var name: String
@@ -164,80 +164,64 @@ class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        let output = """
-        public struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveInitWithComputedProperties() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            var isAdult: Bool {
-                return age >= 18
-            }
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-            var isAdult: Bool {
-                return age >= 18
-            }
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testDontRemoveInitWithComputedPropertyInitialization() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            var isAdult: Bool
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-                self.isAdult = age >= 18
-            }
-        }
-        """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testRemoveInitWithStaticProperties() {
+    func testRemoveInternalInitFromPublicStruct() {
         let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            static var defaultAge = 0
-
+        public struct Person {
             init(name: String, age: Int) {
                 self.name = name
                 self.age = age
             }
+
+            public let name: String
+            public let age: Int
         }
         """
         let output = """
-        struct Person {
-            var name: String
-            var age: Int
-            static var defaultAge = 0
+        public struct Person {
+            public let name: String
+            public let age: Int
         }
         """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf])
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testRemoveInternalInitFromPublicStructWithInternalProperties() {
+        let input = """
+        public struct Foo {
+            init(a: Int, b: Bool) {
+                self.a = a
+                self.b = b
+            }
+
+            let a: Int
+            let b: Bool
+        }
+        """
+        let output = """
+        public struct Foo {
+            let a: Int
+            let b: Bool
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemovePrivateInitFromInternalStruct() {
+        let input = """
+        struct Bar {
+            private init(a: Int, b: Bool) {
+                self.a = a
+                self.b = b
+            }
+
+            let a: Int
+            let b: Bool
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
     func testDontRemoveInitWithPrivateProperties() {
@@ -249,23 +233,6 @@ class RedundantMemberwiseInitTests: XCTestCase {
             init(name: String, age: Int) {
                 self.name = name
                 self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithPartialParameterMatch() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            var city: String
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-                self.city = "Unknown"
             }
         }
         """
@@ -301,639 +268,13 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.trailingSpace])
     }
 
-    func testHandleEmptyStruct() {
-        let input = """
-        struct Empty {
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.emptyBraces])
-    }
-
-    func testHandleStructWithOnlyComputedProperties() {
-        let input = """
-        struct Calculator {
-            var result: Int {
-                return 42
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemoveRedundantInitWithComplexTypes() {
-        let input = """
-        struct Container {
-            var items: [String]
-            var metadata: [String: Any]
-
-            init(items: [String], metadata: [String: Any]) {
-                self.items = items
-                self.metadata = metadata
-            }
-        }
-        """
-        let output = """
-        struct Container {
-            var items: [String]
-            var metadata: [String: Any]
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveRedundantInitWithOptionalTypes() {
-        let input = """
-        struct Person {
-            var name: String?
-            var age: Int?
-
-            init(name: String?, age: Int?) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String?
-            var age: Int?
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testDontRemoveInitWithMethodCall() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-                self.validate()
-            }
-
-            func validate() {}
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithMethodCallBefore() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                setupDefaults()
-                self.name = name
-                self.age = age
-            }
-
-            func setupDefaults() {}
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithPrintStatement() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                print("Creating person: \\(name)")
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithMultipleStatements() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-                print("Person created")
-                NotificationCenter.default.post(name: .personCreated, object: nil)
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithGuardStatement() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                guard age >= 0 else { fatalError("Invalid age") }
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .blankLinesAfterGuardStatements, .wrapConditionalBodies])
-    }
-
-    func testDontRemoveInitWithComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                // Initialize properties
-                self.name = name
-                self.age = age
-                // Initialization complete
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithConditionalLogic() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                if age < 0 {
-                    self.age = 0
-                } else {
-                    self.age = age
-                }
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithDefaultArguments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int = 0) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithMultipleDefaultArguments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            var city: String
-
-            init(name: String, age: Int = 0, city: String = "Unknown") {
-                self.name = name
-                self.age = age
-                self.city = city
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithDifferentExternalLabels() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(withName name: String, andAge age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithMixedExternalLabels() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, withAge age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithUnderscoreExternalLabel() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(_ name: String, _ age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInternalInitFromPublicStruct() {
-        let input = """
-        public struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemovePublicInitFromPublicStruct() {
-        let input = """
-        public struct Person {
-            var name: String
-            var age: Int
-
-            public init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        public struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testDontRemoveInitWhenMultipleInitsExist() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-
-            init(name: String) {
-                self.name = name
-                self.age = 0
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWhenThreeInitsExist() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-
-            init(name: String) {
-                self.name = name
-                self.age = 0
-            }
-
-            init() {
-                self.name = "Unknown"
-                self.age = 0
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemoveInitWithAttributes() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            @inlinable
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveInitWithMultipleAttributes() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            @inlinable
-            @available(iOS 13.0, *)
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveInitWithAttributesAndComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            /// Initializes a person with name and age
-            @inlinable
-            internal init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testDontRemoveInitWithPrivateStoredProperty() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            private var id: String
-
-            init(name: String, age: Int, id: String) {
-                self.name = name
-                self.age = age
-                self.id = id
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithFileprivateStoredProperty() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            fileprivate var secret: String
-
-            init(name: String, age: Int, secret: String) {
-                self.name = name
-                self.age = age
-                self.secret = secret
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemovePrivateInitWithPrivateStoredProperty() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-            private var id: String
-
-            private init(name: String, age: Int, id: String) {
-                self.name = name
-                self.age = age
-                self.id = id
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-            private var id: String
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testDontRemovePublicInitWithPrivateStoredProperty() {
-        let input = """
-        public struct Person {
-            var name: String
-            var age: Int
-            private var id: String
-
-            public init(name: String, age: Int, id: String) {
-                self.name = name
-                self.age = age
-                self.id = id
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWhenPrivatePropertiesWithDefaultValues() {
-        let input = """
-        struct PayoutView {
-            let dataModel: String
-            private var style = DefaultStyle()
-
-            init(dataModel: String) {
-                self.dataModel = dataModel
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent, .propertyTypes])
-    }
-
-    func testDontRemoveInitWhenPrivatePropertiesHaveNoDefaultValues() {
-        let input = """
-        struct PayoutView {
-            let dataModel: String
-            private var shadowedStyle: ShadowedStyle
-
-            init(dataModel: String, shadowedStyle: ShadowedStyle) {
-                self.dataModel = dataModel
-                self.shadowedStyle = shadowedStyle
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWhenAllPropertiesInitialized() {
-        let input = """
-        struct Person {
-            let name: String
-            let age: Int
-            private var id: String = "default"
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWhenPrivatePropertiesWithDefaultsMakesSynthesizedInitPrivate() {
-        let input = """
-        struct Person {
-            let name: String
-            let age: Int
-            private var id: String = "default"
-
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithDocumentationComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            /// Creates a Person with the specified name and age
-            init(name: String, age: Int) {
-                self.name = name  
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testDontRemoveInitWithMultiLineDocumentationComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            /**
-             * Creates a Person with the specified name and age.
-             * - Parameter name: The person's full name
-             * - Parameter age: The person's age in years
-             */
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
-    }
-
-    func testRemoveInitWithRegularComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            // This is just a regular comment
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveRedundantPublicMemberwiseInitWithProperFormattingOfFirstProperty() {
-        let input = """
-        public struct CardViewAnimationState {
-            public init(
-            style: CardStyle,
-            backgroundColor: UIColor?
-            ) {
-            self.style = style
-            self.backgroundColor = backgroundColor
-            }
-
-            public let style: CardStyle
-            public let backgroundColor: UIColor?
-        }
-        """
-        let output = """
-        public struct CardViewAnimationState {
-            public let style: CardStyle
-            public let backgroundColor: UIColor?
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
     func testRemoveRedundantMemberwiseInitWithComplexStruct() {
         let input = """
-        public struct Foo {
+        struct Foo {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             name: String,
             value: Int,
             isEnabled: Bool
@@ -945,16 +286,16 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let name: String
-          public let value: Int
-          public let isEnabled: Bool
+          let name: String
+          let value: Int
+          let isEnabled: Bool
         }
 
-        public struct Bar: Equatable {
+        struct Bar: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             id: String,
             count: Int
           ) {
@@ -964,17 +305,17 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let id: String
-          public let count: Int
+          let id: String
+          let count: Int
         }
 
         // MARK: - Baz
 
-        public struct Baz: Equatable {
+        struct Baz: Equatable {
 
           // MARK: Lifecycle
 
-          public init(
+          init(
             title: String,
             subtitle: String?,
             data: [String]
@@ -986,245 +327,57 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
           // MARK: Public
 
-          public let title: String
-          public let subtitle: String?
-          public let data: [String]
-        }
-
-        // MARK: - Qux
-
-        public struct Qux: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(
-            key: String,
-            value: String?
-          ) {
-            self.key = key
-            self.value = value
-          }
-
-          // MARK: Public
-
-          public let key: String
-          public let value: String?
-        }
-
-        // MARK: - Widget
-
-        public struct Widget: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(
-            name: String,
-            color: String,
-            size: Int
-          ) {
-            self.name = name
-            self.color = color
-            self.size = size
-          }
-
-          // MARK: Public
-
-          public let name: String
-          public let color: String
-          public let size: Int
-        }
-
-        // MARK: - Item
-
-        public struct Item: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(
-            identifier: String,
-            label: String
-          ) {
-            self.identifier = identifier
-            self.label = label
-          }
-
-          // MARK: Public
-
-          public let identifier: String
-          public let label: String
+          let title: String
+          let subtitle: String?
+          let data: [String]
         }
 
         // MARK: - Component
 
-        public struct Component: Equatable {
-          public init(type: String, config: [String: Any]) {
+        struct Component: Equatable {
+          init(type: String, config: [String: Any]) {
             self.type = type
             self.config = config
           }
 
-          public let type: String
-          public let config: [String: Any]
-        }
-
-        // MARK: - Element
-
-        public struct Element: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(
-            tag: String,
-            attributes: [String]?,
-            content: String
-          ) {
-            self.tag = tag
-            self.attributes = attributes
-            self.content = content
-          }
-
-          // MARK: Public
-
-          public let tag: String
-          public let attributes: [String]?
-          public let content: String
-        }
-
-        // MARK: - Node
-
-        public struct Node: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(id: String, parent: String?, children: [String]) {
-            self.id = id
-            self.parent = parent
-            self.children = children
-          }
-
-          // MARK: Public
-
-          public let id: String
-          public let parent: String?
-          public let children: [String]
-        }
-
-        // MARK: - Record
-
-        public struct Record: Equatable {
-
-          // MARK: Lifecycle
-
-          public init(
-            timestamp: Double,
-            message: String
-          ) {
-            self.timestamp = timestamp
-            self.message = message
-          }
-
-          // MARK: Public
-
-          public let timestamp: Double
-          public let message: String
+          let type: String
+          let config: [String: Any]
         }
         """
         let output = """
-        public struct Foo {
+        struct Foo {
 
           // MARK: Public
 
-          public let name: String
-          public let value: Int
-          public let isEnabled: Bool
+          let name: String
+          let value: Int
+          let isEnabled: Bool
         }
 
-        public struct Bar: Equatable {
+        struct Bar: Equatable {
 
           // MARK: Public
 
-          public let id: String
-          public let count: Int
+          let id: String
+          let count: Int
         }
 
         // MARK: - Baz
 
-        public struct Baz: Equatable {
+        struct Baz: Equatable {
 
           // MARK: Public
 
-          public let title: String
-          public let subtitle: String?
-          public let data: [String]
-        }
-
-        // MARK: - Qux
-
-        public struct Qux: Equatable {
-
-          // MARK: Public
-
-          public let key: String
-          public let value: String?
-        }
-
-        // MARK: - Widget
-
-        public struct Widget: Equatable {
-
-          // MARK: Public
-
-          public let name: String
-          public let color: String
-          public let size: Int
-        }
-
-        // MARK: - Item
-
-        public struct Item: Equatable {
-
-          // MARK: Public
-
-          public let identifier: String
-          public let label: String
+          let title: String
+          let subtitle: String?
+          let data: [String]
         }
 
         // MARK: - Component
 
-        public struct Component: Equatable {
-          public let type: String
-          public let config: [String: Any]
-        }
-
-        // MARK: - Element
-
-        public struct Element: Equatable {
-
-          // MARK: Public
-
-          public let tag: String
-          public let attributes: [String]?
-          public let content: String
-        }
-
-        // MARK: - Node
-
-        public struct Node: Equatable {
-
-          // MARK: Public
-
-          public let id: String
-          public let parent: String?
-          public let children: [String]
-        }
-
-        // MARK: - Record
-
-        public struct Record: Equatable {
-
-          // MARK: Public
-
-          public let timestamp: Double
-          public let message: String
+        struct Component: Equatable {
+          let type: String
+          let config: [String: Any]
         }
         """
         testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.indent, .acronyms, .blankLinesAtStartOfScope])

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -575,6 +575,21 @@ class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
+    func testDontRemovePackageInitFromPublicStruct() {
+        let input = """
+        public struct Person {
+            var name: String
+            var age: Int
+
+            package init(name: String, age: Int) {
+                self.name = name
+                self.age = age
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
     func testDontRemoveInitWhenMultipleInitsExist() {
         let input = """
         struct Person {
@@ -1269,6 +1284,38 @@ class RedundantMemberwiseInitTests: XCTestCase {
 
             let a: Int
             let b: Bool
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveFileprivateInitFromInternalStructWithInternalProperties() {
+        // The synthesized init would be internal, which is broader than fileprivate
+        let input = """
+        struct Bar {
+            fileprivate init(a: Int, b: Bool) {
+                self.a = a
+                self.b = b
+            }
+
+            let a: Int
+            let b: Bool
+        }
+        """
+        testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
+    }
+
+    func testDontRemoveFileprivateInitFromInternalStructWithPrivateProperties() {
+        // The synthesized init would be private, which is lower than fileprivate
+        let input = """
+        struct Bar {
+            fileprivate init(a: Int, b: Bool) {
+                self.a = a
+                self.b = b
+            }
+
+            let a: Int
+            private let b: Bool
         }
         """
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])


### PR DESCRIPTION
This commit fixes the handling of public structs in the redundantMemberwiseInit rule:

- Fix access level logic: preserve public inits in public structs, remove internal inits from public structs
- Add comprehensive test coverage for public struct scenarios
- Add test for private init preservation in internal structs

Key fixes:
- Internal inits in public structs are now correctly removed (compiler generates internal memberwise init)
- Public inits in public structs are preserved (explicit public API)
- Private inits in internal structs are preserved (maintain access level restrictions)

The rule now correctly handles the Swift compiler's memberwise init generation rules:
- Compiler never generates public memberwise inits
- Internal inits in public structs are redundant with compiler-generated internal memberwise init
- Public inits in public structs provide explicit public API that should be preserved