### PR TITLE
Support escaping `#` characters in config files

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3503,12 +3503,12 @@ Replace force-unwrapped `URL(string:)` initializers with the configured `#URL(_:
 
 Option | Description
 --- | ---
-`--urlmacro` | For example: "#URL,URLFoundation"
+`--urlmacro` | For example: --urlmacro "#URL,URLFoundation"
 
 <details>
 <summary>Examples</summary>
 
-With `--urlmacro #URL,URLFoundation`:
+With `--urlmacro "#URL,URLFoundation"`:
 
 ```diff
 - let url = URL(string: "https://example.com")!

--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -374,9 +374,29 @@ private func cumulate(successiveLines: [String]) throws -> [String] {
 }
 
 private func effectiveContent(of line: String) -> String {
-    line
-        .prefix { $0 != "#" }
-        .trimmingCharacters(in: .whitespaces)
+    var result = ""
+    var inQuotes = false
+    var escaped = false
+
+    for char in line {
+        if escaped {
+            result.append(char)
+            escaped = false
+        } else if char == "\\" {
+            result.append(char)
+            escaped = true
+        } else if char == "\"" {
+            result.append(char)
+            inQuotes.toggle()
+        } else if char == "#", !inQuotes {
+            // Found unquoted comment marker, stop here
+            break
+        } else {
+            result.append(char)
+        }
+    }
+
+    return result.trimmingCharacters(in: .whitespaces)
 }
 
 /// Serialize a set of options into either an arguments string or a file

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1269,7 +1269,7 @@ struct _Descriptors {
     let urlMacro = OptionDescriptor(
         argumentName: "urlmacro",
         displayName: "The name and module of a URL macro",
-        help: "For example: \"#URL,URLFoundation\"",
+        help: "For example: --urlmacro \"#URL,URLFoundation\"",
         keyPath: \.urlMacro
     )
     let preferFileMacro = OptionDescriptor(

--- a/Sources/Rules/URLMacro.swift
+++ b/Sources/Rules/URLMacro.swift
@@ -81,7 +81,7 @@ public extension FormatRule {
         }
     } examples: {
         """
-        With `--urlmacro #URL,URLFoundation`:
+        With `--urlmacro "#URL,URLFoundation"`:
 
         ```diff
         - let url = URL(string: "https://example.com")!

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -119,6 +119,12 @@ class ArgumentsTests: XCTestCase {
         XCTAssertEqual(parseArguments(input, ignoreComments: false), output)
     }
 
+    func testQuotedURLMacro() {
+        let input = "--urlmacro \"#URL,URLFoundation\""
+        let output = ["", "--urlmacro", "#URL,URLFoundation"]
+        XCTAssertEqual(parseArguments(input, ignoreComments: false), output)
+    }
+
     // MARK: arg preprocessor
 
     func testPreprocessArguments() {
@@ -338,6 +344,23 @@ class ArgumentsTests: XCTestCase {
         let args = try parseConfigFile(data)
         XCTAssertEqual(args.count, 1)
         XCTAssertEqual(args["rules"], "braces, fileHeader, consecutiveSpaces")
+    }
+
+    func testParseURLMacroArgumentInConfigFileFailsWithoutQuotes() throws {
+        let config = "--urlmacro #URL,URLFoundation"
+        let data = Data(config.utf8)
+        let args = try parseConfigFile(data)
+        // This should fail because #URL,URLFoundation is treated as a comment
+        XCTAssertEqual(args.count, 1)
+        XCTAssertEqual(args["urlmacro"], "")
+    }
+
+    func testParseURLMacroArgumentInConfigFileWithQuotes() throws {
+        let config = "--urlmacro \"#URL,URLFoundation\""
+        let data = Data(config.utf8)
+        let args = try parseConfigFile(data)
+        XCTAssertEqual(args.count, 1)
+        XCTAssertEqual(args["urlmacro"], "#URL,URLFoundation")
     }
 
     func testParseArgumentsOnMultipleLines() throws {


### PR DESCRIPTION
We noticed that adding `--urlmarco "#URL,URLFoundation"` in config files didn't work properly, because the `#` within the string literal wasn't being escaped, and was being treated as the start of a comment.

This PR fixes the issue so `#` can be escaped in config files.