### PR TITLE
Add test case to validate diff code block formatting in rule examples

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -677,7 +677,7 @@ Option | Description
 +     "bar"
   }
 
-// With --condassignment always (disabled by default)
+  // With --condassignment always (disabled by default)
 - switch condition {
 + foo.bar = switch condition {
   case true:
@@ -1162,11 +1162,11 @@ Option | Description
 <summary>Examples</summary>
 
 ```diff
-// --filemacro #file
+  // --filemacro #file
 - func foo(file: StaticString = #fileID) { ... }
 + func foo(file: StaticString = #file) { ... }
 
-// --filemacro #fileID
+  // --filemacro #fileID
 - func foo(file: StaticString = #file) { ... }
 + func foo(file: StaticString = #fileID) { ... }
 ```
@@ -1196,7 +1196,7 @@ Option | Description
 + extension Dictionary<Key, Value> {}
 + extension Collection<Foo> {}
 
-// With `typeSugar` also enabled:
+  // With `typeSugar` also enabled:
 - extension Array where Element == Foo {}
 - extension Optional where Wrapped == Foo {}
 - extension Dictionary where Key == Foo, Value == Bar {}
@@ -1204,7 +1204,7 @@ Option | Description
 + extension Foo? {}
 + extension [Key: Value] {}
 
-// Also supports user-defined types!
+  // Also supports user-defined types!
 - extension LinkedList where Element == Foo {}
 - extension Reducer where
 -     State == FooState,
@@ -1486,15 +1486,15 @@ Option | Description
 ```diff
 + // MARK: - FooViewController
 +
- final class FooViewController: UIViewController { }
+  final class FooViewController: UIViewController { }
 
 + // MARK: UICollectionViewDelegate
 +
- extension FooViewController: UICollectionViewDelegate { }
+  extension FooViewController: UICollectionViewDelegate { }
 
 + // MARK: - String + FooProtocol
 +
- extension String: FooProtocol { }
+  extension String: FooProtocol { }
 ```
 
 </details>
@@ -1583,34 +1583,34 @@ or `try XCTUnwrap(...)` / `XCTAssert(...)`.
 <summary>Examples</summary>
 
 ```diff
-import XCTest
+  import XCTest
 
-final class SomeTestCase: XCTestCase {
--   func test_something() {
-+   func test_something() throws {
--     guard let value = optionalValue, value.matchesCondition else {
--       XCTFail()
--       return
--     }
-+     let value = try XCTUnwrap(optionalValue)
-+     XCTAssert(value.matchesCondition)
+  final class SomeTestCase: XCTestCase {
+-     func test_something() {
++     func test_something() throws {
+-         guard let value = optionalValue, value.matchesCondition else {
+-             XCTFail()
+-             return
+-         }
++         let value = try XCTUnwrap(optionalValue)
++         XCTAssert(value.matchesCondition)
+      }
   }
-}
 ```
 
 ```diff
-import Testing
+  import Testing
 
-struct SomeTests {
-  @Test
-  func something() throws {
--   guard let value = optionalValue, value.matchesCondition else {
--     return
--   }
-+   let value = try #require(optionalValue)
-+   #expect(value.matchesCondition)
+  struct SomeTests {
+      @Test
+      func something() throws {
+-         guard let value = optionalValue, value.matchesCondition else {
+-             return
+-         }
++         let value = try #require(optionalValue)
++         #expect(value.matchesCondition)
+      }
   }
-}
 ```
 
 </details>
@@ -1680,7 +1680,7 @@ Option | Description
       print(value)
   }
 
-// With `--someany enabled` (the default)
+  // With `--someany enabled` (the default)
 - func handle<T>(_ value: T) {
 + func handle(_ value: some Any) {
       print(value)
@@ -1754,7 +1754,7 @@ Without this declaration, only functions will be reordered, while properties wil
 -     func f() {}
 -     init() {}
 -     deinit() {}
- }
+  }
 
   public class Foo {
 +
@@ -1781,7 +1781,7 @@ Without this declaration, only functions will be reordered, while properties wil
 +
 +     private let g: Int = 2
 +
- }
+  }
 ```
 
 `--organizationmode type`
@@ -1799,7 +1799,7 @@ Without this declaration, only functions will be reordered, while properties wil
 -     func f() {}
 -     init() {}
 -     deinit() {}
- }
+  }
 
   public class Foo {
 +
@@ -1822,7 +1822,7 @@ Without this declaration, only functions will be reordered, while properties wil
 +     public func c() -> String {}
 +     public func d() {}
 +
- }
+  }
 ```
 
 </details>
@@ -2023,15 +2023,15 @@ Option | Description
 <summary>Examples</summary>
 
 ```diff
-// with --propertytypes inferred
+  // with --propertytypes inferred
 - let view: UIView = UIView()
 + let view = UIView()
 
-// with --propertytypes explicit
+  // with --propertytypes explicit
 - let view: UIView = UIView()
 + let view: UIView = .init()
 
-// with --propertytypes infer-locals-only
+  // with --propertytypes infer-locals-only
   class Foo {
 -     let view: UIView = UIView()
 +     let view: UIView = .init()
@@ -2330,15 +2330,15 @@ Remove explicit internal memberwise initializers that are redundant.
 <summary>Examples</summary>
 
 ```diff
-struct Person {
-    var name: String
-    var age: Int
+  struct Person {
+      var name: String
+      var age: Int
 
--   init(name: String, age: Int) {
--       self.name = name
--       self.age = age
--   }
-}
+-     init(name: String, age: Int) {
+-         self.name = name
+-         self.age = age
+-     }
+  }
 ```
 
 </details>
@@ -2363,13 +2363,13 @@ Option | Description
 ```
 
 ```diff
-// doesn't apply to `let` properties
-let foo: Int? = nil
+  // doesn't apply to `let` properties
+  let foo: Int? = nil
 ```
 
 ```diff
-// doesn't affect non-nil initialization
-var foo: Int? = 0
+  // doesn't affect non-nil initialization
+  var foo: Int? = 0
 ```
 
 `--nilinit insert`
@@ -2663,15 +2663,15 @@ Option | Description
 <summary>Examples</summary>
 
 ```diff
-// with --propertytypes inferred
+  // with --propertytypes inferred
 - let view: UIView = UIView()
 + let view = UIView()
 
-// with --propertytypes explicit
+  // with --propertytypes explicit
 - let view: UIView = UIView()
 + let view: UIView = .init()
 
-// with --propertytypes infer-locals-only
+  // with --propertytypes infer-locals-only
   class Foo {
 -     let view: UIView = UIView()
 +     let view: UIView = .init()
@@ -2682,7 +2682,7 @@ Option | Description
       }
   }
 
-// Swift 5.9+, with --propertytypes inferred (SE-0380)
+  // Swift 5.9+, with --propertytypes inferred (SE-0380)
 - let foo: Foo = if condition {
 + let foo = if condition {
       Foo("foo")
@@ -2690,7 +2690,7 @@ Option | Description
       Foo("bar")
   }
 
-// Swift 5.9+, with --propertytypes explicit (SE-0380)
+  // Swift 5.9+, with --propertytypes explicit (SE-0380)
   let foo: Foo = if condition {
 -     Foo("foo")
 +     .init("foo")
@@ -2772,9 +2772,9 @@ Option | Description
 ```
 
 ```diff
-// semicolon is not removed if it would affect the behavior of the code
-return;
-goto(fail)
+  // semicolon is not removed if it would affect the behavior of the code
+  return;
+  goto(fail)
 ```
 
 </details>
@@ -2842,11 +2842,7 @@ Option | Description
 +     case upsellB
   }
 
-config:
-```
-    sortedpatterns: 'Feature'
-```
-
+  /// With --sortedpatterns Feature
   enum FeatureFlags {
 -     case upsellB
 -     case fooFeature
@@ -3278,6 +3274,7 @@ Write tests that use `throws` instead of using `try!`.
 +           try MyFeature().doSomething()
       }
     }
+```
 
 </details>
 <br/>

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -1139,9 +1139,9 @@ func processInput(_ inputURLs: [URL],
                     // Format individual code blocks in markdown files is enabled
                     if inputURL.pathExtension == "md", options.fileOptions?.supportedFileExtensions.contains("md") == true {
                         var markdown = input
-                        let swiftCodeBlocks: [(range: Range<String.Index>, text: String, options: String?, lineStartIndex: Int)]
+                        let swiftCodeBlocks: [MarkdownCodeBlock]
                         do {
-                            swiftCodeBlocks = try parseSwiftCodeBlocks(fromMarkdown: input)
+                            swiftCodeBlocks = try parseCodeBlocks(fromMarkdown: input, language: "swift")
                         } catch {
                             switch options.fileOptions?.markdownFormattingMode {
                             case .strict:
@@ -1349,21 +1349,35 @@ private struct OutputTokensData: Encodable {
     }
 }
 
-/// Parses Swift code blocks in the given code file.
-///
-/// Any text on following the open delimiter on that initial line is returned in `options`.
+/// A code block from a markdown file
 ///
 /// For example:
 ///
-/// ```swift {{options like `no-format`, `--disable ruleName` can be put here}}
+/// ```{language} {{options like `no-format`, `--disable ruleName` can be put here}}
 /// // This content is returned as text,
 /// // and its range in the markdown string is returned as range.
 /// ```
-func parseSwiftCodeBlocks(fromMarkdown markdown: String)
-    throws -> [(range: Range<String.Index>, text: String, options: String?, lineStartIndex: Int)]
-{
+struct MarkdownCodeBlock {
+    let language: String
+    let range: Range<String.Index>
+    let text: String
+    let options: String?
+    let lineStartIndex: Int
+}
+
+/// Parses code blocks of a specific language in the given markdown file.
+///
+/// Any text following the open delimiter on that initial line is returned in `options`.
+///
+/// For example:
+///
+/// ```{language} {{options like `no-format`, `--disable ruleName` can be put here}}
+/// // This content is returned as text,
+/// // and its range in the markdown string is returned as range.
+/// ```
+func parseCodeBlocks(fromMarkdown markdown: String, language: String) throws -> [MarkdownCodeBlock] {
     let lines = markdown.lineRanges
-    var codeBlocks: [(range: Range<String.Index>, text: String, options: String?, lineStartIndex: Int)] = []
+    var codeBlocks: [MarkdownCodeBlock] = []
     var codeStartLineIndex: Int?
     var codeBlockOptions: String?
     var codeBlockStack = 0
@@ -1375,12 +1389,12 @@ func parseSwiftCodeBlocks(fromMarkdown markdown: String)
             // If we're already inside a code block, don't start a new one
             if codeStartLineIndex != nil {
                 codeBlockStack += 1
-            } else if lineText.hasPrefix("```swift"), lineIndex != lines.indices.last {
+            } else if lineText.hasPrefix("```\(language)"), lineIndex != lines.indices.last {
                 codeStartLineIndex = lineIndex + 1
 
-                // Any text following the code block start delimiter are treated as SwiftFormat options
-                if lineText.hasPrefix("```swift ") {
-                    codeBlockOptions = String(lineText.dropFirst("```swift ".count))
+                // Any text following the code block start delimiter are treated as options
+                if lineText.hasPrefix("```\(language) ") {
+                    codeBlockOptions = String(lineText.dropFirst("```\(language) ".count))
                 }
             }
         } else if lineText == "```", let startLine = codeStartLineIndex {
@@ -1394,7 +1408,10 @@ func parseSwiftCodeBlocks(fromMarkdown markdown: String)
                 let codeText = String(markdown[range])
 
                 assert(markdown[range] == codeText)
-                codeBlocks.append((range, codeText, codeBlockOptions, startLine))
+
+                let codeBlock = MarkdownCodeBlock(language: language, range: range, text: codeText, options: codeBlockOptions, lineStartIndex: startLine)
+
+                codeBlocks.append(codeBlock)
                 codeStartLineIndex = nil
                 codeBlockOptions = nil
             }

--- a/Sources/Rules/ConditionalAssignment.swift
+++ b/Sources/Rules/ConditionalAssignment.swift
@@ -156,7 +156,7 @@ public extension FormatRule {
         +     "bar"
           }
 
-        // With --condassignment always (disabled by default)
+          // With --condassignment always (disabled by default)
         - switch condition {
         + foo.bar = switch condition {
           case true:

--- a/Sources/Rules/FileMacro.swift
+++ b/Sources/Rules/FileMacro.swift
@@ -30,11 +30,11 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        // --filemacro #file
+          // --filemacro #file
         - func foo(file: StaticString = #fileID) { ... }
         + func foo(file: StaticString = #file) { ... }
 
-        // --filemacro #fileID
+          // --filemacro #fileID
         - func foo(file: StaticString = #file) { ... }
         + func foo(file: StaticString = #fileID) { ... }
         ```

--- a/Sources/Rules/GenericExtensions.swift
+++ b/Sources/Rules/GenericExtensions.swift
@@ -134,7 +134,7 @@ public extension FormatRule {
         + extension Dictionary<Key, Value> {}
         + extension Collection<Foo> {}
 
-        // With `typeSugar` also enabled:
+          // With `typeSugar` also enabled:
         - extension Array where Element == Foo {}
         - extension Optional where Wrapped == Foo {}
         - extension Dictionary where Key == Foo, Value == Bar {}
@@ -142,7 +142,7 @@ public extension FormatRule {
         + extension Foo? {}
         + extension [Key: Value] {}
 
-        // Also supports user-defined types!
+          // Also supports user-defined types!
         - extension LinkedList where Element == Foo {}
         - extension Reducer where
         -     State == FooState,

--- a/Sources/Rules/MarkTypes.swift
+++ b/Sources/Rules/MarkTypes.swift
@@ -222,15 +222,15 @@ public extension FormatRule {
         ```diff
         + // MARK: - FooViewController
         +
-         final class FooViewController: UIViewController { }
+          final class FooViewController: UIViewController { }
 
         + // MARK: UICollectionViewDelegate
         +
-         extension FooViewController: UICollectionViewDelegate { }
+          extension FooViewController: UICollectionViewDelegate { }
 
         + // MARK: - String + FooProtocol
         +
-         extension String: FooProtocol { }
+          extension String: FooProtocol { }
         ```
         """
     }

--- a/Sources/Rules/NoGuardInTests.swift
+++ b/Sources/Rules/NoGuardInTests.swift
@@ -209,34 +209,34 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        import XCTest
+          import XCTest
 
-        final class SomeTestCase: XCTestCase {
-        -   func test_something() {
-        +   func test_something() throws {
-        -     guard let value = optionalValue, value.matchesCondition else {
-        -       XCTFail()
-        -       return
-        -     }
-        +     let value = try XCTUnwrap(optionalValue)
-        +     XCTAssert(value.matchesCondition)
+          final class SomeTestCase: XCTestCase {
+        -     func test_something() {
+        +     func test_something() throws {
+        -         guard let value = optionalValue, value.matchesCondition else {
+        -             XCTFail()
+        -             return
+        -         }
+        +         let value = try XCTUnwrap(optionalValue)
+        +         XCTAssert(value.matchesCondition)
+              }
           }
-        }
         ```
 
         ```diff
-        import Testing
+          import Testing
 
-        struct SomeTests {
-          @Test
-          func something() throws {
-        -   guard let value = optionalValue, value.matchesCondition else {
-        -     return
-        -   }
-        +   let value = try #require(optionalValue)
-        +   #expect(value.matchesCondition)
+          struct SomeTests {
+              @Test
+              func something() throws {
+        -         guard let value = optionalValue, value.matchesCondition else {
+        -             return
+        -         }
+        +         let value = try #require(optionalValue)
+        +         #expect(value.matchesCondition)
+              }
           }
-        }
         ```
         """
     }

--- a/Sources/Rules/OpaqueGenericParameters.swift
+++ b/Sources/Rules/OpaqueGenericParameters.swift
@@ -271,7 +271,7 @@ public extension FormatRule {
               print(value)
           }
 
-        // With `--someany enabled` (the default)
+          // With `--someany enabled` (the default)
         - func handle<T>(_ value: T) {
         + func handle(_ value: some Any) {
               print(value)

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -68,7 +68,7 @@ public extension FormatRule {
         -     func f() {}
         -     init() {}
         -     deinit() {}
-         }
+          }
 
           public class Foo {
         +
@@ -95,7 +95,7 @@ public extension FormatRule {
         +
         +     private let g: Int = 2
         +
-         }
+          }
         ```
 
         `--organizationmode type`
@@ -113,7 +113,7 @@ public extension FormatRule {
         -     func f() {}
         -     init() {}
         -     deinit() {}
-         }
+          }
 
           public class Foo {
         +
@@ -136,7 +136,7 @@ public extension FormatRule {
         +     public func c() -> String {}
         +     public func d() {}
         +
-         }
+          }
         ```
         """
     }

--- a/Sources/Rules/PropertyTypes.swift
+++ b/Sources/Rules/PropertyTypes.swift
@@ -219,15 +219,15 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        // with --propertytypes inferred
+          // with --propertytypes inferred
         - let view: UIView = UIView()
         + let view = UIView()
 
-        // with --propertytypes explicit
+          // with --propertytypes explicit
         - let view: UIView = UIView()
         + let view: UIView = .init()
 
-        // with --propertytypes infer-locals-only
+          // with --propertytypes infer-locals-only
           class Foo {
         -     let view: UIView = UIView()
         +     let view: UIView = .init()

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -285,15 +285,15 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        struct Person {
-            var name: String
-            var age: Int
+          struct Person {
+              var name: String
+              var age: Int
 
-        -   init(name: String, age: Int) {
-        -       self.name = name
-        -       self.age = age
-        -   }
-        }
+        -     init(name: String, age: Int) {
+        -         self.name = name
+        -         self.age = age
+        -     }
+          }
         ```
         """
     }

--- a/Sources/Rules/RedundantNilInit.swift
+++ b/Sources/Rules/RedundantNilInit.swift
@@ -86,13 +86,13 @@ public extension FormatRule {
         ```
 
         ```diff
-        // doesn't apply to `let` properties
-        let foo: Int? = nil
+          // doesn't apply to `let` properties
+          let foo: Int? = nil
         ```
 
         ```diff
-        // doesn't affect non-nil initialization
-        var foo: Int? = 0
+          // doesn't affect non-nil initialization
+          var foo: Int? = 0
         ```
 
         `--nilinit insert`

--- a/Sources/Rules/RedundantType.swift
+++ b/Sources/Rules/RedundantType.swift
@@ -135,15 +135,15 @@ public extension FormatRule {
     } examples: {
         """
         ```diff
-        // with --propertytypes inferred
+          // with --propertytypes inferred
         - let view: UIView = UIView()
         + let view = UIView()
 
-        // with --propertytypes explicit
+          // with --propertytypes explicit
         - let view: UIView = UIView()
         + let view: UIView = .init()
 
-        // with --propertytypes infer-locals-only
+          // with --propertytypes infer-locals-only
           class Foo {
         -     let view: UIView = UIView()
         +     let view: UIView = .init()
@@ -154,7 +154,7 @@ public extension FormatRule {
               }
           }
 
-        // Swift 5.9+, with --propertytypes inferred (SE-0380)
+          // Swift 5.9+, with --propertytypes inferred (SE-0380)
         - let foo: Foo = if condition {
         + let foo = if condition {
               Foo("foo")
@@ -162,7 +162,7 @@ public extension FormatRule {
               Foo("bar")
           }
 
-        // Swift 5.9+, with --propertytypes explicit (SE-0380)
+          // Swift 5.9+, with --propertytypes explicit (SE-0380)
           let foo: Foo = if condition {
         -     Foo("foo")
         +     .init("foo")

--- a/Sources/Rules/Semicolons.swift
+++ b/Sources/Rules/Semicolons.swift
@@ -62,9 +62,9 @@ public extension FormatRule {
         ```
 
         ```diff
-        // semicolon is not removed if it would affect the behavior of the code
-        return;
-        goto(fail)
+          // semicolon is not removed if it would affect the behavior of the code
+          return;
+          goto(fail)
         ```
         """
     }

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -167,11 +167,7 @@ public extension FormatRule {
         +     case upsellB
           }
 
-        config:
-        ```
-            sortedpatterns: 'Feature'
-        ```
-
+          /// With --sortedpatterns Feature
           enum FeatureFlags {
         -     case upsellB
         -     case fooFeature

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -69,6 +69,7 @@ public extension FormatRule {
         +           try MyFeature().doSomething()
               }
             }
+        ```
         """
     }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2805,7 +2805,7 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(formatter.tokens[secondInit.bodyRange!].string, "{ return nil }")
     }
 
-    func testParseMarkdownFile() {
+    func testParseMarkdownFile() throws {
         let input = #"""
         # Sample README
 
@@ -2845,7 +2845,7 @@ class ParsingHelpersTests: XCTestCase {
         Try it out!
         """#
 
-        let codeBlocks = parseSwiftCodeBlocks(fromMarkdown: input)
+        let codeBlocks = try parseSwiftCodeBlocks(fromMarkdown: input)
 
         XCTAssertEqual(
             codeBlocks[0].text,
@@ -2886,5 +2886,25 @@ class ParsingHelpersTests: XCTestCase {
         )
 
         XCTAssertEqual(codeBlocks[2].options, "--indentstrings true")
+    }
+
+    func testParseMarkdownWithUnbalancedDelimiters() {
+        let input = """
+        # Sample README
+
+        This is a nice project with lots of cool APIs to know about, including:
+
+        ```swift
+        func foo(
+            bar: Bar
+            baaz: Baaz
+        ) -> Foo {}
+
+        ```swift
+        foo(bar: bar, baaz: baaz)
+        ```
+        """
+
+        XCTAssertThrowsError(try parseSwiftCodeBlocks(fromMarkdown: input))
     }
 }

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2845,7 +2845,7 @@ class ParsingHelpersTests: XCTestCase {
         Try it out!
         """#
 
-        let codeBlocks = try parseSwiftCodeBlocks(fromMarkdown: input)
+        let codeBlocks = try parseCodeBlocks(fromMarkdown: input, language: "swift")
 
         XCTAssertEqual(
             codeBlocks[0].text,
@@ -2905,6 +2905,6 @@ class ParsingHelpersTests: XCTestCase {
         ```
         """
 
-        XCTAssertThrowsError(try parseSwiftCodeBlocks(fromMarkdown: input))
+        XCTAssertThrowsError(try parseCodeBlocks(fromMarkdown: input, language: "swift"))
     }
 }


### PR DESCRIPTION
This PR adds a test case to validate diff code block formatting in rule examples:
 - the string should have balanced ``` delimiters
 - the first column diff code blocks is for `+/-` characters
 - the second column of diff code blocks should be a space