### PR TITLE
Fix config file generation in SwiftFormat for Xcode app to escape options with # character in quotes

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -446,6 +446,9 @@ func serialize(arguments: [String: String],
         if value.contains(" ") {
             value = "\"\(value.replacingOccurrences(of: "\"", with: "\\\""))\""
         }
+        if value.contains("#") {
+            value = "\"\(value)\""
+        }
         return "--\($0) \(value)"
     }.sorted().joined(separator: separator)
 }

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -506,6 +506,18 @@ class ArgumentsTests: XCTestCase {
         XCTAssertEqual(config, "--header \"// hello\\n// world\"")
     }
 
+    func testSerializeOptionsWithPoundCharacter() throws {
+        let options = Options(formatOptions: FormatOptions(
+            urlMacro: .macro("#URL", module: "URLFoundation"),
+            preferFileMacro: false
+        ))
+        let config = serialize(options: options, excludingDefaults: true)
+        XCTAssertEqual(config, """
+        --filemacro "#fileID"
+        --urlmacro "#URL,URLFoundation"
+        """)
+    }
+
     // trailing separator
 
     func testSerializeOptionsDisabledDefaultRulesEnabledIsEmpty() throws {


### PR DESCRIPTION
Fixes #2119