### PR TITLE
Support :this and :previous in comment directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,11 @@ You can configure options for specific files or code ranges by using `swiftforma
 // swiftformat:options --indent 2 --allman true
 ```
 
-To apply an options override only to a particular line, use the `:next` modifier:
+To apply an options override only to a particular line, use the `:this`, `:next` or `:previous` modifiers:
 
 ```swift
+let indexUrl: URL // swiftformat:options:this --preserve-acronyms url 
+
 // swiftformat:options:next --semicolons inline
 doTheThing(); print("Did the thing")
 ```
@@ -662,7 +664,7 @@ let foo = bar // rule(s) will be disabled for this line
 let bar = baz // rule(s) will be re-enabled for this line
 ```
 
-There is no need to manually re-enable a rule after using the `next` directive.
+You can also use `this` or `previous` to enable or disable rules for the current or previous line. There is no need to manually re-enable a rule after using the `next`, `this` or `previous` directives.
 
 **NOTE:** The `swiftformat:enable` directive only serves to counter a previous `swiftformat:disable` directive in the same file. It is not possible to use `swiftformat:enable` to enable a rule that was not already enabled when formatting started.
 

--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -880,14 +880,9 @@ private struct Inference {
                 case let .keyword(name):
                     lastKeyword = name
                     lastKeywordIndex = index
-                case .startOfScope("//"), .startOfScope("/*"):
-                    if case let .commentBody(comment)? = formatter.next(.nonSpace, after: index) {
-                        formatter.processCommentBody(comment, at: index)
-                        if token == .startOfScope("//") {
-                            formatter.processLinebreak()
-                        }
-                    }
+                case .startOfScope("/*"), .startOfScope("//"):
                     index = formatter.endOfScope(at: index) ?? (formatter.tokens.count - 1)
+                    formatter.updateEnablement(at: index)
                 case .startOfScope("("):
                     if case let .identifier(fn)? = formatter.last(.nonSpaceOrCommentOrLinebreak, before: index),
                        selfRequired.contains(fn) || fn == "expect"
@@ -1107,7 +1102,7 @@ private struct Inference {
                         return
                     }
                 case .linebreak:
-                    formatter.processLinebreak()
+                    formatter.updateEnablement(at: index)
                 default:
                     break
                 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1725,7 +1725,7 @@ extension Formatter {
 
             // If the current rule is disabled at this index, don't keep the declaration.
             // This makes it easy for parseDeclarations-based rules to support directives
-            // like swiftformat:disable, swiftformat:disable:next.
+            // like disable and disable:next.
             if isEnabled {
                 declarations.append(_Declaration(
                     keyword: declarationKeyword,
@@ -2522,11 +2522,7 @@ extension Formatter {
             switch tokens[startIndex] {
             case .startOfScope("//"):
                 if case let .commentBody(body)? = next(.nonSpace, after: startIndex) {
-                    processCommentBody(body, at: startIndex)
-                    defer {
-                        processLinebreak()
-                        processLinebreak()
-                    }
+                    updateEnablement(at: startIndex)
                     if !isEnabled || (body.hasPrefix("/") && !body.hasPrefix("//")) ||
                         body.hasPrefix("swift-tools-version")
                     {
@@ -2562,11 +2558,7 @@ extension Formatter {
                 }
             case .startOfScope("/*"):
                 if case let .commentBody(body)? = next(.nonSpace, after: startIndex) {
-                    processCommentBody(body, at: startIndex)
-                    defer {
-                        processLinebreak()
-                        processLinebreak()
-                    }
+                    updateEnablement(at: startIndex)
                     if !isEnabled || (body.hasPrefix("*") && !body.hasPrefix("**")) {
                         return nil
                     } else if body.isCommentDirective {
@@ -2589,6 +2581,8 @@ extension Formatter {
                     }
                     startIndex = nextIndex
                 }
+            case .endOfScope("*/"), .linebreak:
+                updateEnablement(at: startIndex)
             default:
                 break
             }


### PR DESCRIPTION
This PR refactors the way that `swiftformat:` comment directives are processed so that we can support `:this` and `:previous` in addition to `:next` (a [frequently](https://github.com/nicklockwood/SwiftFormat/issues/2097) [requested](https://github.com/nicklockwood/SwiftFormat/issues/1753) [feature](https://github.com/nicklockwood/SwiftFormat/issues/2001)).