### PR TITLE
Update `--wrap-return-type never` to work with `--allman true`

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -358,7 +358,10 @@ extension Formatter {
                     if let nextIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: cursorIndex - 1),
                        tokens[nextIndex] == .startOfScope("{")
                     {
-                        unwrapLine(before: nextIndex, preservingComments: true)
+                        // Don't unwrap the brace line if using Allman braces
+                        if !options.allmanBraces {
+                            unwrapLine(before: nextIndex, preservingComments: true)
+                        }
                     }
                 }
             }

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -2176,6 +2176,32 @@ class WrapArgumentsTests: XCTestCase {
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
+    func testAllmanBraceWithWrapReturnTypeNever() {
+        let input = """
+        func makeStuff(
+            param1: String = "",
+            param2: Int? = nil,
+            param3: String = ""
+        ) -> String {
+            print(param1, param2, param3)
+            return "return"
+        }
+        """
+        let output = """
+        func makeStuff(
+            param1: String = "",
+            param2: Int? = nil,
+            param3: String = ""
+        ) -> String
+        {
+            print(param1, param2, param3)
+            return "return"
+        }
+        """
+        let options = FormatOptions(allmanBraces: true, wrapReturnType: .never)
+        testFormatting(for: input, [output], rules: [.wrapArguments, .braces], options: options)
+    }
+
     func testWrapArgumentsDoesntBreakFunctionDeclaration_issue_1776() {
         let input = """
         struct OpenAPIController: RouteCollection {


### PR DESCRIPTION
This PR updates `--wrap-return-type never` to work with `--allman true`.

Fixes #2131