### PR TITLE
Fix issue where `redundantPublic` rule didn't handle extensions on types defined in public extensions

### DIFF
--- a/Sources/Rules/RedundantPublic.swift
+++ b/Sources/Rules/RedundantPublic.swift
@@ -22,7 +22,15 @@ public extension FormatRule {
                let typeName = declaration.fullyQualifiedName,
                declaration.visibility() == .internal || declaration.visibility() == nil
             {
-                internalTypes.insert(typeName)
+                // Inside public extensions, types with no access control modifier are public.
+                // This case is handled by the extensionAccessControl rule.
+                let insidePublicExtension = declaration.parentDeclarations.contains(where: {
+                    $0.keyword == "extension" && $0.visibility() == .public
+                })
+
+                if !insidePublicExtension {
+                    internalTypes.insert(typeName)
+                }
             }
         }
 

--- a/Tests/Rules/RedundantPublicTests.swift
+++ b/Tests/Rules/RedundantPublicTests.swift
@@ -312,7 +312,7 @@ class RedundantPublicTests: XCTestCase {
     }
 
     func testPreservesPublicInProtocolExtension() {
-        // A method in an extenison of an internal protocol may actually be publically accessible
+        // A method in an extension of an internal protocol may actually be publicly accessible
         // via some public type that implements the protocol.
         let input = """
         protocol Foo {}
@@ -322,5 +322,56 @@ class RedundantPublicTests: XCTestCase {
         }
         """
         testFormatting(for: input, rules: [.redundantPublic])
+    }
+
+    func testTreatsTypeInPublicExtensionAsPublic() {
+        let input = """
+        public enum Foo {}
+
+        public extension Foo {
+            enum Bar {}
+        }
+
+        extension Foo {
+            enum Baaz {}
+        }
+
+        extension Foo.Bar: CustomStringConvertible {
+            public var description: String {
+                ""
+            }
+        }
+
+        extension Foo.Baaz: CustomStringConvertible {
+            public var description: String {
+                ""
+            }
+        }
+        """
+
+        let output = """
+        public enum Foo {}
+
+        public extension Foo {
+            enum Bar {}
+        }
+
+        extension Foo {
+            enum Baaz {}
+        }
+
+        extension Foo.Bar: CustomStringConvertible {
+            public var description: String {
+                ""
+            }
+        }
+
+        extension Foo.Baaz: CustomStringConvertible {
+            var description: String {
+                ""
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantPublic)
     }
 }


### PR DESCRIPTION
This PR fixes an issue where `redundantPublic` rule didn't handle extensions on types defined in public extensions.

Fixes #2136.