### PR TITLE
Add `@Bindable` to list of SwiftUI property wrappers used by `organizedDeclarations` rule

### DIFF
--- a/Sources/DeclarationType.swift
+++ b/Sources/DeclarationType.swift
@@ -274,6 +274,7 @@ extension Declaration {
         [
             "@AccessibilityFocusState",
             "@AppStorage",
+            "@Bindable",
             "@Binding",
             "@Environment",
             "@EnvironmentObject",

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3036,6 +3036,7 @@ class OrganizeDeclarationsTests: XCTestCase {
             @State var foo: Foo
             @Binding var isOn: Bool
             @Environment(\\.quux) var quux: Quux
+            @Bindable var model: MyModel
 
             @ViewBuilder
             var body: some View {
@@ -3053,6 +3054,7 @@ class OrganizeDeclarationsTests: XCTestCase {
 
             // MARK: Internal
 
+            @Bindable var model: MyModel
             @Binding var isOn: Bool
             @Environment(\\.colorScheme) var colorScheme
             @Environment(\\.quux) var quux: Quux


### PR DESCRIPTION
This PR adds `@Bindable` to the list of SwiftUI property wrappers used by the `organizeDeclarations` rule.

Fixes #2137.