### PR TITLE
Update `--trailing-commas always` to preserve trailing commas even when not known to be supported by Swift 6.1

### DIFF
--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -57,6 +57,15 @@ public extension FormatRule {
                     }
                 }
 
+                // If the previous token is the closing `>` of a generic list, then this is a function declaration or initializer,
+                // like `func foo<T>(args...)` or `Foo<Bar>(args...)`.
+                if formatter.options.swiftVersion >= "6.1",
+                   let tokenBeforeStartOfScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: startOfScope),
+                   formatter.tokens[tokenBeforeStartOfScope] == .endOfScope(">")
+                {
+                    trailingCommaSupported = true
+                }
+
                 // In Swift 6.1, trailing commas are also supported in tuple values,
                 // but not tuple types: https://github.com/swiftlang/swift/issues/81485
                 // If we know this is a tuple value, then trailing commas are supported.

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -1667,4 +1667,54 @@ class TrailingCommasTests: XCTestCase {
         let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.unusedArguments])
     }
+
+    func testTrailingCommaNotRemovedFromTupleTypeSwift6_1() {
+        let input = """
+        let foo: (
+            bar: String,
+            quux: String,
+        )
+
+        let bar: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+
+        public func testClosureArgumentInTuple() {
+            _ = object.methodWithTupleArgument((
+                closureArgument: { capturedObject in
+                    _ = capturedObject
+                },
+            ))
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommaNotRemovedFromClosureTypeSwift6_1_mutliElementLists() {
+        let input = """
+        let foo: (
+            bar: String,
+        ) -> Void
+
+        let foo: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+        """
+
+        let output = """
+        let foo: (
+            bar: String
+        ) -> Void
+
+        let foo: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
 }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -305,6 +305,37 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
+    func testTrailingCommasAddedToGenericFunctionParameters() {
+        let input = """
+        struct Foo {
+            func foo<
+                Bar,
+                Baaz
+            >(
+                bar: Bar,
+                baaz: Baaz
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let output = """
+        struct Foo {
+            func foo<
+                Bar,
+                Baaz,
+            >(
+                bar: Bar,
+                baaz: Baaz,
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.opaqueGenericParameters])
+    }
+
     func testTrailingCommasNotAddedToFunctionParametersBeforeSwift6_1() {
         let input = """
         func foo(
@@ -546,6 +577,26 @@ class TrailingCommasTests: XCTestCase {
         """
         let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn])
+    }
+
+    func testTrailingCommasAddedToTupleInGenericInitCall() {
+        let input = """
+        let setModeSwizzle = Swizzle<AVAudioSession>(
+            instance: instance,
+            original: #selector(AVAudioSession.setMode(_:)),
+            swizzled: #selector(AVAudioSession.swizzled_setMode(_:))
+        )
+        """
+
+        let output = """
+        let setModeSwizzle = Swizzle<AVAudioSession>(
+            instance: instance,
+            original: #selector(AVAudioSession.setMode(_:)),
+            swizzled: #selector(AVAudioSession.swizzled_setMode(_:)),
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn, .propertyTypes])
     }
 
     func testTrailingCommasAddedToParensAroundSingleValue() {


### PR DESCRIPTION
This PR fixes #2142 and #2143.

In cases where we don't know whether or not a trailing comma is supported, we previously would always remove the comma. This resulted in false negatives (#2142). Instead, we should preserve the comma in these cases.

Also, this PR fixes support for inserting trailing commas in function declarations with generic parameters.