### PR TITLE
Fix spurious `--commas option is deprecated. Use '--trailingcommas' instead` warning

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -531,7 +531,7 @@ func argumentsFor(_ options: Options, excludingDefaults: Bool = false) -> [Strin
         assert(arguments.isEmpty)
     }
     if let formatOptions = options.formatOptions {
-        for descriptor in Descriptors.all where !descriptor.isRenamed {
+        for descriptor in Descriptors.all where !descriptor.isRenamed && !descriptor.isDeprecated {
             let value = descriptor.fromOptions(formatOptions)
             guard value != descriptor.fromOptions(.default) ||
                 (!excludingDefaults && !descriptor.isDeprecated)

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -1051,4 +1051,22 @@ class CommandLineTests: XCTestCase {
         XCTAssertEqual(errors.count, 1)
         XCTAssert(errors[0].contains("Unbalanced code block delimiters in markdown"))
     }
+
+    func testTrailingCommasCollectionsOnlyDoesNotTriggerDeprecationWarning_issue_2141() throws {
+        var warnings = [String]()
+        CLI.print = { message, type in
+            if type == .warning {
+                warnings.append(message)
+            }
+        }
+
+        try withTmpFiles([
+            "foo/bar/baz.swift": "",
+        ]) { url in
+            _ = processArguments(["", url.path, "--trailing-commas", "collections-only", "--swift-version", "6.0"], in: "")
+        }
+
+        // Should not contain the deprecation warning about --commas
+        XCTAssertEqual(warnings, [])
+    }
 }


### PR DESCRIPTION
This PR fixes a spurious `--commas option is deprecated. Use '--trailingcommas' instead` warning when using `--trailing-commas collections-only`.

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2141