### PR TITLE
Fix issue where `hoistTry` rule could break @Test attributes containing `try`

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1206,6 +1206,8 @@ extension Formatter {
                 }
             case let .keyword(name) where name.hasPrefix("#") && prevToken == .startOfScope("("):
                 return
+            case .keyword where tokens[i].isAttribute && prevToken == .startOfScope("("):
+                return
             case .keyword("try") where keyword == "await":
                 break loop
             case let .keyword(name) where ["is", "as", "try", "await"].contains(name):

--- a/Sources/Rules/SpaceAroundBrackets.swift
+++ b/Sources/Rules/SpaceAroundBrackets.swift
@@ -37,7 +37,8 @@ public extension FormatRule {
                     case .identifier("as"), .identifier("is"), // not treated as keywords inside macro
                          .identifier("borrowing") where formatter.isTypePosition(at: index),
                          .identifier("consuming") where formatter.isTypePosition(at: index),
-                         .identifier("sending") where formatter.isTypePosition(at: index):
+                         .identifier("sending") where formatter.isTypePosition(at: index),
+                         .identifier("try"), .keyword("try"):
                         break
                     case .identifier, .number, .endOfScope("]"), .endOfScope("}"), .endOfScope(")"):
                         formatter.removeToken(at: i - 1)

--- a/Tests/Rules/HoistTryTests.swift
+++ b/Tests/Rules/HoistTryTests.swift
@@ -437,4 +437,17 @@ class HoistTryTests: XCTestCase {
         """#
         testFormatting(for: input, output, rule: .hoistTry)
     }
+
+    func testNoHoistTryInTestAttribute() {
+        let input = """
+        @Test(arguments: [try Identifier(101), nil])
+        func testFunction() {}
+        """
+
+        let output = """
+        @Test(arguments: try [Identifier(101), nil])
+        func testFunction() {}
+        """
+        testFormatting(for: input, output, rule: .hoistTry)
+    }
 }

--- a/Tests/Rules/SpaceAroundBracketsTests.swift
+++ b/Tests/Rules/SpaceAroundBracketsTests.swift
@@ -103,4 +103,9 @@ class SpaceAroundBracketsTests: XCTestCase {
         let input = "@Test(arguments: [kSecReturnRef, kSecReturnAttributes] as [String])"
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
+
+    func testSpaceNotRemovedBetweenTryAndBracket() {
+        let input = "@Test(arguments: try [Identifier(101), nil])"
+        testFormatting(for: input, rule: .spaceAroundBrackets)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the `hoistTry` rule could break `@Test` attributes containing `try`.

Fixes #1985.