### PR TITLE
Fix issue where `redundantVoidReturnType` rule accidentally removed closure return type

### DIFF
--- a/Sources/Rules/RedundantVoidReturnType.swift
+++ b/Sources/Rules/RedundantVoidReturnType.swift
@@ -32,6 +32,11 @@ public extension FormatRule {
 
             guard let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: endIndex) else { return }
 
+            // Ensure that `-> ()` isn't actually a closure, like `-> () -> Void`.
+            guard !formatter.isStartOfClosureType(at: startIndex) else {
+                return
+            }
+
             let isInProtocol = nextToken == .endOfScope("}") || (nextToken.isKeywordOrAttribute && nextToken != .keyword("in"))
 
             // After a `Void` we could see the start of a function's body, or if the function is inside a protocol declaration

--- a/Tests/Rules/RedundantVoidReturnTypeTests.swift
+++ b/Tests/Rules/RedundantVoidReturnTypeTests.swift
@@ -112,4 +112,20 @@ class RedundantVoidReturnTypeTests: XCTestCase {
         """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
+
+    func testNoRemoveThrowingClosureVoidReturnType() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/1978
+        let input = "func foo(bar: Bar) -> () throws -> Void"
+        testFormatting(for: input, rule: .redundantVoidReturnType)
+    }
+
+    func testNoRemoveClosureVoidReturnType() {
+        let input = "func foo(bar: Bar) -> () -> Void"
+        testFormatting(for: input, rule: .redundantVoidReturnType)
+    }
+
+    func testNoRemoveAsyncClosureVoidReturnType() {
+        let input = "func foo(bar: Bar) -> () async -> Void"
+        testFormatting(for: input, rule: .redundantVoidReturnType)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the `redundantVoidReturnType` rule could accidentally remove a closure return type, since it was confusing the `-> ()` for a void return.

Fixes #1978.