### PR TITLE
Update `organizeDeclarations` to treat `associatedtype` declarations as nested types, like `typealias` declarations.

### DIFF
--- a/Sources/DeclarationType.swift
+++ b/Sources/DeclarationType.swift
@@ -250,7 +250,7 @@ extension Declaration {
                 return .instanceLifecycle
 
             // Type-like declarations
-            case "typealias":
+            case "typealias", "associatedtype":
                 return .nestedType
 
             case "case":

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3856,4 +3856,33 @@ class OrganizeDeclarationsTests: XCTestCase {
         let options = FormatOptions(indent: "  ")
         testFormatting(for: input, rule: .organizeDeclarations, options: options, exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope])
     }
+
+    func testOrganizesProtocol() {
+        let input = """
+        protocol Foo {
+            func foo()
+            var bar: Bar { get }
+            func baaz()
+            associatedtype Baaz
+            var quux: Quux { get set }
+            associatedtype Quux
+        }
+        """
+
+        let output = """
+        protocol Foo {
+            associatedtype Baaz
+            associatedtype Quux
+
+            var bar: Bar { get }
+            var quux: Quux { get set }
+
+            func foo()
+            func baaz()
+        }
+        """
+
+        let options = FormatOptions(organizeTypes: ["protocol"])
+        testFormatting(for: input, output, rule: .organizeDeclarations, options: options)
+    }
 }


### PR DESCRIPTION
This PR updates `organizeDeclarations` to treat `associatedtype` declarations as nested types, like `typealias` declarations.

This makes the rule property support `protocol`s.