### PR TITLE
Don't add access control marks in protocol bodies

### DIFF
--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -357,7 +357,13 @@ extension Formatter {
         let numberOfCategories: Int = {
             switch options.organizationMode {
             case .visibility:
-                return Set(sortedDeclarations.map(\.category).map(\.visibility)).count
+                if typeDeclaration.keyword == "protocol" {
+                    // There is no access control in protocols, so all declarations are part of the same category.
+                    return 1
+                } else {
+                    return Set(sortedDeclarations.map(\.category).map(\.visibility)).count
+                }
+
             case .type:
                 return Set(sortedDeclarations.map(\.category).map(\.type)).count
             }

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3885,4 +3885,26 @@ class OrganizeDeclarationsTests: XCTestCase {
         let options = FormatOptions(organizeTypes: ["protocol"])
         testFormatting(for: input, output, rule: .organizeDeclarations, options: options)
     }
+
+    func testOrganizesProtocolWithInit() {
+        let input = """
+        public protocol Foo {
+            func foo()
+            func bar()
+            init()
+        }
+        """
+
+        let output = """
+        public protocol Foo {
+            init()
+
+            func foo()
+            func bar()
+        }
+        """
+
+        let options = FormatOptions(organizeTypes: ["protocol"])
+        testFormatting(for: input, output, rule: .organizeDeclarations, options: options)
+    }
 }


### PR DESCRIPTION
Before, the `organizeDeclarations` rule would add access control marks to protocols:

```swift
public protocol Foo {

    // MARK: Lifecycle 

    init()

    // MARK: Internal 

    func foo()
    func bar()
}
```

This is wrong, because these declarations are public, not internal. This also only happens if the protocol includes `init()` requirements, otherwise all declarations would be in the same category.

Instead of making this `// MARK: Public`, let's just omit the marks:

```swift
public protocol Foo {
    init()

    func foo()
    func bar()
}
```