### PR TITLE
Set up job to build and notarize SwiftFormat for Xcode

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -80,11 +80,11 @@ jobs:
           echo "app-path=$APP_PATH" >> $GITHUB_OUTPUT
           echo "Copied app to: $APP_PATH"
           
-          # Re-sign the app and all components
+          # Re-sign the app and all components with hardened runtime
           echo "Re-signing app components..."
-          find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
-          find "$APP_PATH" -name "*.framework" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
-          find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
+          find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
+          find "$APP_PATH" -name "*.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
+          find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
           
           # Verify signing

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -20,6 +20,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
+      - name: Import Code Signing Certificate
+        run: |
+          # Create keychain
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security set-keychain-settings -t 3600 -l build.keychain
+          
+          # Import certificate
+          echo "${{ secrets.SIGNING_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          
+          # Clean up
+          rm certificate.p12
+      
       - name: Archive SwiftFormat for Xcode App
         run: |
           ARCHIVE_PATH="build/SwiftFormatForXcode.xcarchive"

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -80,17 +80,18 @@ jobs:
           echo "Re-signing app components..."
           find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           # Skip Apple's XcodeKit.framework - don't re-sign it
-          find "$APP_PATH" -name "*.framework" ! -name "XcodeKit.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
+          find "$APP_PATH" -name "*.framework" -not -path "*/XcodeKit.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
           
-          # Verify signing - fail if verification fails
+          # Verify signing - fail if verification fails but continue workflow
           echo "Verifying code signature..."
           if ! codesign --verify --deep --strict "$APP_PATH"; then
             echo "ERROR: Code signature verification failed!"
             exit 1
           fi
           echo "App signing verified successfully"
+        continue-on-error: true
       
       - name: Notarize App
         uses: lando/notarize-action@v2
@@ -101,6 +102,7 @@ jobs:
           appstore-connect-team-id: 8VQKF583ED
           primary-bundle-id: com.nicklockwood.SwiftFormat-for-Xcode
           verbose: true
+        continue-on-error: true
       
       - name: Staple Notarization
         id: staple
@@ -130,14 +132,12 @@ jobs:
           fi
       
       - name: Zip App
-        if: steps.staple.outcome == 'success'
         run: |
           cd "$(dirname "${{ steps.export-app.outputs.app-path }}")"
           zip -r SwiftFormat.for.Xcode.app.zip "SwiftFormat for Xcode.app"
           echo "ZIP_DIR=$(pwd)" >> $GITHUB_ENV
       
       - name: Upload App Artifact
-        if: steps.staple.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: SwiftFormat-for-Xcode

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -92,7 +92,6 @@ jobs:
           echo "App signing verified successfully"
       
       - name: Notarize App
-        id: notarize
         uses: lando/notarize-action@v2
         with:
           product-path: ${{ steps.export-app.outputs.app-path }}
@@ -101,22 +100,9 @@ jobs:
           appstore-connect-team-id: 8VQKF583ED
           primary-bundle-id: com.nicklockwood.SwiftFormat-for-Xcode
           verbose: true
-        continue-on-error: true
-      
-      - name: Get Notarization Logs on Failure
-        if: steps.notarize.outcome == 'failure'
-        run: |
-          echo "Notarization failed, getting detailed logs..."
-          # Get the request UUID from notarytool history
-          REQUEST_UUID=$(xcrun notarytool history --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}" --output-format json | jq -r '.[0].id')
-          echo "Request UUID: $REQUEST_UUID"
-          
-          # Get detailed logs
-          xcrun notarytool log "$REQUEST_UUID" --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}"
-          
-          exit 1
       
       - name: Staple Notarization
+        id: staple
         run: |
           # Retry stapling up to 3 times with delays
           for i in {1..3}; do
@@ -134,6 +120,27 @@ jobs:
               fi
             fi
           done
+        continue-on-error: true
+      
+      - name: Get Notarization Logs
+        run: |
+          echo "Getting notarization history and logs..."
+          
+          # Show recent history
+          echo "=== Recent Notarization History ==="
+          xcrun notarytool history --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}"
+          
+          # Get the most recent request UUID and its detailed logs
+          echo ""
+          echo "=== Getting detailed logs for most recent submission ==="
+          REQUEST_UUID=$(xcrun notarytool history --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}" | grep -E "id:\s*[a-f0-9-]{36}" | head -1 | sed 's/.*id: //')
+          
+          if [ -n "$REQUEST_UUID" ]; then
+            echo "Getting logs for request: $REQUEST_UUID"
+            xcrun notarytool log "$REQUEST_UUID" --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}"
+          else
+            echo "Could not extract request UUID from history"
+          fi
       
       - name: Zip App
         run: |

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,11 +1,8 @@
 name: Build and Notarize SwiftFormat for Xcode
 
 on:
-  push:
-    branches: [develop, main]
-  pull_request:
-    branches: [develop, main]
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-and-notarize:
@@ -148,3 +145,10 @@ jobs:
         with:
           name: SwiftFormat-for-Xcode
           path: ${{ env.ZIP_DIR }}/SwiftFormat.for.Xcode.app.zip
+      
+      - name: Upload to Release
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${{ env.ZIP_DIR }}/SwiftFormat.for.Xcode.app.zip

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -92,6 +92,7 @@ jobs:
           echo "App signing verified successfully"
       
       - name: Notarize App
+        id: notarize
         uses: lando/notarize-action@v2
         with:
           product-path: ${{ steps.export-app.outputs.app-path }}
@@ -100,6 +101,20 @@ jobs:
           appstore-connect-team-id: 8VQKF583ED
           primary-bundle-id: com.nicklockwood.SwiftFormat-for-Xcode
           verbose: true
+        continue-on-error: true
+      
+      - name: Get Notarization Logs on Failure
+        if: steps.notarize.outcome == 'failure'
+        run: |
+          echo "Notarization failed, getting detailed logs..."
+          # Get the request UUID from notarytool history
+          REQUEST_UUID=$(xcrun notarytool history --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}" --output-format json | jq -r '.[0].id')
+          echo "Request UUID: $REQUEST_UUID"
+          
+          # Get detailed logs
+          xcrun notarytool log "$REQUEST_UUID" --team-id 8VQKF583ED --apple-id "${{ secrets.NOTARIZATION_USERNAME }}" --password "${{ secrets.NOTARIZATION_PASSWORD }}"
+          
+          exit 1
       
       - name: Staple Notarization
         run: |

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -66,44 +66,30 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             archive
       
-      - name: Export App from Archive
+      - name: Copy and Sign App from Archive
         id: export-app
         run: |
           ARCHIVE_PATH="build/SwiftFormatForXcode.xcarchive"
           EXPORT_PATH="build/Export"
+          mkdir -p "$EXPORT_PATH"
           
-          # Create export options plist
-          cat > export_options.plist << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>developer-id</string>
-              <key>destination</key>
-              <string>export</string>
-              <key>signingStyle</key>
-              <string>manual</string>
-              <key>stripSwiftSymbols</key>
-              <true/>
-              <key>teamID</key>
-              <string>8VQKF583ED</string>
-              <key>signingCertificate</key>
-              <string>Developer ID Application</string>
-          </dict>
-          </plist>
-          EOF
+          # Copy app from archive
+          cp -R "$ARCHIVE_PATH/Products/Applications/SwiftFormat for Xcode.app" "$EXPORT_PATH/"
           
-          xcodebuild \
-            -exportArchive \
-            -archivePath "$ARCHIVE_PATH" \
-            -exportPath "$EXPORT_PATH" \
-            -exportOptionsPlist export_options.plist
-          
-          APP_PATH=$(find "$EXPORT_PATH" -name "SwiftFormat for Xcode.app" -type d | head -1)
+          APP_PATH="$EXPORT_PATH/SwiftFormat for Xcode.app"
           echo "app-path=$APP_PATH" >> $GITHUB_OUTPUT
-          echo "Found exported app at: $APP_PATH"
-          ls -la "$APP_PATH"
+          echo "Copied app to: $APP_PATH"
+          
+          # Re-sign the app and all components
+          echo "Re-signing app components..."
+          find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
+          find "$APP_PATH" -name "*.framework" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
+          find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp {} \;
+          codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
+          
+          # Verify signing
+          codesign --verify --deep --strict "$APP_PATH"
+          echo "App signing verified successfully"
       
       - name: Notarize App
         uses: lando/notarize-action@v2

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,0 +1,87 @@
+name: Build and Notarize SwiftFormat for Xcode
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+jobs:
+  build-and-notarize:
+    runs-on: macos-15
+    
+    steps:
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.3'
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Archive SwiftFormat for Xcode App
+        run: |
+          ARCHIVE_PATH="build/SwiftFormatForXcode.xcarchive"
+          xcodebuild \
+            -project SwiftFormat.xcodeproj \
+            -scheme "SwiftFormat for Xcode" \
+            -configuration Release \
+            -archivePath "$ARCHIVE_PATH" \
+            archive
+      
+      - name: Export App from Archive
+        id: export-app
+        run: |
+          ARCHIVE_PATH="build/SwiftFormatForXcode.xcarchive"
+          EXPORT_PATH="build/Export"
+          
+          # Create export options plist
+          cat > export_options.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>developer-id</string>
+              <key>destination</key>
+              <string>export</string>
+          </dict>
+          </plist>
+          EOF
+          
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$ARCHIVE_PATH" \
+            -exportPath "$EXPORT_PATH" \
+            -exportOptionsPlist export_options.plist
+          
+          APP_PATH=$(find "$EXPORT_PATH" -name "SwiftFormat for Xcode.app" -type d | head -1)
+          echo "app-path=$APP_PATH" >> $GITHUB_OUTPUT
+          echo "Found exported app at: $APP_PATH"
+          ls -la "$APP_PATH"
+      
+      - name: Notarize App
+        uses: lando/notarize-action@v2
+        with:
+          product-path: ${{ steps.export-app.outputs.app-path }}
+          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+          appstore-connect-team-id: 8VQKF583ED
+          primary-bundle-id: com.nicklockwood.SwiftFormat-for-Xcode
+          verbose: true
+      
+      - name: Staple Notarization
+        run: |
+          xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
+      
+      - name: Zip App
+        run: |
+          cd "$(dirname "${{ steps.export-app.outputs.app-path }}")"
+          zip -r SwiftFormat-for-Xcode.zip "SwiftFormat for Xcode.app"
+          echo "ZIP_PATH=$(pwd)/SwiftFormat-for-Xcode.zip" >> $GITHUB_ENV
+      
+      - name: Upload App Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.ZIP_PATH }}

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -78,6 +78,14 @@ jobs:
           
           # Use app from archive as-is without additional signing
           echo "Using app from archive without modification"
+          
+          # Validate the signature from archive
+          echo "Validating archive signature..."
+          if ! codesign --verify --deep --strict "$APP_PATH"; then
+            echo "ERROR: Archive produced invalid signature!"
+            exit 1
+          fi
+          echo "Archive signature is valid"
         continue-on-error: true
       
       - name: Notarize App

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -86,6 +86,14 @@ jobs:
             exit 1
           fi
           echo "Archive signature is valid"
+          
+          # Check Gatekeeper assessment
+          echo "Checking Gatekeeper assessment..."
+          if ! spctl -a -v "$APP_PATH"; then
+            echo "ERROR: Gatekeeper would reject this app!"
+            exit 1
+          fi
+          echo "Gatekeeper assessment passed"
         continue-on-error: true
       
       - name: Notarize App

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -102,24 +102,8 @@ jobs:
           verbose: true
       
       - name: Staple Notarization
-        id: staple
         run: |
-          # Retry stapling up to 3 times with delays
-          for i in {1..3}; do
-            echo "Stapling attempt $i..."
-            if xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"; then
-              echo "Stapling successful on attempt $i"
-              exit 0
-            else
-              if [ $i -eq 3 ]; then
-                echo "Stapling failed after 3 attempts"
-                exit 1
-              else
-                echo "Stapling attempt $i failed, waiting 30 seconds before retry..."
-                sleep 30
-              fi
-            fi
-          done
+          xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
         continue-on-error: true
       
       - name: Get Notarization Logs

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -47,10 +47,6 @@ jobs:
           
           # Clean up
           rm certificate.p12
-          
-          # Debug: List available certificates
-          echo "Available signing identities:"
-          security find-identity -v -p codesigning build.keychain
       
       - name: Archive SwiftFormat for Xcode App
         run: |
@@ -105,8 +101,10 @@ jobs:
         id: staple
         run: |
           xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
+        continue-on-error: true
       
       - name: Get Notarization Logs
+        if: steps.staple.outcome == 'failure'
         run: |
           echo "Getting notarization history and logs..."
           

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -102,9 +102,9 @@ jobs:
           verbose: true
       
       - name: Staple Notarization
+        id: staple
         run: |
           xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
-        continue-on-error: true
       
       - name: Get Notarization Logs
         run: |
@@ -127,12 +127,15 @@ jobs:
           fi
       
       - name: Zip App
+        if: steps.staple.outcome == 'success'
         run: |
           cd "$(dirname "${{ steps.export-app.outputs.app-path }}")"
           zip -r SwiftFormat.for.Xcode.app.zip "SwiftFormat for Xcode.app"
-          echo "ZIP_PATH=$(pwd)/SwiftFormat.for.Xcode.app.zip" >> $GITHUB_ENV
+          echo "ZIP_DIR=$(pwd)" >> $GITHUB_ENV
       
       - name: Upload App Artifact
+        if: steps.staple.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.ZIP_PATH }}
+          name: SwiftFormat-for-Xcode
+          path: ${{ env.ZIP_DIR }}/SwiftFormat.for.Xcode.app.zip

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -79,6 +79,12 @@ jobs:
           # Use app from archive as-is without additional signing
           echo "Using app from archive without modification"
           
+          # Check and fix XcodeKit.framework structure
+          XCODE_KIT_PATH="$APP_PATH/Contents/PlugIns/SwiftFormat.appex/Contents/Frameworks/XcodeKit.framework"
+          echo "Checking XcodeKit.framework structure..."
+          ls -la "$XCODE_KIT_PATH/Versions/"
+          file "$XCODE_KIT_PATH/Versions/Current"
+          
           # Validate the signature from archive
           echo "Validating archive signature..."
           if ! codesign --verify --deep --strict "$APP_PATH"; then
@@ -137,7 +143,7 @@ jobs:
       - name: Zip App
         run: |
           cd "$(dirname "${{ steps.export-app.outputs.app-path }}")"
-          zip -r SwiftFormat.for.Xcode.app.zip "SwiftFormat for Xcode.app"
+          zip -r --symlinks SwiftFormat.for.Xcode.app.zip "SwiftFormat for Xcode.app"
           echo "ZIP_DIR=$(pwd)" >> $GITHUB_ENV
       
       - name: Upload App Artifact

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -100,7 +100,6 @@ jobs:
             exit 1
           fi
           echo "Gatekeeper assessment passed"
-        continue-on-error: true
       
       - name: Notarize App
         uses: lando/notarize-action@v2
@@ -111,16 +110,14 @@ jobs:
           appstore-connect-team-id: 8VQKF583ED
           primary-bundle-id: com.nicklockwood.SwiftFormat-for-Xcode
           verbose: true
-        continue-on-error: true
       
       - name: Staple Notarization
         id: staple
         run: |
           xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
-        continue-on-error: true
       
       - name: Get Notarization Logs
-        if: steps.staple.outcome == 'failure'
+        if: failure()
         run: |
           echo "Getting notarization history and logs..."
           

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -84,8 +84,12 @@ jobs:
           find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
           
-          # Verify signing
-          codesign --verify --deep --strict "$APP_PATH"
+          # Verify signing - fail if verification fails
+          echo "Verifying code signature..."
+          if ! codesign --verify --deep --strict "$APP_PATH"; then
+            echo "ERROR: Code signature verification failed!"
+            exit 1
+          fi
           echo "App signing verified successfully"
       
       - name: Notarize App

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -22,6 +22,18 @@ jobs:
       
       - name: Import Code Signing Certificate
         run: |
+          # Debug: Check if secrets exist (without revealing them)
+          if [ -z "${{ secrets.SIGNING_CERTIFICATE_BASE64 }}" ]; then
+            echo "ERROR: SIGNING_CERTIFICATE_BASE64 secret is empty or not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}" ]; then
+            echo "ERROR: SIGNING_CERTIFICATE_PASSWORD secret is empty or not set"  
+            exit 1
+          fi
+          
+          echo "Secrets are present, proceeding with certificate import..."
+          
           # Create keychain
           security create-keychain -p "" build.keychain
           security default-keychain -s build.keychain
@@ -35,6 +47,10 @@ jobs:
           
           # Clean up
           rm certificate.p12
+          
+          # Debug: List available certificates
+          echo "Available signing identities:"
+          security find-identity -v -p codesigning build.keychain
       
       - name: Archive SwiftFormat for Xcode App
         run: |

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -76,21 +76,8 @@ jobs:
           echo "app-path=$APP_PATH" >> $GITHUB_OUTPUT
           echo "Copied app to: $APP_PATH"
           
-          # Re-sign the app and all components with hardened runtime
-          echo "Re-signing app components..."
-          find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
-          # Skip Apple's XcodeKit.framework - don't re-sign it
-          find "$APP_PATH" -name "*.framework" -not -path "*/XcodeKit.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
-          find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
-          codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
-          
-          # Verify signing - fail if verification fails but continue workflow
-          echo "Verifying code signature..."
-          if ! codesign --verify --deep --strict "$APP_PATH"; then
-            echo "ERROR: Code signature verification failed!"
-            exit 1
-          fi
-          echo "App signing verified successfully"
+          # Use app from archive as-is without additional signing
+          echo "Using app from archive without modification"
         continue-on-error: true
       
       - name: Notarize App

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Import Code Signing Certificate
         run: |
           # Debug: Check if secrets exist (without revealing them)
-          if [ -z "${{ secrets.SIGNING_CERTIFICATE_BASE64 }}" ]; then
-            echo "ERROR: SIGNING_CERTIFICATE_BASE64 secret is empty or not set"
+          if [ -z "${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}" ]; then
+            echo "ERROR: DEVELOPER_ID_CERTIFICATE_BASE64 secret is empty or not set"
             exit 1
           fi
-          if [ -z "${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}" ]; then
-            echo "ERROR: SIGNING_CERTIFICATE_PASSWORD secret is empty or not set"  
+          if [ -z "${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}" ]; then
+            echo "ERROR: DEVELOPER_ID_CERTIFICATE_PASSWORD secret is empty or not set"  
             exit 1
           fi
           
@@ -41,8 +41,8 @@ jobs:
           security set-keychain-settings -t 3600 -l build.keychain
           
           # Import certificate
-          echo "${{ secrets.SIGNING_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
-          security import certificate.p12 -k build.keychain -P "${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
+          echo "${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
           
           # Clean up
@@ -60,6 +60,10 @@ jobs:
             -scheme "SwiftFormat for Xcode" \
             -configuration Release \
             -archivePath "$ARCHIVE_PATH" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            DEVELOPMENT_TEAM="8VQKF583ED" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
             archive
       
       - name: Export App from Archive

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -79,7 +79,8 @@ jobs:
           # Re-sign the app and all components with hardened runtime
           echo "Re-signing app components..."
           find "$APP_PATH" -name "*.dylib" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
-          find "$APP_PATH" -name "*.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
+          # Skip Apple's XcodeKit.framework - don't re-sign it
+          find "$APP_PATH" -name "*.framework" ! -name "XcodeKit.framework" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           find "$APP_PATH" -name "*.appex" -exec codesign --force --sign "Developer ID Application" --timestamp --options runtime {} \;
           codesign --force --sign "Developer ID Application" --timestamp --options runtime "$APP_PATH"
           

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -122,8 +122,8 @@ jobs:
       - name: Zip App
         run: |
           cd "$(dirname "${{ steps.export-app.outputs.app-path }}")"
-          zip -r SwiftFormat-for-Xcode.zip "SwiftFormat for Xcode.app"
-          echo "ZIP_PATH=$(pwd)/SwiftFormat-for-Xcode.zip" >> $GITHUB_ENV
+          zip -r SwiftFormat.for.Xcode.app.zip "SwiftFormat for Xcode.app"
+          echo "ZIP_PATH=$(pwd)/SwiftFormat.for.Xcode.app.zip" >> $GITHUB_ENV
       
       - name: Upload App Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -3,6 +3,11 @@ name: Build and Notarize SwiftFormat for Xcode
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.2.3)'
+        required: true
 
 jobs:
   build-and-notarize:
@@ -16,6 +21,8 @@ jobs:
       
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
       
       - name: Import Code Signing Certificate
         run: |

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -103,7 +103,22 @@ jobs:
       
       - name: Staple Notarization
         run: |
-          xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"
+          # Retry stapling up to 3 times with delays
+          for i in {1..3}; do
+            echo "Stapling attempt $i..."
+            if xcrun stapler staple "${{ steps.export-app.outputs.app-path }}"; then
+              echo "Stapling successful on attempt $i"
+              exit 0
+            else
+              if [ $i -eq 3 ]; then
+                echo "Stapling failed after 3 attempts"
+                exit 1
+              else
+                echo "Stapling attempt $i failed, waiting 30 seconds before retry..."
+                sleep 30
+              fi
+            fi
+          done
       
       - name: Zip App
         run: |

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -82,6 +82,14 @@ jobs:
               <string>developer-id</string>
               <key>destination</key>
               <string>export</string>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>stripSwiftSymbols</key>
+              <true/>
+              <key>teamID</key>
+              <string>8VQKF583ED</string>
+              <key>signingCertificate</key>
+              <string>Developer ID Application</string>
           </dict>
           </plist>
           EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,3 @@ Then complete the following steps manually:
 * Publish a new release
   * All binaries are built and uploaded to the release automatically
 * pod trunk push --allow-warnings
-
-Finally, these steps require App Store Connect access, so only Nick can do them:
-
-* Select SwiftFormat for Xcode and run Product > Archive
-* Notarize and export built app

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		2EF8BF1D2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		2EF8BF1E2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		37D828AB24BF77DA0012FC0A /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; };
-		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6E954FF32E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
 		6E954FF42E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
 		6E954FF52E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -1485,12 +1485,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_ENTITLEMENTS = EditorExtension/Application/SwiftFormatter.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 8VQKF583ED;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = EditorExtension/Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -1485,11 +1485,12 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_ENTITLEMENTS = EditorExtension/Application/SwiftFormatter.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 8VQKF583ED;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = EditorExtension/Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		2EF8BF1D2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		2EF8BF1E2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
 		37D828AB24BF77DA0012FC0A /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; };
-		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		37D828AC24BF77DA0012FC0A /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37D828AA24BF77DA0012FC0A /* XcodeKit.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6E954FF32E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
 		6E954FF42E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };
 		6E954FF52E0DEACC004EE019 /* SARIFReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E954FF22E0DEACC004EE019 /* SARIFReporter.swift */; };

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -1485,11 +1485,12 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_ENTITLEMENTS = EditorExtension/Application/SwiftFormatter.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 8VQKF583ED;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = EditorExtension/Application/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1513,6 +1514,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_ENTITLEMENTS = EditorExtension/Extension/SwiftFormatter.entitlements;
 				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -1542,10 +1544,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_ENTITLEMENTS = EditorExtension/Extension/SwiftFormatter.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 8VQKF583ED;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = EditorExtension/Extension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
This PR adds a GitHub action job to build, sign, and notarize the SwiftFormat for Xcode app. This runs automatically for a new release.

Example notarized app:

[SwiftFormat-for-Xcode.zip](https://github.com/user-attachments/files/21415657/SwiftFormat-for-Xcode.zip)
