### PR TITLE
Add `organizeDeclarations` threshold options to organize types without adding marks

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1763,6 +1763,10 @@ Option | Description
 `--class-threshold` | Minimum line count to organize class body. Defaults to 0
 `--enum-threshold` | Minimum line count to organize enum body. Defaults to 0
 `--extension-threshold` | Minimum line count to organize extension body. Defaults to 0
+`--mark-struct-threshold` | Minimum line count to add MARK comments in struct body. Defaults to 0
+`--mark-class-threshold` | Minimum line count to add MARK comments in class body. Defaults to 0
+`--mark-enum-threshold` | Minimum line count to add MARK comments in enum body. Defaults to 0
+`--mark-extension-threshold` | Minimum line count to add MARK comments in extension body. Defaults to 0
 `--organization-mode` | Organize declarations by: "visibility" (default) or "type"
 `--visibility-order` | Order for visibility groups inside declaration
 `--type-order` | Order for declaration type groups inside declaration

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1070,6 +1070,30 @@ struct _Descriptors {
         help: "Minimum line count to organize extension body. Defaults to 0",
         keyPath: \.organizeExtensionThreshold
     )
+    let markStructThreshold = OptionDescriptor(
+        argumentName: "mark-struct-threshold",
+        displayName: "Mark Struct Threshold",
+        help: "Minimum line count to add MARK comments in struct body. Defaults to 0",
+        keyPath: \.markStructThreshold
+    )
+    let markClassThreshold = OptionDescriptor(
+        argumentName: "mark-class-threshold",
+        displayName: "Mark Class Threshold",
+        help: "Minimum line count to add MARK comments in class body. Defaults to 0",
+        keyPath: \.markClassThreshold
+    )
+    let markEnumThreshold = OptionDescriptor(
+        argumentName: "mark-enum-threshold",
+        displayName: "Mark Enum Threshold",
+        help: "Minimum line count to add MARK comments in enum body. Defaults to 0",
+        keyPath: \.markEnumThreshold
+    )
+    let markExtensionThreshold = OptionDescriptor(
+        argumentName: "mark-extension-threshold",
+        displayName: "Mark Extension Threshold",
+        help: "Minimum line count to add MARK comments in extension body. Defaults to 0",
+        keyPath: \.markExtensionThreshold
+    )
     let organizationMode = OptionDescriptor(
         argumentName: "organization-mode",
         displayName: "Declaration Organization Mode",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -776,6 +776,10 @@ public struct FormatOptions: CustomStringConvertible {
     public var organizeStructThreshold: Int
     public var organizeEnumThreshold: Int
     public var organizeExtensionThreshold: Int
+    public var markStructThreshold: Int
+    public var markClassThreshold: Int
+    public var markEnumThreshold: Int
+    public var markExtensionThreshold: Int
     public var organizationMode: DeclarationOrganizationMode
     public var visibilityOrder: [String]?
     public var typeOrder: [String]?
@@ -911,6 +915,10 @@ public struct FormatOptions: CustomStringConvertible {
                 organizeStructThreshold: Int = 0,
                 organizeEnumThreshold: Int = 0,
                 organizeExtensionThreshold: Int = 0,
+                markStructThreshold: Int = 0,
+                markClassThreshold: Int = 0,
+                markEnumThreshold: Int = 0,
+                markExtensionThreshold: Int = 0,
                 organizationMode: DeclarationOrganizationMode = .visibility,
                 visibilityOrder: [String]? = nil,
                 typeOrder: [String]? = nil,
@@ -1035,6 +1043,10 @@ public struct FormatOptions: CustomStringConvertible {
         self.organizeStructThreshold = organizeStructThreshold
         self.organizeEnumThreshold = organizeEnumThreshold
         self.organizeExtensionThreshold = organizeExtensionThreshold
+        self.markStructThreshold = markStructThreshold
+        self.markClassThreshold = markClassThreshold
+        self.markEnumThreshold = markEnumThreshold
+        self.markExtensionThreshold = markExtensionThreshold
         self.organizationMode = organizationMode
         self.visibilityOrder = visibilityOrder
         self.typeOrder = typeOrder

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3907,4 +3907,124 @@ class OrganizeDeclarationsTests: XCTestCase {
         let options = FormatOptions(organizeTypes: ["protocol"])
         testFormatting(for: input, output, rule: .organizeDeclarations, options: options)
     }
+
+    func testBelowCustomStructMarkThreshold() {
+        let input = """
+        struct SmallStruct {
+            func foo() {}
+            let a = 1
+            private let b = 2
+        }
+        """
+
+        let output = """
+        struct SmallStruct {
+            let a = 1
+
+            func foo() {}
+
+            private let b = 2
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(markStructThreshold: 20),
+            exclude: [.blankLinesAtStartOfScope]
+        )
+    }
+
+    func testOrganizedStructNowOverMarkThreshold() {
+        let input = """
+        struct SmallStruct {
+            func foo() {}
+            let a = 1
+            private let b = 2
+        }
+        """
+
+        let output = """
+        struct SmallStruct {
+
+            // MARK: Internal
+
+            let a = 1
+
+            func foo() {}
+
+            // MARK: Private
+
+            private let b = 2
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(markStructThreshold: 4),
+            exclude: [.blankLinesAtStartOfScope]
+        )
+    }
+
+    func testBelowCustomStructMarkThresholdDoesntRemoveMarks() {
+        let input = """
+        struct SmallStruct {
+
+            // MARK: Internal
+
+            let a = 1
+
+            func foo() {}
+
+            // MARK: Private
+
+            private let b = 2
+        }
+        """
+
+        testFormatting(
+            for: input,
+            rule: .organizeDeclarations,
+            options: FormatOptions(markStructThreshold: 20),
+            exclude: [.blankLinesAtStartOfScope]
+        )
+    }
+
+    func testAboveCustomStructMarkThreshold() {
+        let input = """
+        public struct LargeStruct {
+            let a = 1
+            let b = 2
+            let c = 3
+            public func foo() {}
+            public func bar() {}
+            public func baz() {}
+        }
+        """
+
+        let output = """
+        public struct LargeStruct {
+
+            // MARK: Public
+
+            public func foo() {}
+            public func bar() {}
+            public func baz() {}
+
+            // MARK: Internal
+
+            let a = 1
+            let b = 2
+            let c = 3
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(markStructThreshold: 5),
+            exclude: [.blankLinesAtStartOfScope]
+        )
+    }
 }


### PR DESCRIPTION
This PR adds threshold-based options for organizing type bodies without adding `// MARK` comments.

For example, for structs under 20 lines, you may want to organize the type body, but not add `// MARK` comments.