### PR TITLE
Fix issue where `redundantPublic` broke @_spi annotated members

### DIFF
--- a/Sources/Rules/RedundantPublic.swift
+++ b/Sources/Rules/RedundantPublic.swift
@@ -50,6 +50,10 @@ public extension FormatRule {
                 return
             }
 
+            if declaration.modifiers.contains("@_spi") {
+                return
+            }
+
             switch parentType.keyword {
             case "extension":
                 // Inside an extension where the extended type is internal, any `public` modifier has no effect.

--- a/Tests/Rules/RedundantPublicTests.swift
+++ b/Tests/Rules/RedundantPublicTests.swift
@@ -38,6 +38,16 @@ class RedundantPublicTests: XCTestCase {
         testFormatting(for: input, [output], rules: [.redundantPublic])
     }
 
+    func testDoesNotRemovePublicFromMethodInInternalClassWithSPI() {
+        let input = """
+        class Example {
+            @_spi(Example)
+            public func doSomething() {}
+        }
+        """
+        testFormatting(for: input, rules: [.redundantPublic])
+    }
+
     func testRemovesPublicFromMultipleDeclarationsInInternalType() {
         let input = """
         struct Container {


### PR DESCRIPTION
For `@_spi` annotated functions the visibility needs to be `public` or you get the following warning

> Internal instance method cannot be declared '@_spi' because only public and open declarations can be '@_spi'

This commit guards by checking if the modifier is present