### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+<!--
+Thank you for contributing to SwiftFormat!
+
+Pull request checklist:
+- [ ] The base branch of the pull request is `develop`
+- [ ] Any code changes include corresponding test cases
+-->


### PR DESCRIPTION
This PR adds a PR template. Hopefully this will make it more likely that new contributors notice their PR should target `develop` rather than `main`.