### PR TITLE
Add support for Swift 6.2 raw identifiers

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3303,6 +3303,13 @@ In Swift Testing, don't prefix @Test methods with 'test'.
           #expect(myFeature.crashes.isEmpty, "My feature doesn't crash")
           #expect(myFeature.crashReport == nil)
       }
+
+-     @Test func `test feature works as expected`(_ feature: Feature) {
++     @Test func `feature works as expected`(_ feature: Feature) {
+        let myFeature = MyFeature()
+        myFeature.run(feature)
+        #expect(myFeature.worksAsExpected)
+    }
   }
 ```
 

--- a/Sources/Rules/SwiftTestingTestCaseNames.swift
+++ b/Sources/Rules/SwiftTestingTestCaseNames.swift
@@ -26,6 +26,13 @@ public extension FormatRule {
                   #expect(myFeature.crashes.isEmpty, "My feature doesn't crash")
                   #expect(myFeature.crashReport == nil)
               }
+
+        -     @Test func `test feature works as expected`(_ feature: Feature) {
+        +     @Test func `feature works as expected`(_ feature: Feature) {
+                let myFeature = MyFeature()
+                myFeature.run(feature)
+                #expect(myFeature.worksAsExpected)
+            }
           }
         ```
         """

--- a/Tests/Rules/PropertyTypesTests.swift
+++ b/Tests/Rules/PropertyTypesTests.swift
@@ -598,4 +598,19 @@ class PropertyTypesTests: XCTestCase {
         let options = FormatOptions(propertyTypes: .inferLocalsOnly)
         testFormatting(for: input, rule: .propertyTypes, options: options)
     }
+
+    func testHandlesEscapedIdentifiers() {
+        let input = """
+        let `property with raw identifier 1` = `function with raw identifier`()
+        let `property with raw identifier 2` = `Escaped Type Name`.staticMember
+        """
+
+        let output = """
+        let `property with raw identifier 1` = `function with raw identifier`()
+        let `property with raw identifier 2`: `Escaped Type Name` = .staticMember
+        """
+
+        let options = FormatOptions(propertyTypes: .explicit)
+        testFormatting(for: input, output, rule: .propertyTypes, options: options)
+    }
 }

--- a/Tests/Rules/RedundantBackticksTests.swift
+++ b/Tests/Rules/RedundantBackticksTests.swift
@@ -105,7 +105,7 @@ class RedundantBackticksTests: XCTestCase {
 
     func testNoRemoveBackticksAroundTrueProperty() {
         let input = "var type = Foo.`true`"
-        testFormatting(for: input, rule: .redundantBackticks)
+        testFormatting(for: input, rule: .redundantBackticks, exclude: [.propertyTypes])
     }
 
     func testRemoveBackticksAroundTrueProperty() {
@@ -209,6 +209,17 @@ class RedundantBackticksTests: XCTestCase {
 
     func testNoRemoveBackticksAroundDollar() {
         let input = "@attached(peer, names: prefixed(`$`))"
+        testFormatting(for: input, rule: .redundantBackticks)
+    }
+
+    func testNoRemoveBackticksAroundRawIdentifier() {
+        let input = """
+        func `function with raw identifier`() -> String {
+            "foo"
+        }
+
+        let `property with raw identifier` = `function with raw identifier`()
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 }

--- a/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
+++ b/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
@@ -55,6 +55,56 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames)
     }
 
+    func testRemovesTestPrefixFromMethodWithRawIdentifier() {
+        let input = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test func `test my feature has no bugs`() {
+                let myFeature = MyFeature()
+                myFeature.runAction()
+                #expect(!myFeature.hasBugs)
+            }
+
+            @Test("Features work as expected", arguments: [
+                .foo,
+                .bar,
+                .baaz,
+            ])
+            func `Test Feature Works As Expected`(_ feature: Feature) {
+                let myFeature = MyFeature()
+                myFeature.run(feature)
+                #expect(myFeature.worksAsExpected)
+            }
+        }
+        """
+
+        let output = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test func `my feature has no bugs`() {
+                let myFeature = MyFeature()
+                myFeature.runAction()
+                #expect(!myFeature.hasBugs)
+            }
+
+            @Test("Features work as expected", arguments: [
+                .foo,
+                .bar,
+                .baaz,
+            ])
+            func `Feature Works As Expected`(_ feature: Feature) {
+                let myFeature = MyFeature()
+                myFeature.run(feature)
+                #expect(myFeature.worksAsExpected)
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .swiftTestingTestCaseNames)
+    }
+
     func testDoesntUpdateNameToIdentifierRequiringBackTicks() {
         let input = """
         import Testing

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -5121,4 +5121,75 @@ class TokenizerTests: XCTestCase {
         ]
         XCTAssertEqual(tokenize(input), output)
     }
+
+    func testRawIdentifiers() {
+        let input = """
+        func `square returns x * x`() -> Int { 42 }
+        enum ColorVariant { case `50`, `100`, `200` }
+        let `1.circle` = "SF Symbol"
+        struct `class` { let `for` = true }
+        """
+        let output: [Token] = [
+            .keyword("func"),
+            .space(" "),
+            .identifier("`square returns x * x`"),
+            .startOfScope("("),
+            .endOfScope(")"),
+            .space(" "),
+            .operator("->", .infix),
+            .space(" "),
+            .identifier("Int"),
+            .space(" "),
+            .startOfScope("{"),
+            .space(" "),
+            .number("42", .integer),
+            .space(" "),
+            .endOfScope("}"),
+            .linebreak("\n", 1),
+            .keyword("enum"),
+            .space(" "),
+            .identifier("ColorVariant"),
+            .space(" "),
+            .startOfScope("{"),
+            .space(" "),
+            .keyword("case"),
+            .space(" "),
+            .identifier("`50`"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("`100`"),
+            .delimiter(","),
+            .space(" "),
+            .identifier("`200`"),
+            .space(" "),
+            .endOfScope("}"),
+            .linebreak("\n", 2),
+            .keyword("let"),
+            .space(" "),
+            .identifier("`1.circle`"),
+            .space(" "),
+            .operator("=", .infix),
+            .space(" "),
+            .startOfScope("\""),
+            .stringBody("SF Symbol"),
+            .endOfScope("\""),
+            .linebreak("\n", 3),
+            .keyword("struct"),
+            .space(" "),
+            .identifier("`class`"),
+            .space(" "),
+            .startOfScope("{"),
+            .space(" "),
+            .keyword("let"),
+            .space(" "),
+            .identifier("`for`"),
+            .space(" "),
+            .operator("=", .infix),
+            .space(" "),
+            .identifier("true"),
+            .space(" "),
+            .endOfScope("}"),
+        ]
+        XCTAssertEqual(tokenize(input), output)
+    }
 }


### PR DESCRIPTION
This PR adds support for Swift 6.2 raw identifiers: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0451-escaped-identifiers.md

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2093.