### PR TITLE
Update rule tests to use multi-line strings

### DIFF
--- a/Tests/Rules/AndOperatorTests.swift
+++ b/Tests/Rules/AndOperatorTests.swift
@@ -11,66 +11,104 @@ import XCTest
 
 class AndOperatorTests: XCTestCase {
     func testIfAndReplaced() {
-        let input = "if true && true {}"
-        let output = "if true, true {}"
+        let input = """
+        if true && true {}
+        """
+        let output = """
+        if true, true {}
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 
     func testGuardAndReplaced() {
-        let input = "guard true && true\nelse { return }"
-        let output = "guard true, true\nelse { return }"
+        let input = """
+        guard true && true
+        else { return }
+        """
+        let output = """
+        guard true, true
+        else { return }
+        """
         testFormatting(for: input, output, rule: .andOperator,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testWhileAndReplaced() {
-        let input = "while true && true {}"
-        let output = "while true, true {}"
+        let input = """
+        while true && true {}
+        """
+        let output = """
+        while true, true {}
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 
     func testIfDoubleAndReplaced() {
-        let input = "if true && true && true {}"
-        let output = "if true, true, true {}"
+        let input = """
+        if true && true && true {}
+        """
+        let output = """
+        if true, true, true {}
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 
     func testIfAndParensReplaced() {
-        let input = "if true && (true && true) {}"
-        let output = "if true, (true && true) {}"
+        let input = """
+        if true && (true && true) {}
+        """
+        let output = """
+        if true, (true && true) {}
+        """
         testFormatting(for: input, output, rule: .andOperator,
                        exclude: [.redundantParens])
     }
 
     func testIfFunctionAndReplaced() {
-        let input = "if functionReturnsBool() && true {}"
-        let output = "if functionReturnsBool(), true {}"
+        let input = """
+        if functionReturnsBool() && true {}
+        """
+        let output = """
+        if functionReturnsBool(), true {}
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 
     func testNoReplaceIfOrAnd() {
-        let input = "if foo || bar && baz {}"
+        let input = """
+        if foo || bar && baz {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testNoReplaceIfAndOr() {
-        let input = "if foo && bar || baz {}"
+        let input = """
+        if foo && bar || baz {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testIfAndReplacedInFunction() {
-        let input = "func someFunc() { if bar && baz {} }"
-        let output = "func someFunc() { if bar, baz {} }"
+        let input = """
+        func someFunc() { if bar && baz {} }
+        """
+        let output = """
+        func someFunc() { if bar, baz {} }
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 
     func testNoReplaceIfCaseLetAnd() {
-        let input = "if case let a = foo && bar {}"
+        let input = """
+        if case let a = foo && bar {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testNoReplaceWhileCaseLetAnd() {
-        let input = "while case let a = foo && bar {}"
+        let input = """
+        while case let a = foo && bar {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
@@ -83,35 +121,57 @@ class AndOperatorTests: XCTestCase {
     }
 
     func testNoReplaceIfLetAndLetAnd() {
-        let input = "if let a = b && c, let d = e && f {}"
+        let input = """
+        if let a = b && c, let d = e && f {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testNoReplaceIfTryAnd() {
-        let input = "if try true && explode() {}"
+        let input = """
+        if try true && explode() {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testHandleAndAtStartOfLine() {
-        let input = "if a == b\n    && b == c {}"
-        let output = "if a == b,\n    b == c {}"
+        let input = """
+        if a == b
+            && b == c {}
+        """
+        let output = """
+        if a == b,
+            b == c {}
+        """
         testFormatting(for: input, output, rule: .andOperator, exclude: [.indent])
     }
 
     func testHandleAndAtStartOfLineAfterComment() {
-        let input = "if a == b // foo\n    && b == c {}"
-        let output = "if a == b, // foo\n    b == c {}"
+        let input = """
+        if a == b // foo
+            && b == c {}
+        """
+        let output = """
+        if a == b, // foo
+            b == c {}
+        """
         testFormatting(for: input, output, rule: .andOperator, exclude: [.indent])
     }
 
     func testNoReplaceAndOperatorWhereGenericsAmbiguous() {
-        let input = "if x < y && z > (a * b) {}"
+        let input = """
+        if x < y && z > (a * b) {}
+        """
         testFormatting(for: input, rule: .andOperator)
     }
 
     func testNoReplaceAndOperatorWhereGenericsAmbiguous2() {
-        let input = "if x < y && z && w > (a * b) {}"
-        let output = "if x < y, z && w > (a * b) {}"
+        let input = """
+        if x < y && z && w > (a * b) {}
+        """
+        let output = """
+        if x < y, z && w > (a * b) {}
+        """
         testFormatting(for: input, output, rule: .andOperator)
     }
 

--- a/Tests/Rules/AnyObjectProtocolTests.swift
+++ b/Tests/Rules/AnyObjectProtocolTests.swift
@@ -11,41 +11,61 @@ import XCTest
 
 class AnyObjectProtocolTests: XCTestCase {
     func testClassReplacedByAnyObject() {
-        let input = "protocol Foo: class {}"
-        let output = "protocol Foo: AnyObject {}"
+        let input = """
+        protocol Foo: class {}
+        """
+        let output = """
+        protocol Foo: AnyObject {}
+        """
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, output, rule: .anyObjectProtocol, options: options)
     }
 
     func testClassReplacedByAnyObjectWithOtherProtocols() {
-        let input = "protocol Foo: class, Codable {}"
-        let output = "protocol Foo: AnyObject, Codable {}"
+        let input = """
+        protocol Foo: class, Codable {}
+        """
+        let output = """
+        protocol Foo: AnyObject, Codable {}
+        """
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, output, rule: .anyObjectProtocol, options: options)
     }
 
     func testClassReplacedByAnyObjectImmediatelyAfterImport() {
-        let input = "import Foundation\nprotocol Foo: class {}"
-        let output = "import Foundation\nprotocol Foo: AnyObject {}"
+        let input = """
+        import Foundation
+        protocol Foo: class {}
+        """
+        let output = """
+        import Foundation
+        protocol Foo: AnyObject {}
+        """
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, output, rule: .anyObjectProtocol, options: options,
                        exclude: [.blankLineAfterImports])
     }
 
     func testClassDeclarationNotReplacedByAnyObject() {
-        let input = "class Foo: Codable {}"
+        let input = """
+        class Foo: Codable {}
+        """
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, rule: .anyObjectProtocol, options: options)
     }
 
     func testClassImportNotReplacedByAnyObject() {
-        let input = "import class Foo.Bar"
+        let input = """
+        import class Foo.Bar
+        """
         let options = FormatOptions(swiftVersion: "4.1")
         testFormatting(for: input, rule: .anyObjectProtocol, options: options)
     }
 
     func testClassNotReplacedByAnyObjectIfSwiftVersionLessThan4_1() {
-        let input = "protocol Foo: class {}"
+        let input = """
+        protocol Foo: class {}
+        """
         let options = FormatOptions(swiftVersion: "4.0")
         testFormatting(for: input, rule: .anyObjectProtocol, options: options)
     }

--- a/Tests/Rules/AssertionFailuresTests.swift
+++ b/Tests/Rules/AssertionFailuresTests.swift
@@ -11,14 +11,22 @@ import XCTest
 
 class AssertionFailuresTests: XCTestCase {
     func testAssertionFailuresForAssertFalse() {
-        let input = "assert(false)"
-        let output = "assertionFailure()"
+        let input = """
+        assert(false)
+        """
+        let output = """
+        assertionFailure()
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForAssertFalseWithSpaces() {
-        let input = "assert ( false )"
-        let output = "assertionFailure()"
+        let input = """
+        assert ( false )
+        """
+        let output = """
+        assertionFailure()
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 
@@ -28,35 +36,53 @@ class AssertionFailuresTests: XCTestCase {
             false
         )
         """
-        let output = "assertionFailure()"
+        let output = """
+        assertionFailure()
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForAssertTrue() {
-        let input = "assert(true)"
+        let input = """
+        assert(true)
+        """
         testFormatting(for: input, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForAssertFalseWithArgs() {
-        let input = "assert(false, msg, 20, 21)"
-        let output = "assertionFailure(msg, 20, 21)"
+        let input = """
+        assert(false, msg, 20, 21)
+        """
+        let output = """
+        assertionFailure(msg, 20, 21)
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForPreconditionFalse() {
-        let input = "precondition(false)"
-        let output = "preconditionFailure()"
+        let input = """
+        precondition(false)
+        """
+        let output = """
+        preconditionFailure()
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForPreconditionTrue() {
-        let input = "precondition(true)"
+        let input = """
+        precondition(true)
+        """
         testFormatting(for: input, rule: .assertionFailures)
     }
 
     func testAssertionFailuresForPreconditionFalseWithArgs() {
-        let input = "precondition(false, msg, 0, 1)"
-        let output = "preconditionFailure(msg, 0, 1)"
+        let input = """
+        precondition(false, msg, 0, 1)
+        """
+        let output = """
+        preconditionFailure(msg, 0, 1)
+        """
         testFormatting(for: input, output, rule: .assertionFailures)
     }
 }

--- a/Tests/Rules/BlankLinesBetweenScopesTests.swift
+++ b/Tests/Rules/BlankLinesBetweenScopesTests.swift
@@ -11,108 +11,245 @@ import XCTest
 
 class BlankLinesBetweenScopesTests: XCTestCase {
     func testBlankLineBetweenFunctions() {
-        let input = "func foo() {\n}\nfunc bar() {\n}"
-        let output = "func foo() {\n}\n\nfunc bar() {\n}"
+        let input = """
+        func foo() {
+        }
+        func bar() {
+        }
+        """
+        let output = """
+        func foo() {
+        }
+
+        func bar() {
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testNoBlankLineBetweenPropertyAndFunction() {
-        let input = "var foo: Int\nfunc bar() {\n}"
+        let input = """
+        var foo: Int
+        func bar() {
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testBlankLineBetweenFunctionsIsBeforeComment() {
-        let input = "func foo() {\n}\n/// headerdoc\nfunc bar() {\n}"
-        let output = "func foo() {\n}\n\n/// headerdoc\nfunc bar() {\n}"
+        let input = """
+        func foo() {
+        }
+        /// headerdoc
+        func bar() {
+        }
+        """
+        let output = """
+        func foo() {
+        }
+
+        /// headerdoc
+        func bar() {
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testBlankLineBeforeAtObjcOnLineBeforeProtocol() {
-        let input = "@objc\nprotocol Foo {\n}\n@objc\nprotocol Bar {\n}"
-        let output = "@objc\nprotocol Foo {\n}\n\n@objc\nprotocol Bar {\n}"
+        let input = """
+        @objc
+        protocol Foo {
+        }
+        @objc
+        protocol Bar {
+        }
+        """
+        let output = """
+        @objc
+        protocol Foo {
+        }
+
+        @objc
+        protocol Bar {
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testBlankLineBeforeAtAvailabilityOnLineBeforeClass() {
-        let input = "protocol Foo {\n}\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
-        let output = "protocol Foo {\n}\n\n@available(iOS 8.0, OSX 10.10, *)\nclass Bar {\n}"
+        let input = """
+        protocol Foo {
+        }
+        @available(iOS 8.0, OSX 10.10, *)
+        class Bar {
+        }
+        """
+        let output = """
+        protocol Foo {
+        }
+
+        @available(iOS 8.0, OSX 10.10, *)
+        class Bar {
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testNoExtraBlankLineBetweenFunctions() {
-        let input = "func foo() {\n}\n\nfunc bar() {\n}"
+        let input = """
+        func foo() {
+        }
+
+        func bar() {
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testNoBlankLineBetweenFunctionsInProtocol() {
-        let input = "protocol Foo {\n    func bar()\n    func baz() -> Int\n}"
+        let input = """
+        protocol Foo {
+            func bar()
+            func baz() -> Int
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testNoBlankLineInsideInitFunction() {
-        let input = "init() {\n    super.init()\n}"
+        let input = """
+        init() {
+            super.init()
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testBlankLineAfterProtocolBeforeProperty() {
-        let input = "protocol Foo {\n}\nvar bar: String"
-        let output = "protocol Foo {\n}\n\nvar bar: String"
+        let input = """
+        protocol Foo {
+        }
+        var bar: String
+        """
+        let output = """
+        protocol Foo {
+        }
+
+        var bar: String
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testNoExtraBlankLineAfterSingleLineComment() {
-        let input = "var foo: Bar? // comment\n\nfunc bar() {}"
+        let input = """
+        var foo: Bar? // comment
+
+        func bar() {}
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testNoExtraBlankLineAfterMultilineComment() {
-        let input = "var foo: Bar? /* comment */\n\nfunc bar() {}"
+        let input = """
+        var foo: Bar? /* comment */
+
+        func bar() {}
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testNoBlankLineBeforeFuncAsIdentifier() {
-        let input = "var foo: Bar?\nfoo.func(x) {}"
+        let input = """
+        var foo: Bar?
+        foo.func(x) {}
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testNoBlankLineBetweenFunctionsWithInlineBody() {
-        let input = "class Foo {\n    func foo() { print(\"foo\") }\n    func bar() { print(\"bar\") }\n}"
+        let input = """
+        class Foo {
+            func foo() { print(\"foo\") }
+            func bar() { print(\"bar\") }
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes)
     }
 
     func testNoBlankLineBetweenIfStatements() {
-        let input = "func foo() {\n    if x {\n    }\n    if y {\n    }\n}"
+        let input = """
+        func foo() {
+            if x {
+            }
+            if y {
+            }
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
     func testNoBlanksInsideClassFunc() {
-        let input = "class func foo {\n    if x {\n    }\n    if y {\n    }\n}"
+        let input = """
+        class func foo {
+            if x {
+            }
+            if y {
+            }
+        }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options,
                        exclude: [.emptyBraces])
     }
 
     func testNoBlanksInsideClassVar() {
-        let input = "class var foo: Int {\n    if x {\n    }\n    if y {\n    }\n}"
+        let input = """
+        class var foo: Int {
+            if x {
+            }
+            if y {
+            }
+        }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .blankLinesBetweenScopes, options: options,
                        exclude: [.emptyBraces])
     }
 
     func testBlankLineBetweenCalledClosures() {
-        let input = "class Foo {\n    var foo = {\n    }()\n    func bar {\n    }\n}"
-        let output = "class Foo {\n    var foo = {\n    }()\n\n    func bar {\n    }\n}"
+        let input = """
+        class Foo {
+            var foo = {
+            }()
+            func bar {
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            var foo = {
+            }()
+
+            func bar {
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes,
                        exclude: [.emptyBraces])
     }
 
     func testNoBlankLineAfterCalledClosureAtEndOfScope() {
-        let input = "class Foo {\n    var foo = {\n    }()\n}"
+        let input = """
+        class Foo {
+            var foo = {
+            }()
+        }
+        """
         testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
@@ -128,8 +265,23 @@ class BlankLinesBetweenScopesTests: XCTestCase {
     }
 
     func testBlankLineBeforeWhileIfNotRepeatWhile() {
-        let input = "func foo(x)\n{\n}\nwhile true\n{\n}"
-        let output = "func foo(x)\n{\n}\n\nwhile true\n{\n}"
+        let input = """
+        func foo(x)
+        {
+        }
+        while true
+        {
+        }
+        """
+        let output = """
+        func foo(x)
+        {
+        }
+
+        while true
+        {
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .blankLinesBetweenScopes, options: options,
                        exclude: [.emptyBraces])

--- a/Tests/Rules/BlockCommentsTests.swift
+++ b/Tests/Rules/BlockCommentsTests.swift
@@ -11,19 +11,29 @@ import XCTest
 
 class BlockCommentsTests: XCTestCase {
     func testBlockCommentsOneLine() {
-        let input = "foo = bar /* comment */"
-        let output = "foo = bar // comment"
+        let input = """
+        foo = bar /* comment */
+        """
+        let output = """
+        foo = bar // comment
+        """
         testFormatting(for: input, output, rule: .blockComments)
     }
 
     func testDocBlockCommentsOneLine() {
-        let input = "foo = bar /** doc comment */"
-        let output = "foo = bar /// doc comment"
+        let input = """
+        foo = bar /** doc comment */
+        """
+        let output = """
+        foo = bar /// doc comment
+        """
         testFormatting(for: input, output, rule: .blockComments)
     }
 
     func testPreservesBlockCommentInSingleLineScope() {
-        let input = "if foo { /* code */ }"
+        let input = """
+        if foo { /* code */ }
+        """
         testFormatting(for: input, rule: .blockComments)
     }
 

--- a/Tests/Rules/BracesTests.swift
+++ b/Tests/Rules/BracesTests.swift
@@ -11,8 +11,17 @@ import XCTest
 
 class BracesTests: XCTestCase {
     func testAllmanBracesAreConverted() {
-        let input = "func foo()\n{\n    statement\n}"
-        let output = "func foo() {\n    statement\n}"
+        let input = """
+        func foo()
+        {
+            statement
+        }
+        """
+        let output = """
+        func foo() {
+            statement
+        }
+        """
         testFormatting(for: input, output, rule: .braces)
     }
 
@@ -37,12 +46,22 @@ class BracesTests: XCTestCase {
     }
 
     func testKnRBracesAfterComment() {
-        let input = "func foo() // comment\n{\n    statement\n}"
+        let input = """
+        func foo() // comment
+        {
+            statement
+        }
+        """
         testFormatting(for: input, rule: .braces)
     }
 
     func testKnRBracesAfterMultilineComment() {
-        let input = "func foo() /* comment/ncomment */\n{\n    statement\n}"
+        let input = """
+        func foo() /* comment/ncomment */
+        {
+            statement
+        }
+        """
         testFormatting(for: input, rule: .braces)
     }
 
@@ -59,12 +78,17 @@ class BracesTests: XCTestCase {
     }
 
     func testKnRExtraSpaceNotAddedBeforeBrace() {
-        let input = "foo({ bar })"
+        let input = """
+        foo({ bar })
+        """
         testFormatting(for: input, rule: .braces, exclude: [.trailingClosures])
     }
 
     func testKnRLinebreakNotRemovedBeforeInlineBlockNot() {
-        let input = "func foo() -> Bool\n{ return false }"
+        let input = """
+        func foo() -> Bool
+        { return false }
+        """
         testFormatting(for: input, rule: .braces)
     }
 
@@ -144,13 +168,22 @@ class BracesTests: XCTestCase {
     }
 
     func testKnRClosingBraceWrapped() {
-        let input = "func foo() {\n    print(bar) }"
-        let output = "func foo() {\n    print(bar)\n}"
+        let input = """
+        func foo() {
+            print(bar) }
+        """
+        let output = """
+        func foo() {
+            print(bar)
+        }
+        """
         testFormatting(for: input, output, rule: .braces)
     }
 
     func testKnRInlineBracesNotWrapped() {
-        let input = "func foo() { print(bar) }"
+        let input = """
+        func foo() { print(bar) }
+        """
         testFormatting(for: input, rule: .braces)
     }
 
@@ -323,87 +356,204 @@ class BracesTests: XCTestCase {
     // allman style
 
     func testKnRBracesAreConverted() {
-        let input = "func foo() {\n    statement\n}"
-        let output = "func foo()\n{\n    statement\n}"
+        let input = """
+        func foo() {
+            statement
+        }
+        """
+        let output = """
+        func foo()
+        {
+            statement
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBlankLineAfterBraceRemoved() {
-        let input = "func foo() {\n    \n    statement\n}"
-        let output = "func foo()\n{\n    statement\n}"
+        let input = """
+        func foo() {
+
+            statement
+        }
+        """
+        let output = """
+        func foo()
+        {
+            statement
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceInsideParensNotConverted() {
-        let input = "foo({\n    bar\n})"
+        let input = """
+        foo({
+            bar
+        })
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .braces, options: options,
                        exclude: [.trailingClosures])
     }
 
     func testAllmanBraceDoClauseIndent() {
-        let input = "do {\n    foo\n}"
-        let output = "do\n{\n    foo\n}"
+        let input = """
+        do {
+            foo
+        }
+        """
+        let output = """
+        do
+        {
+            foo
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceCatchClauseIndent() {
-        let input = "do {\n    try foo\n}\ncatch {\n}"
-        let output = "do\n{\n    try foo\n}\ncatch\n{\n}"
+        let input = """
+        do {
+            try foo
+        }
+        catch {
+        }
+        """
+        let output = """
+        do
+        {
+            try foo
+        }
+        catch
+        {
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options,
                        exclude: [.emptyBraces])
     }
 
     func testAllmanBraceDoThrowsCatchClauseIndent() {
-        let input = "do throws(Foo) {\n    try foo\n}\ncatch {\n}"
-        let output = "do throws(Foo)\n{\n    try foo\n}\ncatch\n{\n}"
+        let input = """
+        do throws(Foo) {
+            try foo
+        }
+        catch {
+        }
+        """
+        let output = """
+        do throws(Foo)
+        {
+            try foo
+        }
+        catch
+        {
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options,
                        exclude: [.emptyBraces])
     }
 
     func testAllmanBraceRepeatWhileIndent() {
-        let input = "repeat {\n    foo\n}\nwhile x"
-        let output = "repeat\n{\n    foo\n}\nwhile x"
+        let input = """
+        repeat {
+            foo
+        }
+        while x
+        """
+        let output = """
+        repeat
+        {
+            foo
+        }
+        while x
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceOptionalComputedPropertyIndent() {
-        let input = "var foo: Int? {\n    return 5\n}"
-        let output = "var foo: Int?\n{\n    return 5\n}"
+        let input = """
+        var foo: Int? {
+            return 5
+        }
+        """
+        let output = """
+        var foo: Int?
+        {
+            return 5
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceThrowsFunctionIndent() {
-        let input = "func foo() throws {\n    bar\n}"
-        let output = "func foo() throws\n{\n    bar\n}"
+        let input = """
+        func foo() throws {
+            bar
+        }
+        """
+        let output = """
+        func foo() throws
+        {
+            bar
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceAsyncFunctionIndent() {
-        let input = "func foo() async {\n    bar\n}"
-        let output = "func foo() async\n{\n    bar\n}"
+        let input = """
+        func foo() async {
+            bar
+        }
+        """
+        let output = """
+        func foo() async
+        {
+            bar
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceAfterCommentIndent() {
-        let input = "func foo() { // foo\n\n    bar\n}"
-        let output = "func foo()\n{ // foo\n    bar\n}"
+        let input = """
+        func foo() { // foo
+
+            bar
+        }
+        """
+        let output = """
+        func foo()
+        { // foo
+            bar
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }
 
     func testAllmanBraceAfterSwitch() {
-        let input = "switch foo {\ncase bar: break\n}"
-        let output = "switch foo\n{\ncase bar: break\n}"
+        let input = """
+        switch foo {
+        case bar: break
+        }
+        """
+        let output = """
+        switch foo
+        {
+        case bar: break
+        }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .braces, options: options)
     }

--- a/Tests/Rules/ConsecutiveBlankLinesTests.swift
+++ b/Tests/Rules/ConsecutiveBlankLinesTests.swift
@@ -11,42 +11,102 @@ import XCTest
 
 class ConsecutiveBlankLinesTests: XCTestCase {
     func testConsecutiveBlankLines() {
-        let input = "foo\n\n    \nbar"
-        let output = "foo\n\nbar"
+        let input = """
+        foo
+
+
+        bar
+        """
+        let output = """
+        foo
+
+        bar
+        """
         testFormatting(for: input, output, rule: .consecutiveBlankLines)
     }
 
     func testConsecutiveBlankLinesAtEndOfFile() {
-        let input = "foo\n\n"
-        let output = "foo\n"
+        let input = """
+        foo
+
+
+        """
+        let output = """
+        foo
+
+        """
         testFormatting(for: input, output, rule: .consecutiveBlankLines)
     }
 
     func testConsecutiveBlankLinesAtStartOfFile() {
-        let input = "\n\n\nfoo"
-        let output = "\n\nfoo"
+        let input = """
+
+
+
+        foo
+        """
+        let output = """
+
+
+        foo
+        """
         testFormatting(for: input, output, rule: .consecutiveBlankLines)
     }
 
     func testConsecutiveBlankLinesInsideStringLiteral() {
-        let input = "\"\"\"\nhello\n\n\nworld\n\"\"\""
+        let input = """
+        \"\"\"
+        hello
+
+
+        world
+        \"\"\"
+        """
         testFormatting(for: input, rule: .consecutiveBlankLines)
     }
 
     func testConsecutiveBlankLinesAtStartOfStringLiteral() {
-        let input = "\"\"\"\n\n\nhello world\n\"\"\""
+        let input = """
+        \"\"\"
+
+
+        hello world
+        \"\"\"
+        """
         testFormatting(for: input, rule: .consecutiveBlankLines)
     }
 
     func testConsecutiveBlankLinesAfterStringLiteral() {
-        let input = "\"\"\"\nhello world\n\"\"\"\n\n\nfoo()"
-        let output = "\"\"\"\nhello world\n\"\"\"\n\nfoo()"
+        let input = """
+        \"\"\"
+        hello world
+        \"\"\"
+
+
+        foo()
+        """
+        let output = """
+        \"\"\"
+        hello world
+        \"\"\"
+
+        foo()
+        """
         testFormatting(for: input, output, rule: .consecutiveBlankLines)
     }
 
     func testFragmentWithTrailingLinebreaks() {
-        let input = "func foo() {}\n\n\n"
-        let output = "func foo() {}\n\n"
+        let input = """
+        func foo() {}
+
+
+
+        """
+        let output = """
+        func foo() {}
+
+
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .consecutiveBlankLines, options: options)
     }
@@ -78,7 +138,12 @@ class ConsecutiveBlankLinesTests: XCTestCase {
     }
 
     func testLintingConsecutiveBlankLinesReportsCorrectLine() {
-        let input = "foo\n   \n\nbar"
+        let input = """
+        foo
+
+
+        bar
+        """
         XCTAssertEqual(try lint(input, rules: [.consecutiveBlankLines]), [
             .init(line: 3, rule: .consecutiveBlankLines, filePath: nil, isMove: false),
         ])

--- a/Tests/Rules/ConsecutiveSpacesTests.swift
+++ b/Tests/Rules/ConsecutiveSpacesTests.swift
@@ -11,46 +11,76 @@ import XCTest
 
 class ConsecutiveSpacesTests: XCTestCase {
     func testConsecutiveSpaces() {
-        let input = "let foo  = bar"
-        let output = "let foo = bar"
+        let input = """
+        let foo  = bar
+        """
+        let output = """
+        let foo = bar
+        """
         testFormatting(for: input, output, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesAfterComment() {
-        let input = "// comment\nfoo  bar"
-        let output = "// comment\nfoo bar"
+        let input = """
+        // comment
+        foo  bar
+        """
+        let output = """
+        // comment
+        foo bar
+        """
         testFormatting(for: input, output, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesDoesntStripIndent() {
-        let input = "{\n    let foo  = bar\n}"
-        let output = "{\n    let foo = bar\n}"
+        let input = """
+        {
+            let foo  = bar
+        }
+        """
+        let output = """
+        {
+            let foo = bar
+        }
+        """
         testFormatting(for: input, output, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesDoesntAffectMultilineComments() {
-        let input = "/*    comment  */"
+        let input = """
+        /*    comment  */
+        """
         testFormatting(for: input, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesRemovedBetweenComments() {
-        let input = "/* foo */  /* bar */"
-        let output = "/* foo */ /* bar */"
+        let input = """
+        /* foo */  /* bar */
+        """
+        let output = """
+        /* foo */ /* bar */
+        """
         testFormatting(for: input, output, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesDoesntAffectNestedMultilineComments() {
-        let input = "/*  foo  /*  bar  */  baz  */"
+        let input = """
+        /*  foo  /*  bar  */  baz  */
+        """
         testFormatting(for: input, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesDoesntAffectNestedMultilineComments2() {
-        let input = "/*  /*  foo  */  /*  bar  */  */"
+        let input = """
+        /*  /*  foo  */  /*  bar  */  */
+        """
         testFormatting(for: input, rule: .consecutiveSpaces)
     }
 
     func testConsecutiveSpacesDoesntAffectSingleLineComments() {
-        let input = "//    foo  bar"
+        let input = """
+        //    foo  bar
+        """
         testFormatting(for: input, rule: .consecutiveSpaces)
     }
 }

--- a/Tests/Rules/DuplicateImportsTests.swift
+++ b/Tests/Rules/DuplicateImportsTests.swift
@@ -11,54 +11,106 @@ import XCTest
 
 class DuplicateImportsTests: XCTestCase {
     func testRemoveDuplicateImport() {
-        let input = "import Foundation\nimport Foundation"
-        let output = "import Foundation"
+        let input = """
+        import Foundation
+        import Foundation
+        """
+        let output = """
+        import Foundation
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testRemoveDuplicateConditionalImport() {
-        let input = "#if os(iOS)\n    import Foo\n    import Foo\n#else\n    import Bar\n    import Bar\n#endif"
-        let output = "#if os(iOS)\n    import Foo\n#else\n    import Bar\n#endif"
+        let input = """
+        #if os(iOS)
+            import Foo
+            import Foo
+        #else
+            import Bar
+            import Bar
+        #endif
+        """
+        let output = """
+        #if os(iOS)
+            import Foo
+        #else
+            import Bar
+        #endif
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testNoRemoveOverlappingImports() {
-        let input = "import MyModule\nimport MyModule.Private"
+        let input = """
+        import MyModule
+        import MyModule.Private
+        """
         testFormatting(for: input, rule: .duplicateImports)
     }
 
     func testNoRemoveCaseDifferingImports() {
-        let input = "import Auth0.Authentication\nimport Auth0.authentication"
+        let input = """
+        import Auth0.Authentication
+        import Auth0.authentication
+        """
         testFormatting(for: input, rule: .duplicateImports)
     }
 
     func testRemoveDuplicateImportFunc() {
-        let input = "import func Foo.bar\nimport func Foo.bar"
-        let output = "import func Foo.bar"
+        let input = """
+        import func Foo.bar
+        import func Foo.bar
+        """
+        let output = """
+        import func Foo.bar
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testNoRemoveTestableDuplicateImport() {
-        let input = "import Foo\n@testable import Foo"
-        let output = "\n@testable import Foo"
+        let input = """
+        import Foo
+        @testable import Foo
+        """
+        let output = """
+
+        @testable import Foo
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testNoRemoveTestableDuplicateImport2() {
-        let input = "@testable import Foo\nimport Foo"
-        let output = "@testable import Foo"
+        let input = """
+        @testable import Foo
+        import Foo
+        """
+        let output = """
+        @testable import Foo
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testNoRemoveExportedDuplicateImport() {
-        let input = "import Foo\n@_exported import Foo"
-        let output = "\n@_exported import Foo"
+        let input = """
+        import Foo
+        @_exported import Foo
+        """
+        let output = """
+
+        @_exported import Foo
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 
     func testNoRemoveExportedDuplicateImport2() {
-        let input = "@_exported import Foo\nimport Foo"
-        let output = "@_exported import Foo"
+        let input = """
+        @_exported import Foo
+        import Foo
+        """
+        let output = """
+        @_exported import Foo
+        """
         testFormatting(for: input, output, rule: .duplicateImports)
     }
 }

--- a/Tests/Rules/ElseOnSameLineTests.swift
+++ b/Tests/Rules/ElseOnSameLineTests.swift
@@ -11,67 +11,129 @@ import XCTest
 
 class ElseOnSameLineTests: XCTestCase {
     func testElseOnSameLine() {
-        let input = "if true {\n    1\n}\nelse { 2 }"
-        let output = "if true {\n    1\n} else { 2 }"
+        let input = """
+        if true {
+            1
+        }
+        else { 2 }
+        """
+        let output = """
+        if true {
+            1
+        } else { 2 }
+        """
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnSameLineOnlyAppliedToDanglingBrace() {
-        let input = "if true { 1 }\nelse { 2 }"
+        let input = """
+        if true { 1 }
+        else { 2 }
+        """
         testFormatting(for: input, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testGuardNotAffectedByElseOnSameLine() {
-        let input = "guard true\nelse { return }"
+        let input = """
+        guard true
+        else { return }
+        """
         testFormatting(for: input, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnSameLineDoesntEatPreviousStatement() {
-        let input = "if true {}\nguard true else { return }"
+        let input = """
+        if true {}
+        guard true else { return }
+        """
         testFormatting(for: input, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testElseNotOnSameLineForAllman() {
-        let input = "if true\n{\n    1\n} else { 2 }"
-        let output = "if true\n{\n    1\n}\nelse { 2 }"
+        let input = """
+        if true
+        {
+            1
+        } else { 2 }
+        """
+        let output = """
+        if true
+        {
+            1
+        }
+        else { 2 }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testElseOnNextLineOption() {
-        let input = "if true {\n    1\n} else { 2 }"
-        let output = "if true {\n    1\n}\nelse { 2 }"
+        let input = """
+        if true {
+            1
+        } else { 2 }
+        """
+        let output = """
+        if true {
+            1
+        }
+        else { 2 }
+        """
         let options = FormatOptions(elsePosition: .nextLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testGuardNotAffectedByElseOnSameLineForAllman() {
-        let input = "guard true else { return }"
+        let input = """
+        guard true else { return }
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testRepeatWhileNotOnSameLineForAllman() {
-        let input = "repeat\n{\n    foo\n} while x"
-        let output = "repeat\n{\n    foo\n}\nwhile x"
+        let input = """
+        repeat
+        {
+            foo
+        } while x
+        """
+        let output = """
+        repeat
+        {
+            foo
+        }
+        while x
+        """
         let options = FormatOptions(allmanBraces: true)
         testFormatting(for: input, output, rule: .elseOnSameLine, options: options)
     }
 
     func testWhileNotAffectedByElseOnSameLineIfNotRepeatWhile() {
-        let input = "func foo(x) {}\n\nwhile true {}"
+        let input = """
+        func foo(x) {}
+
+        while true {}
+        """
         testFormatting(for: input, rule: .elseOnSameLine)
     }
 
     func testCommentsNotDiscardedByElseOnSameLineRule() {
-        let input = "if true {\n    1\n}\n\n// comment\nelse {}"
+        let input = """
+        if true {
+            1
+        }
+
+        // comment
+        else {}
+        """
         testFormatting(for: input, rule: .elseOnSameLine)
     }
 
@@ -117,20 +179,31 @@ class ElseOnSameLineTests: XCTestCase {
     // guardelse = auto
 
     func testSingleLineGuardElseNotWrappedByDefault() {
-        let input = "guard foo = bar else {}"
+        let input = """
+        guard foo = bar else {}
+        """
         testFormatting(for: input, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseNotUnwrappedByDefault() {
-        let input = "guard foo = bar\nelse {}"
+        let input = """
+        guard foo = bar
+        else {}
+        """
         testFormatting(for: input, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseWrappedByDefaultIfBracesOnNextLine() {
-        let input = "guard foo = bar else\n{}"
-        let output = "guard foo = bar\nelse {}"
+        let input = """
+        guard foo = bar else
+        {}
+        """
+        let output = """
+        guard foo = bar
+        else {}
+        """
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        exclude: [.wrapConditionalBodies])
     }
@@ -207,22 +280,33 @@ class ElseOnSameLineTests: XCTestCase {
     // guardelse = nextLine
 
     func testSingleLineGuardElseNotWrapped() {
-        let input = "guard foo = bar else {}"
+        let input = """
+        guard foo = bar else {}
+        """
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseNotUnwrapped() {
-        let input = "guard foo = bar\nelse {}"
+        let input = """
+        guard foo = bar
+        else {}
+        """
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
     }
 
     func testSingleLineGuardElseWrappedIfBracesOnNextLine() {
-        let input = "guard foo = bar else\n{}"
-        let output = "guard foo = bar\nelse {}"
+        let input = """
+        guard foo = bar else
+        {}
+        """
+        let output = """
+        guard foo = bar
+        else {}
+        """
         let options = FormatOptions(guardElsePosition: .nextLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        options: options, exclude: [.wrapConditionalBodies])
@@ -269,8 +353,13 @@ class ElseOnSameLineTests: XCTestCase {
     }
 
     func testGuardElseUnwrappedIfBracesOnNextLine() {
-        let input = "guard foo = bar\nelse {}"
-        let output = "guard foo = bar else {}"
+        let input = """
+        guard foo = bar
+        else {}
+        """
+        let output = """
+        guard foo = bar else {}
+        """
         let options = FormatOptions(guardElsePosition: .sameLine)
         testFormatting(for: input, output, rule: .elseOnSameLine,
                        options: options)

--- a/Tests/Rules/EmptyBracesTests.swift
+++ b/Tests/Rules/EmptyBracesTests.swift
@@ -11,13 +11,22 @@ import XCTest
 
 class EmptyBracesTests: XCTestCase {
     func testLinebreaksRemovedInsideBraces() {
-        let input = "func foo() {\n  \n }"
-        let output = "func foo() {}"
+        let input = """
+        func foo() {
+
+         }
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .emptyBraces)
     }
 
     func testCommentNotRemovedInsideBraces() {
-        let input = "func foo() { // foo\n}"
+        let input = """
+        func foo() { // foo
+        }
+        """
         testFormatting(for: input, rule: .emptyBraces)
     }
 
@@ -40,27 +49,44 @@ class EmptyBracesTests: XCTestCase {
     }
 
     func testSpaceRemovedInsideEmptybraces() {
-        let input = "foo { }"
-        let output = "foo {}"
+        let input = """
+        foo { }
+        """
+        let output = """
+        foo {}
+        """
         testFormatting(for: input, output, rule: .emptyBraces)
     }
 
     func testSpaceAddedInsideEmptyBracesWithSpacedConfiguration() {
-        let input = "foo {}"
-        let output = "foo { }"
+        let input = """
+        foo {}
+        """
+        let output = """
+        foo { }
+        """
         let options = FormatOptions(emptyBracesSpacing: .spaced)
         testFormatting(for: input, output, rule: .emptyBraces, options: options)
     }
 
     func testLinebreaksRemovedInsideBracesWithSpacedConfiguration() {
-        let input = "func foo() {\n  \n }"
-        let output = "func foo() { }"
+        let input = """
+        func foo() {
+
+         }
+        """
+        let output = """
+        func foo() { }
+        """
         let options = FormatOptions(emptyBracesSpacing: .spaced)
         testFormatting(for: input, output, rule: .emptyBraces, options: options)
     }
 
     func testCommentNotRemovedInsideBracesWithSpacedConfiguration() {
-        let input = "func foo() { // foo\n}"
+        let input = """
+        func foo() { // foo
+        }
+        """
         let options = FormatOptions(emptyBracesSpacing: .spaced)
         testFormatting(for: input, rule: .emptyBraces, options: options)
     }

--- a/Tests/Rules/EmptyExtensionsTests.swift
+++ b/Tests/Rules/EmptyExtensionsTests.swift
@@ -28,7 +28,9 @@ class EmptyExtensionsTests: XCTestCase {
 
         extension Array where Element: Foo {}
         """
-        let output = ""
+        let output = """
+
+        """
         testFormatting(for: input, output, rule: .emptyExtensions)
     }
 
@@ -58,7 +60,9 @@ class EmptyExtensionsTests: XCTestCase {
 
         }
         """
-        let output = ""
+        let output = """
+
+        """
         testFormatting(for: input, output, rule: .emptyExtensions)
     }
 

--- a/Tests/Rules/EnumNamespacesTests.swift
+++ b/Tests/Rules/EnumNamespacesTests.swift
@@ -20,7 +20,9 @@ class EnumNamespacesTests: XCTestCase {
     }
 
     func testEnumNamespacesConformingOtherType() {
-        let input = "private final class CustomUITableViewCell: UITableViewCell {}"
+        let input = """
+        private final class CustomUITableViewCell: UITableViewCell {}
+        """
         testFormatting(for: input, rule: .enumNamespaces)
     }
 

--- a/Tests/Rules/FileHeaderTests.swift
+++ b/Tests/Rules/FileHeaderTests.swift
@@ -11,8 +11,22 @@ import XCTest
 
 class FileHeaderTests: XCTestCase {
     func testStripHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
-        let output = "/// func\nfunc foo() {}"
+        let input = """
+        //
+        //  test.swift
+        //  SwiftFormat
+        //
+        //  Created by Nick Lockwood on 08/11/2016.
+        //  Copyright © 2016 Nick Lockwood. All rights reserved.
+        //
+
+        /// func
+        func foo() {}
+        """
+        let output = """
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
@@ -31,110 +45,239 @@ class FileHeaderTests: XCTestCase {
         /// func
         func foo() {}
         """
-        let output = "/// func\nfunc foo() {}"
+        let output = """
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testReplaceHeaderWhenFileContainsNoCode() {
-        let input = "// foobar"
+        let input = """
+        // foobar
+        """
         let options = FormatOptions(fileHeader: "// foobar")
         testFormatting(for: input, rule: .fileHeader, options: options,
                        exclude: [.linebreakAtEndOfFile])
     }
 
     func testReplaceHeaderWhenFileContainsNoCode2() {
-        let input = "// foobar\n"
+        let input = """
+        // foobar
+
+        """
         let options = FormatOptions(fileHeader: "// foobar")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testMultilineCommentHeader() {
-        let input = "/****************************/\n/* Created by Nick Lockwood */\n/****************************/\n\n\n/// func\nfunc foo() {}"
-        let output = "/// func\nfunc foo() {}"
+        let input = """
+        /****************************/
+        /* Created by Nick Lockwood */
+        /****************************/
+
+
+        /// func
+        func foo() {}
+        """
+        let output = """
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testNoStripHeaderWhenDisabled() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
+        let input = """
+        //
+        //  test.swift
+        //  SwiftFormat
+        //
+        //  Created by Nick Lockwood on 08/11/2016.
+        //  Copyright © 2016 Nick Lockwood. All rights reserved.
+        //
+
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: .ignore)
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripComment() {
-        let input = "\n/// func\nfunc foo() {}"
+        let input = """
+
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripPackageHeader() {
-        let input = "// swift-tools-version:4.2\n\nimport PackageDescription"
+        let input = """
+        // swift-tools-version:4.2
+
+        import PackageDescription
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripFormatDirective() {
-        let input = "// swiftformat:options --swiftversion 5.2\n\nimport PackageDescription"
+        let input = """
+        // swiftformat:options --swiftversion 5.2
+
+        import PackageDescription
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripFormatDirectiveAfterHeader() {
-        let input = "// header\n// swiftformat:options --swiftversion 5.2\n\nimport PackageDescription"
+        let input = """
+        // header
+        // swiftformat:options --swiftversion 5.2
+
+        import PackageDescription
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoReplaceFormatDirective() {
-        let input = "// swiftformat:options --swiftversion 5.2\n\nimport PackageDescription"
-        let output = "// Hello World\n\n// swiftformat:options --swiftversion 5.2\n\nimport PackageDescription"
+        let input = """
+        // swiftformat:options --swiftversion 5.2
+
+        import PackageDescription
+        """
+        let output = """
+        // Hello World
+
+        // swiftformat:options --swiftversion 5.2
+
+        import PackageDescription
+        """
         let options = FormatOptions(fileHeader: "// Hello World")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testSetSingleLineHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
-        let output = "// Hello World\n\n/// func\nfunc foo() {}"
+        let input = """
+        //
+        //  test.swift
+        //  SwiftFormat
+        //
+        //  Created by Nick Lockwood on 08/11/2016.
+        //  Copyright © 2016 Nick Lockwood. All rights reserved.
+        //
+
+        /// func
+        func foo() {}
+        """
+        let output = """
+        // Hello World
+
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "// Hello World")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testSetMultilineHeader() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
-        let output = "// Hello\n// World\n\n/// func\nfunc foo() {}"
+        let input = """
+        //
+        //  test.swift
+        //  SwiftFormat
+        //
+        //  Created by Nick Lockwood on 08/11/2016.
+        //  Copyright © 2016 Nick Lockwood. All rights reserved.
+        //
+
+        /// func
+        func foo() {}
+        """
+        let output = """
+        // Hello
+        // World
+
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "// Hello\n// World")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testSetMultilineHeaderWithMarkup() {
-        let input = "//\n//  test.swift\n//  SwiftFormat\n//\n//  Created by Nick Lockwood on 08/11/2016.\n//  Copyright © 2016 Nick Lockwood. All rights reserved.\n//\n\n/// func\nfunc foo() {}"
-        let output = "/*--- Hello ---*/\n/*--- World ---*/\n\n/// func\nfunc foo() {}"
+        let input = """
+        //
+        //  test.swift
+        //  SwiftFormat
+        //
+        //  Created by Nick Lockwood on 08/11/2016.
+        //  Copyright © 2016 Nick Lockwood. All rights reserved.
+        //
+
+        /// func
+        func foo() {}
+        """
+        let output = """
+        /*--- Hello ---*/
+        /*--- World ---*/
+
+        /// func
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "/*--- Hello ---*/\n/*--- World ---*/")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testNoStripHeaderIfRuleDisabled() {
-        let input = "// swiftformat:disable fileHeader\n// test\n// swiftformat:enable fileHeader\n\nfunc foo() {}"
+        let input = """
+        // swiftformat:disable fileHeader
+        // test
+        // swiftformat:enable fileHeader
+
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripHeaderIfNextRuleDisabled() {
-        let input = "// swiftformat:disable:next fileHeader\n// test\n\nfunc foo() {}"
+        let input = """
+        // swiftformat:disable:next fileHeader
+        // test
+
+        func foo() {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
     func testNoStripHeaderDocWithNewlineBeforeCode() {
-        let input = "/// Header doc\n\nclass Foo {}"
+        let input = """
+        /// Header doc
+
+        class Foo {}
+        """
         let options = FormatOptions(fileHeader: "")
         testFormatting(for: input, rule: .fileHeader, options: options, exclude: [.docComments])
     }
 
     func testNoDuplicateHeaderIfMissingTrailingBlankLine() {
-        let input = "// Header comment\nclass Foo {}"
-        let output = "// Header comment\n\nclass Foo {}"
+        let input = """
+        // Header comment
+        class Foo {}
+        """
+        let output = """
+        // Header comment
+
+        class Foo {}
+        """
         let options = FormatOptions(fileHeader: "Header comment")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
@@ -178,7 +321,9 @@ class FileHeaderTests: XCTestCase {
     }
 
     func testFileHeaderYearReplacement() {
-        let input = "let foo = bar"
+        let input = """
+        let foo = bar
+        """
         let output: String = {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy"
@@ -189,7 +334,9 @@ class FileHeaderTests: XCTestCase {
     }
 
     func testFileHeaderCreationYearReplacement() {
-        let input = "let foo = bar"
+        let input = """
+        let foo = bar
+        """
         let date = Date(timeIntervalSince1970: 0)
         let output: String = {
             let formatter = DateFormatter()
@@ -202,35 +349,64 @@ class FileHeaderTests: XCTestCase {
     }
 
     func testFileHeaderAuthorReplacement() {
-        let name = "Test User"
-        let email = "test@email.com"
-        let input = "let foo = bar"
-        let output = "// Created by \(name) \(email)\n\nlet foo = bar"
+        let name = """
+        Test User
+        """
+        let email = """
+        test@email.com
+        """
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // Created by \(name) \(email)
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(replacements: [.authorName: .constant(name), .authorEmail: .constant(email)])
         let options = FormatOptions(fileHeader: "// Created by {author.name} {author.email}", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testFileHeaderAuthorReplacement2() {
-        let author = "Test User <test@email.com>"
-        let input = "let foo = bar"
-        let output = "// Created by \(author)\n\nlet foo = bar"
+        let author = """
+        Test User <test@email.com>
+        """
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // Created by \(author)
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(replacements: [.author: .constant(author)])
         let options = FormatOptions(fileHeader: "// Created by {author}", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testFileHeaderMultipleReplacement() {
-        let name = "Test User"
-        let input = "let foo = bar"
-        let output = "// Copyright © \(name)\n// Created by \(name)\n\nlet foo = bar"
+        let name = """
+        Test User
+        """
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // Copyright © \(name)
+        // Created by \(name)
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(replacements: [.authorName: .constant(name)])
         let options = FormatOptions(fileHeader: "// Copyright © {author.name}\n// Created by {author.name}", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testFileHeaderCreationDateReplacement() {
-        let input = "let foo = bar"
+        let input = """
+        let foo = bar
+        """
         let date = Date(timeIntervalSince1970: 0)
         let output: String = {
             let formatter = DateFormatter()
@@ -246,8 +422,14 @@ class FileHeaderTests: XCTestCase {
     func testFileHeaderDateFormattingIso() {
         let date = createTestDate("2023-08-09")
 
-        let input = "let foo = bar"
-        let output = "// 2023-08-09\n\nlet foo = bar"
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // 2023-08-09
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// {created}", dateFormat: .iso, fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
@@ -256,8 +438,14 @@ class FileHeaderTests: XCTestCase {
     func testFileHeaderDateFormattingDayMonthYear() {
         let date = createTestDate("2023-08-09")
 
-        let input = "let foo = bar"
-        let output = "// 09/08/2023\n\nlet foo = bar"
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // 09/08/2023
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// {created}", dateFormat: .dayMonthYear, fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
@@ -266,8 +454,14 @@ class FileHeaderTests: XCTestCase {
     func testFileHeaderDateFormattingMonthDayYear() {
         let date = createTestDate("2023-08-09")
 
-        let input = "let foo = bar"
-        let output = "// 08/09/2023\n\nlet foo = bar"
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // 08/09/2023
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// {created}",
                                     dateFormat: .monthDayYear,
@@ -278,8 +472,14 @@ class FileHeaderTests: XCTestCase {
     func testFileHeaderDateFormattingCustom() {
         let date = createTestDate("2023-08-09T12:59:30.345Z", .timestamp)
 
-        let input = "let foo = bar"
-        let output = "// 23.08.09-12.59.30.345\n\nlet foo = bar"
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // 23.08.09-12.59.30.345
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// {created}",
                                     dateFormat: .custom("yy.MM.dd-HH.mm.ss.SSS"),
@@ -289,16 +489,31 @@ class FileHeaderTests: XCTestCase {
     }
 
     func testFileHeaderFileReplacement() {
-        let input = "let foo = bar"
-        let output = "// MyFile.swift\n\nlet foo = bar"
+        let input = """
+        let foo = bar
+        """
+        let output = """
+        // MyFile.swift
+
+        let foo = bar
+        """
         let fileInfo = FileInfo(filePath: "~/MyFile.swift")
         let options = FormatOptions(fileHeader: "// {file}", fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
     func testEdgeCaseHeaderEndIndexPlusNewHeaderTokensCountEqualsFileTokensEndIndex() {
-        let input = "// Header comment\n\nclass Foo {}"
-        let output = "// Header line1\n// Header line2\n\nclass Foo {}"
+        let input = """
+        // Header comment
+
+        class Foo {}
+        """
+        let output = """
+        // Header line1
+        // Header line2
+
+        class Foo {}
+        """
         let options = FormatOptions(fileHeader: "// Header line1\n// Header line2")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
@@ -418,8 +633,14 @@ class FileHeaderTests: XCTestCase {
     ) {
         for (input, expected) in tests {
             let date = createTestDate(input, .time)
-            let input = "let foo = bar"
-            let output = "// \(expected)\n\nlet foo = bar"
+            let input = """
+            let foo = bar
+            """
+            let output = """
+            // \(expected)
+
+            let foo = bar
+            """
 
             let fileInfo = FileInfo(creationDate: date)
 
@@ -493,13 +714,17 @@ class FileHeaderTests: XCTestCase {
     }
 
     func testFileHeaderRuleThrowsIfCreationDateUnavailable() {
-        let input = "let foo = bar"
+        let input = """
+        let foo = bar
+        """
         let options = FormatOptions(fileHeader: "// Created by Nick Lockwood on {created}.", fileInfo: FileInfo())
         XCTAssertThrowsError(try format(input, rules: [.fileHeader], options: options))
     }
 
     func testFileHeaderRuleThrowsIfFileNameUnavailable() {
-        let input = "let foo = bar"
+        let input = """
+        let foo = bar
+        """
         let options = FormatOptions(fileHeader: "// {file}.", fileInfo: FileInfo())
         XCTAssertThrowsError(try format(input, rules: [.fileHeader], options: options))
     }

--- a/Tests/Rules/GenericExtensionsTests.swift
+++ b/Tests/Rules/GenericExtensionsTests.swift
@@ -11,40 +11,60 @@ import XCTest
 
 class GenericExtensionsTests: XCTestCase {
     func testUpdatesArrayGenericExtensionToAngleBracketSyntax() {
-        let input = "extension Array where Element == Foo {}"
-        let output = "extension Array<Foo> {}"
+        let input = """
+        extension Array where Element == Foo {}
+        """
+        let output = """
+        extension Array<Foo> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
     }
 
     func testUpdatesOptionalGenericExtensionToAngleBracketSyntax() {
-        let input = "extension Optional where Wrapped == Foo {}"
-        let output = "extension Optional<Foo> {}"
+        let input = """
+        extension Optional where Wrapped == Foo {}
+        """
+        let output = """
+        extension Optional<Foo> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
     }
 
     func testUpdatesArrayGenericExtensionToAngleBracketSyntaxWithSelf() {
-        let input = "extension Array where Self.Element == Foo {}"
-        let output = "extension Array<Foo> {}"
+        let input = """
+        extension Array where Self.Element == Foo {}
+        """
+        let output = """
+        extension Array<Foo> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
     }
 
     func testUpdatesArrayWithGenericElement() {
-        let input = "extension Array where Element == Foo<Bar> {}"
-        let output = "extension Array<Foo<Bar>> {}"
+        let input = """
+        extension Array where Element == Foo<Bar> {}
+        """
+        let output = """
+        extension Array<Foo<Bar>> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
     }
 
     func testUpdatesDictionaryGenericExtensionToAngleBracketSyntax() {
-        let input = "extension Dictionary where Key == Foo, Value == Bar {}"
-        let output = "extension Dictionary<Foo, Bar> {}"
+        let input = """
+        extension Dictionary where Key == Foo, Value == Bar {}
+        """
+        let output = """
+        extension Dictionary<Foo, Bar> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
@@ -52,15 +72,21 @@ class GenericExtensionsTests: XCTestCase {
 
     func testRequiresAllGenericTypesToBeProvided() {
         // No type provided for `Value`, so we can't use the angle bracket syntax
-        let input = "extension Dictionary where Key == Foo {}"
+        let input = """
+        extension Dictionary where Key == Foo {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, rule: .genericExtensions, options: options, exclude: [.emptyExtensions])
     }
 
     func testHandlesNestedCollectionTypes() {
-        let input = "extension Array where Element == [[Foo: Bar]] {}"
-        let output = "extension Array<[[Foo: Bar]]> {}"
+        let input = """
+        extension Array where Element == [[Foo: Bar]] {}
+        """
+        let output = """
+        extension Array<[[Foo: Bar]]> {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.typeSugar, .emptyExtensions])
@@ -69,15 +95,21 @@ class GenericExtensionsTests: XCTestCase {
     func testDoesntUpdateIneligibleConstraints() {
         // This could potentially by `extension Optional<some Fooable>` in a future language version
         // but that syntax isn't implemented as of Swift 5.7
-        let input = "extension Optional where Wrapped: Fooable {}"
+        let input = """
+        extension Optional where Wrapped: Fooable {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, rule: .genericExtensions, options: options, exclude: [.emptyExtensions])
     }
 
     func testPreservesOtherConstraintsInWhereClause() {
-        let input = "extension Collection where Element == String, Index == Int {}"
-        let output = "extension Collection<String> where Index == Int {}"
+        let input = """
+        extension Collection where Element == String, Index == Int {}
+        """
+        let output = """
+        extension Collection<String> where Index == Int {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .genericExtensions, options: options, exclude: [.emptyExtensions])

--- a/Tests/Rules/HoistAwaitTests.swift
+++ b/Tests/Rules/HoistAwaitTests.swift
@@ -11,15 +11,23 @@ import XCTest
 
 class HoistAwaitTests: XCTestCase {
     func testHoistAwait() {
-        let input = "greet(await name, await surname)"
-        let output = "await greet(name, surname)"
+        let input = """
+        greet(await name, await surname)
+        """
+        let output = """
+        await greet(name, surname)
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testHoistAwaitInsideIf() {
-        let input = "if !(await isSomething()) {}"
-        let output = "if await !(isSomething()) {}"
+        let input = """
+        if !(await isSomething()) {}
+        """
+        let output = """
+        if await !(isSomething()) {}
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"),
                        exclude: [.redundantParens])
@@ -37,8 +45,12 @@ class HoistAwaitTests: XCTestCase {
     }
 
     func testHoistAwaitInsideStringInterpolation() {
-        let input = "\"\\(replace(regex: await something()))\""
-        let output = "await \"\\(replace(regex: something()))\""
+        let input = """
+        \"\\(replace(regex: await something()))\"
+        """
+        let output = """
+        await \"\\(replace(regex: something()))\"
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
@@ -85,71 +97,109 @@ class HoistAwaitTests: XCTestCase {
     }
 
     func testHoistAwaitInExpressionWithNoSpaces() {
-        let input = "let foo=bar(contentsOf:await baz())"
-        let output = "let foo=await bar(contentsOf:baz())"
+        let input = """
+        let foo=bar(contentsOf:await baz())
+        """
+        let output = """
+        let foo=await bar(contentsOf:baz())
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.spaceAroundOperators])
     }
 
     func testHoistAwaitInExpressionWithExcessSpaces() {
-        let input = "let foo = bar ( contentsOf: await baz() )"
-        let output = "let foo = await bar ( contentsOf: baz() )"
+        let input = """
+        let foo = bar ( contentsOf: await baz() )
+        """
+        let output = """
+        let foo = await bar ( contentsOf: baz() )
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"),
                        exclude: [.spaceAroundParens, .spaceInsideParens])
     }
 
     func testHoistAwaitWithReturn() {
-        let input = "return .enumCase(try await service.greet())"
-        let output = "return await .enumCase(try service.greet())"
+        let input = """
+        return .enumCase(try await service.greet())
+        """
+        let output = """
+        return await .enumCase(try service.greet())
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistDeeplyNestedAwaits() {
-        let input = "let foo = (bar: (5, (await quux(), 6)), baz: (7, quux: await quux()))"
-        let output = "let foo = await (bar: (5, (quux(), 6)), baz: (7, quux: quux()))"
+        let input = """
+        let foo = (bar: (5, (await quux(), 6)), baz: (7, quux: await quux()))
+        """
+        let output = """
+        let foo = await (bar: (5, (quux(), 6)), baz: (7, quux: quux()))
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testAwaitNotHoistedOutOfClosure() {
-        let input = "let foo = { (await bar(), 5) }"
-        let output = "let foo = { await (bar(), 5) }"
+        let input = """
+        let foo = { (await bar(), 5) }
+        """
+        let output = """
+        let foo = { await (bar(), 5) }
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testAwaitNotHoistedOutOfClosureWithArguments() {
-        let input = "let foo = { bar in (await baz(bar), 5) }"
-        let output = "let foo = { bar in await (baz(bar), 5) }"
+        let input = """
+        let foo = { bar in (await baz(bar), 5) }
+        """
+        let output = """
+        let foo = { bar in await (baz(bar), 5) }
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testAwaitNotHoistedOutOfForCondition() {
-        let input = "for foo in bar(await baz()) {}"
-        let output = "for foo in await bar(baz()) {}"
+        let input = """
+        for foo in bar(await baz()) {}
+        """
+        let output = """
+        for foo in await bar(baz()) {}
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testAwaitNotHoistedOutOfForIndex() {
-        let input = "for await foo in asyncSequence() {}"
+        let input = """
+        for await foo in asyncSequence() {}
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testHoistAwaitWithInitAssignment() {
-        let input = "let variable = String(try await asyncFunction())"
-        let output = "let variable = await String(try asyncFunction())"
+        let input = """
+        let variable = String(try await asyncFunction())
+        """
+        let output = """
+        let variable = await String(try asyncFunction())
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
 
     func testHoistAwaitWithAssignment() {
-        let input = "let variable = (try await asyncFunction())"
-        let output = "let variable = await (try asyncFunction())"
+        let input = """
+        let variable = (try await asyncFunction())
+        """
+        let output = """
+        let variable = await (try asyncFunction())
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.hoistTry])
     }
@@ -168,66 +218,96 @@ class HoistAwaitTests: XCTestCase {
     }
 
     func testHoistAwaitOnlyOne() {
-        let input = "greet(name, await surname)"
-        let output = "await greet(name, surname)"
+        let input = """
+        greet(name, await surname)
+        """
+        let output = """
+        await greet(name, surname)
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testHoistAwaitRedundantAwait() {
-        let input = "await greet(await name, await surname)"
-        let output = "await greet(name, surname)"
+        let input = """
+        await greet(await name, await surname)
+        """
+        let output = """
+        await greet(name, surname)
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testHoistAwaitDoesNothing() {
-        let input = "await greet(name, surname)"
+        let input = """
+        await greet(name, surname)
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testNoHoistAwaitBeforeTry() {
-        let input = "try foo(await bar())"
-        let output = "try await foo(bar())"
+        let input = """
+        try foo(await bar())
+        """
+        let output = """
+        try await foo(bar())
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testNoHoistAwaitInCapturingFunction() {
-        let input = "foo(await bar)"
+        let input = """
+        foo(await bar)
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(asyncCapturing: ["foo"], swiftVersion: "5.5"))
     }
 
     func testNoHoistSecondArgumentAwaitInCapturingFunction() {
-        let input = "foo(bar, await baz)"
+        let input = """
+        foo(bar, await baz)
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(asyncCapturing: ["foo"], swiftVersion: "5.5"))
     }
 
     func testHoistAwaitAfterOrdinaryOperator() {
-        let input = "let foo = bar + (await baz)"
-        let output = "let foo = await bar + (baz)"
+        let input = """
+        let foo = bar + (await baz)
+        """
+        let output = """
+        let foo = await bar + (baz)
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.redundantParens])
     }
 
     func testHoistAwaitAfterUnknownOperator() {
-        let input = "let foo = bar ??? (await baz)"
-        let output = "let foo = await bar ??? (baz)"
+        let input = """
+        let foo = bar ??? (await baz)
+        """
+        let output = """
+        let foo = await bar ??? (baz)
+        """
         testFormatting(for: input, output, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.redundantParens])
     }
 
     func testNoHoistAwaitAfterCapturingOperator() {
-        let input = "let foo = await bar ??? (await baz)"
+        let input = """
+        let foo = await bar ??? (await baz)
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(asyncCapturing: ["???"], swiftVersion: "5.5"))
     }
 
     func testNoHoistAwaitInMacroArgument() {
-        let input = "#expect (await monitor.isAvailable == false)"
+        let input = """
+        #expect (await monitor.isAvailable == false)
+        """
         testFormatting(for: input, rule: .hoistAwait,
                        options: FormatOptions(swiftVersion: "5.5"), exclude: [.spaceAroundParens])
     }

--- a/Tests/Rules/HoistPatternLetTests.swift
+++ b/Tests/Rules/HoistPatternLetTests.swift
@@ -13,77 +13,131 @@ class HoistPatternLetTests: XCTestCase {
     // hoist = true
 
     func testHoistCaseLet() {
-        let input = "if case .foo(let bar, let baz) = quux {}"
-        let output = "if case let .foo(bar, baz) = quux {}"
+        let input = """
+        if case .foo(let bar, let baz) = quux {}
+        """
+        let output = """
+        if case let .foo(bar, baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistLabelledCaseLet() {
-        let input = "if case .foo(bar: let bar, baz: let baz) = quux {}"
-        let output = "if case let .foo(bar: bar, baz: baz) = quux {}"
+        let input = """
+        if case .foo(bar: let bar, baz: let baz) = quux {}
+        """
+        let output = """
+        if case let .foo(bar: bar, baz: baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistCaseVar() {
-        let input = "if case .foo(var bar, var baz) = quux {}"
-        let output = "if case var .foo(bar, baz) = quux {}"
+        let input = """
+        if case .foo(var bar, var baz) = quux {}
+        """
+        let output = """
+        if case var .foo(bar, baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testNoHoistMixedCaseLetVar() {
-        let input = "if case .foo(let bar, var baz) = quux {}"
+        let input = """
+        if case .foo(let bar, var baz) = quux {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet)
     }
 
     func testNoHoistIfFirstArgSpecified() {
-        let input = "if case .foo(bar, let baz) = quux {}"
+        let input = """
+        if case .foo(bar, let baz) = quux {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet)
     }
 
     func testNoHoistIfLastArgSpecified() {
-        let input = "if case .foo(let bar, baz) = quux {}"
+        let input = """
+        if case .foo(let bar, baz) = quux {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet)
     }
 
     func testHoistIfArgIsNumericLiteral() {
-        let input = "if case .foo(5, let baz) = quux {}"
-        let output = "if case let .foo(5, baz) = quux {}"
+        let input = """
+        if case .foo(5, let baz) = quux {}
+        """
+        let output = """
+        if case let .foo(5, baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistIfArgIsEnumCaseLiteral() {
-        let input = "if case .foo(.bar, let baz) = quux {}"
-        let output = "if case let .foo(.bar, baz) = quux {}"
+        let input = """
+        if case .foo(.bar, let baz) = quux {}
+        """
+        let output = """
+        if case let .foo(.bar, baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistIfArgIsNamespacedEnumCaseLiteralInParens() {
-        let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
-        let output = "switch foo {\ncase let (Foo.bar(baz)):\n}"
+        let input = """
+        switch foo {
+        case (Foo.bar(let baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case let (Foo.bar(baz)):
+        }
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet, exclude: [.redundantParens])
     }
 
     func testHoistIfFirstArgIsUnderscore() {
-        let input = "if case .foo(_, let baz) = quux {}"
-        let output = "if case let .foo(_, baz) = quux {}"
+        let input = """
+        if case .foo(_, let baz) = quux {}
+        """
+        let output = """
+        if case let .foo(_, baz) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistIfSecondArgIsUnderscore() {
-        let input = "if case .foo(let baz, _) = quux {}"
-        let output = "if case let .foo(baz, _) = quux {}"
+        let input = """
+        if case .foo(let baz, _) = quux {}
+        """
+        let output = """
+        if case let .foo(baz, _) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testNestedHoistLet() {
-        let input = "if case (.foo(let a, let b), .bar(let c, let d)) = quux {}"
-        let output = "if case let (.foo(a, b), .bar(c, d)) = quux {}"
+        let input = """
+        if case (.foo(let a, let b), .bar(let c, let d)) = quux {}
+        """
+        let output = """
+        if case let (.foo(a, b), .bar(c, d)) = quux {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testHoistCommaSeparatedSwitchCaseLets() {
-        let input = "switch foo {\ncase .foo(let bar), .bar(let bar):\n}"
-        let output = "switch foo {\ncase let .foo(bar), let .bar(bar):\n}"
+        let input = """
+        switch foo {
+        case .foo(let bar), .bar(let bar):
+        }
+        """
+        let output = """
+        switch foo {
+        case let .foo(bar), let .bar(bar):
+        }
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet,
                        exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
@@ -108,45 +162,69 @@ class HoistPatternLetTests: XCTestCase {
     }
 
     func testHoistCatchLet() {
-        let input = "do {} catch Foo.foo(bar: let bar) {}"
-        let output = "do {} catch let Foo.foo(bar: bar) {}"
+        let input = """
+        do {} catch Foo.foo(bar: let bar) {}
+        """
+        let output = """
+        do {} catch let Foo.foo(bar: bar) {}
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
     func testNoNestedHoistLetWithSpecifiedArgs() {
-        let input = "if case (.foo(let a, b), .bar(let c, d)) = quux {}"
+        let input = """
+        if case (.foo(let a, b), .bar(let c, d)) = quux {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet)
     }
 
     func testNoHoistClosureVariables() {
-        let input = "foo({ let bar = 5 })"
+        let input = """
+        foo({ let bar = 5 })
+        """
         testFormatting(for: input, rule: .hoistPatternLet, exclude: [.trailingClosures])
     }
 
     // TODO: this should actually hoist the let, but that's tricky to implement without
     // breaking the `testNoOverHoistSwitchCaseWithNestedParens` case
     func testHoistSwitchCaseWithNestedParens() {
-        let input = "import Foo\nswitch (foo, bar) {\ncase (.baz(let quux), Foo.bar): break\n}"
+        let input = """
+        import Foo
+        switch (foo, bar) {
+        case (.baz(let quux), Foo.bar): break
+        }
+        """
         testFormatting(for: input, rule: .hoistPatternLet,
                        exclude: [.blankLineAfterImports])
     }
 
     // TODO: this could actually hoist the let by one level, but that's tricky to implement
     func testNoOverHoistSwitchCaseWithNestedParens() {
-        let input = "import Foo\nswitch (foo, bar) {\ncase (.baz(let quux), bar): break\n}"
+        let input = """
+        import Foo
+        switch (foo, bar) {
+        case (.baz(let quux), bar): break
+        }
+        """
         testFormatting(for: input, rule: .hoistPatternLet,
                        exclude: [.blankLineAfterImports])
     }
 
     func testNoHoistLetWithEmptArg() {
-        let input = "if .foo(let _) = bar {}"
+        let input = """
+        if .foo(let _) = bar {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet,
                        exclude: [.redundantLet, .redundantPattern])
     }
 
     func testHoistLetWithNoSpaceAfterCase() {
-        let input = "switch x { case.some(let y): return y }"
-        let output = "switch x { case let .some(y): return y }"
+        let input = """
+        switch x { case.some(let y): return y }
+        """
+        let output = """
+        switch x { case let .some(y): return y }
+        """
         testFormatting(for: input, output, rule: .hoistPatternLet)
     }
 
@@ -171,15 +249,21 @@ class HoistPatternLetTests: XCTestCase {
     func testNoHoistCaseLetContainingGenerics() {
         // Hoisting in this case causes a compilation error as-of Swift 5.3
         // See: https://github.com/nicklockwood/SwiftFormat/issues/768
-        let input = "if case .some(Optional<Any>.some(let foo)) = bar else {}"
+        let input = """
+        if case .some(Optional<Any>.some(let foo)) = bar else {}
+        """
         testFormatting(for: input, rule: .hoistPatternLet, exclude: [.typeSugar])
     }
 
     // hoist = false
 
     func testUnhoistCaseLet() {
-        let input = "if case let .foo(bar, baz) = quux {}"
-        let output = "if case .foo(let bar, let baz) = quux {}"
+        let input = """
+        if case let .foo(bar, baz) = quux {}
+        """
+        let output = """
+        if case .foo(let bar, let baz) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
@@ -202,15 +286,23 @@ class HoistPatternLetTests: XCTestCase {
     }
 
     func testUnhoistLabelledCaseLet() {
-        let input = "if case let .foo(bar: bar, baz: baz) = quux {}"
-        let output = "if case .foo(bar: let bar, baz: let baz) = quux {}"
+        let input = """
+        if case let .foo(bar: bar, baz: baz) = quux {}
+        """
+        let output = """
+        if case .foo(bar: let bar, baz: let baz) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testUnhoistCaseVar() {
-        let input = "if case var .foo(bar, baz) = quux {}"
-        let output = "if case .foo(var bar, var baz) = quux {}"
+        let input = """
+        if case var .foo(bar, baz) = quux {}
+        """
+        let output = """
+        if case .foo(var bar, var baz) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
@@ -249,99 +341,169 @@ class HoistPatternLetTests: XCTestCase {
     }
 
     func testUnhoistSingleCaseLet() {
-        let input = "if case let .foo(bar) = quux {}"
-        let output = "if case .foo(let bar) = quux {}"
+        let input = """
+        if case let .foo(bar) = quux {}
+        """
+        let output = """
+        if case .foo(let bar) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testUnhoistIfArgIsEnumCaseLiteral() {
-        let input = "if case let .foo(.bar, baz) = quux {}"
-        let output = "if case .foo(.bar, let baz) = quux {}"
+        let input = """
+        if case let .foo(.bar, baz) = quux {}
+        """
+        let output = """
+        if case .foo(.bar, let baz) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testUnhoistIfArgIsEnumCaseLiteralInParens() {
-        let input = "switch foo {\ncase let (.bar(baz)):\n}"
-        let output = "switch foo {\ncase (.bar(let baz)):\n}"
+        let input = """
+        switch foo {
+        case let (.bar(baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case (.bar(let baz)):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
                        exclude: [.redundantParens])
     }
 
     func testUnhoistIfArgIsNamespacedEnumCaseLiteral() {
-        let input = "switch foo {\ncase let Foo.bar(baz):\n}"
-        let output = "switch foo {\ncase Foo.bar(let baz):\n}"
+        let input = """
+        switch foo {
+        case let Foo.bar(baz):
+        }
+        """
+        let output = """
+        switch foo {
+        case Foo.bar(let baz):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testUnhoistIfArgIsNamespacedEnumCaseLiteralInParens() {
-        let input = "switch foo {\ncase let (Foo.bar(baz)):\n}"
-        let output = "switch foo {\ncase (Foo.bar(let baz)):\n}"
+        let input = """
+        switch foo {
+        case let (Foo.bar(baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case (Foo.bar(let baz)):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
                        exclude: [.redundantParens])
     }
 
     func testUnhoistIfArgIsUnderscore() {
-        let input = "if case let .foo(_, baz) = quux {}"
-        let output = "if case .foo(_, let baz) = quux {}"
+        let input = """
+        if case let .foo(_, baz) = quux {}
+        """
+        let output = """
+        if case .foo(_, let baz) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testNestedUnhoistLet() {
-        let input = "if case let (.foo(a, b), .bar(c, d)) = quux {}"
-        let output = "if case (.foo(let a, let b), .bar(let c, let d)) = quux {}"
+        let input = """
+        if case let (.foo(a, b), .bar(c, d)) = quux {}
+        """
+        let output = """
+        if case (.foo(let a, let b), .bar(let c, let d)) = quux {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testUnhoistCommaSeparatedSwitchCaseLets() {
-        let input = "switch foo {\ncase let .foo(bar), let .bar(bar):\n}"
-        let output = "switch foo {\ncase .foo(let bar), .bar(let bar):\n}"
+        let input = """
+        switch foo {
+        case let .foo(bar), let .bar(bar):
+        }
+        """
+        let output = """
+        switch foo {
+        case .foo(let bar), .bar(let bar):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
                        exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testUnhoistCommaSeparatedSwitchCaseLets2() {
-        let input = "switch foo {\ncase let Foo.foo(bar), let Foo.bar(bar):\n}"
-        let output = "switch foo {\ncase Foo.foo(let bar), Foo.bar(let bar):\n}"
+        let input = """
+        switch foo {
+        case let Foo.foo(bar), let Foo.bar(bar):
+        }
+        """
+        let output = """
+        switch foo {
+        case Foo.foo(let bar), Foo.bar(let bar):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options,
                        exclude: [.wrapSwitchCases, .sortSwitchCases])
     }
 
     func testUnhoistCatchLet() {
-        let input = "do {} catch let Foo.foo(bar: bar) {}"
-        let output = "do {} catch Foo.foo(bar: let bar) {}"
+        let input = """
+        do {} catch let Foo.foo(bar: bar) {}
+        """
+        let output = """
+        do {} catch Foo.foo(bar: let bar) {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, output, rule: .hoistPatternLet, options: options)
     }
 
     func testNoUnhoistTupleLet() {
-        let input = "let (bar, baz) = quux()"
+        let input = """
+        let (bar, baz) = quux()
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options)
     }
 
     func testNoUnhoistIfLetTuple() {
-        let input = "if let x = y, let (_, a) = z {}"
+        let input = """
+        if let x = y, let (_, a) = z {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options)
     }
 
     func testNoUnhoistIfCaseFollowedByLetTuple() {
-        let input = "if case .foo = bar, let (foo, bar) = baz {}"
+        let input = """
+        if case .foo = bar, let (foo, bar) = baz {}
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options)
     }
 
     func testNoUnhoistIfArgIsNamespacedEnumCaseLiteralInParens() {
-        let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
+        let input = """
+        switch foo {
+        case (Foo.bar(let baz)):
+        }
+        """
         let options = FormatOptions(hoistPatternLet: false)
         testFormatting(for: input, rule: .hoistPatternLet, options: options,
                        exclude: [.redundantParens])

--- a/Tests/Rules/HoistTryTests.swift
+++ b/Tests/Rules/HoistTryTests.swift
@@ -11,20 +11,32 @@ import XCTest
 
 class HoistTryTests: XCTestCase {
     func testHoistTry() {
-        let input = "greet(try name(), try surname())"
-        let output = "try greet(name(), surname())"
+        let input = """
+        greet(try name(), try surname())
+        """
+        let output = """
+        try greet(name(), surname())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryWithOptionalTry() {
-        let input = "greet(try name(), try? surname())"
-        let output = "try greet(name(), try? surname())"
+        let input = """
+        greet(try name(), try? surname())
+        """
+        let output = """
+        try greet(name(), try? surname())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryInsideStringInterpolation() {
-        let input = "\"\\(replace(regex: try something()))\""
-        let output = "try \"\\(replace(regex: something()))\""
+        let input = """
+        \"\\(replace(regex: try something()))\"
+        """
+        let output = """
+        try \"\\(replace(regex: something()))\"
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
@@ -113,24 +125,36 @@ class HoistTryTests: XCTestCase {
     }
 
     func testNoHoistTryInsideXCTAssert() {
-        let input = "XCTAssertFalse(try foo())"
+        let input = """
+        XCTAssertFalse(try foo())
+        """
         testFormatting(for: input, rule: .hoistTry)
     }
 
     func testNoMergeTrysInsideXCTAssert() {
-        let input = "XCTAssertEqual(try foo(), try bar())"
+        let input = """
+        XCTAssertEqual(try foo(), try bar())
+        """
         testFormatting(for: input, rule: .hoistTry)
     }
 
     func testNoHoistTryInsideDo() {
-        let input = "do { rg.box.seal(.fulfilled(try body(error))) }"
-        let output = "do { try rg.box.seal(.fulfilled(body(error))) }"
+        let input = """
+        do { rg.box.seal(.fulfilled(try body(error))) }
+        """
+        let output = """
+        do { try rg.box.seal(.fulfilled(body(error))) }
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testNoHoistTryInsideDoThrows() {
-        let input = "do throws(Foo) { rg.box.seal(.fulfilled(try body(error))) }"
-        let output = "do throws(Foo) { try rg.box.seal(.fulfilled(body(error))) }"
+        let input = """
+        do throws(Foo) { rg.box.seal(.fulfilled(try body(error))) }
+        """
+        let output = """
+        do throws(Foo) { try rg.box.seal(.fulfilled(body(error))) }
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
@@ -149,79 +173,127 @@ class HoistTryTests: XCTestCase {
     }
 
     func testHoistedTryPlacedBeforeAwait() {
-        let input = "let foo = await bar(contentsOf: try baz())"
-        let output = "let foo = try await bar(contentsOf: baz())"
+        let input = """
+        let foo = await bar(contentsOf: try baz())
+        """
+        let output = """
+        let foo = try await bar(contentsOf: baz())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryInExpressionWithNoSpaces() {
-        let input = "let foo=bar(contentsOf:try baz())"
-        let output = "let foo=try bar(contentsOf:baz())"
+        let input = """
+        let foo=bar(contentsOf:try baz())
+        """
+        let output = """
+        let foo=try bar(contentsOf:baz())
+        """
         testFormatting(for: input, output, rule: .hoistTry,
                        exclude: [.spaceAroundOperators])
     }
 
     func testHoistTryInExpressionWithExcessSpaces() {
-        let input = "let foo = bar ( contentsOf: try baz() )"
-        let output = "let foo = try bar ( contentsOf: baz() )"
+        let input = """
+        let foo = bar ( contentsOf: try baz() )
+        """
+        let output = """
+        let foo = try bar ( contentsOf: baz() )
+        """
         testFormatting(for: input, output, rule: .hoistTry,
                        exclude: [.spaceAroundParens, .spaceInsideParens])
     }
 
     func testHoistTryWithReturn() {
-        let input = "return .enumCase(try await service.greet())"
-        let output = "return try .enumCase(await service.greet())"
+        let input = """
+        return .enumCase(try await service.greet())
+        """
+        let output = """
+        return try .enumCase(await service.greet())
+        """
         testFormatting(for: input, output, rule: .hoistTry,
                        exclude: [.hoistAwait])
     }
 
     func testHoistDeeplyNestedTrys() {
-        let input = "let foo = (bar: (5, (try quux(), 6)), baz: (7, quux: try quux()))"
-        let output = "let foo = try (bar: (5, (quux(), 6)), baz: (7, quux: quux()))"
+        let input = """
+        let foo = (bar: (5, (try quux(), 6)), baz: (7, quux: try quux()))
+        """
+        let output = """
+        let foo = try (bar: (5, (quux(), 6)), baz: (7, quux: quux()))
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testTryNotHoistedOutOfClosure() {
-        let input = "let foo = { (try bar(), 5) }"
-        let output = "let foo = { try (bar(), 5) }"
+        let input = """
+        let foo = { (try bar(), 5) }
+        """
+        let output = """
+        let foo = { try (bar(), 5) }
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testTryNotHoistedOutOfClosureWithArguments() {
-        let input = "let foo = { bar in (try baz(bar), 5) }"
-        let output = "let foo = { bar in try (baz(bar), 5) }"
+        let input = """
+        let foo = { bar in (try baz(bar), 5) }
+        """
+        let output = """
+        let foo = { bar in try (baz(bar), 5) }
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testTryNotHoistedOutOfForCondition() {
-        let input = "for foo in bar(try baz()) {}"
-        let output = "for foo in try bar(baz()) {}"
+        let input = """
+        for foo in bar(try baz()) {}
+        """
+        let output = """
+        for foo in try bar(baz()) {}
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryWithInitAssignment() {
-        let input = "let variable = String(try await asyncFunction())"
-        let output = "let variable = try String(await asyncFunction())"
+        let input = """
+        let variable = String(try await asyncFunction())
+        """
+        let output = """
+        let variable = try String(await asyncFunction())
+        """
         testFormatting(for: input, output, rule: .hoistTry,
                        exclude: [.hoistAwait])
     }
 
     func testHoistTryWithAssignment() {
-        let input = "let variable = (try await asyncFunction())"
-        let output = "let variable = try (await asyncFunction())"
+        let input = """
+        let variable = (try await asyncFunction())
+        """
+        let output = """
+        let variable = try (await asyncFunction())
+        """
         testFormatting(for: input, output, rule: .hoistTry,
                        exclude: [.hoistAwait])
     }
 
     func testHoistTryOnlyOne() {
-        let input = "greet(name, try surname())"
-        let output = "try greet(name, surname())"
+        let input = """
+        greet(name, try surname())
+        """
+        let output = """
+        try greet(name, surname())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryRedundantTry() {
-        let input = "try greet(try name(), try surname())"
-        let output = "try greet(name(), surname())"
+        let input = """
+        try greet(try name(), try surname())
+        """
+        let output = """
+        try greet(name(), surname())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
@@ -248,12 +320,16 @@ class HoistTryTests: XCTestCase {
     }
 
     func testHoistTryDoesNothing() {
-        let input = "try greet(name, surname)"
+        let input = """
+        try greet(name, surname)
+        """
         testFormatting(for: input, rule: .hoistTry)
     }
 
     func testHoistOptionalTryDoesNothing() {
-        let input = "try? greet(name, surname)"
+        let input = """
+        try? greet(name, surname)
+        """
         testFormatting(for: input, rule: .hoistTry)
     }
 
@@ -306,13 +382,17 @@ class HoistTryTests: XCTestCase {
     }
 
     func testNoHoistTryInCapturingFunction() {
-        let input = "foo(try bar)"
+        let input = """
+        foo(try bar)
+        """
         testFormatting(for: input, rule: .hoistTry,
                        options: FormatOptions(throwCapturing: ["foo"]))
     }
 
     func testNoHoistSecondArgumentTryInCapturingFunction() {
-        let input = "foo(bar, try baz)"
+        let input = """
+        foo(bar, try baz)
+        """
         testFormatting(for: input, rule: .hoistTry,
                        options: FormatOptions(throwCapturing: ["foo"]))
     }
@@ -348,37 +428,59 @@ class HoistTryTests: XCTestCase {
     }
 
     func testHoistTryInsideOptionalFunction() {
-        let input = "foo?(try bar())"
-        let output = "try foo?(bar())"
+        let input = """
+        foo?(try bar())
+        """
+        let output = """
+        try foo?(bar())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testNoHoistTryAfterOptionalTry() {
-        let input = "let foo = try? bar(try baz())"
+        let input = """
+        let foo = try? bar(try baz())
+        """
         testFormatting(for: input, rule: .hoistTry)
     }
 
     func testHoistTryInsideOptionalSubscript() {
-        let input = "foo?[try bar()]"
-        let output = "try foo?[bar()]"
+        let input = """
+        foo?[try bar()]
+        """
+        let output = """
+        try foo?[bar()]
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryAfterGenericType() {
-        let input = "let foo = Tree<T>.Foo(bar: try baz())"
-        let output = "let foo = try Tree<T>.Foo(bar: baz())"
+        let input = """
+        let foo = Tree<T>.Foo(bar: try baz())
+        """
+        let output = """
+        let foo = try Tree<T>.Foo(bar: baz())
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryAfterArrayLiteral() {
-        let input = "if [.first, .second].contains(try foo()) {}"
-        let output = "if try [.first, .second].contains(foo()) {}"
+        let input = """
+        if [.first, .second].contains(try foo()) {}
+        """
+        let output = """
+        if try [.first, .second].contains(foo()) {}
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
     func testHoistTryAfterSubscript() {
-        let input = "if foo[5].bar(try baz()) {}"
-        let output = "if try foo[5].bar(baz()) {}"
+        let input = """
+        if foo[5].bar(try baz()) {}
+        """
+        let output = """
+        if try foo[5].bar(baz()) {}
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 
@@ -397,8 +499,12 @@ class HoistTryTests: XCTestCase {
     }
 
     func testHoistTryInsideArrayClosure() {
-        let input = "foo[bar](try parseFile(path: $0))"
-        let output = "try foo[bar](parseFile(path: $0))"
+        let input = """
+        foo[bar](try parseFile(path: $0))
+        """
+        let output = """
+        try foo[bar](parseFile(path: $0))
+        """
         testFormatting(for: input, output, rule: .hoistTry)
     }
 

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -11,70 +11,152 @@ import XCTest
 
 class IndentTests: XCTestCase {
     func testReduceIndentAtStartOfFile() {
-        let input = "    foo()"
-        let output = "foo()"
+        let input = """
+            foo()
+        """
+        let output = """
+        foo()
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testReduceIndentAtEndOfFile() {
-        let input = "foo()\n   bar()"
-        let output = "foo()\nbar()"
+        let input = """
+        foo()
+           bar()
+        """
+        let output = """
+        foo()
+        bar()
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     // indent parens
 
     func testSimpleScope() {
-        let input = "foo(\nbar\n)"
-        let output = "foo(\n    bar\n)"
+        let input = """
+        foo(
+        bar
+        )
+        """
+        let output = """
+        foo(
+            bar
+        )
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNestedScope() {
-        let input = "foo(\nbar {\n}\n)"
-        let output = "foo(\n    bar {\n    }\n)"
+        let input = """
+        foo(
+        bar {
+        }
+        )
+        """
+        let output = """
+        foo(
+            bar {
+            }
+        )
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.emptyBraces])
     }
 
     func testNestedScopeOnSameLine() {
-        let input = "foo(bar(\nbaz\n))"
-        let output = "foo(bar(\n    baz\n))"
+        let input = """
+        foo(bar(
+        baz
+        ))
+        """
+        let output = """
+        foo(bar(
+            baz
+        ))
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNestedScopeOnSameLine2() {
-        let input = "foo(bar(in:\nbaz))"
-        let output = "foo(bar(in:\n    baz))"
+        let input = """
+        foo(bar(in:
+        baz))
+        """
+        let output = """
+        foo(bar(in:
+            baz))
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentNestedArrayLiteral() {
-        let input = "foo(bar: [\n.baz,\n])"
-        let output = "foo(bar: [\n    .baz,\n])"
+        let input = """
+        foo(bar: [
+        .baz,
+        ])
+        """
+        let output = """
+        foo(bar: [
+            .baz,
+        ])
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testClosingScopeAfterContent() {
-        let input = "foo(\nbar\n)"
-        let output = "foo(\n    bar\n)"
+        let input = """
+        foo(
+        bar
+        )
+        """
+        let output = """
+        foo(
+            bar
+        )
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testClosingNestedScopeAfterContent() {
-        let input = "foo(bar(\nbaz\n))"
-        let output = "foo(bar(\n    baz\n))"
+        let input = """
+        foo(bar(
+        baz
+        ))
+        """
+        let output = """
+        foo(bar(
+            baz
+        ))
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedFunctionArguments() {
-        let input = "foo(\nbar,\nbaz\n)"
-        let output = "foo(\n    bar,\n    baz\n)"
+        let input = """
+        foo(
+        bar,
+        baz
+        )
+        """
+        let output = """
+        foo(
+            bar,
+            baz
+        )
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testFunctionArgumentsWrappedAfterFirst() {
-        let input = "func foo(bar: Int,\nbaz: Int)"
-        let output = "func foo(bar: Int,\n         baz: Int)"
+        let input = """
+        func foo(bar: Int,
+        baz: Int)
+        """
+        let output = """
+        func foo(bar: Int,
+                 baz: Int)
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -189,45 +271,111 @@ class IndentTests: XCTestCase {
     // indent modifiers
 
     func testNoIndentWrappedModifiersForProtocol() {
-        let input = "@objc\nprivate\nprotocol Foo {}"
+        let input = """
+        @objc
+        private
+        protocol Foo {}
+        """
         testFormatting(for: input, rule: .indent, exclude: [.modifiersOnSameLine])
     }
 
     // indent braces
 
     func testElseClauseIndenting() {
-        let input = "if x {\nbar\n} else {\nbaz\n}"
-        let output = "if x {\n    bar\n} else {\n    baz\n}"
+        let input = """
+        if x {
+        bar
+        } else {
+        baz
+        }
+        """
+        let output = """
+        if x {
+            bar
+        } else {
+            baz
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNoIndentBlankLines() {
-        let input = "{\n\n// foo\n}"
-        let output = "{\n\n    // foo\n}"
+        let input = """
+        {
+
+        // foo
+        }
+        """
+        let output = """
+        {
+
+            // foo
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.blankLinesAtStartOfScope])
     }
 
     func testNestedBraces() {
-        let input = "({\n// foo\n}, {\n// bar\n})"
-        let output = "({\n    // foo\n}, {\n    // bar\n})"
+        let input = """
+        ({
+        // foo
+        }, {
+        // bar
+        })
+        """
+        let output = """
+        ({
+            // foo
+        }, {
+            // bar
+        })
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testBraceIndentAfterComment() {
-        let input = "if foo { // comment\nbar\n}"
-        let output = "if foo { // comment\n    bar\n}"
+        let input = """
+        if foo { // comment
+        bar
+        }
+        """
+        let output = """
+        if foo { // comment
+            bar
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testBraceIndentAfterClosingScope() {
-        let input = "foo(bar(baz), {\nquux\nbleem\n})"
-        let output = "foo(bar(baz), {\n    quux\n    bleem\n})"
+        let input = """
+        foo(bar(baz), {
+        quux
+        bleem
+        })
+        """
+        let output = """
+        foo(bar(baz), {
+            quux
+            bleem
+        })
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.trailingClosures])
     }
 
     func testBraceIndentAfterLineWithParens() {
-        let input = "({\nfoo()\nbar\n})"
-        let output = "({\n    foo()\n    bar\n})"
+        let input = """
+        ({
+        foo()
+        bar
+        })
+        """
+        let output = """
+        ({
+            foo()
+            bar
+        })
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
@@ -488,49 +636,168 @@ class IndentTests: XCTestCase {
     // indent switch/case
 
     func testSwitchCaseIndenting() {
-        let input = "switch x {\ncase foo:\nbreak\ncase bar:\nbreak\ndefault:\nbreak\n}"
-        let output = "switch x {\ncase foo:\n    break\ncase bar:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case foo:
+        break
+        case bar:
+        break
+        default:
+        break
+        }
+        """
+        let output = """
+        switch x {
+        case foo:
+            break
+        case bar:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testSwitchWrappedCaseIndenting() {
-        let input = "switch x {\ncase foo,\nbar,\n    baz:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase foo,\n     bar,\n     baz:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case foo,
+        bar,
+            baz:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+        case foo,
+             bar,
+             baz:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIndenting() {
-        let input = "switch x {\ncase .foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase .foo,\n     .bar,\n     .baz:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case .foo,
+        .bar,
+            .baz:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+        case .foo,
+             .bar,
+             .baz:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIndentingVariant2() {
-        let input = "switch x {\ncase\n.foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase\n    .foo,\n    .bar,\n    .baz:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case
+        .foo,
+        .bar,
+            .baz:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+        case
+            .foo,
+            .bar,
+            .baz:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchWrappedEnumCaseIsIndenting() {
-        let input = "switch x {\ncase is Foo.Type,\n    is Bar.Type:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase is Foo.Type,\n     is Bar.Type:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case is Foo.Type,
+            is Bar.Type:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+        case is Foo.Type,
+             is Bar.Type:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.sortSwitchCases])
     }
 
     func testSwitchCaseIsDictionaryIndenting() {
-        let input = "switch x {\ncase foo is [Key: Value]:\nfallthrough\ndefault:\nbreak\n}"
-        let output = "switch x {\ncase foo is [Key: Value]:\n    fallthrough\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case foo is [Key: Value]:
+        fallthrough
+        default:
+        break
+        }
+        """
+        let output = """
+        switch x {
+        case foo is [Key: Value]:
+            fallthrough
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testEnumCaseIndenting() {
-        let input = "enum Foo {\ncase Bar\ncase Baz\n}"
-        let output = "enum Foo {\n    case Bar\n    case Baz\n}"
+        let input = """
+        enum Foo {
+        case Bar
+        case Baz
+        }
+        """
+        let output = """
+        enum Foo {
+            case Bar
+            case Baz
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testEnumCaseIndentingCommas() {
-        let input = "enum Foo {\ncase Bar,\nBaz\n}"
+        let input = """
+        enum Foo {
+        case Bar,
+        Baz
+        }
+        """
         let output = """
         enum Foo {
             case Bar,
@@ -541,24 +808,70 @@ class IndentTests: XCTestCase {
     }
 
     func testGenericEnumCaseIndenting() {
-        let input = "enum Foo<T> {\ncase Bar\ncase Baz\n}"
-        let output = "enum Foo<T> {\n    case Bar\n    case Baz\n}"
+        let input = """
+        enum Foo<T> {
+        case Bar
+        case Baz
+        }
+        """
+        let output = """
+        enum Foo<T> {
+            case Bar
+            case Baz
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentSwitchAfterRangeCase() {
-        let input = "switch x {\ncase 0 ..< 2:\n    switch y {\n    default:\n        break\n    }\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case 0 ..< 2:
+            switch y {
+            default:
+                break
+            }
+        default:
+            break
+        }
+        """
         testFormatting(for: input, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentEnumDeclarationInsideSwitchCase() {
-        let input = "switch x {\ncase y:\nenum Foo {\ncase z\n}\nbar()\ndefault: break\n}"
-        let output = "switch x {\ncase y:\n    enum Foo {\n        case z\n    }\n    bar()\ndefault: break\n}"
+        let input = """
+        switch x {
+        case y:
+        enum Foo {
+        case z
+        }
+        bar()
+        default: break
+        }
+        """
+        let output = """
+        switch x {
+        case y:
+            enum Foo {
+                case z
+            }
+            bar()
+        default: break
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIndentEnumCaseBodyAfterWhereClause() {
-        let input = "switch foo {\ncase _ where baz < quux:\n    print(1)\n    print(2)\ndefault:\n    break\n}"
+        let input = """
+        switch foo {
+        case _ where baz < quux:
+            print(1)
+            print(2)
+        default:
+            break
+        }
+        """
         testFormatting(for: input, rule: .indent, exclude: [.blankLineAfterSwitchCase])
     }
 
@@ -637,20 +950,52 @@ class IndentTests: XCTestCase {
     }
 
     func testIndentMultipleSingleLineSwitchCaseCommentsCorrectly() {
-        let input = "switch x {\n// comment 1\n// comment 2\ncase y:\n// comment\nbreak\n}"
-        let output = "switch x {\n// comment 1\n// comment 2\ncase y:\n    // comment\n    break\n}"
+        let input = """
+        switch x {
+        // comment 1
+        // comment 2
+        case y:
+        // comment
+        break
+        }
+        """
+        let output = """
+        switch x {
+        // comment 1
+        // comment 2
+        case y:
+            // comment
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentIfCase() {
-        let input = "{\nif case let .foo(msg) = error {}\n}"
-        let output = "{\n    if case let .foo(msg) = error {}\n}"
+        let input = """
+        {
+        if case let .foo(msg) = error {}
+        }
+        """
+        let output = """
+        {
+            if case let .foo(msg) = error {}
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentGuardCase() {
-        let input = "{\nguard case .Foo = error else {}\n}"
-        let output = "{\n    guard case .Foo = error else {}\n}"
+        let input = """
+        {
+        guard case .Foo = error else {}
+        }
+        """
+        let output = """
+        {
+            guard case .Foo = error else {}
+        }
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.wrapConditionalBodies])
     }
@@ -885,28 +1230,94 @@ class IndentTests: XCTestCase {
     // indentCase = true
 
     func testSwitchCaseWithIndentCaseTrue() {
-        let input = "switch x {\ncase foo:\nbreak\ncase bar:\nbreak\ndefault:\nbreak\n}"
-        let output = "switch x {\n    case foo:\n        break\n    case bar:\n        break\n    default:\n        break\n}"
+        let input = """
+        switch x {
+        case foo:
+        break
+        case bar:
+        break
+        default:
+        break
+        }
+        """
+        let output = """
+        switch x {
+            case foo:
+                break
+            case bar:
+                break
+            default:
+                break
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchWrappedEnumCaseWithIndentCaseTrue() {
-        let input = "switch x {\ncase .foo,\n.bar,\n    .baz:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\n    case .foo,\n         .bar,\n         .baz:\n        break\n    default:\n        break\n}"
+        let input = """
+        switch x {
+        case .foo,
+        .bar,
+            .baz:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+            case .foo,
+                 .bar,
+                 .baz:
+                break
+            default:
+                break
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options, exclude: [.sortSwitchCases])
     }
 
     func testIndentMultilineSwitchCaseCommentsWithIndentCaseTrue() {
-        let input = "switch x {\n/*\n * comment\n */\ncase y:\nbreak\n/*\n * comment\n */\ndefault:\nbreak\n}"
-        let output = "switch x {\n    /*\n     * comment\n     */\n    case y:\n        break\n    /*\n     * comment\n     */\n    default:\n        break\n}"
+        let input = """
+        switch x {
+        /*
+         * comment
+         */
+        case y:
+        break
+        /*
+         * comment
+         */
+        default:
+        break
+        }
+        """
+        let output = """
+        switch x {
+            /*
+             * comment
+             */
+            case y:
+                break
+            /*
+             * comment
+             */
+            default:
+                break
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testNoMangleLabelWhenIndentCaseTrue() {
-        let input = "foo: while true {\n    break foo\n}"
+        let input = """
+        foo: while true {
+            break foo
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, rule: .indent, options: options)
     }
@@ -981,67 +1392,139 @@ class IndentTests: XCTestCase {
     // indent wrapped lines
 
     func testWrappedLineAfterOperator() {
-        let input = "if x {\nlet y = foo +\nbar\n}"
-        let output = "if x {\n    let y = foo +\n        bar\n}"
+        let input = """
+        if x {
+        let y = foo +
+        bar
+        }
+        """
+        let output = """
+        if x {
+            let y = foo +
+                bar
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineAfterComma() {
-        let input = "let a = b,\nb = c"
-        let output = "let a = b,\n    b = c"
+        let input = """
+        let a = b,
+        b = c
+        """
+        let output = """
+        let a = b,
+            b = c
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.singlePropertyPerLine])
     }
 
     func testWrappedBeforeComma() {
-        let input = "let a = b\n, b = c"
-        let output = "let a = b\n    , b = c"
+        let input = """
+        let a = b
+        , b = c
+        """
+        let output = """
+        let a = b
+            , b = c
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.leadingDelimiters, .singlePropertyPerLine])
     }
 
     func testWrappedLineAfterCommaInsideArray() {
-        let input = "[\nfoo,\nbar,\n]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [
+        foo,
+        bar,
+        ]
+        """
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeCommaInsideArray() {
-        let input = "[\nfoo\n, bar,\n]"
-        let output = "[\n    foo\n    , bar,\n]"
+        let input = """
+        [
+        foo
+        , bar,
+        ]
+        """
+        let output = """
+        [
+            foo
+            , bar,
+        ]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options,
                        exclude: [.leadingDelimiters])
     }
 
     func testWrappedLineAfterCommaInsideInlineArray() {
-        let input = "[foo,\nbar]"
-        let output = "[foo,\n bar]"
+        let input = """
+        [foo,
+        bar]
+        """
+        let output = """
+        [foo,
+         bar]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testWrappedLineBeforeCommaInsideInlineArray() {
-        let input = "[foo\n, bar]"
-        let output = "[foo\n , bar]"
+        let input = """
+        [foo
+        , bar]
+        """
+        let output = """
+        [foo
+         , bar]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options,
                        exclude: [.leadingDelimiters])
     }
 
     func testWrappedLineAfterColonInFunction() {
-        let input = "func foo(bar:\nbaz)"
-        let output = "func foo(bar:\n    baz)"
+        let input = """
+        func foo(bar:
+        baz)
+        """
+        let output = """
+        func foo(bar:
+            baz)
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNoDoubleIndentOfWrapAfterAsAfterOpenScope() {
-        let input = "(foo as\nBar)"
-        let output = "(foo as\n    Bar)"
+        let input = """
+        (foo as
+        Bar)
+        """
+        let output = """
+        (foo as
+            Bar)
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
     func testNoDoubleIndentOfWrapBeforeAsAfterOpenScope() {
-        let input = "(foo\nas Bar)"
-        let output = "(foo\n    as Bar)"
+        let input = """
+        (foo
+        as Bar)
+        """
+        let output = """
+        (foo
+            as Bar)
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.redundantParens])
     }
 
@@ -1062,88 +1545,186 @@ class IndentTests: XCTestCase {
     }
 
     func testNoDoubleIndentWhenScopesSeparatedByWrap() {
-        let input = "(foo\nas Bar {\nbaz\n}\n)"
-        let output = "(foo\n    as Bar {\n        baz\n    }\n)"
+        let input = """
+        (foo
+        as Bar {
+        baz
+        }
+        )
+        """
+        let output = """
+        (foo
+            as Bar {
+                baz
+            }
+        )
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.wrapArguments, .redundantParens])
     }
 
     func testNoPermanentReductionInScopeAfterWrap() {
-        let input = "{ foo\nas Bar\nlet baz = 5\n}"
-        let output = "{ foo\n    as Bar\n    let baz = 5\n}"
+        let input = """
+        { foo
+        as Bar
+        let baz = 5
+        }
+        """
+        let output = """
+        { foo
+            as Bar
+            let baz = 5
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeOperator() {
-        let input = "if x {\nlet y = foo\n+ bar\n}"
-        let output = "if x {\n    let y = foo\n        + bar\n}"
+        let input = """
+        if x {
+        let y = foo
+        + bar
+        }
+        """
+        let output = """
+        if x {
+            let y = foo
+                + bar
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeIsOperator() {
-        let input = "if x {\nlet y = foo\nis Bar\n}"
-        let output = "if x {\n    let y = foo\n        is Bar\n}"
+        let input = """
+        if x {
+        let y = foo
+        is Bar
+        }
+        """
+        let output = """
+        if x {
+            let y = foo
+                is Bar
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineAfterForKeyword() {
-        let input = "for\ni in range {}"
-        let output = "for\n    i in range {}"
+        let input = """
+        for
+        i in range {}
+        """
+        let output = """
+        for
+            i in range {}
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineAfterInKeyword() {
-        let input = "for i in\nrange {}"
-        let output = "for i in\n    range {}"
+        let input = """
+        for i in
+        range {}
+        """
+        let output = """
+        for i in
+            range {}
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineAfterDot() {
-        let input = "let foo = bar.\nbaz"
-        let output = "let foo = bar.\n    baz"
+        let input = """
+        let foo = bar.
+        baz
+        """
+        let output = """
+        let foo = bar.
+            baz
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeDot() {
-        let input = "let foo = bar\n.baz"
-        let output = "let foo = bar\n    .baz"
+        let input = """
+        let foo = bar
+        .baz
+        """
+        let output = """
+        let foo = bar
+            .baz
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeWhere() {
-        let input = "let foo = bar\nwhere foo == baz"
-        let output = "let foo = bar\n    where foo == baz"
+        let input = """
+        let foo = bar
+        where foo == baz
+        """
+        let output = """
+        let foo = bar
+            where foo == baz
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineAfterWhere() {
-        let input = "let foo = bar where\nfoo == baz"
-        let output = "let foo = bar where\n    foo == baz"
+        let input = """
+        let foo = bar where
+        foo == baz
+        """
+        let output = """
+        let foo = bar where
+            foo == baz
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineBeforeGuardElse() {
-        let input = "guard let foo = bar\nelse { return }"
+        let input = """
+        guard let foo = bar
+        else { return }
+        """
         testFormatting(for: input, rule: .indent,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testWrappedLineAfterGuardElse() {
         // Don't indent because this case is handled by braces rule
-        let input = "guard let foo = bar else\n{ return }"
+        let input = """
+        guard let foo = bar else
+        { return }
+        """
         testFormatting(for: input, rule: .indent,
                        exclude: [.elseOnSameLine, .wrapConditionalBodies])
     }
 
     func testWrappedLineAfterComment() {
-        let input = "foo = bar && // comment\nbaz"
-        let output = "foo = bar && // comment\n    baz"
+        let input = """
+        foo = bar && // comment
+        baz
+        """
+        let output = """
+        foo = bar && // comment
+            baz
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrappedLineInClosure() {
-        let input = "forEach { item in\nprint(item)\n}"
-        let output = "forEach { item in\n    print(item)\n}"
+        let input = """
+        forEach { item in
+        print(item)
+        }
+        """
+        let output = """
+        forEach { item in
+            print(item)
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -1159,70 +1740,169 @@ class IndentTests: XCTestCase {
     }
 
     func testConsecutiveWraps() {
-        let input = "let a = b +\nc +\nd"
-        let output = "let a = b +\n    c +\n    d"
+        let input = """
+        let a = b +
+        c +
+        d
+        """
+        let output = """
+        let a = b +
+            c +
+            d
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testWrapReset() {
-        let input = "let a = b +\nc +\nd\nlet a = b +\nc +\nd"
-        let output = "let a = b +\n    c +\n    d\nlet a = b +\n    c +\n    d"
+        let input = """
+        let a = b +
+        c +
+        d
+        let a = b +
+        c +
+        d
+        """
+        let output = """
+        let a = b +
+            c +
+            d
+        let a = b +
+            c +
+            d
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentElseAfterComment() {
-        let input = "if x {}\n// comment\nelse {}"
+        let input = """
+        if x {}
+        // comment
+        else {}
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testWrappedLinesWithComments() {
-        let input = "let foo = bar ||\n // baz||\nquux"
-        let output = "let foo = bar ||\n    // baz||\n    quux"
+        let input = """
+        let foo = bar ||
+         // baz||
+        quux
+        """
+        let output = """
+        let foo = bar ||
+            // baz||
+            quux
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNoIndentAfterAssignOperatorToVariable() {
-        let input = "let greaterThan = >\nlet lessThan = <"
+        let input = """
+        let greaterThan = >
+        let lessThan = <
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testNoIndentAfterDefaultAsIdentifier() {
-        let input = "let foo = FileManager.default\n/// Comment\nlet bar = 0"
+        let input = """
+        let foo = FileManager.default
+        /// Comment
+        let bar = 0
+        """
         testFormatting(for: input, rule: .indent, exclude: [.propertyTypes])
     }
 
     func testIndentClosureStartingOnIndentedLine() {
-        let input = "foo\n.bar {\nbaz()\n}"
-        let output = "foo\n    .bar {\n        baz()\n    }"
+        let input = """
+        foo
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        foo
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentClosureStartingOnIndentedLineInVar() {
-        let input = "var foo = foo\n.bar {\nbaz()\n}"
-        let output = "var foo = foo\n    .bar {\n        baz()\n    }"
+        let input = """
+        var foo = foo
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        var foo = foo
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentClosureStartingOnIndentedLineInLet() {
-        let input = "let foo = foo\n.bar {\nbaz()\n}"
-        let output = "let foo = foo\n    .bar {\n        baz()\n    }"
+        let input = """
+        let foo = foo
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        let foo = foo
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentClosureStartingOnIndentedLineInTypedVar() {
-        let input = "var: Int foo = foo\n.bar {\nbaz()\n}"
-        let output = "var: Int foo = foo\n    .bar {\n        baz()\n    }"
+        let input = """
+        var: Int foo = foo
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        var: Int foo = foo
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentClosureStartingOnIndentedLineInTypedLet() {
-        let input = "let: Int foo = foo\n.bar {\nbaz()\n}"
-        let output = "let: Int foo = foo\n    .bar {\n        baz()\n    }"
+        let input = """
+        let: Int foo = foo
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        let: Int foo = foo
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testNestedWrappedIfIndents() {
-        let input = "if foo {\nif bar &&\n(baz ||\nquux) {\nfoo()\n}\n}"
+        let input = """
+        if foo {
+        if bar &&
+        (baz ||
+        quux) {
+        foo()
+        }
+        }
+        """
         let output = """
         if foo {
             if bar &&
@@ -1236,20 +1916,72 @@ class IndentTests: XCTestCase {
     }
 
     func testWrappedEnumThatLooksLikeIf() {
-        let input = "foo &&\n bar.if {\nfoo()\n}"
-        let output = "foo &&\n    bar.if {\n        foo()\n    }"
+        let input = """
+        foo &&
+         bar.if {
+        foo()
+        }
+        """
+        let output = """
+        foo &&
+            bar.if {
+                foo()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testChainedClosureIndents() {
-        let input = "foo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
-        let output = "foo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"
+        let input = """
+        foo
+        .bar {
+        baz()
+        }
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        foo
+            .bar {
+                baz()
+            }
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testChainedClosureIndentsAfterIfCondition() {
-        let input = "if foo {\nbar()\n.baz()\n}\n\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
-        let output = "if foo {\n    bar()\n        .baz()\n}\n\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"
+        let input = """
+        if foo {
+        bar()
+        .baz()
+        }
+
+        foo
+        .bar {
+        baz()
+        }
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        if foo {
+            bar()
+                .baz()
+        }
+
+        foo
+            .bar {
+                baz()
+            }
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -1284,14 +2016,50 @@ class IndentTests: XCTestCase {
     }
 
     func testChainedClosureIndentsAfterVarDeclaration() {
-        let input = "var foo: Int\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
-        let output = "var foo: Int\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"
+        let input = """
+        var foo: Int
+        foo
+        .bar {
+        baz()
+        }
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        var foo: Int
+        foo
+            .bar {
+                baz()
+            }
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testChainedClosureIndentsAfterLetDeclaration() {
-        let input = "let foo: Int\nfoo\n.bar {\nbaz()\n}\n.bar {\nbaz()\n}"
-        let output = "let foo: Int\nfoo\n    .bar {\n        baz()\n    }\n    .bar {\n        baz()\n    }"
+        let input = """
+        let foo: Int
+        foo
+        .bar {
+        baz()
+        }
+        .bar {
+        baz()
+        }
+        """
+        let output = """
+        let foo: Int
+        foo
+            .bar {
+                baz()
+            }
+            .bar {
+                baz()
+            }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -1376,83 +2144,207 @@ class IndentTests: XCTestCase {
     }
 
     func testChainedFunctionsInsideIf() {
-        let input = "if foo {\nreturn bar()\n.baz()\n}"
-        let output = "if foo {\n    return bar()\n        .baz()\n}"
+        let input = """
+        if foo {
+        return bar()
+        .baz()
+        }
+        """
+        let output = """
+        if foo {
+            return bar()
+                .baz()
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testChainedFunctionsInsideForLoop() {
-        let input = "for x in y {\nfoo\n.bar {\nbaz()\n}\n.quux()\n}"
-        let output = "for x in y {\n    foo\n        .bar {\n            baz()\n        }\n        .quux()\n}"
+        let input = """
+        for x in y {
+        foo
+        .bar {
+        baz()
+        }
+        .quux()
+        }
+        """
+        let output = """
+        for x in y {
+            foo
+                .bar {
+                    baz()
+                }
+                .quux()
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testChainedFunctionsAfterAnIfStatement() {
-        let input = "if foo {}\nbar\n.baz {\n}\n.quux()"
-        let output = "if foo {}\nbar\n    .baz {\n    }\n    .quux()"
+        let input = """
+        if foo {}
+        bar
+        .baz {
+        }
+        .quux()
+        """
+        let output = """
+        if foo {}
+        bar
+            .baz {
+            }
+            .quux()
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.emptyBraces])
     }
 
     func testIndentInsideWrappedIfStatementWithClosureCondition() {
-        let input = "if foo({ 1 }) ||\nbar {\nbaz()\n}"
-        let output = "if foo({ 1 }) ||\n    bar {\n    baz()\n}"
+        let input = """
+        if foo({ 1 }) ||
+        bar {
+        baz()
+        }
+        """
+        let output = """
+        if foo({ 1 }) ||
+            bar {
+            baz()
+        }
+        """
         testFormatting(for: input, output, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedClassDefinition() {
-        let input = "class Foo\n: Bar {\nbaz()\n}"
-        let output = "class Foo\n    : Bar {\n    baz()\n}"
+        let input = """
+        class Foo
+        : Bar {
+        baz()
+        }
+        """
+        let output = """
+        class Foo
+            : Bar {
+            baz()
+        }
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.leadingDelimiters, .wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedProtocolDefinition() {
-        let input = "protocol Foo\n: Bar, Baz {\nbaz()\n}"
-        let output = "protocol Foo\n    : Bar, Baz {\n    baz()\n}"
+        let input = """
+        protocol Foo
+        : Bar, Baz {
+        baz()
+        }
+        """
+        let output = """
+        protocol Foo
+            : Bar, Baz {
+            baz()
+        }
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.leadingDelimiters, .wrapMultilineStatementBraces])
     }
 
     func testIndentInsideWrappedVarStatement() {
-        let input = "var Foo:\nBar {\nreturn 5\n}"
-        let output = "var Foo:\n    Bar {\n    return 5\n}"
+        let input = """
+        var Foo:
+        Bar {
+        return 5
+        }
+        """
+        let output = """
+        var Foo:
+            Bar {
+            return 5
+        }
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.wrapMultilineStatementBraces])
     }
 
     func testNoIndentAfterOperatorDeclaration() {
-        let input = "infix operator ?=\nfunc ?= (lhs _: Int, rhs _: Int) -> Bool {}"
+        let input = """
+        infix operator ?=
+        func ?= (lhs _: Int, rhs _: Int) -> Bool {}
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testNoIndentAfterChevronOperatorDeclaration() {
-        let input = "infix operator =<<\nfunc =<< <T>(lhs _: T, rhs _: T) -> T {}"
+        let input = """
+        infix operator =<<
+        func =<< <T>(lhs _: T, rhs _: T) -> T {}
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testIndentWrappedStringDictionaryKeysAndValues() {
-        let input = "[\n\"foo\":\n\"bar\",\n\"baz\":\n\"quux\",\n]"
-        let output = "[\n    \"foo\":\n        \"bar\",\n    \"baz\":\n        \"quux\",\n]"
+        let input = """
+        [
+        \"foo\":
+        \"bar\",
+        \"baz\":
+        \"quux\",
+        ]
+        """
+        let output = """
+        [
+            \"foo\":
+                \"bar\",
+            \"baz\":
+                \"quux\",
+        ]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIndentWrappedEnumDictionaryKeysAndValues() {
-        let input = "[\n.foo:\n.bar,\n.baz:\n.quux,\n]"
-        let output = "[\n    .foo:\n        .bar,\n    .baz:\n        .quux,\n]"
+        let input = """
+        [
+        .foo:
+        .bar,
+        .baz:
+        .quux,
+        ]
+        """
+        let output = """
+        [
+            .foo:
+                .bar,
+            .baz:
+                .quux,
+        ]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIndentWrappedFunctionArgument() {
-        let input = "foobar(baz: a &&\nb)"
-        let output = "foobar(baz: a &&\n    b)"
+        let input = """
+        foobar(baz: a &&
+        b)
+        """
+        let output = """
+        foobar(baz: a &&
+            b)
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentWrappedFunctionClosureArgument() {
-        let input = "foobar(baz: { a &&\nb })"
-        let output = "foobar(baz: { a &&\n        b })"
+        let input = """
+        foobar(baz: { a &&
+        b })
+        """
+        let output = """
+        foobar(baz: { a &&
+                b })
+        """
         testFormatting(for: input, output, rule: .indent,
                        exclude: [.trailingClosures, .braces])
     }
@@ -1469,7 +2361,11 @@ class IndentTests: XCTestCase {
     }
 
     func testIndentClassDeclarationContainingComment() {
-        let input = "class Foo: Bar,\n    // Comment\n    Baz {}"
+        let input = """
+        class Foo: Bar,
+            // Comment
+            Baz {}
+        """
         testFormatting(for: input, rule: .indent)
     }
 
@@ -2384,20 +3280,40 @@ class IndentTests: XCTestCase {
     // indent comments
 
     func testCommentIndenting() {
-        let input = "/* foo\nbar */"
-        let output = "/* foo\n bar */"
+        let input = """
+        /* foo
+        bar */
+        """
+        let output = """
+        /* foo
+         bar */
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testCommentIndentingWithTrailingClose() {
-        let input = "/*\nfoo\n*/"
-        let output = "/*\n foo\n */"
+        let input = """
+        /*
+        foo
+        */
+        """
+        let output = """
+        /*
+         foo
+         */
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testCommentIndentingWithTrailingClose2() {
-        let input = "/* foo\n*/"
-        let output = "/* foo\n */"
+        let input = """
+        /* foo
+        */
+        """
+        let output = """
+        /* foo
+         */
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -2440,12 +3356,20 @@ class IndentTests: XCTestCase {
     }
 
     func testCommentedCodeBlocksNotIndented() {
-        let input = "func foo() {\n//    var foo: Int\n}"
+        let input = """
+        func foo() {
+        //    var foo: Int
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testBlankCodeCommentBlockLinesNotIndented() {
-        let input = "func foo() {\n//\n}"
+        let input = """
+        func foo() {
+        //
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
@@ -2486,18 +3410,42 @@ class IndentTests: XCTestCase {
     // indent multiline strings
 
     func testSimpleMultilineString() {
-        let input = "\"\"\"\n    hello\n    world\n\"\"\""
+        let input = """
+        \"\"\"
+            hello
+            world
+        \"\"\"
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testIndentIndentedSimpleMultilineString() {
-        let input = "{\n\"\"\"\n    hello\n    world\n    \"\"\"\n}"
-        let output = "{\n    \"\"\"\n    hello\n    world\n    \"\"\"\n}"
+        let input = """
+        {
+        \"\"\"
+            hello
+            world
+            \"\"\"
+        }
+        """
+        let output = """
+        {
+            \"\"\"
+            hello
+            world
+            \"\"\"
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testMultilineStringWithEscapedLinebreak() {
-        let input = "\"\"\"\n    hello \\n    world\n\"\"\""
+        let input = """
+        \"\"\"
+            hello \
+            world
+        \"\"\"
+        """
         testFormatting(for: input, rule: .indent)
     }
 
@@ -2820,8 +3768,22 @@ class IndentTests: XCTestCase {
     // indent multiline raw strings
 
     func testIndentIndentedSimpleRawMultilineString() {
-        let input = "{\n##\"\"\"\n    hello\n    world\n    \"\"\"##\n}"
-        let output = "{\n    ##\"\"\"\n    hello\n    world\n    \"\"\"##\n}"
+        let input = """
+        {
+        ##\"\"\"
+            hello
+            world
+            \"\"\"##
+        }
+        """
+        let output = """
+        {
+            ##\"\"\"
+            hello
+            world
+            \"\"\"##
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
@@ -2951,82 +3913,260 @@ class IndentTests: XCTestCase {
     // indent #if/#else/#elseif/#endif (mode: indent)
 
     func testIfEndifIndenting() {
-        let input = "#if x\n// foo\n#endif"
-        let output = "#if x\n    // foo\n#endif"
+        let input = """
+        #if x
+        // foo
+        #endif
+        """
+        let output = """
+        #if x
+            // foo
+        #endif
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIndentedIfEndifIndenting() {
-        let input = "{\n#if x\n// foo\nfoo()\n#endif\n}"
-        let output = "{\n    #if x\n        // foo\n        foo()\n    #endif\n}"
+        let input = """
+        {
+        #if x
+        // foo
+        foo()
+        #endif
+        }
+        """
+        let output = """
+        {
+            #if x
+                // foo
+                foo()
+            #endif
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testIfElseEndifIndenting() {
-        let input = "#if x\n    // foo\nfoo()\n#else\n    // bar\n#endif"
-        let output = "#if x\n    // foo\n    foo()\n#else\n    // bar\n#endif"
+        let input = """
+        #if x
+            // foo
+        foo()
+        #else
+            // bar
+        #endif
+        """
+        let output = """
+        #if x
+            // foo
+            foo()
+        #else
+            // bar
+        #endif
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testEnumIfCaseEndifIndenting() {
-        let input = "enum Foo {\ncase bar\n#if x\ncase baz\n#endif\n}"
-        let output = "enum Foo {\n    case bar\n    #if x\n        case baz\n    #endif\n}"
+        let input = """
+        enum Foo {
+        case bar
+        #if x
+        case baz
+        #endif
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar
+            #if x
+                case baz
+            #endif
+        }
+        """
         let options = FormatOptions(indentCase: false)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseEndifIndenting() {
-        let input = "switch foo {\ncase .bar: break\n#if x\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\ncase .bar: break\n#if x\n    case .baz: break\n#endif\n}"
+        let input = """
+        switch foo {
+        case .bar: break
+        #if x
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+        case .bar: break
+        #if x
+            case .baz: break
+        #endif
+        }
+        """
         let options = FormatOptions(indentCase: false)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseEndifIndenting2() {
-        let input = "switch foo {\ncase .bar: break\n#if x\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\n    case .bar: break\n    #if x\n        case .baz: break\n    #endif\n}"
+        let input = """
+        switch foo {
+        case .bar: break
+        #if x
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+            case .bar: break
+            #if x
+                case .baz: break
+            #endif
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseEndifIndenting3() {
-        let input = "switch foo {\n#if x\ncase .bar: break\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\n#if x\n    case .bar: break\n    case .baz: break\n#endif\n}"
+        let input = """
+        switch foo {
+        #if x
+        case .bar: break
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+        #if x
+            case .bar: break
+            case .baz: break
+        #endif
+        }
+        """
         let options = FormatOptions(indentCase: false)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseEndifIndenting4() {
-        let input = "switch foo {\n#if x\ncase .bar:\nbreak\ncase .baz:\nbreak\n#endif\n}"
-        let output = "switch foo {\n    #if x\n        case .bar:\n            break\n        case .baz:\n            break\n    #endif\n}"
+        let input = """
+        switch foo {
+        #if x
+        case .bar:
+        break
+        case .baz:
+        break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+            #if x
+                case .bar:
+                    break
+                case .baz:
+                    break
+            #endif
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseElseCaseEndifIndenting() {
-        let input = "switch foo {\n#if x\ncase .bar: break\n#else\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\n#if x\n    case .bar: break\n#else\n    case .baz: break\n#endif\n}"
+        let input = """
+        switch foo {
+        #if x
+        case .bar: break
+        #else
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+        #if x
+            case .bar: break
+        #else
+            case .baz: break
+        #endif
+        }
+        """
         let options = FormatOptions(indentCase: false)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfCaseElseCaseEndifIndenting2() {
-        let input = "switch foo {\n#if x\ncase .bar: break\n#else\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\n    #if x\n        case .bar: break\n    #else\n        case .baz: break\n    #endif\n}"
+        let input = """
+        switch foo {
+        #if x
+        case .bar: break
+        #else
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+            #if x
+                case .bar: break
+            #else
+                case .baz: break
+            #endif
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testSwitchIfEndifInsideCaseIndenting() {
-        let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
-        let output = "switch foo {\ncase .bar:\n    #if x\n        bar()\n    #endif\n    baz()\ncase .baz: break\n}"
+        let input = """
+        switch foo {
+        case .bar:
+        #if x
+        bar()
+        #endif
+        baz()
+        case .baz: break
+        }
+        """
+        let output = """
+        switch foo {
+        case .bar:
+            #if x
+                bar()
+            #endif
+            baz()
+        case .baz: break
+        }
+        """
         let options = FormatOptions(indentCase: false)
         testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testSwitchIfEndifInsideCaseIndenting2() {
-        let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
-        let output = "switch foo {\n    case .bar:\n        #if x\n            bar()\n        #endif\n        baz()\n    case .baz: break\n}"
+        let input = """
+        switch foo {
+        case .bar:
+        #if x
+        bar()
+        #endif
+        baz()
+        case .baz: break
+        }
+        """
+        let output = """
+        switch foo {
+            case .bar:
+                #if x
+                    bar()
+                #endif
+                baz()
+            case .baz: break
+        }
+        """
         let options = FormatOptions(indentCase: true)
         testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
@@ -3202,33 +4342,76 @@ class IndentTests: XCTestCase {
     // indent #if/#else/#elseif/#endif (mode: noindent)
 
     func testIfEndifNoIndenting() {
-        let input = "#if x\n// foo\n#endif"
+        let input = """
+        #if x
+        // foo
+        #endif
+        """
         let options = FormatOptions(ifdefIndent: .noIndent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIndentedIfEndifNoIndenting() {
-        let input = "{\n#if x\n// foo\n#endif\n}"
-        let output = "{\n    #if x\n    // foo\n    #endif\n}"
+        let input = """
+        {
+        #if x
+        // foo
+        #endif
+        }
+        """
+        let output = """
+        {
+            #if x
+            // foo
+            #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .noIndent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIfElseEndifNoIndenting() {
-        let input = "#if x\n// foo\n#else\n// bar\n#endif"
+        let input = """
+        #if x
+        // foo
+        #else
+        // bar
+        #endif
+        """
         let options = FormatOptions(ifdefIndent: .noIndent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIfCaseEndifNoIndenting() {
-        let input = "switch foo {\ncase .bar: break\n#if x\ncase .baz: break\n#endif\n}"
+        let input = """
+        switch foo {
+        case .bar: break
+        #if x
+        case .baz: break
+        #endif
+        }
+        """
         let options = FormatOptions(indentCase: false, ifdefIndent: .noIndent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIfCaseEndifNoIndenting2() {
-        let input = "switch foo {\ncase .bar: break\n#if x\ncase .baz: break\n#endif\n}"
-        let output = "switch foo {\n    case .bar: break\n    #if x\n    case .baz: break\n    #endif\n}"
+        let input = """
+        switch foo {
+        case .bar: break
+        #if x
+        case .baz: break
+        #endif
+        }
+        """
+        let output = """
+        switch foo {
+            case .bar: break
+            #if x
+            case .baz: break
+            #endif
+        }
+        """
         let options = FormatOptions(indentCase: true, ifdefIndent: .noIndent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
@@ -3260,15 +4443,51 @@ class IndentTests: XCTestCase {
     }
 
     func testIfEndifInsideCaseNoIndenting() {
-        let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
-        let output = "switch foo {\ncase .bar:\n    #if x\n    bar()\n    #endif\n    baz()\ncase .baz: break\n}"
+        let input = """
+        switch foo {
+        case .bar:
+        #if x
+        bar()
+        #endif
+        baz()
+        case .baz: break
+        }
+        """
+        let output = """
+        switch foo {
+        case .bar:
+            #if x
+            bar()
+            #endif
+            baz()
+        case .baz: break
+        }
+        """
         let options = FormatOptions(indentCase: false, ifdefIndent: .noIndent)
         testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
 
     func testIfEndifInsideCaseNoIndenting2() {
-        let input = "switch foo {\ncase .bar:\n#if x\nbar()\n#endif\nbaz()\ncase .baz: break\n}"
-        let output = "switch foo {\n    case .bar:\n        #if x\n        bar()\n        #endif\n        baz()\n    case .baz: break\n}"
+        let input = """
+        switch foo {
+        case .bar:
+        #if x
+        bar()
+        #endif
+        baz()
+        case .baz: break
+        }
+        """
+        let output = """
+        switch foo {
+            case .bar:
+                #if x
+                bar()
+                #endif
+                baz()
+            case .baz: break
+        }
+        """
         let options = FormatOptions(indentCase: true, ifdefIndent: .noIndent)
         testFormatting(for: input, output, rule: .indent, options: options, exclude: [.blankLineAfterSwitchCase])
     }
@@ -3431,60 +4650,179 @@ class IndentTests: XCTestCase {
     // indent #if/#else/#elseif/#endif (mode: outdent)
 
     func testIfEndifOutdenting() {
-        let input = "#if x\n// foo\n#endif"
+        let input = """
+        #if x
+        // foo
+        #endif
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIndentedIfEndifOutdenting() {
-        let input = "{\n#if x\n// foo\n#endif\n}"
-        let output = "{\n#if x\n    // foo\n#endif\n}"
+        let input = """
+        {
+        #if x
+        // foo
+        #endif
+        }
+        """
+        let output = """
+        {
+        #if x
+            // foo
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIfElseEndifOutdenting() {
-        let input = "#if x\n// foo\n#else\n// bar\n#endif"
+        let input = """
+        #if x
+        // foo
+        #else
+        // bar
+        #endif
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIndentedIfElseEndifOutdenting() {
-        let input = "{\n#if x\n// foo\nfoo()\n#else\n// bar\n#endif\n}"
-        let output = "{\n#if x\n    // foo\n    foo()\n#else\n    // bar\n#endif\n}"
+        let input = """
+        {
+        #if x
+        // foo
+        foo()
+        #else
+        // bar
+        #endif
+        }
+        """
+        let output = """
+        {
+        #if x
+            // foo
+            foo()
+        #else
+            // bar
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIfElseifEndifOutdenting() {
-        let input = "#if x\n// foo\n#elseif y\n// bar\n#endif"
+        let input = """
+        #if x
+        // foo
+        #elseif y
+        // bar
+        #endif
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIndentedIfElseifEndifOutdenting() {
-        let input = "{\n#if x\n// foo\nfoo()\n#elseif y\n// bar\n#endif\n}"
-        let output = "{\n#if x\n    // foo\n    foo()\n#elseif y\n    // bar\n#endif\n}"
+        let input = """
+        {
+        #if x
+        // foo
+        foo()
+        #elseif y
+        // bar
+        #endif
+        }
+        """
+        let output = """
+        {
+        #if x
+            // foo
+            foo()
+        #elseif y
+            // bar
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testNestedIndentedIfElseifEndifOutdenting() {
-        let input = "{\n#if x\n#if y\n// foo\nfoo()\n#elseif y\n// bar\n#endif\n#endif\n}"
-        let output = "{\n#if x\n#if y\n    // foo\n    foo()\n#elseif y\n    // bar\n#endif\n#endif\n}"
+        let input = """
+        {
+        #if x
+        #if y
+        // foo
+        foo()
+        #elseif y
+        // bar
+        #endif
+        #endif
+        }
+        """
+        let output = """
+        {
+        #if x
+        #if y
+            // foo
+            foo()
+        #elseif y
+            // bar
+        #endif
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testDoubleNestedIndentedIfElseifEndifOutdenting() {
-        let input = "{\n#if x\n#if y\n#if z\n// foo\nfoo()\n#elseif y\n// bar\n#endif\n#endif\n#endif\n}"
-        let output = "{\n#if x\n#if y\n#if z\n    // foo\n    foo()\n#elseif y\n    // bar\n#endif\n#endif\n#endif\n}"
+        let input = """
+        {
+        #if x
+        #if y
+        #if z
+        // foo
+        foo()
+        #elseif y
+        // bar
+        #endif
+        #endif
+        #endif
+        }
+        """
+        let output = """
+        {
+        #if x
+        #if y
+        #if z
+            // foo
+            foo()
+        #elseif y
+            // bar
+        #endif
+        #endif
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIfCaseEndifOutdenting() {
-        let input = "switch foo {\ncase .bar: break\n#if x\ncase .baz: break\n#endif\n}"
+        let input = """
+        switch foo {
+        case .bar: break
+        #if x
+        case .baz: break
+        #endif
+        }
+        """
         let options = FormatOptions(ifdefIndent: .outdent)
         testFormatting(for: input, rule: .indent, options: options)
     }
@@ -3573,85 +4911,191 @@ class IndentTests: XCTestCase {
     // indent expression after return
 
     func testIndentIdentifierAfterReturn() {
-        let input = "if foo {\n    return\n        bar\n}"
+        let input = """
+        if foo {
+            return
+                bar
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testIndentEnumValueAfterReturn() {
-        let input = "if foo {\n    return\n        .bar\n}"
+        let input = """
+        if foo {
+            return
+                .bar
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testIndentMultilineExpressionAfterReturn() {
-        let input = "if foo {\n    return\n        bar +\n        baz\n}"
+        let input = """
+        if foo {
+            return
+                bar +
+                baz
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testDontIndentClosingBraceAfterReturn() {
-        let input = "if foo {\n    return\n}"
+        let input = """
+        if foo {
+            return
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testDontIndentCaseAfterReturn() {
-        let input = "switch foo {\ncase bar:\n    return\ncase baz:\n    return\n}"
+        let input = """
+        switch foo {
+        case bar:
+            return
+        case baz:
+            return
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testDontIndentCaseAfterWhere() {
-        let input = "switch foo {\ncase bar\nwhere baz:\nreturn\ndefault:\nreturn\n}"
-        let output = "switch foo {\ncase bar\n    where baz:\n    return\ndefault:\n    return\n}"
+        let input = """
+        switch foo {
+        case bar
+        where baz:
+        return
+        default:
+        return
+        }
+        """
+        let output = """
+        switch foo {
+        case bar
+            where baz:
+            return
+        default:
+            return
+        }
+        """
         testFormatting(for: input, output, rule: .indent)
     }
 
     func testDontIndentIfAfterReturn() {
-        let input = "if foo {\n    return\n    if bar {}\n}"
+        let input = """
+        if foo {
+            return
+            if bar {}
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     func testDontIndentFuncAfterReturn() {
-        let input = "if foo {\n    return\n    func bar() {}\n}"
+        let input = """
+        if foo {
+            return
+            func bar() {}
+        }
+        """
         testFormatting(for: input, rule: .indent)
     }
 
     // indent fragments
 
     func testIndentFragment() {
-        let input = "   func foo() {\nbar()\n}"
-        let output = "   func foo() {\n       bar()\n   }"
+        let input = """
+           func foo() {
+        bar()
+        }
+        """
+        let output = """
+           func foo() {
+               bar()
+           }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIndentFragmentAfterBlankLines() {
-        let input = "\n\n   func foo() {\nbar()\n}"
-        let output = "\n\n   func foo() {\n       bar()\n   }"
+        let input = """
+
+
+           func foo() {
+        bar()
+        }
+        """
+        let output = """
+
+
+           func foo() {
+               bar()
+           }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testUnterminatedFragment() {
-        let input = "class Foo {\n\n  func foo() {\nbar()\n}"
-        let output = "class Foo {\n\n    func foo() {\n        bar()\n    }"
+        let input = """
+        class Foo {
+
+          func foo() {
+        bar()
+        }
+        """
+        let output = """
+        class Foo {
+
+            func foo() {
+                bar()
+            }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .indent, options: options,
                        exclude: [.blankLinesAtStartOfScope])
     }
 
     func testOverTerminatedFragment() {
-        let input = "   func foo() {\nbar()\n}\n\n}"
-        let output = "   func foo() {\n       bar()\n   }\n\n}"
+        let input = """
+           func foo() {
+        bar()
+        }
+
+        }
+        """
+        let output = """
+           func foo() {
+               bar()
+           }
+
+        }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testDontCorruptPartialFragment() {
-        let input = "    } foo {\n        bar\n    }\n}"
+        let input = """
+            } foo {
+                bar
+            }
+        }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testDontCorruptPartialFragment2() {
-        let input = "        return completionHandler(nil)\n    }\n}"
+        let input = """
+                return completionHandler(nil)
+            }
+        }
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .indent, options: options)
     }

--- a/Tests/Rules/IsEmptyTests.swift
+++ b/Tests/Rules/IsEmptyTests.swift
@@ -13,147 +13,243 @@ class IsEmptyTests: XCTestCase {
     // count == 0
 
     func testCountEqualsZero() {
-        let input = "if foo.count == 0 {}"
-        let output = "if foo.isEmpty {}"
+        let input = """
+        if foo.count == 0 {}
+        """
+        let output = """
+        if foo.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testFunctionCountEqualsZero() {
-        let input = "if foo().count == 0 {}"
-        let output = "if foo().isEmpty {}"
+        let input = """
+        if foo().count == 0 {}
+        """
+        let output = """
+        if foo().isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testExpressionCountEqualsZero() {
-        let input = "if foo || bar.count == 0 {}"
-        let output = "if foo || bar.isEmpty {}"
+        let input = """
+        if foo || bar.count == 0 {}
+        """
+        let output = """
+        if foo || bar.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCompoundIfCountEqualsZero() {
-        let input = "if foo, bar.count == 0 {}"
-        let output = "if foo, bar.isEmpty {}"
+        let input = """
+        if foo, bar.count == 0 {}
+        """
+        let output = """
+        if foo, bar.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testOptionalCountEqualsZero() {
-        let input = "if foo?.count == 0 {}"
-        let output = "if foo?.isEmpty == true {}"
+        let input = """
+        if foo?.count == 0 {}
+        """
+        let output = """
+        if foo?.isEmpty == true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testOptionalChainCountEqualsZero() {
-        let input = "if foo?.bar.count == 0 {}"
-        let output = "if foo?.bar.isEmpty == true {}"
+        let input = """
+        if foo?.bar.count == 0 {}
+        """
+        let output = """
+        if foo?.bar.isEmpty == true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCompoundIfOptionalCountEqualsZero() {
-        let input = "if foo, bar?.count == 0 {}"
-        let output = "if foo, bar?.isEmpty == true {}"
+        let input = """
+        if foo, bar?.count == 0 {}
+        """
+        let output = """
+        if foo, bar?.isEmpty == true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testTernaryCountEqualsZero() {
-        let input = "foo ? bar.count == 0 : baz.count == 0"
-        let output = "foo ? bar.isEmpty : baz.isEmpty"
+        let input = """
+        foo ? bar.count == 0 : baz.count == 0
+        """
+        let output = """
+        foo ? bar.isEmpty : baz.isEmpty
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     // count != 0
 
     func testCountNotEqualToZero() {
-        let input = "if foo.count != 0 {}"
-        let output = "if !foo.isEmpty {}"
+        let input = """
+        if foo.count != 0 {}
+        """
+        let output = """
+        if !foo.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testFunctionCountNotEqualToZero() {
-        let input = "if foo().count != 0 {}"
-        let output = "if !foo().isEmpty {}"
+        let input = """
+        if foo().count != 0 {}
+        """
+        let output = """
+        if !foo().isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testExpressionCountNotEqualToZero() {
-        let input = "if foo || bar.count != 0 {}"
-        let output = "if foo || !bar.isEmpty {}"
+        let input = """
+        if foo || bar.count != 0 {}
+        """
+        let output = """
+        if foo || !bar.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCompoundIfCountNotEqualToZero() {
-        let input = "if foo, bar.count != 0 {}"
-        let output = "if foo, !bar.isEmpty {}"
+        let input = """
+        if foo, bar.count != 0 {}
+        """
+        let output = """
+        if foo, !bar.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     // count > 0
 
     func testCountGreaterThanZero() {
-        let input = "if foo.count > 0 {}"
-        let output = "if !foo.isEmpty {}"
+        let input = """
+        if foo.count > 0 {}
+        """
+        let output = """
+        if !foo.isEmpty {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountExpressionGreaterThanZero() {
-        let input = "if a.count - b.count > 0 {}"
+        let input = """
+        if a.count - b.count > 0 {}
+        """
         testFormatting(for: input, rule: .isEmpty)
     }
 
     // optional count
 
     func testOptionalCountNotEqualToZero() {
-        let input = "if foo?.count != 0 {}" // nil evaluates to true
-        let output = "if foo?.isEmpty != true {}"
+        let input = """
+        if foo?.count != 0 {}
+        """ // nil evaluates to true
+        let output = """
+        if foo?.isEmpty != true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testOptionalChainCountNotEqualToZero() {
-        let input = "if foo?.bar.count != 0 {}" // nil evaluates to true
-        let output = "if foo?.bar.isEmpty != true {}"
+        let input = """
+        if foo?.bar.count != 0 {}
+        """ // nil evaluates to true
+        let output = """
+        if foo?.bar.isEmpty != true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCompoundIfOptionalCountNotEqualToZero() {
-        let input = "if foo, bar?.count != 0 {}"
-        let output = "if foo, bar?.isEmpty != true {}"
+        let input = """
+        if foo, bar?.count != 0 {}
+        """
+        let output = """
+        if foo, bar?.isEmpty != true {}
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     // edge cases
 
     func testTernaryCountNotEqualToZero() {
-        let input = "foo ? bar.count != 0 : baz.count != 0"
-        let output = "foo ? !bar.isEmpty : !baz.isEmpty"
+        let input = """
+        foo ? bar.count != 0 : baz.count != 0
+        """
+        let output = """
+        foo ? !bar.isEmpty : !baz.isEmpty
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountEqualsZeroAfterOptionalOnPreviousLine() {
-        let input = "_ = foo?.bar\nbar.count == 0 ? baz() : quux()"
-        let output = "_ = foo?.bar\nbar.isEmpty ? baz() : quux()"
+        let input = """
+        _ = foo?.bar
+        bar.count == 0 ? baz() : quux()
+        """
+        let output = """
+        _ = foo?.bar
+        bar.isEmpty ? baz() : quux()
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountEqualsZeroAfterOptionalCallOnPreviousLine() {
-        let input = "foo?.bar()\nbar.count == 0 ? baz() : quux()"
-        let output = "foo?.bar()\nbar.isEmpty ? baz() : quux()"
+        let input = """
+        foo?.bar()
+        bar.count == 0 ? baz() : quux()
+        """
+        let output = """
+        foo?.bar()
+        bar.isEmpty ? baz() : quux()
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountEqualsZeroAfterTrailingCommentOnPreviousLine() {
-        let input = "foo?.bar() // foobar\nbar.count == 0 ? baz() : quux()"
-        let output = "foo?.bar() // foobar\nbar.isEmpty ? baz() : quux()"
+        let input = """
+        foo?.bar() // foobar
+        bar.count == 0 ? baz() : quux()
+        """
+        let output = """
+        foo?.bar() // foobar
+        bar.isEmpty ? baz() : quux()
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountGreaterThanZeroAfterOpenParen() {
-        let input = "foo(bar.count > 0)"
-        let output = "foo(!bar.isEmpty)"
+        let input = """
+        foo(bar.count > 0)
+        """
+        let output = """
+        foo(!bar.isEmpty)
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 
     func testCountGreaterThanZeroAfterArgumentLabel() {
-        let input = "foo(bar: baz.count > 0)"
-        let output = "foo(bar: !baz.isEmpty)"
+        let input = """
+        foo(bar: baz.count > 0)
+        """
+        let output = """
+        foo(bar: !baz.isEmpty)
+        """
         testFormatting(for: input, output, rule: .isEmpty)
     }
 }

--- a/Tests/Rules/LinebreakAtEndOfFileTests.swift
+++ b/Tests/Rules/LinebreakAtEndOfFileTests.swift
@@ -11,13 +11,23 @@ import XCTest
 
 class LinebreakAtEndOfFileTests: XCTestCase {
     func testLinebreakAtEndOfFile() {
-        let input = "foo\nbar"
-        let output = "foo\nbar\n"
+        let input = """
+        foo
+        bar
+        """
+        let output = """
+        foo
+        bar
+
+        """
         testFormatting(for: input, output, rule: .linebreakAtEndOfFile)
     }
 
     func testNoLinebreakAtEndOfFragment() {
-        let input = "foo\nbar"
+        let input = """
+        foo
+        bar
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, rule: .linebreakAtEndOfFile, options: options)
     }

--- a/Tests/Rules/LinebreaksTests.swift
+++ b/Tests/Rules/LinebreaksTests.swift
@@ -11,26 +11,47 @@ import XCTest
 
 class LinebreaksTests: XCTestCase {
     func testCarriageReturn() {
-        let input = "foo\rbar"
-        let output = "foo\nbar"
+        let input = """
+        foo\rbar
+        """
+        let output = """
+        foo
+        bar
+        """
         testFormatting(for: input, output, rule: .linebreaks)
     }
 
     func testCarriageReturnLinefeed() {
-        let input = "foo\r\nbar"
-        let output = "foo\nbar"
+        let input = """
+        foo\r
+        bar
+        """
+        let output = """
+        foo
+        bar
+        """
         testFormatting(for: input, output, rule: .linebreaks)
     }
 
     func testVerticalTab() {
-        let input = "foo\u{000B}bar"
-        let output = "foo\nbar"
+        let input = """
+        foo\u{000B}bar
+        """
+        let output = """
+        foo
+        bar
+        """
         testFormatting(for: input, output, rule: .linebreaks)
     }
 
     func testFormfeed() {
-        let input = "foo\u{000C}bar"
-        let output = "foo\nbar"
+        let input = """
+        foo\u{000C}bar
+        """
+        let output = """
+        foo
+        bar
+        """
         testFormatting(for: input, output, rule: .linebreaks)
     }
 }

--- a/Tests/Rules/ModifierOrderTests.swift
+++ b/Tests/Rules/ModifierOrderTests.swift
@@ -11,77 +11,125 @@ import XCTest
 
 class ModifierOrderTests: XCTestCase {
     func testVarModifiersCorrected() {
-        let input = "unowned private static var foo"
-        let output = "private unowned static var foo"
+        let input = """
+        unowned private static var foo
+        """
+        let output = """
+        private unowned static var foo
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .modifierOrder, options: options)
     }
 
     func testPrivateSetModifierNotMangled() {
-        let input = "private(set) public weak lazy var foo"
-        let output = "public private(set) lazy weak var foo"
+        let input = """
+        private(set) public weak lazy var foo
+        """
+        let output = """
+        public private(set) lazy weak var foo
+        """
         testFormatting(for: input, output, rule: .modifierOrder)
     }
 
     func testUnownedUnsafeModifierNotMangled() {
-        let input = "unowned(unsafe) lazy var foo"
-        let output = "lazy unowned(unsafe) var foo"
+        let input = """
+        unowned(unsafe) lazy var foo
+        """
+        let output = """
+        lazy unowned(unsafe) var foo
+        """
         testFormatting(for: input, output, rule: .modifierOrder)
     }
 
     func testPrivateRequiredStaticFuncModifiers() {
-        let input = "required static private func foo()"
-        let output = "private required static func foo()"
+        let input = """
+        required static private func foo()
+        """
+        let output = """
+        private required static func foo()
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .modifierOrder, options: options)
     }
 
     func testPrivateConvenienceInit() {
-        let input = "convenience private init()"
-        let output = "private convenience init()"
+        let input = """
+        convenience private init()
+        """
+        let output = """
+        private convenience init()
+        """
         testFormatting(for: input, output, rule: .modifierOrder)
     }
 
     func testSpaceInModifiersLeftIntact() {
-        let input = "weak private(set) /* read-only */\npublic var"
-        let output = "public private(set) /* read-only */\nweak var"
+        let input = """
+        weak private(set) /* read-only */
+        public var
+        """
+        let output = """
+        public private(set) /* read-only */
+        weak var
+        """
         testFormatting(for: input, output, rule: .modifierOrder)
     }
 
     func testSpaceInModifiersLeftIntact2() {
-        let input = "nonisolated(unsafe) public var foo: String"
-        let output = "public nonisolated(unsafe) var foo: String"
+        let input = """
+        nonisolated(unsafe) public var foo: String
+        """
+        let output = """
+        public nonisolated(unsafe) var foo: String
+        """
         testFormatting(for: input, output, rule: .modifierOrder)
     }
 
     func testPrefixModifier() {
-        let input = "prefix public static func - (rhs: Foo) -> Foo"
-        let output = "public static prefix func - (rhs: Foo) -> Foo"
+        let input = """
+        prefix public static func - (rhs: Foo) -> Foo
+        """
+        let output = """
+        public static prefix func - (rhs: Foo) -> Foo
+        """
         let options = FormatOptions(fragment: true)
         testFormatting(for: input, output, rule: .modifierOrder, options: options)
     }
 
     func testModifierOrder() {
-        let input = "override public var foo: Int { 5 }"
-        let output = "public override var foo: Int { 5 }"
+        let input = """
+        override public var foo: Int { 5 }
+        """
+        let output = """
+        public override var foo: Int { 5 }
+        """
         let options = FormatOptions(modifierOrder: ["public", "override"])
         testFormatting(for: input, output, rule: .modifierOrder, options: options)
     }
 
     func testConsumingModifierOrder() {
-        let input = "consuming public func close()"
-        let output = "public consuming func close()"
+        let input = """
+        consuming public func close()
+        """
+        let output = """
+        public consuming func close()
+        """
         let options = FormatOptions(modifierOrder: ["public", "consuming"])
         testFormatting(for: input, output, rule: .modifierOrder, options: options, exclude: [.noExplicitOwnership])
     }
 
     func testNoConfusePostfixIdentifierWithKeyword() {
-        let input = "var foo = .postfix\noverride init() {}"
+        let input = """
+        var foo = .postfix
+        override init() {}
+        """
         testFormatting(for: input, rule: .modifierOrder)
     }
 
     func testNoConfusePostfixIdentifierWithKeyword2() {
-        let input = "var foo = postfix\noverride init() {}"
+        let input = """
+        var foo = postfix
+        override init() {}
+        """
         testFormatting(for: input, rule: .modifierOrder)
     }
 

--- a/Tests/Rules/NumberFormattingTests.swift
+++ b/Tests/Rules/NumberFormattingTests.swift
@@ -13,33 +13,53 @@ class NumberFormattingTests: XCTestCase {
     // hex case
 
     func testLowercaseLiteralConvertedToUpper() {
-        let input = "let foo = 0xabcd"
-        let output = "let foo = 0xABCD"
+        let input = """
+        let foo = 0xabcd
+        """
+        let output = """
+        let foo = 0xABCD
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testMixedCaseLiteralConvertedToUpper() {
-        let input = "let foo = 0xaBcD"
-        let output = "let foo = 0xABCD"
+        let input = """
+        let foo = 0xaBcD
+        """
+        let output = """
+        let foo = 0xABCD
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testUppercaseLiteralConvertedToLower() {
-        let input = "let foo = 0xABCD"
-        let output = "let foo = 0xabcd"
+        let input = """
+        let foo = 0xABCD
+        """
+        let output = """
+        let foo = 0xabcd
+        """
         let options = FormatOptions(uppercaseHex: false)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testPInExponentialNotConvertedToUpper() {
-        let input = "let foo = 0xaBcDp5"
-        let output = "let foo = 0xABCDp5"
+        let input = """
+        let foo = 0xaBcDp5
+        """
+        let output = """
+        let foo = 0xABCDp5
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testPInExponentialNotConvertedToLower() {
-        let input = "let foo = 0xaBcDP5"
-        let output = "let foo = 0xabcdP5"
+        let input = """
+        let foo = 0xaBcDP5
+        """
+        let output = """
+        let foo = 0xabcdP5
+        """
         let options = FormatOptions(uppercaseHex: false, uppercaseExponent: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
@@ -47,28 +67,44 @@ class NumberFormattingTests: XCTestCase {
     // exponent case
 
     func testLowercaseExponent() {
-        let input = "let foo = 0.456E-5"
-        let output = "let foo = 0.456e-5"
+        let input = """
+        let foo = 0.456E-5
+        """
+        let output = """
+        let foo = 0.456e-5
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testUppercaseExponent() {
-        let input = "let foo = 0.456e-5"
-        let output = "let foo = 0.456E-5"
+        let input = """
+        let foo = 0.456e-5
+        """
+        let output = """
+        let foo = 0.456E-5
+        """
         let options = FormatOptions(uppercaseExponent: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testUppercaseHexExponent() {
-        let input = "let foo = 0xFF00p54"
-        let output = "let foo = 0xFF00P54"
+        let input = """
+        let foo = 0xFF00p54
+        """
+        let output = """
+        let foo = 0xFF00P54
+        """
         let options = FormatOptions(uppercaseExponent: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testUppercaseGroupedHexExponent() {
-        let input = "let foo = 0xFF00_AABB_CCDDp54"
-        let output = "let foo = 0xFF00_AABB_CCDDP54"
+        let input = """
+        let foo = 0xFF00_AABB_CCDDp54
+        """
+        let output = """
+        let foo = 0xFF00_AABB_CCDDP54
+        """
         let options = FormatOptions(uppercaseExponent: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
@@ -76,40 +112,60 @@ class NumberFormattingTests: XCTestCase {
     // decimal grouping
 
     func testDefaultDecimalGrouping() {
-        let input = "let foo = 1234_56_78"
-        let output = "let foo = 12_345_678"
+        let input = """
+        let foo = 1234_56_78
+        """
+        let output = """
+        let foo = 12_345_678
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testIgnoreDecimalGrouping() {
-        let input = "let foo = 1234_5_678"
+        let input = """
+        let foo = 1234_5_678
+        """
         let options = FormatOptions(decimalGrouping: .ignore)
         testFormatting(for: input, rule: .numberFormatting, options: options)
     }
 
     func testNoDecimalGrouping() {
-        let input = "let foo = 1234_5_678"
-        let output = "let foo = 12345678"
+        let input = """
+        let foo = 1234_5_678
+        """
+        let output = """
+        let foo = 12345678
+        """
         let options = FormatOptions(decimalGrouping: .none)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testDecimalGroupingThousands() {
-        let input = "let foo = 1234"
-        let output = "let foo = 1_234"
+        let input = """
+        let foo = 1234
+        """
+        let output = """
+        let foo = 1_234
+        """
         let options = FormatOptions(decimalGrouping: .group(3, 3))
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testExponentialGrouping() {
-        let input = "let foo = 1234e5678"
-        let output = "let foo = 1_234e5678"
+        let input = """
+        let foo = 1234e5678
+        """
+        let output = """
+        let foo = 1_234e5678
+        """
         let options = FormatOptions(decimalGrouping: .group(3, 3))
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testZeroGrouping() {
-        let input = "let foo = 1234"
+        let input = """
+        let foo = 1234
+        """
         let options = FormatOptions(decimalGrouping: .group(0, 0))
         testFormatting(for: input, rule: .numberFormatting, options: options)
     }
@@ -117,27 +173,41 @@ class NumberFormattingTests: XCTestCase {
     // binary grouping
 
     func testDefaultBinaryGrouping() {
-        let input = "let foo = 0b11101000_00111111"
-        let output = "let foo = 0b1110_1000_0011_1111"
+        let input = """
+        let foo = 0b11101000_00111111
+        """
+        let output = """
+        let foo = 0b1110_1000_0011_1111
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testIgnoreBinaryGrouping() {
-        let input = "let foo = 0b1110_10_00"
+        let input = """
+        let foo = 0b1110_10_00
+        """
         let options = FormatOptions(binaryGrouping: .ignore)
         testFormatting(for: input, rule: .numberFormatting, options: options)
     }
 
     func testNoBinaryGrouping() {
-        let input = "let foo = 0b1110_10_00"
-        let output = "let foo = 0b11101000"
+        let input = """
+        let foo = 0b1110_10_00
+        """
+        let output = """
+        let foo = 0b11101000
+        """
         let options = FormatOptions(binaryGrouping: .none)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testBinaryGroupingCustom() {
-        let input = "let foo = 0b110011"
-        let output = "let foo = 0b11_00_11"
+        let input = """
+        let foo = 0b110011
+        """
+        let output = """
+        let foo = 0b11_00_11
+        """
         let options = FormatOptions(binaryGrouping: .group(2, 2))
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
@@ -145,14 +215,22 @@ class NumberFormattingTests: XCTestCase {
     // hex grouping
 
     func testDefaultHexGrouping() {
-        let input = "let foo = 0xFF01FF01AE45"
-        let output = "let foo = 0xFF01_FF01_AE45"
+        let input = """
+        let foo = 0xFF01FF01AE45
+        """
+        let output = """
+        let foo = 0xFF01_FF01_AE45
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testCustomHexGrouping() {
-        let input = "let foo = 0xFF00p54"
-        let output = "let foo = 0xFF_00p54"
+        let input = """
+        let foo = 0xFF00p54
+        """
+        let output = """
+        let foo = 0xFF_00p54
+        """
         let options = FormatOptions(hexGrouping: .group(2, 2))
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
@@ -160,14 +238,22 @@ class NumberFormattingTests: XCTestCase {
     // octal grouping
 
     func testDefaultOctalGrouping() {
-        let input = "let foo = 0o123456701234"
-        let output = "let foo = 0o1234_5670_1234"
+        let input = """
+        let foo = 0o123456701234
+        """
+        let output = """
+        let foo = 0o1234_5670_1234
+        """
         testFormatting(for: input, output, rule: .numberFormatting)
     }
 
     func testCustomOctalGrouping() {
-        let input = "let foo = 0o12345670"
-        let output = "let foo = 0o12_34_56_70"
+        let input = """
+        let foo = 0o12345670
+        """
+        let output = """
+        let foo = 0o12_34_56_70
+        """
         let options = FormatOptions(octalGrouping: .group(2, 2))
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
@@ -175,28 +261,42 @@ class NumberFormattingTests: XCTestCase {
     // fraction grouping
 
     func testIgnoreFractionGrouping() {
-        let input = "let foo = 1.234_5_678"
+        let input = """
+        let foo = 1.234_5_678
+        """
         let options = FormatOptions(decimalGrouping: .ignore, fractionGrouping: true)
         testFormatting(for: input, rule: .numberFormatting, options: options)
     }
 
     func testNoFractionGrouping() {
-        let input = "let foo = 1.234_5_678"
-        let output = "let foo = 1.2345678"
+        let input = """
+        let foo = 1.234_5_678
+        """
+        let output = """
+        let foo = 1.2345678
+        """
         let options = FormatOptions(decimalGrouping: .none, fractionGrouping: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testFractionGroupingThousands() {
-        let input = "let foo = 12.34_56_78"
-        let output = "let foo = 12.345_678"
+        let input = """
+        let foo = 12.34_56_78
+        """
+        let output = """
+        let foo = 12.345_678
+        """
         let options = FormatOptions(decimalGrouping: .group(3, 3), fractionGrouping: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }
 
     func testHexFractionGrouping() {
-        let input = "let foo = 0x12.34_56_78p56"
-        let output = "let foo = 0x12.34_5678p56"
+        let input = """
+        let foo = 0x12.34_56_78p56
+        """
+        let output = """
+        let foo = 0x12.34_5678p56
+        """
         let options = FormatOptions(hexGrouping: .group(4, 4), fractionGrouping: true)
         testFormatting(for: input, output, rule: .numberFormatting, options: options)
     }

--- a/Tests/Rules/OpaqueGenericParametersTests.swift
+++ b/Tests/Rules/OpaqueGenericParametersTests.swift
@@ -521,7 +521,9 @@ class OpaqueGenericParametersTests: XCTestCase {
     // MARK: - genericExtensions
 
     func testGenericExtensionNotModifiedBeforeSwift5_7() {
-        let input = "extension Array where Element == Foo {}"
+        let input = """
+        extension Array where Element == Foo {}
+        """
 
         let options = FormatOptions(swiftVersion: "5.6")
         testFormatting(for: input, rule: .opaqueGenericParameters, options: options, exclude: [.emptyExtensions])
@@ -685,8 +687,12 @@ class OpaqueGenericParametersTests: XCTestCase {
     }
 
     func testOpaqueGenericParametersDoesntleaveTrailingComma() {
-        let input = "func f<T, U>(x: U) -> T where T: A, U: B {}"
-        let output = "func f<T>(x: some B) -> T where T: A {}"
+        let input = """
+        func f<T, U>(x: U) -> T where T: A, U: B {}
+        """
+        let output = """
+        func f<T>(x: some B) -> T where T: A {}
+        """
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .opaqueGenericParameters,
                        options: options, exclude: [.unusedArguments])

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -199,8 +199,12 @@ class OrganizeDeclarationsTests: XCTestCase {
 
         // The configuration used in Airbnb's Swift Style Guide,
         // as defined here: https://github.com/airbnb/swift#subsection-organization
-        let airbnbVisibilityOrder = "beforeMarks,instanceLifecycle,open,public,package,internal,private,fileprivate"
-        let airbnbTypeOrder = "nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod"
+        let airbnbVisibilityOrder = """
+        beforeMarks,instanceLifecycle,open,public,package,internal,private,fileprivate
+        """
+        let airbnbTypeOrder = """
+        nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod
+        """
 
         testFormatting(
             for: input, output,

--- a/Tests/Rules/PreferForLoopTests.swift
+++ b/Tests/Rules/PreferForLoopTests.swift
@@ -75,8 +75,12 @@ class PreferForLoopTests: XCTestCase {
     }
 
     func testConvertSingleLineForEachToForLoop() {
-        let input = "potatoes.forEach({ item in item.bake() })"
-        let output = "for item in potatoes { item.bake() }"
+        let input = """
+        potatoes.forEach({ item in item.bake() })
+        """
+        let output = """
+        for item in potatoes { item.bake() }
+        """
 
         let options = FormatOptions(preserveSingleLineForEach: false)
         testFormatting(for: input, output, rule: .preferForLoop, options: options,
@@ -84,8 +88,12 @@ class PreferForLoopTests: XCTestCase {
     }
 
     func testConvertSingleLineAnonymousForEachToForLoop() {
-        let input = "potatoes.forEach({ $0.bake() })"
-        let output = "for potato in potatoes { potato.bake() }"
+        let input = """
+        potatoes.forEach({ $0.bake() })
+        """
+        let output = """
+        for potato in potatoes { potato.bake() }
+        """
 
         let options = FormatOptions(preserveSingleLineForEach: false)
         testFormatting(for: input, output, rule: .preferForLoop, options: options,

--- a/Tests/Rules/PreferKeyPathTests.swift
+++ b/Tests/Rules/PreferKeyPathTests.swift
@@ -11,32 +11,48 @@ import XCTest
 
 class PreferKeyPathTests: XCTestCase {
     func testMapPropertyToKeyPath() {
-        let input = "let foo = bar.map { $0.foo }"
-        let output = "let foo = bar.map(\\.foo)"
+        let input = """
+        let foo = bar.map { $0.foo }
+        """
+        let output = """
+        let foo = bar.map(\\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options)
     }
 
     func testCompactMapPropertyToKeyPath() {
-        let input = "let foo = bar.compactMap { $0.foo }"
-        let output = "let foo = bar.compactMap(\\.foo)"
+        let input = """
+        let foo = bar.compactMap { $0.foo }
+        """
+        let output = """
+        let foo = bar.compactMap(\\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options)
     }
 
     func testFlatMapPropertyToKeyPath() {
-        let input = "let foo = bar.flatMap { $0.foo }"
-        let output = "let foo = bar.flatMap(\\.foo)"
+        let input = """
+        let foo = bar.flatMap { $0.foo }
+        """
+        let output = """
+        let foo = bar.flatMap(\\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options)
     }
 
     func testMapNestedPropertyWithSpacesToKeyPath() {
-        let input = "let foo = bar.map { $0 . foo . bar }"
-        let output = "let foo = bar.map(\\ . foo . bar)"
+        let input = """
+        let foo = bar.map { $0 . foo . bar }
+        """
+        let output = """
+        let foo = bar.map(\\ . foo . bar)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options, exclude: [.spaceAroundOperators])
@@ -48,79 +64,109 @@ class PreferKeyPathTests: XCTestCase {
             $0.foo
         }
         """
-        let output = "let foo = bar.map(\\.foo)"
+        let output = """
+        let foo = bar.map(\\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options)
     }
 
     func testParenthesizedMapPropertyToKeyPath() {
-        let input = "let foo = bar.map({ $0.foo })"
-        let output = "let foo = bar.map(\\.foo)"
+        let input = """
+        let foo = bar.map({ $0.foo })
+        """
+        let output = """
+        let foo = bar.map(\\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath,
                        options: options)
     }
 
     func testNoMapSelfToKeyPath() {
-        let input = "let foo = bar.map { $0 }"
+        let input = """
+        let foo = bar.map { $0 }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testNoMapPropertyToKeyPathForSwiftLessThan5_2() {
-        let input = "let foo = bar.map { $0.foo }"
+        let input = """
+        let foo = bar.map { $0.foo }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testNoMapPropertyToKeyPathForFunctionCalls() {
-        let input = "let foo = bar.map { $0.foo() }"
+        let input = """
+        let foo = bar.map { $0.foo() }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testNoMapPropertyToKeyPathForCompoundExpressions() {
-        let input = "let foo = bar.map { $0.foo || baz }"
+        let input = """
+        let foo = bar.map { $0.foo || baz }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testNoMapPropertyToKeyPathForOptionalChaining() {
-        let input = "let foo = bar.map { $0?.foo }"
+        let input = """
+        let foo = bar.map { $0?.foo }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testNoMapPropertyToKeyPathForTrailingContains() {
-        let input = "let foo = bar.contains { $0.foo }"
+        let input = """
+        let foo = bar.contains { $0.foo }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testMapPropertyToKeyPathForContainsWhere() {
-        let input = "let foo = bar.contains(where: { $0.foo })"
-        let output = "let foo = bar.contains(where: \\.foo)"
+        let input = """
+        let foo = bar.contains(where: { $0.foo })
+        """
+        let output = """
+        let foo = bar.contains(where: \\.foo)
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, output, rule: .preferKeyPath, options: options)
     }
 
     func testMultipleTrailingClosuresNotConvertedToKeyPath() {
-        let input = "foo.map { $0.bar } reverse: { $0.bar }"
+        let input = """
+        foo.map { $0.bar } reverse: { $0.bar }
+        """
         let options = FormatOptions(swiftVersion: "5.2")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testSelfNotConvertedToKeyPathBeforeSwift6() {
         // https://bugs.swift.org/browse/SR-12897
-        let input = "let foo = bar.compactMap { $0 }"
+        let input = """
+        let foo = bar.compactMap { $0 }
+        """
         let options = FormatOptions(swiftVersion: "5.10")
         testFormatting(for: input, rule: .preferKeyPath, options: options)
     }
 
     func testSelfConvertedToKeyPath() {
-        let input = "let foo = bar.compactMap { $0 }"
-        let output = "let foo = bar.compactMap(\\.self)"
+        let input = """
+        let foo = bar.compactMap { $0 }
+        """
+        let output = """
+        let foo = bar.compactMap(\\.self)
+        """
         let options = FormatOptions(swiftVersion: "6")
         testFormatting(for: input, output, rule: .preferKeyPath, options: options)
     }

--- a/Tests/Rules/RedundantBackticksTests.swift
+++ b/Tests/Rules/RedundantBackticksTests.swift
@@ -11,148 +11,233 @@ import XCTest
 
 class RedundantBackticksTests: XCTestCase {
     func testRemoveRedundantBackticksInLet() {
-        let input = "let `foo` = bar"
-        let output = "let foo = bar"
+        let input = """
+        let `foo` = bar
+        """
+        let output = """
+        let foo = bar
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundKeyword() {
-        let input = "let `let` = foo"
+        let input = """
+        let `let` = foo
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundSelf() {
-        let input = "let `self` = foo"
+        let input = """
+        let `self` = foo
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundClassSelfInTypealias() {
-        let input = "typealias `Self` = Foo"
+        let input = """
+        typealias `Self` = Foo
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundClassSelfAsReturnType() {
-        let input = "func foo(bar: `Self`) { print(bar) }"
-        let output = "func foo(bar: Self) { print(bar) }"
+        let input = """
+        func foo(bar: `Self`) { print(bar) }
+        """
+        let output = """
+        func foo(bar: Self) { print(bar) }
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundClassSelfAsParameterType() {
-        let input = "func foo() -> `Self` {}"
-        let output = "func foo() -> Self {}"
+        let input = """
+        func foo() -> `Self` {}
+        """
+        let output = """
+        func foo() -> Self {}
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundClassSelfArgument() {
-        let input = "func foo(`Self`: Foo) { print(Self) }"
-        let output = "func foo(Self: Foo) { print(Self) }"
+        let input = """
+        func foo(`Self`: Foo) { print(Self) }
+        """
+        let output = """
+        func foo(Self: Foo) { print(Self) }
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundKeywordFollowedByType() {
-        let input = "let `default`: Int = foo"
+        let input = """
+        let `default`: Int = foo
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundContextualGet() {
-        let input = "var foo: Int {\n    `get`()\n    return 5\n}"
+        let input = """
+        var foo: Int {
+            `get`()
+            return 5
+        }
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundGetArgument() {
-        let input = "func foo(`get` value: Int) { print(value) }"
-        let output = "func foo(get value: Int) { print(value) }"
+        let input = """
+        func foo(`get` value: Int) { print(value) }
+        """
+        let output = """
+        func foo(get value: Int) { print(value) }
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundTypeAtRootLevel() {
-        let input = "enum `Type` {}"
-        let output = "enum Type {}"
+        let input = """
+        enum `Type` {}
+        """
+        let output = """
+        enum Type {}
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundTypeInsideType() {
-        let input = "struct Foo {\n    enum `Type` {}\n}"
+        let input = """
+        struct Foo {
+            enum `Type` {}
+        }
+        """
         testFormatting(for: input, rule: .redundantBackticks, exclude: [.enumNamespaces])
     }
 
     func testNoRemoveBackticksAroundLetArgument() {
-        let input = "func foo(`let`: Foo) { print(`let`) }"
+        let input = """
+        func foo(`let`: Foo) { print(`let`) }
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundTrueArgument() {
-        let input = "func foo(`true`: Foo) { print(`true`) }"
+        let input = """
+        func foo(`true`: Foo) { print(`true`) }
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundTrueArgument() {
-        let input = "func foo(`true`: Foo) { print(`true`) }"
-        let output = "func foo(true: Foo) { print(`true`) }"
+        let input = """
+        func foo(`true`: Foo) { print(`true`) }
+        """
+        let output = """
+        func foo(true: Foo) { print(`true`) }
+        """
         let options = FormatOptions(swiftVersion: "4")
         testFormatting(for: input, output, rule: .redundantBackticks, options: options)
     }
 
     func testNoRemoveBackticksAroundTypeProperty() {
-        let input = "var type: Foo.`Type`"
+        let input = """
+        var type: Foo.`Type`
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundTypePropertyInsideType() {
-        let input = "struct Foo {\n    enum `Type` {}\n}"
+        let input = """
+        struct Foo {
+            enum `Type` {}
+        }
+        """
         testFormatting(for: input, rule: .redundantBackticks, exclude: [.enumNamespaces])
     }
 
     func testNoRemoveBackticksAroundTrueProperty() {
-        let input = "var type = Foo.`true`"
+        let input = """
+        var type = Foo.`true`
+        """
         testFormatting(for: input, rule: .redundantBackticks, exclude: [.propertyTypes])
     }
 
     func testRemoveBackticksAroundTrueProperty() {
-        let input = "var type = Foo.`true`"
-        let output = "var type = Foo.true"
+        let input = """
+        var type = Foo.`true`
+        """
+        let output = """
+        var type = Foo.true
+        """
         let options = FormatOptions(swiftVersion: "4")
         testFormatting(for: input, output, rule: .redundantBackticks, options: options, exclude: [.propertyTypes])
     }
 
     func testRemoveBackticksAroundProperty() {
-        let input = "var type = Foo.`bar`"
-        let output = "var type = Foo.bar"
+        let input = """
+        var type = Foo.`bar`
+        """
+        let output = """
+        var type = Foo.bar
+        """
         testFormatting(for: input, output, rule: .redundantBackticks, exclude: [.propertyTypes])
     }
 
     func testRemoveBackticksAroundKeywordProperty() {
-        let input = "var type = Foo.`default`"
-        let output = "var type = Foo.default"
+        let input = """
+        var type = Foo.`default`
+        """
+        let output = """
+        var type = Foo.default
+        """
         testFormatting(for: input, output, rule: .redundantBackticks, exclude: [.propertyTypes])
     }
 
     func testRemoveBackticksAroundKeypathProperty() {
-        let input = "var type = \\.`bar`"
-        let output = "var type = \\.bar"
+        let input = """
+        var type = \\.`bar`
+        """
+        let output = """
+        var type = \\.bar
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundKeypathKeywordProperty() {
-        let input = "var type = \\.`default`"
+        let input = """
+        var type = \\.`default`
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundKeypathKeywordPropertyInSwift5() {
-        let input = "var type = \\.`default`"
-        let output = "var type = \\.default"
+        let input = """
+        var type = \\.`default`
+        """
+        let output = """
+        var type = \\.default
+        """
         let options = FormatOptions(swiftVersion: "5")
         testFormatting(for: input, output, rule: .redundantBackticks, options: options)
     }
 
     func testNoRemoveBackticksAroundInitPropertyInSwift5() {
-        let input = "let foo: Foo = .`init`"
+        let input = """
+        let foo: Foo = .`init`
+        """
         let options = FormatOptions(swiftVersion: "5")
         testFormatting(for: input, rule: .redundantBackticks, options: options, exclude: [.propertyTypes])
     }
 
     func testNoRemoveBackticksAroundAnyProperty() {
-        let input = "enum Foo {\n    case `Any`\n}"
+        let input = """
+        enum Foo {
+            case `Any`
+        }
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
@@ -166,30 +251,46 @@ class RedundantBackticksTests: XCTestCase {
     }
 
     func testNoRemoveBackticksAroundActorProperty() {
-        let input = "let `actor`: Foo"
+        let input = """
+        let `actor`: Foo
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundActorRvalue() {
-        let input = "let foo = `actor`"
-        let output = "let foo = actor"
+        let input = """
+        let foo = `actor`
+        """
+        let output = """
+        let foo = actor
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundActorLabel() {
-        let input = "init(`actor`: Foo)"
-        let output = "init(actor: Foo)"
+        let input = """
+        init(`actor`: Foo)
+        """
+        let output = """
+        init(actor: Foo)
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testRemoveBackticksAroundActorLabel2() {
-        let input = "init(`actor` foo: Foo)"
-        let output = "init(actor foo: Foo)"
+        let input = """
+        init(`actor` foo: Foo)
+        """
+        let output = """
+        init(actor foo: Foo)
+        """
         testFormatting(for: input, output, rule: .redundantBackticks)
     }
 
     func testNoRemoveBackticksAroundUnderscore() {
-        let input = "func `_`<T>(_ foo: T) -> T { foo }"
+        let input = """
+        func `_`<T>(_ foo: T) -> T { foo }
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 
@@ -208,7 +309,9 @@ class RedundantBackticksTests: XCTestCase {
     }
 
     func testNoRemoveBackticksAroundDollar() {
-        let input = "@attached(peer, names: prefixed(`$`))"
+        let input = """
+        @attached(peer, names: prefixed(`$`))
+        """
         testFormatting(for: input, rule: .redundantBackticks)
     }
 

--- a/Tests/Rules/RedundantClosureTests.swift
+++ b/Tests/Rules/RedundantClosureTests.swift
@@ -426,7 +426,9 @@ class RedundantClosureTests: XCTestCase {
     }
 
     func testKeepsClosureThatThrowsError() {
-        let input = "let foo = try bar ?? { throw NSError() }()"
+        let input = """
+        let foo = try bar ?? { throw NSError() }()
+        """
         testFormatting(for: input, rule: .redundantClosure)
     }
 

--- a/Tests/Rules/RedundantGetTests.swift
+++ b/Tests/Rules/RedundantGetTests.swift
@@ -11,35 +11,72 @@ import XCTest
 
 class RedundantGetTests: XCTestCase {
     func testRemoveSingleLineIsolatedGet() {
-        let input = "var foo: Int { get { return 5 } }"
-        let output = "var foo: Int { return 5 }"
+        let input = """
+        var foo: Int { get { return 5 } }
+        """
+        let output = """
+        var foo: Int { return 5 }
+        """
         testFormatting(for: input, output, rule: .redundantGet)
     }
 
     func testRemoveMultilineIsolatedGet() {
-        let input = "var foo: Int {\n    get {\n        return 5\n    }\n}"
-        let output = "var foo: Int {\n    return 5\n}"
+        let input = """
+        var foo: Int {
+            get {
+                return 5
+            }
+        }
+        """
+        let output = """
+        var foo: Int {
+            return 5
+        }
+        """
         testFormatting(for: input, [output], rules: [.redundantGet, .indent])
     }
 
     func testNoRemoveMultilineGetSet() {
-        let input = "var foo: Int {\n    get { return 5 }\n    set { foo = newValue }\n}"
+        let input = """
+        var foo: Int {
+            get { return 5 }
+            set { foo = newValue }
+        }
+        """
         testFormatting(for: input, rule: .redundantGet)
     }
 
     func testNoRemoveAttributedGet() {
-        let input = "var enabled: Bool { @objc(isEnabled) get { true } }"
+        let input = """
+        var enabled: Bool { @objc(isEnabled) get { true } }
+        """
         testFormatting(for: input, rule: .redundantGet)
     }
 
     func testRemoveSubscriptGet() {
-        let input = "subscript(_ index: Int) {\n    get {\n        return lookup(index)\n    }\n}"
-        let output = "subscript(_ index: Int) {\n    return lookup(index)\n}"
+        let input = """
+        subscript(_ index: Int) {
+            get {
+                return lookup(index)
+            }
+        }
+        """
+        let output = """
+        subscript(_ index: Int) {
+            return lookup(index)
+        }
+        """
         testFormatting(for: input, [output], rules: [.redundantGet, .indent])
     }
 
     func testGetNotRemovedInFunction() {
-        let input = "func foo() {\n    get {\n        self.lookup(index)\n    }\n}"
+        let input = """
+        func foo() {
+            get {
+                self.lookup(index)
+            }
+        }
+        """
         testFormatting(for: input, rule: .redundantGet)
     }
 

--- a/Tests/Rules/RedundantInitTests.swift
+++ b/Tests/Rules/RedundantInitTests.swift
@@ -11,55 +11,81 @@ import XCTest
 
 class RedundantInitTests: XCTestCase {
     func testRemoveRedundantInit() {
-        let input = "[1].flatMap { String.init($0) }"
-        let output = "[1].flatMap { String($0) }"
+        let input = """
+        [1].flatMap { String.init($0) }
+        """
+        let output = """
+        [1].flatMap { String($0) }
+        """
         testFormatting(for: input, output, rule: .redundantInit)
     }
 
     func testRemoveRedundantInit2() {
-        let input = "[String.self].map { Type in Type.init(foo: 1) }"
-        let output = "[String.self].map { Type in Type(foo: 1) }"
+        let input = """
+        [String.self].map { Type in Type.init(foo: 1) }
+        """
+        let output = """
+        [String.self].map { Type in Type(foo: 1) }
+        """
         testFormatting(for: input, output, rule: .redundantInit)
     }
 
     func testRemoveRedundantInit3() {
-        let input = "String.init(\"text\")"
-        let output = "String(\"text\")"
+        let input = """
+        String.init(\"text\")
+        """
+        let output = """
+        String(\"text\")
+        """
         testFormatting(for: input, output, rule: .redundantInit)
     }
 
     func testDontRemoveInitInSuperCall() {
-        let input = "class C: NSObject { override init() { super.init() } }"
+        let input = """
+        class C: NSObject { override init() { super.init() } }
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitInSelfCall() {
-        let input = "struct S { let n: Int }; extension S { init() { self.init(n: 1) } }"
+        let input = """
+        struct S { let n: Int }; extension S { init() { self.init(n: 1) } }
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitWhenPassedAsFunction() {
-        let input = "[1].flatMap(String.init)"
+        let input = """
+        [1].flatMap(String.init)
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitWhenUsedOnMetatype() {
-        let input = "[String.self].map { type in type.init(1) }"
+        let input = """
+        [String.self].map { type in type.init(1) }
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitWhenUsedOnImplicitClosureMetatype() {
-        let input = "[String.self].map { $0.init(1) }"
+        let input = """
+        [String.self].map { $0.init(1) }
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitWhenUsedOnPossibleMetatype() {
-        let input = "let something = Foo.bar.init()"
+        let input = """
+        let something = Foo.bar.init()
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 
     func testDontRemoveInitWithExplicitSignature() {
-        let input = "[String.self].map(Foo.init(bar:))"
+        let input = """
+        [String.self].map(Foo.init(bar:))
+        """
         testFormatting(for: input, rule: .redundantInit)
     }
 

--- a/Tests/Rules/RedundantInternalTests.swift
+++ b/Tests/Rules/RedundantInternalTests.swift
@@ -87,7 +87,9 @@ class RedundantInternalTests: XCTestCase {
     }
 
     func testPreserveInternalImport() {
-        let input = "internal import MyPackage"
+        let input = """
+        internal import MyPackage
+        """
         testFormatting(for: input, rule: .redundantInternal)
     }
 

--- a/Tests/Rules/RedundantLetErrorTests.swift
+++ b/Tests/Rules/RedundantLetErrorTests.swift
@@ -11,14 +11,22 @@ import XCTest
 
 class RedundantLetErrorTests: XCTestCase {
     func testCatchLetError() {
-        let input = "do {} catch let error {}"
-        let output = "do {} catch {}"
+        let input = """
+        do {} catch let error {}
+        """
+        let output = """
+        do {} catch {}
+        """
         testFormatting(for: input, output, rule: .redundantLetError)
     }
 
     func testCatchLetErrorWithTypedThrows() {
-        let input = "do throws(Foo) {} catch let error {}"
-        let output = "do throws(Foo) {} catch {}"
+        let input = """
+        do throws(Foo) {} catch let error {}
+        """
+        let output = """
+        do throws(Foo) {} catch {}
+        """
         testFormatting(for: input, output, rule: .redundantLetError)
     }
 }

--- a/Tests/Rules/RedundantLetTests.swift
+++ b/Tests/Rules/RedundantLetTests.swift
@@ -11,46 +11,68 @@ import XCTest
 
 class RedundantLetTests: XCTestCase {
     func testRemoveRedundantLet() {
-        let input = "let _ = bar {}"
-        let output = "_ = bar {}"
+        let input = """
+        let _ = bar {}
+        """
+        let output = """
+        _ = bar {}
+        """
         testFormatting(for: input, output, rule: .redundantLet)
     }
 
     func testNoRemoveLetWithType() {
-        let input = "let _: String = bar {}"
+        let input = """
+        let _: String = bar {}
+        """
         testFormatting(for: input, rule: .redundantLet)
     }
 
     func testRemoveRedundantLetInCase() {
-        let input = "if case .foo(let _) = bar {}"
-        let output = "if case .foo(_) = bar {}"
+        let input = """
+        if case .foo(let _) = bar {}
+        """
+        let output = """
+        if case .foo(_) = bar {}
+        """
         testFormatting(for: input, output, rule: .redundantLet, exclude: [.redundantPattern])
     }
 
     func testRemoveRedundantVarsInCase() {
-        let input = "if case .foo(var _, var /* unused */ _) = bar {}"
-        let output = "if case .foo(_, /* unused */ _) = bar {}"
+        let input = """
+        if case .foo(var _, var /* unused */ _) = bar {}
+        """
+        let output = """
+        if case .foo(_, /* unused */ _) = bar {}
+        """
         testFormatting(for: input, output, rule: .redundantLet)
     }
 
     func testNoRemoveLetInIf() {
-        let input = "if let _ = foo {}"
+        let input = """
+        if let _ = foo {}
+        """
         testFormatting(for: input, rule: .redundantLet)
     }
 
     func testNoRemoveLetInMultiIf() {
-        let input = "if foo == bar, /* comment! */ let _ = baz {}"
+        let input = """
+        if foo == bar, /* comment! */ let _ = baz {}
+        """
         testFormatting(for: input, rule: .redundantLet)
     }
 
     func testNoRemoveLetInGuard() {
-        let input = "guard let _ = foo else {}"
+        let input = """
+        guard let _ = foo else {}
+        """
         testFormatting(for: input, rule: .redundantLet,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveLetInWhile() {
-        let input = "while let _ = foo {}"
+        let input = """
+        while let _ = foo {}
+        """
         testFormatting(for: input, rule: .redundantLet)
     }
 
@@ -129,7 +151,9 @@ class RedundantLetTests: XCTestCase {
     }
 
     func testNoRemoveAsyncLet() {
-        let input = "async let _ = foo()"
+        let input = """
+        async let _ = foo()
+        """
         testFormatting(for: input, rule: .redundantLet)
     }
 

--- a/Tests/Rules/RedundantNilInitTests.swift
+++ b/Tests/Rules/RedundantNilInitTests.swift
@@ -35,72 +35,103 @@ class RedundantNilInitTests: XCTestCase {
     }
 
     func testNoRemoveNonNilInit() {
-        let input = "var foo: Int? = 0"
+        let input = """
+        var foo: Int? = 0
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testRemoveRedundantImplicitUnwrapInit() {
-        let input = "var foo: Int! = nil"
-        let output = "var foo: Int!"
+        let input = """
+        var foo: Int! = nil
+        """
+        let output = """
+        var foo: Int!
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, output, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveLazyVarNilInit() {
-        let input = "lazy var foo: Int? = nil"
+        let input = """
+        lazy var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveLazyPublicPrivateSetVarNilInit() {
-        let input = "lazy private(set) public var foo: Int? = nil"
+        let input = """
+        lazy private(set) public var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit, options: options,
                        exclude: [.modifierOrder])
     }
 
     func testNoRemoveCodableNilInit() {
-        let input = "struct Foo: Codable, Bar {\n    enum CodingKeys: String, CodingKey {\n        case bar = \"_bar\"\n    }\n\n    var bar: Int?\n    var baz: String? = nil\n}"
+        let input = """
+        struct Foo: Codable, Bar {
+            enum CodingKeys: String, CodingKey {
+                case bar = \"_bar\"
+            }
+
+            var bar: Int?
+            var baz: String? = nil
+        }
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveNilInitWithPropertyWrapper() {
-        let input = "@Foo var foo: Int? = nil"
+        let input = """
+        @Foo var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveNilInitWithLowercasePropertyWrapper() {
-        let input = "@foo var foo: Int? = nil"
+        let input = """
+        @foo var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveNilInitWithPropertyWrapperWithArgument() {
-        let input = "@Foo(bar: baz) var foo: Int? = nil"
+        let input = """
+        @Foo(bar: baz) var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoRemoveNilInitWithLowercasePropertyWrapperWithArgument() {
-        let input = "@foo(bar: baz) var foo: Int? = nil"
+        let input = """
+        @foo(bar: baz) var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testRemoveNilInitWithObjcAttributes() {
-        let input = "@objc var foo: Int? = nil"
-        let output = "@objc var foo: Int?"
+        let input = """
+        @objc var foo: Int? = nil
+        """
+        let output = """
+        @objc var foo: Int?
+        """
         let options = FormatOptions(nilInit: .remove)
         testFormatting(for: input, output, rule: .redundantNilInit,
                        options: options)
@@ -252,29 +283,39 @@ class RedundantNilInitTests: XCTestCase {
     }
 
     func testNoInsertNonNilInit() {
-        let input = "var foo: Int? = 0"
+        let input = """
+        var foo: Int? = 0
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testInsertRedundantImplicitUnwrapInit() {
-        let input = "var foo: Int!"
-        let output = "var foo: Int! = nil"
+        let input = """
+        var foo: Int!
+        """
+        let output = """
+        var foo: Int! = nil
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, output, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoInsertLazyVarNilInit() {
-        let input = "lazy var foo: Int?"
+        let input = """
+        lazy var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoInsertLazyPublicPrivateSetVarNilInit() {
-        let input = "lazy private(set) public var foo: Int?"
+        let input = """
+        lazy private(set) public var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit, options: options,
                        exclude: [.modifierOrder])
@@ -297,36 +338,48 @@ class RedundantNilInitTests: XCTestCase {
     }
 
     func testNoInsertNilInitWithPropertyWrapper() {
-        let input = "@Foo var foo: Int?"
+        let input = """
+        @Foo var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithLowercasePropertyWrapper() {
-        let input = "@foo var foo: Int?"
+        let input = """
+        @foo var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithPropertyWrapperWithArgument() {
-        let input = "@Foo(bar: baz) var foo: Int?"
+        let input = """
+        @Foo(bar: baz) var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testNoInsertNilInitWithLowercasePropertyWrapperWithArgument() {
-        let input = "@foo(bar: baz) var foo: Int?"
+        let input = """
+        @foo(bar: baz) var foo: Int?
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, rule: .redundantNilInit,
                        options: options)
     }
 
     func testInsertNilInitWithObjcAttributes() {
-        let input = "@objc var foo: Int?"
-        let output = "@objc var foo: Int? = nil"
+        let input = """
+        @objc var foo: Int?
+        """
+        let output = """
+        @objc var foo: Int? = nil
+        """
         let options = FormatOptions(nilInit: .insert)
         testFormatting(for: input, output, rule: .redundantNilInit,
                        options: options)

--- a/Tests/Rules/RedundantObjcTests.swift
+++ b/Tests/Rules/RedundantObjcTests.swift
@@ -11,36 +11,60 @@ import XCTest
 
 class RedundantObjcTests: XCTestCase {
     func testRedundantObjcRemovedFromBeforeOutlet() {
-        let input = "@objc @IBOutlet var label: UILabel!"
-        let output = "@IBOutlet var label: UILabel!"
+        let input = """
+        @objc @IBOutlet var label: UILabel!
+        """
+        let output = """
+        @IBOutlet var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .redundantObjc)
     }
 
     func testRedundantObjcRemovedFromAfterOutlet() {
-        let input = "@IBOutlet @objc var label: UILabel!"
-        let output = "@IBOutlet var label: UILabel!"
+        let input = """
+        @IBOutlet @objc var label: UILabel!
+        """
+        let output = """
+        @IBOutlet var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .redundantObjc)
     }
 
     func testRedundantObjcRemovedFromLineBeforeOutlet() {
-        let input = "@objc\n@IBOutlet var label: UILabel!"
-        let output = "\n@IBOutlet var label: UILabel!"
+        let input = """
+        @objc
+        @IBOutlet var label: UILabel!
+        """
+        let output = """
+
+        @IBOutlet var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .redundantObjc)
     }
 
     func testRedundantObjcCommentNotRemoved() {
-        let input = "@objc /// an outlet\n@IBOutlet var label: UILabel!"
-        let output = "/// an outlet\n@IBOutlet var label: UILabel!"
+        let input = """
+        @objc /// an outlet
+        @IBOutlet var label: UILabel!
+        """
+        let output = """
+        /// an outlet
+        @IBOutlet var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .redundantObjc)
     }
 
     func testObjcNotRemovedFromNSCopying() {
-        let input = "@objc @NSCopying var foo: String!"
+        let input = """
+        @objc @NSCopying var foo: String!
+        """
         testFormatting(for: input, rule: .redundantObjc)
     }
 
     func testRenamedObjcNotRemoved() {
-        let input = "@IBOutlet @objc(uiLabel) var label: UILabel!"
+        let input = """
+        @IBOutlet @objc(uiLabel) var label: UILabel!
+        """
         testFormatting(for: input, rule: .redundantObjc)
     }
 

--- a/Tests/Rules/RedundantParensTests.swift
+++ b/Tests/Rules/RedundantParensTests.swift
@@ -13,191 +13,295 @@ class RedundantParensTests: XCTestCase {
     // around expressions
 
     func testRedundantParensRemoved() {
-        let input = "(x || y)"
-        let output = "x || y"
+        let input = """
+        (x || y)
+        """
+        let output = """
+        x || y
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemoved2() {
-        let input = "(x) || y"
-        let output = "x || y"
+        let input = """
+        (x) || y
+        """
+        let output = """
+        x || y
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemoved3() {
-        let input = "x + (5)"
-        let output = "x + 5"
+        let input = """
+        x + (5)
+        """
+        let output = """
+        x + 5
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemoved4() {
-        let input = "(.bar)"
-        let output = ".bar"
+        let input = """
+        (.bar)
+        """
+        let output = """
+        .bar
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemoved5() {
-        let input = "(Foo.bar)"
-        let output = "Foo.bar"
+        let input = """
+        (Foo.bar)
+        """
+        let output = """
+        Foo.bar
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemoved6() {
-        let input = "(foo())"
-        let output = "foo()"
+        let input = """
+        (foo())
+        """
+        let output = """
+        foo()
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemoved() {
-        let input = "(x || y) * z"
+        let input = """
+        (x || y) * z
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemoved2() {
-        let input = "(x + y) as Int"
+        let input = """
+        (x + y) as Int
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemoved3() {
-        let input = "x+(-5)"
+        let input = """
+        x+(-5)
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators])
     }
 
     func testRedundantParensAroundIsNotRemoved() {
-        let input = "a = (x is Int)"
+        let input = """
+        a = (x is Int)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedBeforeSubscript() {
-        let input = "(foo + bar)[baz]"
+        let input = """
+        (foo + bar)[baz]
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedBeforeCollectionLiteral() {
-        let input = "(foo + bar)\n[baz]"
-        let output = "foo + bar\n[baz]"
+        let input = """
+        (foo + bar)
+        [baz]
+        """
+        let output = """
+        foo + bar
+        [baz]
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedBeforeFunctionInvocation() {
-        let input = "(foo + bar)(baz)"
+        let input = """
+        (foo + bar)(baz)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedBeforeTuple() {
-        let input = "(foo + bar)\n(baz, quux).0"
-        let output = "foo + bar\n(baz, quux).0"
+        let input = """
+        (foo + bar)
+        (baz, quux).0
+        """
+        let output = """
+        foo + bar
+        (baz, quux).0
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedBeforePostfixOperator() {
-        let input = "(foo + bar)!"
+        let input = """
+        (foo + bar)!
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedBeforeInfixOperator() {
-        let input = "(foo + bar) * baz"
+        let input = """
+        (foo + bar) * baz
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensNotRemovedAroundSelectorStringLiteral() {
-        let input = "Selector((\"foo\"))"
+        let input = """
+        Selector((\"foo\"))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensRemovedOnLineAfterSelectorIdentifier() {
-        let input = "Selector\n((\"foo\"))"
-        let output = "Selector\n(\"foo\")"
+        let input = """
+        Selector
+        ((\"foo\"))
+        """
+        let output = """
+        Selector
+        (\"foo\")
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testMeaningfulParensNotRemovedAroundFileLiteral() {
-        let input = "func foo(_ file: String = (#file)) {}"
+        let input = """
+        func foo(_ file: String = (#file)) {}
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testMeaningfulParensNotRemovedAroundOperator() {
-        let input = "let foo: (Int, Int) -> Bool = (<)"
+        let input = """
+        let foo: (Int, Int) -> Bool = (<)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensNotRemovedAroundOperatorWithSpaces() {
-        let input = "let foo: (Int, Int) -> Bool = ( < )"
+        let input = """
+        let foo: (Int, Int) -> Bool = ( < )
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensNotRemovedAroundPrefixOperator() {
-        let input = "let foo: (Int) -> Int = ( -)"
+        let input = """
+        let foo: (Int) -> Int = ( -)
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensAroundPrefixExpressionFollowedByDotNotRemoved() {
-        let input = "let foo = (!bar).description"
+        let input = """
+        let foo = (!bar).description
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensAroundPrefixExpressionWithSpacesFollowedByDotNotRemoved() {
-        let input = "let foo = ( !bar ).description"
+        let input = """
+        let foo = ( !bar ).description
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators, .spaceInsideParens])
     }
 
     func testMeaningfulParensAroundPrefixExpressionFollowedByPostfixExpressionNotRemoved() {
-        let input = "let foo = (!bar)!"
+        let input = """
+        let foo = (!bar)!
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensAroundPrefixExpressionFollowedBySubscriptNotRemoved() {
-        let input = "let foo = (!bar)[5]"
+        let input = """
+        let foo = (!bar)[5]
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensAroundPostfixExpressionFollowedByPostfixOperatorRemoved() {
-        let input = "let foo = (bar!)!"
-        let output = "let foo = bar!!"
+        let input = """
+        let foo = (bar!)!
+        """
+        let output = """
+        let foo = bar!!
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensAroundPostfixExpressionFollowedByPostfixOperatorRemoved2() {
-        let input = "let foo = ( bar! )!"
-        let output = "let foo = bar!!"
+        let input = """
+        let foo = ( bar! )!
+        """
+        let output = """
+        let foo = bar!!
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensAroundPostfixExpressionRemoved() {
-        let input = "let foo = foo + (bar!)"
-        let output = "let foo = foo + bar!"
+        let input = """
+        let foo = foo + (bar!)
+        """
+        let output = """
+        let foo = foo + bar!
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensAroundPostfixExpressionFollowedBySubscriptRemoved() {
-        let input = "let foo = (bar!)[5]"
-        let output = "let foo = bar![5]"
+        let input = """
+        let foo = (bar!)[5]
+        """
+        let output = """
+        let foo = bar![5]
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensAroundPrefixExpressionRemoved() {
-        let input = "let foo = foo + (!bar)"
-        let output = "let foo = foo + !bar"
+        let input = """
+        let foo = foo + (!bar)
+        """
+        let output = """
+        let foo = foo + !bar
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensAroundInfixExpressionNotRemoved() {
-        let input = "let foo = (foo + bar)"
+        let input = """
+        let foo = (foo + bar)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensAroundInfixEqualsExpressionNotRemoved() {
-        let input = "let foo = (bar == baz)"
+        let input = """
+        let foo = (bar == baz)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensAroundClosureTypeRemoved() {
-        let input = "typealias Foo = ((Int) -> Bool)"
-        let output = "typealias Foo = (Int) -> Bool"
+        let input = """
+        typealias Foo = ((Int) -> Bool)
+        """
+        let output = """
+        typealias Foo = (Int) -> Bool
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
@@ -219,28 +323,40 @@ class RedundantParensTests: XCTestCase {
 //    }
 
     func testRedundantParensAroundNestedClosureTypesNotRemoved() {
-        let input = "typealias Foo = (((Int) -> Bool) -> Int) -> ((String) -> Bool) -> Void"
+        let input = """
+        typealias Foo = (((Int) -> Bool) -> Int) -> ((String) -> Bool) -> Void
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensAroundClosureTypeNotRemoved() {
-        let input = "let foo = ((Int) -> Bool)?"
+        let input = """
+        let foo = ((Int) -> Bool)?
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensAroundTryExpressionNotRemoved() {
-        let input = "let foo = (try? bar()) != nil"
+        let input = """
+        let foo = (try? bar()) != nil
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testMeaningfulParensAroundAwaitExpressionNotRemoved() {
-        let input = "if !(await isSomething()) {}"
+        let input = """
+        if !(await isSomething()) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensInReturnRemoved() {
-        let input = "return (true)"
-        let output = "return true"
+        let input = """
+        return (true)
+        """
+        let output = """
+        return true
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
@@ -263,388 +379,610 @@ class RedundantParensTests: XCTestCase {
     // around conditions
 
     func testRedundantParensRemovedInIf() {
-        let input = "if (x || y) {}"
-        let output = "if x || y {}"
+        let input = """
+        if (x || y) {}
+        """
+        let output = """
+        if x || y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf2() {
-        let input = "if (x) || y {}"
-        let output = "if x || y {}"
+        let input = """
+        if (x) || y {}
+        """
+        let output = """
+        if x || y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf3() {
-        let input = "if x + (5) == 6 {}"
-        let output = "if x + 5 == 6 {}"
+        let input = """
+        if x + (5) == 6 {}
+        """
+        let output = """
+        if x + 5 == 6 {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf4() {
-        let input = "if (x || y), let foo = bar {}"
-        let output = "if x || y, let foo = bar {}"
+        let input = """
+        if (x || y), let foo = bar {}
+        """
+        let output = """
+        if x || y, let foo = bar {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf5() {
-        let input = "if (.bar) {}"
-        let output = "if .bar {}"
+        let input = """
+        if (.bar) {}
+        """
+        let output = """
+        if .bar {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf6() {
-        let input = "if (Foo.bar) {}"
-        let output = "if Foo.bar {}"
+        let input = """
+        if (Foo.bar) {}
+        """
+        let output = """
+        if Foo.bar {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf7() {
-        let input = "if (foo()) {}"
-        let output = "if foo() {}"
+        let input = """
+        if (foo()) {}
+        """
+        let output = """
+        if foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIf8() {
-        let input = "if x, (y == 2) {}"
-        let output = "if x, y == 2 {}"
+        let input = """
+        if x, (y == 2) {}
+        """
+        let output = """
+        if x, y == 2 {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInIfWithNoSpace() {
-        let input = "if(x) {}"
-        let output = "if x {}"
+        let input = """
+        if(x) {}
+        """
+        let output = """
+        if x {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInHashIfWithNoSpace() {
-        let input = "#if(x)\n#endif"
-        let output = "#if x\n#endif"
+        let input = """
+        #if(x)
+        #endif
+        """
+        let output = """
+        #if x
+        #endif
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedInIf() {
-        let input = "if (x || y) * z {}"
+        let input = """
+        if (x || y) * z {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testOuterParensRemovedInWhile() {
-        let input = "while ((x || y) && z) {}"
-        let output = "while (x || y) && z {}"
+        let input = """
+        while ((x || y) && z) {}
+        """
+        let output = """
+        while (x || y) && z {}
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testOuterParensRemovedInIf() {
-        let input = "if (Foo.bar(baz)) {}"
-        let output = "if Foo.bar(baz) {}"
+        let input = """
+        if (Foo.bar(baz)) {}
+        """
+        let output = """
+        if Foo.bar(baz) {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testCaseOuterParensRemoved() {
-        let input = "switch foo {\ncase (Foo.bar(let baz)):\n}"
-        let output = "switch foo {\ncase Foo.bar(let baz):\n}"
+        let input = """
+        switch foo {
+        case (Foo.bar(let baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case Foo.bar(let baz):
+        }
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.hoistPatternLet])
     }
 
     func testCaseLetOuterParensRemoved() {
-        let input = "switch foo {\ncase let (Foo.bar(baz)):\n}"
-        let output = "switch foo {\ncase let Foo.bar(baz):\n}"
+        let input = """
+        switch foo {
+        case let (Foo.bar(baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case let Foo.bar(baz):
+        }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testCaseVarOuterParensRemoved() {
-        let input = "switch foo {\ncase var (Foo.bar(baz)):\n}"
-        let output = "switch foo {\ncase var Foo.bar(baz):\n}"
+        let input = """
+        switch foo {
+        case var (Foo.bar(baz)):
+        }
+        """
+        let output = """
+        switch foo {
+        case var Foo.bar(baz):
+        }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testGuardParensRemoved() {
-        let input = "guard (x == y) else { return }"
-        let output = "guard x == y else { return }"
+        let input = """
+        guard (x == y) else { return }
+        """
+        let output = """
+        guard x == y else { return }
+        """
         testFormatting(for: input, output, rule: .redundantParens,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testForValueParensRemoved() {
-        let input = "for (x) in (y) {}"
-        let output = "for x in y {}"
+        let input = """
+        for (x) in (y) {}
+        """
+        let output = """
+        for x in y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensForLoopWhereClauseMethodNotRemoved() {
-        let input = "for foo in foos where foo.method() { print(foo) }"
+        let input = """
+        for foo in foos where foo.method() { print(foo) }
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.wrapLoopBodies])
     }
 
     func testSpaceInsertedWhenRemovingParens() {
-        let input = "if(x.y) {}"
-        let output = "if x.y {}"
+        let input = """
+        if(x.y) {}
+        """
+        let output = """
+        if x.y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testSpaceInsertedWhenRemovingParens2() {
-        let input = "while(!foo) {}"
-        let output = "while !foo {}"
+        let input = """
+        while(!foo) {}
+        """
+        let output = """
+        while !foo {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testNoDoubleSpaceWhenRemovingParens() {
-        let input = "if ( x.y ) {}"
-        let output = "if x.y {}"
+        let input = """
+        if ( x.y ) {}
+        """
+        let output = """
+        if x.y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testNoDoubleSpaceWhenRemovingParens2() {
-        let input = "if (x.y) {}"
-        let output = "if x.y {}"
+        let input = """
+        if (x.y) {}
+        """
+        let output = """
+        if x.y {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     // around function and closure arguments
 
     func testNestedClosureParensNotRemoved() {
-        let input = "foo { _ in foo(y) {} }"
+        let input = """
+        foo { _ in foo(y) {} }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testClosureTypeNotUnwrapped() {
-        let input = "foo = (Bar) -> Baz"
+        let input = """
+        foo = (Bar) -> Baz
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testOptionalFunctionCallNotUnwrapped() {
-        let input = "foo?(bar)"
+        let input = """
+        foo?(bar)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testOptionalFunctionCallResultNotUnwrapped() {
-        let input = "bar = (foo?()).flatMap(Bar.init)"
+        let input = """
+        bar = (foo?()).flatMap(Bar.init)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testOptionalSubscriptResultNotUnwrapped() {
-        let input = "bar = (foo?[0]).flatMap(Bar.init)"
+        let input = """
+        bar = (foo?[0]).flatMap(Bar.init)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testOptionalMemberResultNotUnwrapped() {
-        let input = "bar = (foo?.baz).flatMap(Bar.init)"
+        let input = """
+        bar = (foo?.baz).flatMap(Bar.init)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testForceUnwrapFunctionCallNotUnwrapped() {
-        let input = "foo!(bar)"
+        let input = """
+        foo!(bar)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testCurriedFunctionCallNotUnwrapped() {
-        let input = "foo(bar)(baz)"
+        let input = """
+        foo(bar)(baz)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testCurriedFunctionCallNotUnwrapped2() {
-        let input = "foo(bar)(baz) + quux"
+        let input = """
+        foo(bar)(baz) + quux
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testSubscriptFunctionCallNotUnwrapped() {
-        let input = "foo[\"bar\"](baz)"
+        let input = """
+        foo[\"bar\"](baz)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedInsideClosure() {
-        let input = "{ (foo) + bar }"
-        let output = "{ foo + bar }"
+        let input = """
+        { (foo) + bar }
+        """
+        let output = """
+        { foo + bar }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensRemovedAroundFunctionArgument() {
-        let input = "foo(bar: (5))"
-        let output = "foo(bar: 5)"
+        let input = """
+        foo(bar: (5))
+        """
+        let output = """
+        foo(bar: 5)
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundOptionalClosureType() {
-        let input = "let foo = (() -> ())?"
+        let input = """
+        let foo = (() -> ())?
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testRequiredParensNotRemovedAroundOptionalRange() {
-        let input = "let foo = (2...)?"
+        let input = """
+        let foo = (2...)?
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundOptionalUnwrap() {
-        let input = "let foo = (bar!)+5"
+        let input = """
+        let foo = (bar!)+5
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators])
     }
 
     func testRedundantParensRemovedAroundOptionalOptional() {
-        let input = "let foo: (Int?)?"
-        let output = "let foo: Int??"
+        let input = """
+        let foo: (Int?)?
+        """
+        let output = """
+        let foo: Int??
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundOptionalOptional2() {
-        let input = "let foo: (Int!)?"
-        let output = "let foo: Int!?"
+        let input = """
+        let foo: (Int!)?
+        """
+        let output = """
+        let foo: Int!?
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundOptionalOptional3() {
-        let input = "let foo: (Int?)!"
-        let output = "let foo: Int?!"
+        let input = """
+        let foo: (Int?)!
+        """
+        let output = """
+        let foo: Int?!
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundOptionalAnyType() {
-        let input = "let foo: (any Foo)?"
+        let input = """
+        let foo: (any Foo)?
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundAnyTypeSelf() {
-        let input = "let foo = (any Foo).self"
+        let input = """
+        let foo = (any Foo).self
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundAnyTypeType() {
-        let input = "let foo: (any Foo).Type"
+        let input = """
+        let foo: (any Foo).Type
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundAnyComposedMetatype() {
-        let input = "let foo: any (A & B).Type"
+        let input = """
+        let foo: any (A & B).Type
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundAnyType() {
-        let input = "let foo: (any Foo)"
-        let output = "let foo: any Foo"
+        let input = """
+        let foo: (any Foo)
+        """
+        let output = """
+        let foo: any Foo
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundAnyTypeInsideArray() {
-        let input = "let foo: [(any Foo)]"
-        let output = "let foo: [any Foo]"
+        let input = """
+        let foo: [(any Foo)]
+        """
+        let output = """
+        let foo: [any Foo]
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensAroundParameterPackEachNotRemoved() {
-        let input = "func f<each V>(_: repeat ((each V).Type, as: (each V) -> String)) {}"
+        let input = """
+        func f<each V>(_: repeat ((each V).Type, as: (each V) -> String)) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundOptionalClosureType() {
-        let input = "let foo = ((() -> ()))?"
-        let output = "let foo = (() -> ())?"
+        let input = """
+        let foo = ((() -> ()))?
+        """
+        let output = """
+        let foo = (() -> ())?
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.void])
     }
 
     func testRequiredParensNotRemovedAfterClosureArgument() {
-        let input = "foo({ /* code */ }())"
+        let input = """
+        foo({ /* code */ }())
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAfterClosureArgument2() {
-        let input = "foo(bar: { /* code */ }())"
+        let input = """
+        foo(bar: { /* code */ }())
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAfterClosureArgument3() {
-        let input = "foo(bar: 5, { /* code */ }())"
+        let input = """
+        foo(bar: 5, { /* code */ }())
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAfterClosureInsideArray() {
-        let input = "[{ /* code */ }()]"
+        let input = """
+        [{ /* code */ }()]
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAfterClosureInsideArrayWithTrailingComma() {
-        let input = "[{ /* code */ }(),]"
+        let input = """
+        [{ /* code */ }(),]
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.trailingCommas])
     }
 
     func testRequiredParensNotRemovedAfterClosureInWhereClause() {
-        let input = "case foo where { x == y }():"
+        let input = """
+        case foo where { x == y }():
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.redundantClosure])
     }
 
     // around closure arguments
 
     func testSingleClosureArgumentUnwrapped() {
-        let input = "{ (foo) in }"
-        let output = "{ foo in }"
+        let input = """
+        { (foo) in }
+        """
+        let output = """
+        { foo in }
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleMainActorClosureArgumentUnwrapped() {
-        let input = "{ @MainActor (foo) in }"
-        let output = "{ @MainActor foo in }"
+        let input = """
+        { @MainActor (foo) in }
+        """
+        let output = """
+        { @MainActor foo in }
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleClosureArgumentWithReturnValueUnwrapped() {
-        let input = "{ (foo) -> Int in 5 }"
-        let output = "{ foo -> Int in 5 }"
+        let input = """
+        { (foo) -> Int in 5 }
+        """
+        let output = """
+        { foo -> Int in 5 }
+        """
         testFormatting(for: input, output, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testSingleAnonymousClosureArgumentUnwrapped() {
-        let input = "{ (_) in }"
-        let output = "{ _ in }"
+        let input = """
+        { (_) in }
+        """
+        let output = """
+        { _ in }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testSingleAnonymousClosureArgumentNotUnwrapped() {
-        let input = "{ (_ foo) in }"
+        let input = """
+        { (_ foo) in }
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.unusedArguments])
     }
 
     func testTypedClosureArgumentNotUnwrapped() {
-        let input = "{ (foo: Int) in print(foo) }"
+        let input = """
+        { (foo: Int) in print(foo) }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testSingleClosureArgumentAfterCaptureListUnwrapped() {
-        let input = "{ [weak self] (foo) in self.bar(foo) }"
-        let output = "{ [weak self] foo in self.bar(foo) }"
+        let input = """
+        { [weak self] (foo) in self.bar(foo) }
+        """
+        let output = """
+        { [weak self] foo in self.bar(foo) }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testMultipleClosureArgumentUnwrapped() {
-        let input = "{ (foo, bar) in foo(bar) }"
-        let output = "{ foo, bar in foo(bar) }"
+        let input = """
+        { (foo, bar) in foo(bar) }
+        """
+        let output = """
+        { foo, bar in foo(bar) }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testTypedMultipleClosureArgumentNotUnwrapped() {
-        let input = "{ (foo: Int, bar: String) in foo(bar) }"
+        let input = """
+        { (foo: Int, bar: String) in foo(bar) }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testEmptyClosureArgsNotUnwrapped() {
-        let input = "{ () in }"
+        let input = """
+        { () in }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testClosureArgsContainingSelfNotUnwrapped() {
-        let input = "{ (self) in self }"
+        let input = """
+        { (self) in self }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testClosureArgsContainingSelfNotUnwrapped2() {
-        let input = "{ (foo, self) in foo(self) }"
+        let input = """
+        { (foo, self) in foo(self) }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testClosureArgsContainingSelfNotUnwrapped3() {
-        let input = "{ (self, foo) in foo(self) }"
+        let input = """
+        { (self, foo) in foo(self) }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testNoRemoveParensAroundArrayInitializer() {
-        let input = "let foo = bar { [Int](foo) }"
+        let input = """
+        let foo = bar { [Int](foo) }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
@@ -658,63 +996,97 @@ class RedundantParensTests: XCTestCase {
     }
 
     func testNoRemoveRequiredParensInsideClosure() {
-        let input = "let foo = { _ in (a + b).c }"
+        let input = """
+        let foo = { _ in (a + b).c }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     // before trailing closure
 
     func testParensRemovedBeforeTrailingClosure() {
-        let input = "var foo = bar() { /* some code */ }"
-        let output = "var foo = bar { /* some code */ }"
+        let input = """
+        var foo = bar() { /* some code */ }
+        """
+        let output = """
+        var foo = bar { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensRemovedBeforeTrailingClosure2() {
-        let input = "let foo = bar() { /* some code */ }"
-        let output = "let foo = bar { /* some code */ }"
+        let input = """
+        let foo = bar() { /* some code */ }
+        """
+        let output = """
+        let foo = bar { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensRemovedBeforeTrailingClosure3() {
-        let input = "var foo = bar() { /* some code */ }"
-        let output = "var foo = bar { /* some code */ }"
+        let input = """
+        var foo = bar() { /* some code */ }
+        """
+        let output = """
+        var foo = bar { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensRemovedBeforeTrailingClosureInsideHashIf() {
-        let input = "#if baz\n    let foo = bar() { /* some code */ }\n#endif"
-        let output = "#if baz\n    let foo = bar { /* some code */ }\n#endif"
+        let input = """
+        #if baz
+            let foo = bar() { /* some code */ }
+        #endif
+        """
+        let output = """
+        #if baz
+            let foo = bar { /* some code */ }
+        #endif
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeVarBody() {
-        let input = "var foo = bar() { didSet {} }"
+        let input = """
+        var foo = bar() { didSet {} }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeFunctionBody() {
-        let input = "func bar() { /* some code */ }"
+        let input = """
+        func bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeIfBody() {
-        let input = "if let foo = bar() { /* some code */ }"
+        let input = """
+        if let foo = bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeIfBody2() {
-        let input = "if try foo as Bar && baz() { /* some code */ }"
+        let input = """
+        if try foo as Bar && baz() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testParensNotRemovedBeforeIfBody3() {
-        let input = "if #selector(foo(_:)) && bar() { /* some code */ }"
+        let input = """
+        if #selector(foo(_:)) && bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.andOperator])
     }
 
     func testParensNotRemovedBeforeIfBody4() {
-        let input = "if let data = #imageLiteral(resourceName: \"abc.png\").pngData() { /* some code */ }"
+        let input = """
+        if let data = #imageLiteral(resourceName: \"abc.png\").pngData() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
@@ -728,309 +1100,455 @@ class RedundantParensTests: XCTestCase {
     }
 
     func testParensNotRemovedBeforeIfBodyAfterTry() {
-        let input = "if let foo = try bar() { /* some code */ }"
+        let input = """
+        if let foo = try bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeCompoundIfBody() {
-        let input = "if let foo = bar(), let baz = quux() { /* some code */ }"
+        let input = """
+        if let foo = bar(), let baz = quux() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeForBody() {
-        let input = "for foo in bar() { /* some code */ }"
+        let input = """
+        for foo in bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeWhileBody() {
-        let input = "while let foo = bar() { /* some code */ }"
+        let input = """
+        while let foo = bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeCaseBody() {
-        let input = "if case foo = bar() { /* some code */ }"
+        let input = """
+        if case foo = bar() { /* some code */ }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedBeforeSwitchBody() {
-        let input = "switch foo() {\ndefault: break\n}"
+        let input = """
+        switch foo() {
+        default: break
+        }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAfterAnonymousClosureInsideIfStatementBody() {
-        let input = "if let foo = bar(), { x == y }() {}"
+        let input = """
+        if let foo = bar(), { x == y }() {}
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.redundantClosure])
     }
 
     func testParensNotRemovedInGenericInit() {
-        let input = "init<T>(_: T) {}"
+        let input = """
+        init<T>(_: T) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedInGenericInit2() {
-        let input = "init<T>() {}"
+        let input = """
+        init<T>() {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedInGenericFunction() {
-        let input = "func foo<T>(_: T) {}"
+        let input = """
+        func foo<T>(_: T) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedInGenericFunction2() {
-        let input = "func foo<T>() {}"
+        let input = """
+        func foo<T>() {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedInGenericInstantiation() {
-        let input = "let foo = Foo<T>()"
+        let input = """
+        let foo = Foo<T>()
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.propertyTypes])
     }
 
     func testParensNotRemovedInGenericInstantiation2() {
-        let input = "let foo = Foo<T>(bar)"
+        let input = """
+        let foo = Foo<T>(bar)
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.propertyTypes])
     }
 
     func testRedundantParensRemovedAfterGenerics() {
-        let input = "let foo: Foo<T>\n(a) + b"
-        let output = "let foo: Foo<T>\na + b"
+        let input = """
+        let foo: Foo<T>
+        (a) + b
+        """
+        let output = """
+        let foo: Foo<T>
+        a + b
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAfterGenerics2() {
-        let input = "let foo: Foo<T>\n(foo())"
-        let output = "let foo: Foo<T>\nfoo()"
+        let input = """
+        let foo: Foo<T>
+        (foo())
+        """
+        let output = """
+        let foo: Foo<T>
+        foo()
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     // closure expression
 
     func testParensAroundClosureRemoved() {
-        let input = "let foo = ({ /* some code */ })"
-        let output = "let foo = { /* some code */ }"
+        let input = """
+        let foo = ({ /* some code */ })
+        """
+        let output = """
+        let foo = { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensAroundClosureAssignmentBlockRemoved() {
-        let input = "let foo = ({ /* some code */ })()"
-        let output = "let foo = { /* some code */ }()"
+        let input = """
+        let foo = ({ /* some code */ })()
+        """
+        let output = """
+        let foo = { /* some code */ }()
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensAroundClosureInCompoundExpressionRemoved() {
-        let input = "if foo == ({ /* some code */ }), let bar = baz {}"
-        let output = "if foo == { /* some code */ }, let bar = baz {}"
+        let input = """
+        if foo == ({ /* some code */ }), let bar = baz {}
+        """
+        let output = """
+        if foo == { /* some code */ }, let bar = baz {}
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundClosure() {
-        let input = "if (foo { $0 }) {}"
+        let input = """
+        if (foo { $0 }) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundClosure2() {
-        let input = "if (foo.filter { $0 > 1 }.isEmpty) {}"
+        let input = """
+        if (foo.filter { $0 > 1 }.isEmpty) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundClosure3() {
-        let input = "if let foo = (bar.filter { $0 > 1 }).first {}"
+        let input = """
+        if let foo = (bar.filter { $0 > 1 }).first {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     // around tuples
 
     func testsTupleNotUnwrapped() {
-        let input = "tuple = (1, 2)"
+        let input = """
+        tuple = (1, 2)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testsTupleOfClosuresNotUnwrapped() {
-        let input = "tuple = ({}, {})"
+        let input = """
+        tuple = ({}, {})
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testSwitchTupleNotUnwrapped() {
-        let input = "switch (x, y) {}"
+        let input = """
+        switch (x, y) {}
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensRemovedAroundTuple() {
-        let input = "let foo = ((bar: Int, baz: String))"
-        let output = "let foo = (bar: Int, baz: String)"
+        let input = """
+        let foo = ((bar: Int, baz: String))
+        """
+        let output = """
+        let foo = (bar: Int, baz: String)
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundTupleFunctionArgument() {
-        let input = "let foo = bar((bar: Int, baz: String))"
+        let input = """
+        let foo = bar((bar: Int, baz: String))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundTupleFunctionArgumentAfterSubscript() {
-        let input = "bar[5]((bar: Int, baz: String))"
+        let input = """
+        bar[5]((bar: Int, baz: String))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testNestedParensRemovedAroundTupleFunctionArgument() {
-        let input = "let foo = bar(((bar: Int, baz: String)))"
-        let output = "let foo = bar((bar: Int, baz: String))"
+        let input = """
+        let foo = bar(((bar: Int, baz: String)))
+        """
+        let output = """
+        let foo = bar((bar: Int, baz: String))
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testNestedParensRemovedAroundTupleFunctionArgument2() {
-        let input = "let foo = bar(foo: ((bar: Int, baz: String)))"
-        let output = "let foo = bar(foo: (bar: Int, baz: String))"
+        let input = """
+        let foo = bar(foo: ((bar: Int, baz: String)))
+        """
+        let output = """
+        let foo = bar(foo: (bar: Int, baz: String))
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testNestedParensRemovedAroundTupleOperands() {
-        let input = "((1, 2)) == ((1, 2))"
-        let output = "(1, 2) == (1, 2)"
+        let input = """
+        ((1, 2)) == ((1, 2))
+        """
+        let output = """
+        (1, 2) == (1, 2)
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundTupleFunctionTypeDeclaration() {
-        let input = "let foo: ((bar: Int, baz: String)) -> Void"
+        let input = """
+        let foo: ((bar: Int, baz: String)) -> Void
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundUnlabelledTupleFunctionTypeDeclaration() {
-        let input = "let foo: ((Int, String)) -> Void"
+        let input = """
+        let foo: ((Int, String)) -> Void
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundTupleFunctionTypeAssignment() {
-        let input = "foo = ((bar: Int, baz: String)) -> Void { _ in }"
+        let input = """
+        foo = ((bar: Int, baz: String)) -> Void { _ in }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundTupleFunctionTypeAssignment() {
-        let input = "foo = ((((bar: Int, baz: String)))) -> Void { _ in }"
-        let output = "foo = ((bar: Int, baz: String)) -> Void { _ in }"
+        let input = """
+        foo = ((((bar: Int, baz: String)))) -> Void { _ in }
+        """
+        let output = """
+        foo = ((bar: Int, baz: String)) -> Void { _ in }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundUnlabelledTupleFunctionTypeAssignment() {
-        let input = "foo = ((Int, String)) -> Void { _ in }"
+        let input = """
+        foo = ((Int, String)) -> Void { _ in }
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRedundantParensRemovedAroundUnlabelledTupleFunctionTypeAssignment() {
-        let input = "foo = ((((Int, String)))) -> Void { _ in }"
-        let output = "foo = ((Int, String)) -> Void { _ in }"
+        let input = """
+        foo = ((((Int, String)))) -> Void { _ in }
+        """
+        let output = """
+        foo = ((Int, String)) -> Void { _ in }
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundTupleArgument() {
-        let input = "foo((bar, baz))"
+        let input = """
+        foo((bar, baz))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundVoidGenerics() {
-        let input = "let foo = Foo<Bar, (), ()>"
+        let input = """
+        let foo = Foo<Bar, (), ()>
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testParensNotRemovedAroundTupleGenerics() {
-        let input = "let foo = Foo<Bar, (Int, String), ()>"
+        let input = """
+        let foo = Foo<Bar, (Int, String), ()>
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     func testParensNotRemovedAroundLabeledTupleGenerics() {
-        let input = "let foo = Foo<Bar, (a: Int, b: String), ()>"
+        let input = """
+        let foo = Foo<Bar, (a: Int, b: String), ()>
+        """
         testFormatting(for: input, rule: .redundantParens, exclude: [.void])
     }
 
     // after indexed tuple
 
     func testParensNotRemovedAfterTupleIndex() {
-        let input = "foo.1()"
+        let input = """
+        foo.1()
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAfterTupleIndex2() {
-        let input = "foo.1(true)"
+        let input = """
+        foo.1(true)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAfterTupleIndex3() {
-        let input = "foo.1((bar: Int, baz: String))"
+        let input = """
+        foo.1((bar: Int, baz: String))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testNestedParensRemovedAfterTupleIndex3() {
-        let input = "foo.1(((bar: Int, baz: String)))"
-        let output = "foo.1((bar: Int, baz: String))"
+        let input = """
+        foo.1(((bar: Int, baz: String)))
+        """
+        let output = """
+        foo.1((bar: Int, baz: String))
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     // inside string interpolation
 
     func testParensInStringNotRemoved() {
-        let input = "\"hello \\(world)\""
+        let input = """
+        \"hello \\(world)\"
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     // around ranges
 
     func testParensAroundRangeNotRemoved() {
-        let input = "(1 ..< 10).reduce(0, combine: +)"
+        let input = """
+        (1 ..< 10).reduce(0, combine: +)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensRemovedAroundRangeArguments() {
-        let input = "(a)...(b)"
-        let output = "a...b"
+        let input = """
+        (a)...(b)
+        """
+        let output = """
+        a...b
+        """
         testFormatting(for: input, output, rule: .redundantParens,
                        exclude: [.spaceAroundOperators])
     }
 
     func testParensNotRemovedAroundRangeArgumentBeginningWithDot() {
-        let input = "a...(.b)"
+        let input = """
+        a...(.b)
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators])
     }
 
     func testParensNotRemovedAroundTrailingRangeFollowedByDot() {
-        let input = "(a...).b"
+        let input = """
+        (a...).b
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testParensNotRemovedAroundRangeArgumentBeginningWithPrefixOperator() {
-        let input = "a...(-b)"
+        let input = """
+        a...(-b)
+        """
         testFormatting(for: input, rule: .redundantParens,
                        exclude: [.spaceAroundOperators])
     }
 
     func testParensRemovedAroundRangeArgumentBeginningWithDot() {
-        let input = "a ... (.b)"
-        let output = "a ... .b"
+        let input = """
+        a ... (.b)
+        """
+        let output = """
+        a ... .b
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     func testParensRemovedAroundRangeArgumentBeginningWithPrefixOperator() {
-        let input = "a ... (-b)"
-        let output = "a ... -b"
+        let input = """
+        a ... (-b)
+        """
+        let output = """
+        a ... -b
+        """
         testFormatting(for: input, output, rule: .redundantParens)
     }
 
     // around ternaries
 
     func testParensNotRemovedAroundTernaryCondition() {
-        let input = "let a = (b == c) ? d : e"
+        let input = """
+        let a = (b == c) ? d : e
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     func testRequiredParensNotRemovedAroundTernaryAssignment() {
-        let input = "a ? (b = c) : (b = d)"
+        let input = """
+        a ? (b = c) : (b = d)
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 
     // around parameter repeat each
 
     func testRequiredParensNotRemovedAroundRepeat() {
-        let input = "(repeat (each foo, each bar))"
+        let input = """
+        (repeat (each foo, each bar))
+        """
         testFormatting(for: input, rule: .redundantParens)
     }
 

--- a/Tests/Rules/RedundantPatternTests.swift
+++ b/Tests/Rules/RedundantPatternTests.swift
@@ -11,45 +11,79 @@ import XCTest
 
 class RedundantPatternTests: XCTestCase {
     func testRemoveRedundantPatternInIfCase() {
-        let input = "if case let .foo(_, _) = bar {}"
-        let output = "if case .foo = bar {}"
+        let input = """
+        if case let .foo(_, _) = bar {}
+        """
+        let output = """
+        if case .foo = bar {}
+        """
         testFormatting(for: input, output, rule: .redundantPattern)
     }
 
     func testNoRemoveRequiredPatternInIfCase() {
-        let input = "if case (_, _) = bar {}"
+        let input = """
+        if case (_, _) = bar {}
+        """
         testFormatting(for: input, rule: .redundantPattern)
     }
 
     func testRemoveRedundantPatternInSwitchCase() {
-        let input = "switch foo {\ncase let .bar(_, _): break\ndefault: break\n}"
-        let output = "switch foo {\ncase .bar: break\ndefault: break\n}"
+        let input = """
+        switch foo {
+        case let .bar(_, _): break
+        default: break
+        }
+        """
+        let output = """
+        switch foo {
+        case .bar: break
+        default: break
+        }
+        """
         testFormatting(for: input, output, rule: .redundantPattern)
     }
 
     func testNoRemoveRequiredPatternLetInSwitchCase() {
-        let input = "switch foo {\ncase let .bar(_, a): break\ndefault: break\n}"
+        let input = """
+        switch foo {
+        case let .bar(_, a): break
+        default: break
+        }
+        """
         testFormatting(for: input, rule: .redundantPattern)
     }
 
     func testNoRemoveRequiredPatternInSwitchCase() {
-        let input = "switch foo {\ncase (_, _): break\ndefault: break\n}"
+        let input = """
+        switch foo {
+        case (_, _): break
+        default: break
+        }
+        """
         testFormatting(for: input, rule: .redundantPattern)
     }
 
     func testSimplifyLetPattern() {
-        let input = "let(_, _) = bar"
-        let output = "let _ = bar"
+        let input = """
+        let(_, _) = bar
+        """
+        let output = """
+        let _ = bar
+        """
         testFormatting(for: input, output, rule: .redundantPattern, exclude: [.redundantLet])
     }
 
     func testNoRemoveVoidFunctionCall() {
-        let input = "if case .foo() = bar {}"
+        let input = """
+        if case .foo() = bar {}
+        """
         testFormatting(for: input, rule: .redundantPattern)
     }
 
     func testNoRemoveMethodSignature() {
-        let input = "func foo(_, _) {}"
+        let input = """
+        func foo(_, _) {}
+        """
         testFormatting(for: input, rule: .redundantPattern)
     }
 }

--- a/Tests/Rules/RedundantRawValuesTests.swift
+++ b/Tests/Rules/RedundantRawValuesTests.swift
@@ -11,27 +11,49 @@ import XCTest
 
 class RedundantRawValuesTests: XCTestCase {
     func testRemoveRedundantRawString() {
-        let input = "enum Foo: String {\n    case bar = \"bar\"\n    case baz = \"baz\"\n}"
-        let output = "enum Foo: String {\n    case bar\n    case baz\n}"
+        let input = """
+        enum Foo: String {
+            case bar = \"bar\"
+            case baz = \"baz\"
+        }
+        """
+        let output = """
+        enum Foo: String {
+            case bar
+            case baz
+        }
+        """
         testFormatting(for: input, output, rule: .redundantRawValues)
     }
 
     func testRemoveCommaDelimitedCaseRawStringCases() {
-        let input = "enum Foo: String { case bar = \"bar\", baz = \"baz\" }"
-        let output = "enum Foo: String { case bar, baz }"
+        let input = """
+        enum Foo: String { case bar = \"bar\", baz = \"baz\" }
+        """
+        let output = """
+        enum Foo: String { case bar, baz }
+        """
         testFormatting(for: input, output, rule: .redundantRawValues,
                        exclude: [.wrapEnumCases])
     }
 
     func testRemoveBacktickCaseRawStringCases() {
-        let input = "enum Foo: String { case `as` = \"as\", `let` = \"let\" }"
-        let output = "enum Foo: String { case `as`, `let` }"
+        let input = """
+        enum Foo: String { case `as` = \"as\", `let` = \"let\" }
+        """
+        let output = """
+        enum Foo: String { case `as`, `let` }
+        """
         testFormatting(for: input, output, rule: .redundantRawValues,
                        exclude: [.wrapEnumCases])
     }
 
     func testNoRemoveRawStringIfNameDoesntMatch() {
-        let input = "enum Foo: String {\n    case bar = \"foo\"\n}"
+        let input = """
+        enum Foo: String {
+            case bar = \"foo\"
+        }
+        """
         testFormatting(for: input, rule: .redundantRawValues)
     }
 }

--- a/Tests/Rules/RedundantReturnTests.swift
+++ b/Tests/Rules/RedundantReturnTests.swift
@@ -11,92 +11,151 @@ import XCTest
 
 class RedundantReturnTests: XCTestCase {
     func testRemoveRedundantReturnInClosure() {
-        let input = "foo(with: { return 5 })"
-        let output = "foo(with: { 5 })"
+        let input = """
+        foo(with: { return 5 })
+        """
+        let output = """
+        foo(with: { 5 })
+        """
         testFormatting(for: input, output, rule: .redundantReturn, exclude: [.trailingClosures])
     }
 
     func testRemoveRedundantReturnInClosureWithArgs() {
-        let input = "foo(with: { foo in return foo })"
-        let output = "foo(with: { foo in foo })"
+        let input = """
+        foo(with: { foo in return foo })
+        """
+        let output = """
+        foo(with: { foo in foo })
+        """
         testFormatting(for: input, output, rule: .redundantReturn, exclude: [.trailingClosures])
     }
 
     func testRemoveRedundantReturnInMap() {
-        let input = "let foo = bar.map { return 1 }"
-        let output = "let foo = bar.map { 1 }"
+        let input = """
+        let foo = bar.map { return 1 }
+        """
+        let output = """
+        let foo = bar.map { 1 }
+        """
         testFormatting(for: input, output, rule: .redundantReturn)
     }
 
     func testNoRemoveReturnInComputedVar() {
-        let input = "var foo: Int { return 5 }"
+        let input = """
+        var foo: Int { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn)
     }
 
     func testRemoveReturnInComputedVar() {
-        let input = "var foo: Int { return 5 }"
-        let output = "var foo: Int { 5 }"
+        let input = """
+        var foo: Int { return 5 }
+        """
+        let output = """
+        var foo: Int { 5 }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options)
     }
 
     func testNoRemoveReturnInGet() {
-        let input = "var foo: Int {\n    get { return 5 }\n    set { _foo = newValue }\n}"
+        let input = """
+        var foo: Int {
+            get { return 5 }
+            set { _foo = newValue }
+        }
+        """
         testFormatting(for: input, rule: .redundantReturn)
     }
 
     func testRemoveReturnInGet() {
-        let input = "var foo: Int {\n    get { return 5 }\n    set { _foo = newValue }\n}"
-        let output = "var foo: Int {\n    get { 5 }\n    set { _foo = newValue }\n}"
+        let input = """
+        var foo: Int {
+            get { return 5 }
+            set { _foo = newValue }
+        }
+        """
+        let output = """
+        var foo: Int {
+            get { 5 }
+            set { _foo = newValue }
+        }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options)
     }
 
     func testNoRemoveReturnInGetClosure() {
-        let input = "let foo = get { return 5 }"
-        let output = "let foo = get { 5 }"
+        let input = """
+        let foo = get { return 5 }
+        """
+        let output = """
+        let foo = get { 5 }
+        """
         testFormatting(for: input, output, rule: .redundantReturn)
     }
 
     func testRemoveReturnInVarClosure() {
-        let input = "var foo = { return 5 }()"
-        let output = "var foo = { 5 }()"
+        let input = """
+        var foo = { return 5 }()
+        """
+        let output = """
+        var foo = { 5 }()
+        """
         testFormatting(for: input, output, rule: .redundantReturn, exclude: [.redundantClosure])
     }
 
     func testRemoveReturnInParenthesizedClosure() {
-        let input = "var foo = ({ return 5 }())"
-        let output = "var foo = ({ 5 }())"
+        let input = """
+        var foo = ({ return 5 }())
+        """
+        let output = """
+        var foo = ({ 5 }())
+        """
         testFormatting(for: input, output, rule: .redundantReturn, exclude: [.redundantParens, .redundantClosure])
     }
 
     func testNoRemoveReturnInFunction() {
-        let input = "func foo() -> Int { return 5 }"
+        let input = """
+        func foo() -> Int { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn)
     }
 
     func testRemoveReturnInFunction() {
-        let input = "func foo() -> Int { return 5 }"
-        let output = "func foo() -> Int { 5 }"
+        let input = """
+        func foo() -> Int { return 5 }
+        """
+        let output = """
+        func foo() -> Int { 5 }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options)
     }
 
     func testNoRemoveReturnInOperatorFunction() {
-        let input = "func + (lhs: Int, rhs: Int) -> Int { return 5 }"
+        let input = """
+        func + (lhs: Int, rhs: Int) -> Int { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn, exclude: [.unusedArguments])
     }
 
     func testRemoveReturnInOperatorFunction() {
-        let input = "func + (lhs: Int, rhs: Int) -> Int { return 5 }"
-        let output = "func + (lhs: Int, rhs: Int) -> Int { 5 }"
+        let input = """
+        func + (lhs: Int, rhs: Int) -> Int { return 5 }
+        """
+        let output = """
+        func + (lhs: Int, rhs: Int) -> Int { 5 }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options,
                        exclude: [.unusedArguments])
     }
 
     func testNoRemoveReturnInFailableInit() {
-        let input = "init?() { return nil }"
+        let input = """
+        init?() { return nil }
+        """
         testFormatting(for: input, rule: .redundantReturn)
     }
 
@@ -134,20 +193,30 @@ class RedundantReturnTests: XCTestCase {
     }
 
     func testRemoveReturnInFailableInit() {
-        let input = "init?() { return nil }"
-        let output = "init?() { nil }"
+        let input = """
+        init?() { return nil }
+        """
+        let output = """
+        init?() { nil }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options)
     }
 
     func testNoRemoveReturnInSubscript() {
-        let input = "subscript(index: Int) -> String { return nil }"
+        let input = """
+        subscript(index: Int) -> String { return nil }
+        """
         testFormatting(for: input, rule: .redundantReturn, exclude: [.unusedArguments])
     }
 
     func testRemoveReturnInSubscript() {
-        let input = "subscript(index: Int) -> String { return nil }"
-        let output = "subscript(index: Int) -> String { nil }"
+        let input = """
+        subscript(index: Int) -> String { return nil }
+        """
+        let output = """
+        subscript(index: Int) -> String { nil }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options,
                        exclude: [.unusedArguments])
@@ -210,54 +279,76 @@ class RedundantReturnTests: XCTestCase {
     }
 
     func testNoRemoveReturnInForIn() {
-        let input = "for foo in bar { return 5 }"
+        let input = """
+        for foo in bar { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveReturnInForWhere() {
-        let input = "for foo in bar where baz { return 5 }"
+        let input = """
+        for foo in bar where baz { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveReturnInIfLetTry() {
-        let input = "if let foo = try? bar() { return 5 }"
+        let input = """
+        if let foo = try? bar() { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnInMultiIfLetTry() {
-        let input = "if let foo = bar, let bar = baz { return 5 }"
+        let input = """
+        if let foo = bar, let bar = baz { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnAfterMultipleAs() {
-        let input = "if foo as? bar as? baz { return 5 }"
+        let input = """
+        if foo as? bar as? baz { return 5 }
+        """
         testFormatting(for: input, rule: .redundantReturn,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testRemoveVoidReturn() {
-        let input = "{ _ in return }"
-        let output = "{ _ in }"
+        let input = """
+        { _ in return }
+        """
+        let output = """
+        { _ in }
+        """
         testFormatting(for: input, output, rule: .redundantReturn)
     }
 
     func testNoRemoveReturnAfterKeyPath() {
-        let input = "func foo() { if bar == #keyPath(baz) { return 5 } }"
+        let input = """
+        func foo() { if bar == #keyPath(baz) { return 5 } }
+        """
         testFormatting(for: input, rule: .redundantReturn,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveReturnAfterParentheses() {
-        let input = "if let foo = (bar as? String) { return foo }"
+        let input = """
+        if let foo = (bar as? String) { return foo }
+        """
         testFormatting(for: input, rule: .redundantReturn,
                        exclude: [.redundantParens, .wrapConditionalBodies])
     }
 
     func testRemoveReturnInTupleVarGetter() {
-        let input = "var foo: (Int, Int) { return (1, 2) }"
-        let output = "var foo: (Int, Int) { (1, 2) }"
+        let input = """
+        var foo: (Int, Int) { return (1, 2) }
+        """
+        let output = """
+        var foo: (Int, Int) { (1, 2) }
+        """
         let options = FormatOptions(swiftVersion: "5.1")
         testFormatting(for: input, output, rule: .redundantReturn, options: options)
     }

--- a/Tests/Rules/RedundantSelfTests.swift
+++ b/Tests/Rules/RedundantSelfTests.swift
@@ -13,55 +13,95 @@ class RedundantSelfTests: XCTestCase {
     // explicitSelf = .remove
 
     func testSimpleRemoveRedundantSelf() {
-        let input = "func foo() { self.bar() }"
-        let output = "func foo() { bar() }"
+        let input = """
+        func foo() { self.bar() }
+        """
+        let output = """
+        func foo() { bar() }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfInsideStringInterpolation() {
-        let input = "class Foo {\n    var bar: String?\n    func baz() {\n        print(\"\\(self.bar)\")\n    }\n}"
-        let output = "class Foo {\n    var bar: String?\n    func baz() {\n        print(\"\\(bar)\")\n    }\n}"
+        let input = """
+        class Foo {
+            var bar: String?
+            func baz() {
+                print(\"\\(self.bar)\")
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            var bar: String?
+            func baz() {
+                print(\"\\(bar)\")
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForArgument() {
-        let input = "func foo(bar: Int) { self.bar = bar }"
+        let input = """
+        func foo(bar: Int) { self.bar = bar }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForLocalVariable() {
-        let input = "func foo() { var bar = self.bar }"
+        let input = """
+        func foo() { var bar = self.bar }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testRemoveSelfForLocalVariableOn5_4() {
-        let input = "func foo() { var bar = self.bar }"
-        let output = "func foo() { var bar = bar }"
+        let input = """
+        func foo() { var bar = self.bar }
+        """
+        let output = """
+        func foo() { var bar = bar }
+        """
         let options = FormatOptions(swiftVersion: "5.4")
         testFormatting(for: input, output, rule: .redundantSelf,
                        options: options)
     }
 
     func testNoRemoveSelfForCommaDelimitedLocalVariables() {
-        let input = "func foo() { let foo = self.foo, bar = self.bar }"
+        let input = """
+        func foo() { let foo = self.foo, bar = self.bar }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.singlePropertyPerLine])
     }
 
     func testRemoveSelfForCommaDelimitedLocalVariablesOn5_4() {
-        let input = "func foo() { let foo = self.foo, bar = self.bar }"
-        let output = "func foo() { let foo = self.foo, bar = bar }"
+        let input = """
+        func foo() { let foo = self.foo, bar = self.bar }
+        """
+        let output = """
+        func foo() { let foo = self.foo, bar = bar }
+        """
         let options = FormatOptions(swiftVersion: "5.4")
         testFormatting(for: input, output, rule: .redundantSelf,
                        options: options, exclude: [.singlePropertyPerLine])
     }
 
     func testNoRemoveSelfForCommaDelimitedLocalVariables2() {
-        let input = "func foo() {\n    let foo: Foo, bar: Bar\n    foo = self.foo\n    bar = self.bar\n}"
+        let input = """
+        func foo() {
+            let foo: Foo, bar: Bar
+            foo = self.foo
+            bar = self.bar
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.singlePropertyPerLine])
     }
 
     func testNoRemoveSelfForTupleAssignedVariables() {
-        let input = "func foo() { let (bar, baz) = (self.bar, self.baz) }"
+        let input = """
+        func foo() { let (bar, baz) = (self.bar, self.baz) }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.singlePropertyPerLine])
     }
 
@@ -75,179 +115,325 @@ class RedundantSelfTests: XCTestCase {
 //    }
 
     func testNoRemoveSelfForTupleAssignedVariablesFollowedByRegularVariable() {
-        let input = "func foo() {\n    let (foo, bar) = (self.foo, self.bar), baz = self.baz\n}"
+        let input = """
+        func foo() {
+            let (foo, bar) = (self.foo, self.bar), baz = self.baz
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.singlePropertyPerLine])
     }
 
     func testNoRemoveSelfForTupleAssignedVariablesFollowedByRegularLet() {
-        let input = "func foo() {\n    let (foo, bar) = (self.foo, self.bar)\n    let baz = self.baz\n}"
+        let input = """
+        func foo() {
+            let (foo, bar) = (self.foo, self.bar)
+            let baz = self.baz
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.singlePropertyPerLine])
     }
 
     func testNoRemoveNonRedundantNestedFunctionSelf() {
-        let input = "func foo() { func bar() { self.bar() } }"
+        let input = """
+        func foo() { func bar() { self.bar() } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveNonRedundantNestedFunctionSelf2() {
-        let input = "func foo() {\n    func bar() {}\n    self.bar()\n}"
+        let input = """
+        func foo() {
+            func bar() {}
+            self.bar()
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveNonRedundantNestedFunctionSelf3() {
-        let input = "func foo() { let bar = 5; func bar() { self.bar = bar } }"
+        let input = """
+        func foo() { let bar = 5; func bar() { self.bar = bar } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveClosureSelf() {
-        let input = "func foo() { bar { self.bar = 5 } }"
+        let input = """
+        func foo() { bar { self.bar = 5 } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfAfterOptionalReturn() {
-        let input = "func foo() -> String? {\n    var index = startIndex\n    if !matching(self[index]) {\n        break\n    }\n    index = self.index(after: index)\n}"
+        let input = """
+        func foo() -> String? {
+            var index = startIndex
+            if !matching(self[index]) {
+                break
+            }
+            index = self.index(after: index)
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveRequiredSelfInExtensions() {
-        let input = "extension Foo {\n    func foo() {\n        var index = 5\n        if true {\n            break\n        }\n        index = self.index(after: index)\n    }\n}"
+        let input = """
+        extension Foo {
+            func foo() {
+                var index = 5
+                if true {
+                    break
+                }
+                index = self.index(after: index)
+            }
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfBeforeInit() {
-        let input = "convenience init() { self.init(5) }"
+        let input = """
+        convenience init() { self.init(5) }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testRemoveSelfInsideSwitch() {
-        let input = "func foo() {\n    switch self.bar {\n    case .foo:\n        self.baz()\n    }\n}"
-        let output = "func foo() {\n    switch bar {\n    case .foo:\n        baz()\n    }\n}"
+        let input = """
+        func foo() {
+            switch self.bar {
+            case .foo:
+                self.baz()
+            }
+        }
+        """
+        let output = """
+        func foo() {
+            switch bar {
+            case .foo:
+                baz()
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfInsideSwitchWhere() {
-        let input = "func foo() {\n    switch self.bar {\n    case .foo where a == b:\n        self.baz()\n    }\n}"
-        let output = "func foo() {\n    switch bar {\n    case .foo where a == b:\n        baz()\n    }\n}"
+        let input = """
+        func foo() {
+            switch self.bar {
+            case .foo where a == b:
+                self.baz()
+            }
+        }
+        """
+        let output = """
+        func foo() {
+            switch bar {
+            case .foo where a == b:
+                baz()
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfInsideSwitchWhereAs() {
-        let input = "func foo() {\n    switch self.bar {\n    case .foo where a == b as C:\n        self.baz()\n    }\n}"
-        let output = "func foo() {\n    switch bar {\n    case .foo where a == b as C:\n        baz()\n    }\n}"
+        let input = """
+        func foo() {
+            switch self.bar {
+            case .foo where a == b as C:
+                self.baz()
+            }
+        }
+        """
+        let output = """
+        func foo() {
+            switch bar {
+            case .foo where a == b as C:
+                baz()
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfInsideClassInit() {
-        let input = "class Foo {\n    var bar = 5\n    init() { self.bar = 6 }\n}"
-        let output = "class Foo {\n    var bar = 5\n    init() { bar = 6 }\n}"
+        let input = """
+        class Foo {
+            var bar = 5
+            init() { self.bar = 6 }
+        }
+        """
+        let output = """
+        class Foo {
+            var bar = 5
+            init() { bar = 6 }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureInsideIf() {
-        let input = "if foo { bar { self.baz() } }"
+        let input = """
+        if foo { bar { self.baz() } }
+        """
         testFormatting(for: input, rule: .redundantSelf,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveSelfForErrorInCatch() {
-        let input = "do {} catch { self.error = error }"
+        let input = """
+        do {} catch { self.error = error }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForErrorInDoThrowsCatch() {
-        let input = "do throws(Foo) {} catch { self.error = error }"
+        let input = """
+        do throws(Foo) {} catch { self.error = error }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForNewValueInSet() {
-        let input = "var foo: Int { set { self.newValue = newValue } get { return 0 } }"
+        let input = """
+        var foo: Int { set { self.newValue = newValue } get { return 0 } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForCustomNewValueInSet() {
-        let input = "var foo: Int { set(n00b) { self.n00b = n00b } get { return 0 } }"
+        let input = """
+        var foo: Int { set(n00b) { self.n00b = n00b } get { return 0 } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForNewValueInWillSet() {
-        let input = "var foo: Int { willSet { self.newValue = newValue } }"
+        let input = """
+        var foo: Int { willSet { self.newValue = newValue } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForCustomNewValueInWillSet() {
-        let input = "var foo: Int { willSet(n00b) { self.n00b = n00b } }"
+        let input = """
+        var foo: Int { willSet(n00b) { self.n00b = n00b } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForOldValueInDidSet() {
-        let input = "var foo: Int { didSet { self.oldValue = oldValue } }"
+        let input = """
+        var foo: Int { didSet { self.oldValue = oldValue } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForCustomOldValueInDidSet() {
-        let input = "var foo: Int { didSet(oldz) { self.oldz = oldz } }"
+        let input = """
+        var foo: Int { didSet(oldz) { self.oldz = oldz } }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForIndexVarInFor() {
-        let input = "for foo in bar { self.foo = foo }"
+        let input = """
+        for foo in bar { self.foo = foo }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveSelfForKeyValueTupleInFor() {
-        let input = "for (foo, bar) in baz { self.foo = foo; self.bar = bar }"
+        let input = """
+        for (foo, bar) in baz { self.foo = foo; self.bar = bar }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testRemoveSelfFromComputedVar() {
-        let input = "var foo: Int { return self.bar }"
-        let output = "var foo: Int { return bar }"
+        let input = """
+        var foo: Int { return self.bar }
+        """
+        let output = """
+        var foo: Int { return bar }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromOptionalComputedVar() {
-        let input = "var foo: Int? { return self.bar }"
-        let output = "var foo: Int? { return bar }"
+        let input = """
+        var foo: Int? { return self.bar }
+        """
+        let output = """
+        var foo: Int? { return bar }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromNamespacedComputedVar() {
-        let input = "var foo: Swift.String { return self.bar }"
-        let output = "var foo: Swift.String { return bar }"
+        let input = """
+        var foo: Swift.String { return self.bar }
+        """
+        let output = """
+        var foo: Swift.String { return bar }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromGenericComputedVar() {
-        let input = "var foo: Foo<Int> { return self.bar }"
-        let output = "var foo: Foo<Int> { return bar }"
+        let input = """
+        var foo: Foo<Int> { return self.bar }
+        """
+        let output = """
+        var foo: Foo<Int> { return bar }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromComputedArrayVar() {
-        let input = "var foo: [Int] { return self.bar }"
-        let output = "var foo: [Int] { return bar }"
+        let input = """
+        var foo: [Int] { return self.bar }
+        """
+        let output = """
+        var foo: [Int] { return bar }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromVarSetter() {
-        let input = "var foo: Int { didSet { self.bar() } }"
-        let output = "var foo: Int { didSet { bar() } }"
+        let input = """
+        var foo: Int { didSet { self.bar() } }
+        """
+        let output = """
+        var foo: Int { didSet { bar() } }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromVarClosure() {
-        let input = "var foo = { self.bar }"
+        let input = """
+        var foo = { self.bar }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromLazyVar() {
-        let input = "lazy var foo = self.bar"
+        let input = """
+        lazy var foo = self.bar
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromLazyVar() {
-        let input = "lazy var foo = self.bar"
-        let output = "lazy var foo = bar"
+        let input = """
+        lazy var foo = self.bar
+        """
+        let output = """
+        lazy var foo = bar
+        """
         let options = FormatOptions(swiftVersion: "4")
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
@@ -274,158 +460,322 @@ class RedundantSelfTests: XCTestCase {
     }
 
     func testNoRemoveSelfFromLazyVarClosure() {
-        let input = "lazy var foo = { self.bar }()"
+        let input = """
+        lazy var foo = { self.bar }()
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.redundantClosure])
     }
 
     func testNoRemoveSelfFromLazyVarClosure2() {
-        let input = "lazy var foo = { let bar = self.baz }()"
+        let input = """
+        lazy var foo = { let bar = self.baz }()
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromLazyVarClosure3() {
-        let input = "lazy var foo = { [unowned self] in let bar = self.baz }()"
+        let input = """
+        lazy var foo = { [unowned self] in let bar = self.baz }()
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromVarInFuncWithUnusedArgument() {
-        let input = "func foo(bar _: Int) { self.baz = 5 }"
-        let output = "func foo(bar _: Int) { baz = 5 }"
+        let input = """
+        func foo(bar _: Int) { self.baz = 5 }
+        """
+        let output = """
+        func foo(bar _: Int) { baz = 5 }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfFromVarMatchingUnusedArgument() {
-        let input = "func foo(bar _: Int) { self.bar = 5 }"
-        let output = "func foo(bar _: Int) { bar = 5 }"
+        let input = """
+        func foo(bar _: Int) { self.bar = 5 }
+        """
+        let output = """
+        func foo(bar _: Int) { bar = 5 }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromVarMatchingRenamedArgument() {
-        let input = "func foo(bar baz: Int) { self.baz = baz }"
+        let input = """
+        func foo(bar baz: Int) { self.baz = baz }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromVarRedeclaredInSubscope() {
-        let input = "func foo() {\n    if quux {\n        let bar = 5\n    }\n    let baz = self.bar\n}"
-        let output = "func foo() {\n    if quux {\n        let bar = 5\n    }\n    let baz = bar\n}"
+        let input = """
+        func foo() {
+            if quux {
+                let bar = 5
+            }
+            let baz = self.bar
+        }
+        """
+        let output = """
+        func foo() {
+            if quux {
+                let bar = 5
+            }
+            let baz = bar
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromVarDeclaredLaterInScope() {
-        let input = "func foo() {\n    let bar = self.baz\n    let baz = quux\n}"
+        let input = """
+        func foo() {
+            let bar = self.baz
+            let baz = quux
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfFromVarDeclaredLaterInOuterScope() {
-        let input = "func foo() {\n    if quux {\n        let bar = self.baz\n    }\n    let baz = 6\n}"
+        let input = """
+        func foo() {
+            if quux {
+                let bar = self.baz
+            }
+            let baz = 6
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInWhilePreceededByVarDeclaration() {
-        let input = "var index = start\nwhile index < end {\n    index = self.index(after: index)\n}"
+        let input = """
+        var index = start
+        while index < end {
+            index = self.index(after: index)
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInLocalVarPrecededByLocalVarFollowedByIfComma() {
-        let input = "func foo() {\n    let bar = Bar()\n    let baz = Baz()\n    self.baz = baz\n    if let bar = bar, bar > 0 {}\n}"
+        let input = """
+        func foo() {
+            let bar = Bar()
+            let baz = Baz()
+            self.baz = baz
+            if let bar = bar, bar > 0 {}
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInLocalVarPrecededByIfLetContainingClosure() {
-        let input = "func foo() {\n    if let bar = 5 { baz { _ in } }\n    let quux = self.quux\n}"
+        let input = """
+        func foo() {
+            if let bar = 5 { baz { _ in } }
+            let quux = self.quux
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoRemoveSelfForVarCreatedInGuardScope() {
-        let input = "func foo() {\n    guard let bar = 5 else {}\n    let baz = self.bar\n}"
+        let input = """
+        func foo() {
+            guard let bar = 5 else {}
+            let baz = self.bar
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf,
                        exclude: [.wrapConditionalBodies, .blankLinesAfterGuardStatements])
     }
 
     func testRemoveSelfForVarCreatedInIfScope() {
-        let input = "func foo() {\n    if let bar = bar {}\n    let baz = self.bar\n}"
-        let output = "func foo() {\n    if let bar = bar {}\n    let baz = bar\n}"
+        let input = """
+        func foo() {
+            if let bar = bar {}
+            let baz = self.bar
+        }
+        """
+        let output = """
+        func foo() {
+            if let bar = bar {}
+            let baz = bar
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForVarDeclaredInWhileCondition() {
-        let input = "while let foo = bar { self.foo = foo }"
+        let input = """
+        while let foo = bar { self.foo = foo }
+        """
         testFormatting(for: input, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testRemoveSelfForVarNotDeclaredInWhileCondition() {
-        let input = "while let foo == bar { self.baz = 5 }"
-        let output = "while let foo == bar { baz = 5 }"
+        let input = """
+        while let foo == bar { self.baz = 5 }
+        """
+        let output = """
+        while let foo == bar { baz = 5 }
+        """
         testFormatting(for: input, output, rule: .redundantSelf, exclude: [.wrapLoopBodies])
     }
 
     func testNoRemoveSelfForVarDeclaredInSwitchCase() {
-        let input = "switch foo {\ncase bar: let baz = self.baz\n}"
+        let input = """
+        switch foo {
+        case bar: let baz = self.baz
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfAfterGenericInit() {
-        let input = "init(bar: Int) {\n    self = Foo<Bar>()\n    self.bar(bar)\n}"
+        let input = """
+        init(bar: Int) {
+            self = Foo<Bar>()
+            self.bar(bar)
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testRemoveSelfInClassFunction() {
-        let input = "class Foo {\n    class func foo() {\n        func bar() { self.foo() }\n    }\n}"
-        let output = "class Foo {\n    class func foo() {\n        func bar() { foo() }\n    }\n}"
+        let input = """
+        class Foo {
+            class func foo() {
+                func bar() { self.foo() }
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            class func foo() {
+                func bar() { foo() }
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
     func testRemoveSelfInStaticFunction() {
-        let input = "struct Foo {\n    static func foo() {\n        func bar() { self.foo() }\n    }\n}"
-        let output = "struct Foo {\n    static func foo() {\n        func bar() { foo() }\n    }\n}"
+        let input = """
+        struct Foo {
+            static func foo() {
+                func bar() { self.foo() }
+            }
+        }
+        """
+        let output = """
+        struct Foo {
+            static func foo() {
+                func bar() { foo() }
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf, exclude: [.enumNamespaces])
     }
 
     func testRemoveSelfInClassFunctionWithModifiers() {
-        let input = "class Foo {\n    class private func foo() {\n        func bar() { self.foo() }\n    }\n}"
-        let output = "class Foo {\n    class private func foo() {\n        func bar() { foo() }\n    }\n}"
+        let input = """
+        class Foo {
+            class private func foo() {
+                func bar() { self.foo() }
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            class private func foo() {
+                func bar() { foo() }
+            }
+        }
+        """
         testFormatting(for: input, output, rule: .redundantSelf,
                        exclude: [.modifierOrder])
     }
 
     func testNoRemoveSelfInClassFunction() {
-        let input = "class Foo {\n    class func foo() {\n        var foo: Int\n        func bar() { self.foo() }\n    }\n}"
+        let input = """
+        class Foo {
+            class func foo() {
+                var foo: Int
+                func bar() { self.foo() }
+            }
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForVarDeclaredAfterRepeatWhile() {
-        let input = "class Foo {\n    let foo = 5\n    func bar() {\n        repeat {} while foo\n        let foo = 6\n        self.foo()\n    }\n}"
+        let input = """
+        class Foo {
+            let foo = 5
+            func bar() {
+                repeat {} while foo
+                let foo = 6
+                self.foo()
+            }
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfForVarInClosureAfterRepeatWhile() {
-        let input = "class Foo {\n    let foo = 5\n    func bar() {\n        repeat {} while foo\n        ({ self.foo() })()\n    }\n}"
+        let input = """
+        class Foo {
+            let foo = 5
+            func bar() {
+                repeat {} while foo
+                ({ self.foo() })()
+            }
+        }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureAfterVar() {
-        let input = "var foo: String\nbar { self.baz() }"
+        let input = """
+        var foo: String
+        bar { self.baz() }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureAfterNamespacedVar() {
-        let input = "var foo: Swift.String\nbar { self.baz() }"
+        let input = """
+        var foo: Swift.String
+        bar { self.baz() }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureAfterOptionalVar() {
-        let input = "var foo: String?\nbar { self.baz() }"
+        let input = """
+        var foo: String?
+        bar { self.baz() }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureAfterGenericVar() {
-        let input = "var foo: Foo<Int>\nbar { self.baz() }"
+        let input = """
+        var foo: Foo<Int>
+        bar { self.baz() }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
     func testNoRemoveSelfInClosureAfterArray() {
-        let input = "var foo: [Int]\nbar { self.baz() }"
+        let input = """
+        var foo: [Int]
+        bar { self.baz() }
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
@@ -1145,7 +1495,9 @@ class RedundantSelfTests: XCTestCase {
     }
 
     func testRedundantSelfDoesntGetStuckIfNoParensFound() {
-        let input = "init<T>_ foo: T {}"
+        let input = """
+        init<T>_ foo: T {}
+        """
         testFormatting(for: input, rule: .redundantSelf,
                        exclude: [.spaceAroundOperators])
     }
@@ -1270,8 +1622,12 @@ class RedundantSelfTests: XCTestCase {
     }
 
     func testRemoveSelfForMemberNamedLazy() {
-        let input = "func foo() { self.lazy() }"
-        let output = "func foo() { lazy() }"
+        let input = """
+        func foo() { self.lazy() }
+        """
+        let output = """
+        func foo() { lazy() }
+        """
         testFormatting(for: input, output, rule: .redundantSelf)
     }
 
@@ -1615,7 +1971,9 @@ class RedundantSelfTests: XCTestCase {
     }
 
     func testRedundantSelfRuleDoesntErrorInForInTryLoop() {
-        let input = "for foo in try bar() {}"
+        let input = """
+        for foo in try bar() {}
+        """
         testFormatting(for: input, rule: .redundantSelf)
     }
 
@@ -1839,135 +2197,313 @@ class RedundantSelfTests: XCTestCase {
     // explicitSelf = .insert
 
     func testInsertSelf() {
-        let input = "class Foo {\n    let foo: Int\n    init() { foo = 5 }\n}"
-        let output = "class Foo {\n    let foo: Int\n    init() { self.foo = 5 }\n}"
+        let input = """
+        class Foo {
+            let foo: Int
+            init() { foo = 5 }
+        }
+        """
+        let output = """
+        class Foo {
+            let foo: Int
+            init() { self.foo = 5 }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testInsertSelfInActor() {
-        let input = "actor Foo {\n    let foo: Int\n    init() { foo = 5 }\n}"
-        let output = "actor Foo {\n    let foo: Int\n    init() { self.foo = 5 }\n}"
+        let input = """
+        actor Foo {
+            let foo: Int
+            init() { foo = 5 }
+        }
+        """
+        let output = """
+        actor Foo {
+            let foo: Int
+            init() { self.foo = 5 }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testInsertSelfAfterReturn() {
-        let input = "class Foo {\n    let foo: Int\n    func bar() -> Int { return foo }\n}"
-        let output = "class Foo {\n    let foo: Int\n    func bar() -> Int { return self.foo }\n}"
+        let input = """
+        class Foo {
+            let foo: Int
+            func bar() -> Int { return foo }
+        }
+        """
+        let output = """
+        class Foo {
+            let foo: Int
+            func bar() -> Int { return self.foo }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testInsertSelfInsideStringInterpolation() {
-        let input = "class Foo {\n    var bar: String?\n    func baz() {\n        print(\"\\(bar)\")\n    }\n}"
-        let output = "class Foo {\n    var bar: String?\n    func baz() {\n        print(\"\\(self.bar)\")\n    }\n}"
+        let input = """
+        class Foo {
+            var bar: String?
+            func baz() {
+                print(\"\\(bar)\")
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            var bar: String?
+            func baz() {
+                print(\"\\(self.bar)\")
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testNoInterpretGenericTypesAsMembers() {
-        let input = "class Foo {\n    let foo: Bar<Int, Int>\n    init() { self.foo = Int(5) }\n}"
+        let input = """
+        class Foo {
+            let foo: Bar<Int, Int>
+            init() { self.foo = Int(5) }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testInsertSelfForStaticMemberInClassFunction() {
-        let input = "class Foo {\n    static var foo: Int\n    class func bar() { foo = 5 }\n}"
-        let output = "class Foo {\n    static var foo: Int\n    class func bar() { self.foo = 5 }\n}"
+        let input = """
+        class Foo {
+            static var foo: Int
+            class func bar() { foo = 5 }
+        }
+        """
+        let output = """
+        class Foo {
+            static var foo: Int
+            class func bar() { self.foo = 5 }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForInstanceMemberInClassFunction() {
-        let input = "class Foo {\n    var foo: Int\n    class func bar() { foo = 5 }\n}"
+        let input = """
+        class Foo {
+            var foo: Int
+            class func bar() { foo = 5 }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForStaticMemberInInstanceFunction() {
-        let input = "class Foo {\n    static var foo: Int\n    func bar() { foo = 5 }\n}"
+        let input = """
+        class Foo {
+            static var foo: Int
+            func bar() { foo = 5 }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForShadowedClassMemberInClassFunction() {
-        let input = "class Foo {\n    class func foo() {\n        var foo: Int\n        func bar() { foo = 5 }\n    }\n}"
+        let input = """
+        class Foo {
+            class func foo() {
+                var foo: Int
+                func bar() { foo = 5 }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfInForLoopTuple() {
-        let input = "class Foo {\n    var bar: Int\n    func foo() { for (bar, baz) in quux {} }\n}"
+        let input = """
+        class Foo {
+            var bar: Int
+            func foo() { for (bar, baz) in quux {} }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForTupleTypeMembers() {
-        let input = "class Foo {\n    var foo: (Int, UIColor) {\n        let bar = UIColor.red\n    }\n}"
+        let input = """
+        class Foo {
+            var foo: (Int, UIColor) {
+                let bar = UIColor.red
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForArrayElements() {
-        let input = "class Foo {\n    var foo = [1, 2, nil]\n    func bar() { baz(nil) }\n}"
+        let input = """
+        class Foo {
+            var foo = [1, 2, nil]
+            func bar() { baz(nil) }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForNestedVarReference() {
-        let input = "class Foo {\n    func bar() {\n        var bar = 5\n        repeat { bar = 6 } while true\n    }\n}"
+        let input = """
+        class Foo {
+            func bar() {
+                var bar = 5
+                repeat { bar = 6 } while true
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options, exclude: [.wrapLoopBodies])
     }
 
     func testNoInsertSelfInSwitchCaseLet() {
-        let input = "class Foo {\n    var foo: Bar? {\n        switch bar {\n        case let .baz(foo, _):\n            return nil\n        }\n    }\n}"
+        let input = """
+        class Foo {
+            var foo: Bar? {
+                switch bar {
+                case let .baz(foo, _):
+                    return nil
+                }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfInFuncAfterImportedClass() {
-        let input = "import class Foo.Bar\nfunc foo() {\n    var bar = 5\n    if true {\n        bar = 6\n    }\n}"
+        let input = """
+        import class Foo.Bar
+        func foo() {
+            var bar = 5
+            if true {
+                bar = 6
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options,
                        exclude: [.blankLineAfterImports])
     }
 
     func testNoInsertSelfForSubscriptGetSet() {
-        let input = "class Foo {\n    func get() {}\n    func set() {}\n    subscript(key: String) -> String {\n        get { return get(key) }\n        set { set(key, newValue) }\n    }\n}"
-        let output = "class Foo {\n    func get() {}\n    func set() {}\n    subscript(key: String) -> String {\n        get { return self.get(key) }\n        set { self.set(key, newValue) }\n    }\n}"
+        let input = """
+        class Foo {
+            func get() {}
+            func set() {}
+            subscript(key: String) -> String {
+                get { return get(key) }
+                set { set(key, newValue) }
+            }
+        }
+        """
+        let output = """
+        class Foo {
+            func get() {}
+            func set() {}
+            subscript(key: String) -> String {
+                get { return self.get(key) }
+                set { self.set(key, newValue) }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, output, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfInIfCaseLet() {
-        let input = "enum Foo {\n    case bar(Int)\n    var value: Int? {\n        if case let .bar(value) = self { return value }\n    }\n}"
+        let input = """
+        enum Foo {
+            case bar(Int)
+            var value: Int? {
+                if case let .bar(value) = self { return value }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoInsertSelfForPatternLet() {
-        let input = "class Foo {\n    func foo() {}\n    func bar() {\n        switch x {\n        case .bar(let foo, var bar): print(foo + bar)\n        }\n    }\n}"
+        let input = """
+        class Foo {
+            func foo() {}
+            func bar() {
+                switch x {
+                case .bar(let foo, var bar): print(foo + bar)
+                }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForPatternLet2() {
-        let input = "class Foo {\n    func foo() {}\n    func bar() {\n        switch x {\n        case let .foo(baz): print(baz)\n        case .bar(let foo, var bar): print(foo + bar)\n        }\n    }\n}"
+        let input = """
+        class Foo {
+            func foo() {}
+            func bar() {
+                switch x {
+                case let .foo(baz): print(baz)
+                case .bar(let foo, var bar): print(foo + bar)
+                }
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForTypeOf() {
-        let input = "class Foo {\n    var type: String?\n    func bar() {\n        print(\"\\(type(of: self))\")\n    }\n}"
+        let input = """
+        class Foo {
+            var type: String?
+            func bar() {
+                print(\"\\(type(of: self))\")
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
     func testNoInsertSelfForConditionalLocal() {
-        let input = "class Foo {\n    func foo() {\n        #if os(watchOS)\n            var foo: Int\n        #else\n            var foo: Float\n        #endif\n        print(foo)\n    }\n}"
+        let input = """
+        class Foo {
+            func foo() {
+                #if os(watchOS)
+                    var foo: Int
+                #else
+                    var foo: Float
+                #endif
+                print(foo)
+            }
+        }
+        """
         let options = FormatOptions(explicitSelf: .insert)
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
@@ -3342,7 +3878,10 @@ class RedundantSelfTests: XCTestCase {
     }
 
     func testNoMistakeProtocolClassModifierForClassFunction() {
-        let input = "protocol Foo: class {}\nfunc bar() {}"
+        let input = """
+        protocol Foo: class {}
+        func bar() {}
+        """
         XCTAssertNoThrow(try format(input, rules: [.redundantSelf]))
         XCTAssertNoThrow(try format(input, rules: FormatRules.all))
     }

--- a/Tests/Rules/RedundantStaticSelfTests.swift
+++ b/Tests/Rules/RedundantStaticSelfTests.swift
@@ -11,14 +11,22 @@ import XCTest
 
 class RedundantStaticSelfTests: XCTestCase {
     func testRedundantStaticSelfInStaticVar() {
-        let input = "enum E { static var x: Int { Self.y } }"
-        let output = "enum E { static var x: Int { y } }"
+        let input = """
+        enum E { static var x: Int { Self.y } }
+        """
+        let output = """
+        enum E { static var x: Int { y } }
+        """
         testFormatting(for: input, output, rule: .redundantStaticSelf)
     }
 
     func testRedundantStaticSelfInStaticMethod() {
-        let input = "enum E { static func foo() { Self.bar() } }"
-        let output = "enum E { static func foo() { bar() } }"
+        let input = """
+        enum E { static func foo() { Self.bar() } }
+        """
+        let output = """
+        enum E { static func foo() { bar() } }
+        """
         testFormatting(for: input, output, rule: .redundantStaticSelf)
     }
 
@@ -42,8 +50,12 @@ class RedundantStaticSelfTests: XCTestCase {
     }
 
     func testRedundantStaticSelfWithReturn() {
-        let input = "enum E { static func foo() { return Self.bar() } }"
-        let output = "enum E { static func foo() { return bar() } }"
+        let input = """
+        enum E { static func foo() { return Self.bar() } }
+        """
+        let output = """
+        enum E { static func foo() { return bar() } }
+        """
         testFormatting(for: input, output, rule: .redundantStaticSelf)
     }
 
@@ -112,12 +124,16 @@ class RedundantStaticSelfTests: XCTestCase {
     }
 
     func testStaticSelfNotRemovedWhenUsedAsImplicitInitializer() {
-        let input = "enum E { static func foo() { Self().bar() } }"
+        let input = """
+        enum E { static func foo() { Self().bar() } }
+        """
         testFormatting(for: input, rule: .redundantStaticSelf)
     }
 
     func testStaticSelfNotRemovedWhenUsedAsExplicitInitializer() {
-        let input = "enum E { static func foo() { Self.init().bar() } }"
+        let input = """
+        enum E { static func foo() { Self.init().bar() } }
+        """
         testFormatting(for: input, rule: .redundantStaticSelf, exclude: [.redundantInit])
     }
 

--- a/Tests/Rules/RedundantTypeTests.swift
+++ b/Tests/Rules/RedundantTypeTests.swift
@@ -11,59 +11,85 @@ import XCTest
 
 class RedundantTypeTests: XCTestCase {
     func testVarRedundantTypeRemoval() {
-        let input = "var view: UIView = UIView()"
-        let output = "var view = UIView()"
+        let input = """
+        var view: UIView = UIView()
+        """
+        let output = """
+        var view = UIView()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testVarRedundantArrayTypeRemoval() {
-        let input = "var foo: [String] = [String]()"
-        let output = "var foo = [String]()"
+        let input = """
+        var foo: [String] = [String]()
+        """
+        let output = """
+        var foo = [String]()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testVarRedundantDictionaryTypeRemoval() {
-        let input = "var foo: [String: Int] = [String: Int]()"
-        let output = "var foo = [String: Int]()"
+        let input = """
+        var foo: [String: Int] = [String: Int]()
+        """
+        let output = """
+        var foo = [String: Int]()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testLetRedundantGenericTypeRemoval() {
-        let input = "let relay: BehaviourRelay<Int?> = BehaviourRelay<Int?>(value: nil)"
-        let output = "let relay = BehaviourRelay<Int?>(value: nil)"
+        let input = """
+        let relay: BehaviourRelay<Int?> = BehaviourRelay<Int?>(value: nil)
+        """
+        let output = """
+        let relay = BehaviourRelay<Int?>(value: nil)
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testVarNonRedundantTypeDoesNothing() {
-        let input = "var view: UIView = UINavigationBar()"
+        let input = """
+        var view: UIView = UINavigationBar()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
 
     func testLetRedundantTypeRemoval() {
-        let input = "let view: UIView = UIView()"
-        let output = "let view = UIView()"
+        let input = """
+        let view: UIView = UIView()
+        """
+        let output = """
+        let view = UIView()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testLetNonRedundantTypeDoesNothing() {
-        let input = "let view: UIView = UINavigationBar()"
+        let input = """
+        let view: UIView = UINavigationBar()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
 
     func testTypeNoRedundancyDoesNothing() {
-        let input = "let foo: Bar = 5"
+        let input = """
+        let foo: Bar = 5
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
@@ -108,31 +134,45 @@ class RedundantTypeTests: XCTestCase {
     }
 
     func testAllRedundantTypesRemovedInCommaDelimitedDeclaration() {
-        let input = "var foo: Int = 0, bar: Int = 0"
-        let output = "var foo = 0, bar = 0"
+        let input = """
+        var foo: Int = 0, bar: Int = 0
+        """
+        let output = """
+        var foo = 0, bar = 0
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.singlePropertyPerLine])
     }
 
     func testRedundantTypeRemovalWithComment() {
-        let input = "var view: UIView /* view */ = UIView()"
-        let output = "var view /* view */ = UIView()"
+        let input = """
+        var view: UIView /* view */ = UIView()
+        """
+        let output = """
+        var view /* view */ = UIView()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testRedundantTypeRemovalWithComment2() {
-        let input = "var view: UIView = /* view */ UIView()"
-        let output = "var view = /* view */ UIView()"
+        let input = """
+        var view: UIView = /* view */ UIView()
+        """
+        let output = """
+        var view = /* view */ UIView()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options)
     }
 
     func testNonRedundantTernaryConditionTypeNotRemoved() {
-        let input = "let foo: Bar = Bar.baz() ? .bar1 : .bar2"
+        let input = """
+        let foo: Bar = Bar.baz() ? .bar1 : .bar2
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
@@ -152,40 +192,52 @@ class RedundantTypeTests: XCTestCase {
     }
 
     func testNoRemoveRedundantTypeIfVoid() {
-        let input = "let foo: Void = Void()"
+        let input = """
+        let foo: Void = Void()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType,
                        options: options, exclude: [.void])
     }
 
     func testNoRemoveRedundantTypeIfVoid2() {
-        let input = "let foo: () = ()"
+        let input = """
+        let foo: () = ()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType,
                        options: options, exclude: [.void])
     }
 
     func testNoRemoveRedundantTypeIfVoid3() {
-        let input = "let foo: [Void] = [Void]()"
+        let input = """
+        let foo: [Void] = [Void]()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
 
     func testNoRemoveRedundantTypeIfVoid4() {
-        let input = "let foo: Array<Void> = Array<Void>()"
+        let input = """
+        let foo: Array<Void> = Array<Void>()
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType,
                        options: options, exclude: [.typeSugar])
     }
 
     func testNoRemoveRedundantTypeIfVoid5() {
-        let input = "let foo: Void? = Void?.none"
+        let input = """
+        let foo: Void? = Void?.none
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
 
     func testNoRemoveRedundantTypeIfVoid6() {
-        let input = "let foo: Optional<Void> = Optional<Void>.none"
+        let input = """
+        let foo: Optional<Void> = Optional<Void>.none
+        """
         let options = FormatOptions(propertyTypes: .inferred)
         testFormatting(for: input, rule: .redundantType,
                        options: options, exclude: [.typeSugar])
@@ -411,46 +463,70 @@ class RedundantTypeTests: XCTestCase {
     // --redundanttype explicit
 
     func testVarRedundantTypeRemovalExplicitType() {
-        let input = "var view: UIView = UIView()"
-        let output = "var view: UIView = .init()"
+        let input = """
+        var view: UIView = UIView()
+        """
+        let output = """
+        var view: UIView = .init()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
     }
 
     func testVarRedundantTypeRemovalExplicitType2() {
-        let input = "var view: UIView = UIView /* foo */()"
-        let output = "var view: UIView = .init /* foo */()"
+        let input = """
+        var view: UIView = UIView /* foo */()
+        """
+        let output = """
+        var view: UIView = .init /* foo */()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.spaceAroundComments, .propertyTypes])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitType() {
-        let input = "let relay: BehaviourRelay<Int?> = BehaviourRelay<Int?>(value: nil)"
-        let output = "let relay: BehaviourRelay<Int?> = .init(value: nil)"
+        let input = """
+        let relay: BehaviourRelay<Int?> = BehaviourRelay<Int?>(value: nil)
+        """
+        let output = """
+        let relay: BehaviourRelay<Int?> = .init(value: nil)
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
     }
 
     func testLetRedundantGenericTypeRemovalExplicitTypeIfValueOnNextLine() {
-        let input = "let relay: Foo<Int?> = Foo<Int?>\n    .default"
-        let output = "let relay: Foo<Int?> = \n    .default"
+        let input = """
+        let relay: Foo<Int?> = Foo<Int?>
+            .default
+        """
+        let output = """
+        let relay: Foo<Int?> = 
+            .default
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.trailingSpace, .propertyTypes])
     }
 
     func testVarNonRedundantTypeDoesNothingExplicitType() {
-        let input = "var view: UIView = UINavigationBar()"
+        let input = """
+        var view: UIView = UINavigationBar()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options)
     }
 
     func testLetRedundantTypeRemovalExplicitType() {
-        let input = "let view: UIView = UIView()"
-        let output = "let view: UIView = .init()"
+        let input = """
+        let view: UIView = UIView()
+        """
+        let output = """
+        let view: UIView = .init()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
@@ -485,16 +561,24 @@ class RedundantTypeTests: XCTestCase {
     }
 
     func testRedundantTypeRemovalWithCommentExplicitType() {
-        let input = "var view: UIView /* view */ = UIView()"
-        let output = "var view: UIView /* view */ = .init()"
+        let input = """
+        var view: UIView /* view */ = UIView()
+        """
+        let output = """
+        var view: UIView /* view */ = .init()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeRemovalWithComment2ExplicitType() {
-        let input = "var view: UIView = /* view */ UIView()"
-        let output = "var view: UIView = /* view */ .init()"
+        let input = """
+        var view: UIView = /* view */ UIView()
+        """
+        let output = """
+        var view: UIView = /* view */ .init()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
@@ -545,52 +629,72 @@ class RedundantTypeTests: XCTestCase {
     }
 
     func testRedundantTypeDoesNothingWithChainedMember() {
-        let input = "let session: URLSession = URLSession.default.makeCopy()"
+        let input = """
+        let session: URLSession = URLSession.default.makeCopy()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantRedundantChainedMemberTypeRemovedOnSwift5_4() {
-        let input = "let session: URLSession = URLSession.default.makeCopy()"
-        let output = "let session: URLSession = .default.makeCopy()"
+        let input = """
+        let session: URLSession = URLSession.default.makeCopy()
+        """
+        let output = """
+        let session: URLSession = .default.makeCopy()
+        """
         let options = FormatOptions(propertyTypes: .explicit, swiftVersion: "5.4")
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember2() {
-        let input = "let color: UIColor = UIColor.red.withAlphaComponent(0.5)"
+        let input = """
+        let color: UIColor = UIColor.red.withAlphaComponent(0.5)
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeDoesNothingWithChainedMember3() {
-        let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
+        let input = """
+        let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeRemovedWithChainedMemberOnSwift5_4() {
-        let input = "let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()"
-        let output = "let url: URL = .init(fileURLWithPath: #file).deletingLastPathComponent()"
+        let input = """
+        let url: URL = URL(fileURLWithPath: #file).deletingLastPathComponent()
+        """
+        let output = """
+        let url: URL = .init(fileURLWithPath: #file).deletingLastPathComponent()
+        """
         let options = FormatOptions(propertyTypes: .explicit, swiftVersion: "5.4")
         testFormatting(for: input, output, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeDoesNothingIfLet() {
-        let input = "if let foo: Foo = Foo() {}"
+        let input = """
+        if let foo: Foo = Foo() {}
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeDoesNothingGuardLet() {
-        let input = "guard let foo: Foo = Foo() else {}"
+        let input = """
+        guard let foo: Foo = Foo() else {}
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeDoesNothingIfLetAfterComma() {
-        let input = "if check == true, let foo: Foo = Foo() {}"
+        let input = """
+        if check == true, let foo: Foo = Foo() {}
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType, options: options, exclude: [.propertyTypes])
     }
@@ -610,36 +714,48 @@ class RedundantTypeTests: XCTestCase {
     }
 
     func testRedundantTypeIfVoid() {
-        let input = "let foo: [Void] = [Void]()"
-        let output = "let foo: [Void] = .init()"
+        let input = """
+        let foo: [Void] = [Void]()
+        """
+        let output = """
+        let foo: [Void] = .init()
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, output, rule: .redundantType,
                        options: options, exclude: [.propertyTypes])
     }
 
     func testRedundantTypeWithIntegerLiteralNotMangled() {
-        let input = "let foo: Int = 1.toFoo"
+        let input = """
+        let foo: Int = 1.toFoo
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType,
                        options: options)
     }
 
     func testRedundantTypeWithFloatLiteralNotMangled() {
-        let input = "let foo: Double = 1.0.toFoo"
+        let input = """
+        let foo: Double = 1.0.toFoo
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType,
                        options: options)
     }
 
     func testRedundantTypeWithArrayLiteralNotMangled() {
-        let input = "let foo: [Int] = [1].toFoo"
+        let input = """
+        let foo: [Int] = [1].toFoo
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType,
                        options: options)
     }
 
     func testRedundantTypeWithBoolLiteralNotMangled() {
-        let input = "let foo: Bool = false.toFoo"
+        let input = """
+        let foo: Bool = false.toFoo
+        """
         let options = FormatOptions(propertyTypes: .explicit)
         testFormatting(for: input, rule: .redundantType,
                        options: options)

--- a/Tests/Rules/RedundantVoidReturnTypeTests.swift
+++ b/Tests/Rules/RedundantVoidReturnTypeTests.swift
@@ -11,83 +11,135 @@ import XCTest
 
 class RedundantVoidReturnTypeTests: XCTestCase {
     func testRemoveRedundantVoidReturnType() {
-        let input = "func foo() -> Void {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() -> Void {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantVoidReturnType2() {
-        let input = "func foo() ->\n    Void {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() ->
+            Void {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantSwiftDotVoidReturnType() {
-        let input = "func foo() -> Swift.Void {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() -> Swift.Void {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantSwiftDotVoidReturnType2() {
-        let input = "func foo() -> Swift\n    .Void {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() -> Swift
+            .Void {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantEmptyReturnType() {
-        let input = "func foo() -> () {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() -> () {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantVoidTupleReturnType() {
-        let input = "func foo() -> (Void) {}"
-        let output = "func foo() {}"
+        let input = """
+        func foo() -> (Void) {}
+        """
+        let output = """
+        func foo() {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveCommentFollowingRedundantVoidReturnType() {
-        let input = "func foo() -> Void /* void */ {}"
-        let output = "func foo() /* void */ {}"
+        let input = """
+        func foo() -> Void /* void */ {}
+        """
+        let output = """
+        func foo() /* void */ {}
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveRequiredVoidReturnType() {
-        let input = "typealias Foo = () -> Void"
+        let input = """
+        typealias Foo = () -> Void
+        """
         testFormatting(for: input, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveChainedVoidReturnType() {
-        let input = "func foo() -> () -> Void {}"
+        let input = """
+        func foo() -> () -> Void {}
+        """
         testFormatting(for: input, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantVoidInClosureArguments() {
-        let input = "{ (foo: Bar) -> Void in foo() }"
-        let output = "{ (foo: Bar) in foo() }"
+        let input = """
+        { (foo: Bar) -> Void in foo() }
+        """
+        let output = """
+        { (foo: Bar) in foo() }
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantEmptyReturnTypeInClosureArguments() {
-        let input = "{ (foo: Bar) -> () in foo() }"
-        let output = "{ (foo: Bar) in foo() }"
+        let input = """
+        { (foo: Bar) -> () in foo() }
+        """
+        let output = """
+        { (foo: Bar) in foo() }
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantVoidInClosureArguments2() {
-        let input = "methodWithTrailingClosure { foo -> Void in foo() }"
-        let output = "methodWithTrailingClosure { foo in foo() }"
+        let input = """
+        methodWithTrailingClosure { foo -> Void in foo() }
+        """
+        let output = """
+        methodWithTrailingClosure { foo in foo() }
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testRemoveRedundantSwiftDotVoidInClosureArguments2() {
-        let input = "methodWithTrailingClosure { foo -> Swift.Void in foo() }"
-        let output = "methodWithTrailingClosure { foo in foo() }"
+        let input = """
+        methodWithTrailingClosure { foo -> Swift.Void in foo() }
+        """
+        let output = """
+        methodWithTrailingClosure { foo in foo() }
+        """
         testFormatting(for: input, output, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveRedundantVoidInClosureArgument() {
-        let input = "{ (foo: Bar) -> Void in foo() }"
+        let input = """
+        { (foo: Bar) -> Void in foo() }
+        """
         let options = FormatOptions(closureVoidReturn: .preserve)
         testFormatting(for: input, rule: .redundantVoidReturnType, options: options)
     }
@@ -115,17 +167,23 @@ class RedundantVoidReturnTypeTests: XCTestCase {
 
     func testNoRemoveThrowingClosureVoidReturnType() {
         // https://github.com/nicklockwood/SwiftFormat/issues/1978
-        let input = "func foo(bar: Bar) -> () throws -> Void"
+        let input = """
+        func foo(bar: Bar) -> () throws -> Void
+        """
         testFormatting(for: input, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveClosureVoidReturnType() {
-        let input = "func foo(bar: Bar) -> () -> Void"
+        let input = """
+        func foo(bar: Bar) -> () -> Void
+        """
         testFormatting(for: input, rule: .redundantVoidReturnType)
     }
 
     func testNoRemoveAsyncClosureVoidReturnType() {
-        let input = "func foo(bar: Bar) -> () async -> Void"
+        let input = """
+        func foo(bar: Bar) -> () async -> Void
+        """
         testFormatting(for: input, rule: .redundantVoidReturnType)
     }
 }

--- a/Tests/Rules/SemicolonsTests.swift
+++ b/Tests/Rules/SemicolonsTests.swift
@@ -11,57 +11,97 @@ import XCTest
 
 class SemicolonsTests: XCTestCase {
     func testSemicolonRemovedAtEndOfLine() {
-        let input = "print(\"hello\");\n"
-        let output = "print(\"hello\")\n"
+        let input = """
+        print(\"hello\");
+
+        """
+        let output = """
+        print(\"hello\")
+
+        """
         testFormatting(for: input, output, rule: .semicolons)
     }
 
     func testSemicolonRemovedAtStartOfLine() {
-        let input = "\n;print(\"hello\")"
-        let output = "\nprint(\"hello\")"
+        let input = """
+
+        ;print(\"hello\")
+        """
+        let output = """
+
+        print(\"hello\")
+        """
         testFormatting(for: input, output, rule: .semicolons)
     }
 
     func testSemicolonRemovedAtEndOfProgram() {
-        let input = "print(\"hello\");"
-        let output = "print(\"hello\")"
+        let input = """
+        print(\"hello\");
+        """
+        let output = """
+        print(\"hello\")
+        """
         testFormatting(for: input, output, rule: .semicolons)
     }
 
     func testSemicolonRemovedAtStartOfProgram() {
-        let input = ";print(\"hello\")"
-        let output = "print(\"hello\")"
+        let input = """
+        ;print(\"hello\")
+        """
+        let output = """
+        print(\"hello\")
+        """
         testFormatting(for: input, output, rule: .semicolons)
     }
 
     func testIgnoreInlineSemicolon() {
-        let input = "print(\"hello\"); print(\"goodbye\")"
+        let input = """
+        print(\"hello\"); print(\"goodbye\")
+        """
         let options = FormatOptions(semicolons: .inlineOnly)
         testFormatting(for: input, rule: .semicolons, options: options)
     }
 
     func testReplaceInlineSemicolon() {
-        let input = "print(\"hello\"); print(\"goodbye\")"
-        let output = "print(\"hello\")\nprint(\"goodbye\")"
+        let input = """
+        print(\"hello\"); print(\"goodbye\")
+        """
+        let output = """
+        print(\"hello\")
+        print(\"goodbye\")
+        """
         let options = FormatOptions(semicolons: .never)
         testFormatting(for: input, output, rule: .semicolons, options: options)
     }
 
     func testReplaceSemicolonFollowedByComment() {
-        let input = "print(\"hello\"); // comment\nprint(\"goodbye\")"
-        let output = "print(\"hello\") // comment\nprint(\"goodbye\")"
+        let input = """
+        print(\"hello\"); // comment
+        print(\"goodbye\")
+        """
+        let output = """
+        print(\"hello\") // comment
+        print(\"goodbye\")
+        """
         let options = FormatOptions(semicolons: .inlineOnly)
         testFormatting(for: input, output, rule: .semicolons, options: options)
     }
 
     func testSemicolonNotReplacedAfterReturn() {
-        let input = "return;\nfoo()"
+        let input = """
+        return;
+        foo()
+        """
         testFormatting(for: input, rule: .semicolons)
     }
 
     func testSemicolonReplacedAfterReturnIfEndOfScope() {
-        let input = "do { return; }"
-        let output = "do { return }"
+        let input = """
+        do { return; }
+        """
+        let output = """
+        do { return }
+        """
         testFormatting(for: input, output, rule: .semicolons)
     }
 

--- a/Tests/Rules/SinglePropertyPerLineTests.swift
+++ b/Tests/Rules/SinglePropertyPerLineTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 class SinglePropertyPerLineTests: XCTestCase {
     func testSeparateLetDeclarations() {
-        let input = "let a: Int, b: Int"
+        let input = """
+        let a: Int, b: Int
+        """
         let output = """
         let a: Int
         let b: Int
@@ -20,7 +22,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateVarDeclarations() {
-        let input = "var x = 10, y = 20"
+        let input = """
+        var x = 10, y = 20
+        """
         let output = """
         var x = 10
         var y = 20
@@ -29,7 +33,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePublicVarDeclarations() {
-        let input = "public var c = 10, d = false, e = \"string\""
+        let input = """
+        public var c = 10, d = false, e = \"string\"
+        """
         let output = """
         public var c = 10
         public var d = false
@@ -39,7 +45,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateObjcVarDeclarations() {
-        let input = "@objc var f = true, g: Bool"
+        let input = """
+        @objc var f = true, g: Bool
+        """
         let output = """
         @objc var f = true
         @objc var g: Bool
@@ -64,7 +72,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateDeclarationsWithComplexTypes() {
-        let input = "let dict: [String: Int], array: [String]"
+        let input = """
+        let dict: [String: Int], array: [String]
+        """
         let output = """
         let dict: [String: Int]
         let array: [String]
@@ -73,7 +83,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateDeclarationsWithGenericTypes() {
-        let input = "var optional: Optional<String>, result: Result<Int, Error>"
+        let input = """
+        var optional: Optional<String>, result: Result<Int, Error>
+        """
         let output = """
         var optional: Optional<String>
         var result: Result<Int, Error>
@@ -82,7 +94,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateDeclarationsWithClosureTypes() {
-        let input = "let callback: () -> Void, handler: (String) -> Int"
+        let input = """
+        let callback: () -> Void, handler: (String) -> Int
+        """
         let output = """
         let callback: () -> Void
         let handler: (String) -> Int
@@ -91,7 +105,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparateDeclarationsWithTupleTypes() {
-        let input = "let point: (Int, Int), size: (width: Int, height: Int)"
+        let input = """
+        let point: (Int, Int), size: (width: Int, height: Int)
+        """
         let output = """
         let point: (Int, Int)
         let size: (width: Int, height: Int)
@@ -115,7 +131,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testPreserveMultipleAttributes() {
-        let input = "@available(iOS 13.0, *) @objc private var a = 1, b = 2"
+        let input = """
+        @available(iOS 13.0, *) @objc private var a = 1, b = 2
+        """
         let output = """
         @available(iOS 13.0, *) @objc private var a = 1
         @available(iOS 13.0, *) @objc private var b = 2
@@ -124,7 +142,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testNoChangeForSingleProperty() {
-        let input = "let single: String = \"value\""
+        let input = """
+        let single: String = \"value\"
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
@@ -138,27 +158,37 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testIgnoreCommasInFunctionCalls() {
-        let input = "let result = someFunction(param1, param2, param3)"
+        let input = """
+        let result = someFunction(param1, param2, param3)
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testIgnoreCommasInArrayLiterals() {
-        let input = "let array = [1, 2, 3, 4, 5]"
+        let input = """
+        let array = [1, 2, 3, 4, 5]
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testIgnoreCommasInDictionaryLiterals() {
-        let input = "let dict = [\"a\": 1, \"b\": 2, \"c\": 3]"
+        let input = """
+        let dict = [\"a\": 1, \"b\": 2, \"c\": 3]
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testIgnoreCommasInTuples() {
-        let input = "let tuple = (1, 2, 3)"
+        let input = """
+        let tuple = (1, 2, 3)
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testSeparatePropertiesWithComplexInitializers() {
-        let input = "let a = [1, 2, 3], b = (x: 1, y: 2)"
+        let input = """
+        let a = [1, 2, 3], b = (x: 1, y: 2)
+        """
         let output = """
         let a = [1, 2, 3]
         let b = (x: 1, y: 2)
@@ -167,7 +197,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithFunctionCallInitializers() {
-        let input = "let result1 = process(data, options), result2 = transform(input)"
+        let input = """
+        let result1 = process(data, options), result2 = transform(input)
+        """
         let output = """
         let result1 = process(data, options)
         let result2 = transform(input)
@@ -292,7 +324,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithArrayTypes() {
-        let input = "let numbers: [Int], strings: [String], optionals: [Int?]"
+        let input = """
+        let numbers: [Int], strings: [String], optionals: [Int?]
+        """
         let output = """
         let numbers: [Int]
         let strings: [String]
@@ -302,7 +336,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithDictionaryTypes() {
-        let input = "var userMap: [String: User], settingsMap: [String: Any], counters: [String: Int]"
+        let input = """
+        var userMap: [String: User], settingsMap: [String: Any], counters: [String: Int]
+        """
         let output = """
         var userMap: [String: User]
         var settingsMap: [String: Any]
@@ -312,7 +348,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithArrayLiteralValues() {
-        let input = "let primes = [2, 3, 5, 7], evens = [2, 4, 6, 8], odds = [1, 3, 5, 7]"
+        let input = """
+        let primes = [2, 3, 5, 7], evens = [2, 4, 6, 8], odds = [1, 3, 5, 7]
+        """
         let output = """
         let primes = [2, 3, 5, 7]
         let evens = [2, 4, 6, 8]
@@ -322,7 +360,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithDictionaryLiteralValues() {
-        let input = "let colors = [\"red\": 0xFF0000, \"green\": 0x00FF00], settings = [\"theme\": \"dark\", \"language\": \"en\"]"
+        let input = """
+        let colors = [\"red\": 0xFF0000, \"green\": 0x00FF00], settings = [\"theme\": \"dark\", \"language\": \"en\"]
+        """
         let output = """
         let colors = ["red": 0xFF0000, "green": 0x00FF00]
         let settings = ["theme": "dark", "language": "en"]
@@ -348,7 +388,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithNestedArrayTypes() {
-        let input = "let matrix: [[Int]], jaggedArray: [[String?]], coordinates: [(Double, Double)]"
+        let input = """
+        let matrix: [[Int]], jaggedArray: [[String?]], coordinates: [(Double, Double)]
+        """
         let output = """
         let matrix: [[Int]]
         let jaggedArray: [[String?]]
@@ -358,7 +400,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithComplexGenericTypes() {
-        let input = "var publisher: AnyPublisher<String, Error>, subject: PassthroughSubject<Int, Never>"
+        let input = """
+        var publisher: AnyPublisher<String, Error>, subject: PassthroughSubject<Int, Never>
+        """
         let output = """
         var publisher: AnyPublisher<String, Error>
         var subject: PassthroughSubject<Int, Never>
@@ -367,7 +411,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithOptionalArrayTypes() {
-        let input = "let optionalArray: [String]?, arrayOfOptionals: [String?], bothOptional: [String?]?"
+        let input = """
+        let optionalArray: [String]?, arrayOfOptionals: [String?], bothOptional: [String?]?
+        """
         let output = """
         let optionalArray: [String]?
         let arrayOfOptionals: [String?]
@@ -377,7 +423,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithFunctionTypes() {
-        let input = "let transformer: (String) -> Int, validator: (String) -> Bool, processor: ([Int]) -> [String]"
+        let input = """
+        let transformer: (String) -> Int, validator: (String) -> Bool, processor: ([Int]) -> [String]
+        """
         let output = """
         let transformer: (String) -> Int
         let validator: (String) -> Bool
@@ -387,7 +435,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithEscapingClosureTypes() {
-        let input = "var onSuccess: (@escaping (Data) -> Void)?, onError: (@escaping (Error) -> Void)?"
+        let input = """
+        var onSuccess: (@escaping (Data) -> Void)?, onError: (@escaping (Error) -> Void)?
+        """
         let output = """
         var onSuccess: (@escaping (Data) -> Void)?
         var onError: (@escaping (Error) -> Void)?
@@ -396,7 +446,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithSetValues() {
-        let input = "let vowels: Set = [\"a\", \"e\", \"i\", \"o\", \"u\"], consonants: Set<Character> = [\"b\", \"c\", \"d\"]"
+        let input = """
+        let vowels: Set = [\"a\", \"e\", \"i\", \"o\", \"u\"], consonants: Set<Character> = [\"b\", \"c\", \"d\"]
+        """
         let output = """
         let vowels: Set = ["a", "e", "i", "o", "u"]
         let consonants: Set<Character> = ["b", "c", "d"]
@@ -405,7 +457,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithTupleValues() {
-        let input = "let point = (x: 10, y: 20), size = (width: 100, height: 200), origin = (0, 0)"
+        let input = """
+        let point = (x: 10, y: 20), size = (width: 100, height: 200), origin = (0, 0)
+        """
         let output = """
         let point = (x: 10, y: 20)
         let size = (width: 100, height: 200)
@@ -415,7 +469,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithObjectInitializers() {
-        let input = "let url = URL(string: \"https://api.example.com\")!, client = HTTPClient(session: .shared), config = AppConfig.default"
+        let input = """
+        let url = URL(string: \"https://api.example.com\")!, client = HTTPClient(session: .shared), config = AppConfig.default
+        """
         let output = """
         let url = URL(string: "https://api.example.com")!
         let client = HTTPClient(session: .shared)
@@ -425,7 +481,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithChainedMethodCalls() {
-        let input = "let trimmed = input.trimmingCharacters(in: .whitespaces), uppercased = text.uppercased().replacingOccurrences(of: \" \", with: \"_\")"
+        let input = """
+        let trimmed = input.trimmingCharacters(in: .whitespaces), uppercased = text.uppercased().replacingOccurrences(of: \" \", with: \"_\")
+        """
         let output = """
         let trimmed = input.trimmingCharacters(in: .whitespaces)
         let uppercased = text.uppercased().replacingOccurrences(of: " ", with: "_")
@@ -434,7 +492,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithConditionalValues() {
-        let input = "let result = condition ? value1 : value2, fallback = optional ?? defaultValue"
+        let input = """
+        let result = condition ? value1 : value2, fallback = optional ?? defaultValue
+        """
         let output = """
         let result = condition ? value1 : value2
         let fallback = optional ?? defaultValue
@@ -443,7 +503,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSeparatePropertiesWithTypeInference() {
-        let input = "let items = [\"apple\", \"banana\", \"cherry\"], counts = [1: \"one\", 2: \"two\"], flags = [true, false, true]"
+        let input = """
+        let items = [\"apple\", \"banana\", \"cherry\"], counts = [1: \"one\", 2: \"two\"], flags = [true, false, true]
+        """
         let output = """
         let items = ["apple", "banana", "cherry"]
         let counts = [1: "one", 2: "two"]
@@ -643,7 +705,9 @@ class SinglePropertyPerLineTests: XCTestCase {
 
     func testBasicCommaDetection() {
         // Test if parseExpressionRange is working correctly for simple cases
-        let input = "let x = 5, y = 10"
+        let input = """
+        let x = 5, y = 10
+        """
         let output = """
         let x = 5
         let y = 10
@@ -652,7 +716,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSimpleSharedType() {
-        let input = "let a, b: Int"
+        let input = """
+        let a, b: Int
+        """
         let output = """
         let a: Int
         let b: Int
@@ -661,7 +727,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testEnumDeclarationWithConformances() {
-        let input = "enum DiagnosticFailure: Error, CustomStringConvertible { }"
+        let input = """
+        enum DiagnosticFailure: Error, CustomStringConvertible { }
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine, exclude: [.emptyBraces])
     }
 
@@ -693,7 +761,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testClassDeclarationWithMultipleInheritance() {
-        let input = "public final class PrimaryButton: BaseMarginView, ConstellationView, PrimaryActionLoggable { }"
+        let input = """
+        public final class PrimaryButton: BaseMarginView, ConstellationView, PrimaryActionLoggable { }
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine, exclude: [.emptyBraces])
     }
 
@@ -740,7 +810,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testSimpleTupleDestructuring() {
-        let input = "let (foo, bar, baaz) = (1, 2, 3)"
+        let input = """
+        let (foo, bar, baaz) = (1, 2, 3)
+        """
         let output = """
         let foo = 1
         let bar = 2
@@ -750,7 +822,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithVarKeyword() {
-        let input = "var (x, y, z) = (10, 20, 30)"
+        let input = """
+        var (x, y, z) = (10, 20, 30)
+        """
         let output = """
         var x = 10
         var y = 20
@@ -760,7 +834,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithSpaces() {
-        let input = "let ( a , b , c ) = ( 1 , 2 , 3 )"
+        let input = """
+        let ( a , b , c ) = ( 1 , 2 , 3 )
+        """
         let output = """
         let a = 1
         let b = 2
@@ -770,7 +846,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithComplexValues() {
-        let input = "let (name, age, active) = (\"John\", 25, true)"
+        let input = """
+        let (name, age, active) = (\"John\", 25, true)
+        """
         let output = """
         let name = "John"
         let age = 25
@@ -780,7 +858,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithModifiers() {
-        let input = "private let (width, height) = (100.0, 200.0)"
+        let input = """
+        private let (width, height) = (100.0, 200.0)
+        """
         let output = """
         private let width = 100.0
         private let height = 200.0
@@ -789,7 +869,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithAttributes() {
-        let input = "@available(iOS 15, *) let (feature1, feature2) = (true, false)"
+        let input = """
+        @available(iOS 15, *) let (feature1, feature2) = (true, false)
+        """
         let output = """
         @available(iOS 15, *) let feature1 = true
         @available(iOS 15, *) let feature2 = false
@@ -798,7 +880,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithNestedValues() {
-        let input = "let (array, dict) = ([1, 2, 3], [\"key\": \"value\"])"
+        let input = """
+        let (array, dict) = ([1, 2, 3], [\"key\": \"value\"])
+        """
         let output = """
         let array = [1, 2, 3]
         let dict = ["key": "value"]
@@ -807,7 +891,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithFunctionCalls() {
-        let input = "let (min, max) = (calculateMin(), calculateMax())"
+        let input = """
+        let (min, max) = (calculateMin(), calculateMax())
+        """
         let output = """
         let min = calculateMin()
         let max = calculateMax()
@@ -831,22 +917,30 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testPreserveTupleDestructuringWithSingleValue() {
-        let input = "let (result) = (42)"
+        let input = """
+        let (result) = (42)
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine, exclude: [.redundantParens])
     }
 
     func testPreserveTupleDestructuringWithNonTupleRHS() {
-        let input = "let (foo, bar, baz) = someFunction()"
+        let input = """
+        let (foo, bar, baz) = someFunction()
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testPreserveTupleDestructuringWithMethodCall() {
-        let input = "let (x, y) = point.coordinates()"
+        let input = """
+        let (x, y) = point.coordinates()
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testPreserveTupleDestructuringWithPropertyAccess2() {
-        let input = "let (width, height) = view.size"
+        let input = """
+        let (width, height) = view.size
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
@@ -881,7 +975,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithTypeAnnotation() {
-        let input = "let (a, b): (Int, Bool)"
+        let input = """
+        let (a, b): (Int, Bool)
+        """
         let output = """
         let a: Int
         let b: Bool
@@ -901,7 +997,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithComplexTypes() {
-        let input = "let (items, count): ([String], Int)"
+        let input = """
+        let (items, count): ([String], Int)
+        """
         let output = """
         let items: [String]
         let count: Int
@@ -910,7 +1008,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithOptionalTypes() {
-        let input = "var (name, age): (String?, Int?)"
+        let input = """
+        var (name, age): (String?, Int?)
+        """
         let output = """
         var name: String?
         var age: Int?
@@ -919,7 +1019,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithModifiersAndTypeAnnotation() {
-        let input = "private let (width, height): (Double, Double)"
+        let input = """
+        private let (width, height): (Double, Double)
+        """
         let output = """
         private let width: Double
         private let height: Double
@@ -928,7 +1030,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithAttributesAndTypeAnnotation() {
-        let input = "@available(iOS 15, *) let (x, y): (CGFloat, CGFloat)"
+        let input = """
+        @available(iOS 15, *) let (x, y): (CGFloat, CGFloat)
+        """
         let output = """
         @available(iOS 15, *) let x: CGFloat
         @available(iOS 15, *) let y: CGFloat
@@ -937,7 +1041,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithFunctionTypes() {
-        let input = "let (handler, validator): ((String) -> Void, (Int) -> Bool)"
+        let input = """
+        let (handler, validator): ((String) -> Void, (Int) -> Bool)
+        """
         let output = """
         let handler: (String) -> Void
         let validator: (Int) -> Bool
@@ -946,7 +1052,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithNestedTupleTypes() {
-        let input = "let (point, size): ((Int, Int), (Int, Int))"
+        let input = """
+        let (point, size): ((Int, Int), (Int, Int))
+        """
         let output = """
         let point: (Int, Int)
         let size: (Int, Int)
@@ -955,7 +1063,9 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testTupleDestructuringWithTypeAnnotationAndPartialValues() {
-        let input = "let (result, error): (String?, Error?) = (getValue(), nil)"
+        let input = """
+        let (result, error): (String?, Error?) = (getValue(), nil)
+        """
         let output = """
         let result: String? = getValue()
         let error: Error? = nil
@@ -976,22 +1086,30 @@ class SinglePropertyPerLineTests: XCTestCase {
     }
 
     func testPreserveTupleDestructuringWithFunctionCall() {
-        let input = "let (result, _): DecodedResponseWithContextCompletionArgument<Response> = castQueryResponse(from: query)"
+        let input = """
+        let (result, _): DecodedResponseWithContextCompletionArgument<Response> = castQueryResponse(from: query)
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testPreserveTupleDestructuringWithClosureLiteral() {
-        let input = "let (_, observers): (Value?, Observers<Value>) = storage.mutate { storage in (nil, storage.observers) }"
+        let input = """
+        let (_, observers): (Value?, Observers<Value>) = storage.mutate { storage in (nil, storage.observers) }
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testPreserveTupleDestructuringWithPropertyAccess() {
-        let input = "let (width, height) = view.bounds.size"
+        let input = """
+        let (width, height) = view.bounds.size
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 
     func testPreserveTupleDestructuringWithComplexExpression() {
-        let input = "let (min, max) = array.isEmpty ? (0, 0) : (array.min()!, array.max()!)"
+        let input = """
+        let (min, max) = array.isEmpty ? (0, 0) : (array.min()!, array.max()!)
+        """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
 }

--- a/Tests/Rules/SortImportsTests.swift
+++ b/Tests/Rules/SortImportsTests.swift
@@ -11,127 +11,292 @@ import XCTest
 
 class SortImportsTests: XCTestCase {
     func testSortImportsSimpleCase() {
-        let input = "import Foo\nimport Bar"
-        let output = "import Bar\nimport Foo"
+        let input = """
+        import Foo
+        import Bar
+        """
+        let output = """
+        import Bar
+        import Foo
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testSortImportsKeepsPreviousCommentWithImport() {
-        let input = "import Foo\n// important comment\n// (very important)\nimport Bar"
-        let output = "// important comment\n// (very important)\nimport Bar\nimport Foo"
+        let input = """
+        import Foo
+        // important comment
+        // (very important)
+        import Bar
+        """
+        let output = """
+        // important comment
+        // (very important)
+        import Bar
+        import Foo
+        """
         testFormatting(for: input, output, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsKeepsPreviousCommentWithImport2() {
-        let input = "// important comment\n// (very important)\nimport Foo\nimport Bar"
-        let output = "import Bar\n// important comment\n// (very important)\nimport Foo"
+        let input = """
+        // important comment
+        // (very important)
+        import Foo
+        import Bar
+        """
+        let output = """
+        import Bar
+        // important comment
+        // (very important)
+        import Foo
+        """
         testFormatting(for: input, output, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsDoesntMoveHeaderComment() {
-        let input = "// header comment\n\nimport Foo\nimport Bar"
-        let output = "// header comment\n\nimport Bar\nimport Foo"
+        let input = """
+        // header comment
+
+        import Foo
+        import Bar
+        """
+        let output = """
+        // header comment
+
+        import Bar
+        import Foo
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testSortImportsDoesntMoveHeaderCommentFollowedByImportComment() {
-        let input = "// header comment\n\n// important comment\nimport Foo\nimport Bar"
-        let output = "// header comment\n\nimport Bar\n// important comment\nimport Foo"
+        let input = """
+        // header comment
+
+        // important comment
+        import Foo
+        import Bar
+        """
+        let output = """
+        // header comment
+
+        import Bar
+        // important comment
+        import Foo
+        """
         testFormatting(for: input, output, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }
 
     func testSortImportsOnSameLine() {
-        let input = "import Foo; import Bar\nimport Baz"
-        let output = "import Baz\nimport Foo; import Bar"
+        let input = """
+        import Foo; import Bar
+        import Baz
+        """
+        let output = """
+        import Baz
+        import Foo; import Bar
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testSortImportsWithSemicolonAndCommentOnSameLine() {
-        let input = "import Foo; // foobar\nimport Bar\nimport Baz"
-        let output = "import Bar\nimport Baz\nimport Foo; // foobar"
+        let input = """
+        import Foo; // foobar
+        import Bar
+        import Baz
+        """
+        let output = """
+        import Bar
+        import Baz
+        import Foo; // foobar
+        """
         testFormatting(for: input, output, rule: .sortImports, exclude: [.semicolons])
     }
 
     func testSortImportEnum() {
-        let input = "import enum Foo.baz\nimport Foo.bar"
-        let output = "import Foo.bar\nimport enum Foo.baz"
+        let input = """
+        import enum Foo.baz
+        import Foo.bar
+        """
+        let output = """
+        import Foo.bar
+        import enum Foo.baz
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testSortImportFunc() {
-        let input = "import func Foo.baz\nimport Foo.bar"
-        let output = "import Foo.bar\nimport func Foo.baz"
+        let input = """
+        import func Foo.baz
+        import Foo.bar
+        """
+        let output = """
+        import Foo.bar
+        import func Foo.baz
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testAlreadySortImportsDoesNothing() {
-        let input = "import Bar\nimport Foo"
+        let input = """
+        import Bar
+        import Foo
+        """
         testFormatting(for: input, rule: .sortImports)
     }
 
     func testPreprocessorSortImports() {
-        let input = "#if os(iOS)\n    import Foo2\n    import Bar2\n#else\n    import Foo1\n    import Bar1\n#endif\nimport Foo3\nimport Bar3"
-        let output = "#if os(iOS)\n    import Bar2\n    import Foo2\n#else\n    import Bar1\n    import Foo1\n#endif\nimport Bar3\nimport Foo3"
+        let input = """
+        #if os(iOS)
+            import Foo2
+            import Bar2
+        #else
+            import Foo1
+            import Bar1
+        #endif
+        import Foo3
+        import Bar3
+        """
+        let output = """
+        #if os(iOS)
+            import Bar2
+            import Foo2
+        #else
+            import Bar1
+            import Foo1
+        #endif
+        import Bar3
+        import Foo3
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testTestableSortImports() {
-        let input = "@testable import Foo3\nimport Bar3"
-        let output = "import Bar3\n@testable import Foo3"
+        let input = """
+        @testable import Foo3
+        import Bar3
+        """
+        let output = """
+        import Bar3
+        @testable import Foo3
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testLengthSortImports() {
-        let input = "import Foo\nimport Module\nimport Bar3"
-        let output = "import Foo\nimport Bar3\nimport Module"
+        let input = """
+        import Foo
+        import Module
+        import Bar3
+        """
+        let output = """
+        import Foo
+        import Bar3
+        import Module
+        """
         let options = FormatOptions(importGrouping: .length)
         testFormatting(for: input, output, rule: .sortImports, options: options)
     }
 
     func testTestableImportsWithTestableOnPreviousLine() {
-        let input = "@testable\nimport Foo3\nimport Bar3"
-        let output = "import Bar3\n@testable\nimport Foo3"
+        let input = """
+        @testable
+        import Foo3
+        import Bar3
+        """
+        let output = """
+        import Bar3
+        @testable
+        import Foo3
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testTestableImportsWithGroupingTestableBottom() {
-        let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
-        let output = "import Foo\n@testable import Bar\n@testable import UIKit"
+        let input = """
+        @testable import Bar
+        import Foo
+        @testable import UIKit
+        """
+        let output = """
+        import Foo
+        @testable import Bar
+        @testable import UIKit
+        """
         let options = FormatOptions(importGrouping: .testableLast)
         testFormatting(for: input, output, rule: .sortImports, options: options)
     }
 
     func testTestableImportsWithGroupingTestableTop() {
-        let input = "@testable import Bar\nimport Foo\n@testable import UIKit"
-        let output = "@testable import Bar\n@testable import UIKit\nimport Foo"
+        let input = """
+        @testable import Bar
+        import Foo
+        @testable import UIKit
+        """
+        let output = """
+        @testable import Bar
+        @testable import UIKit
+        import Foo
+        """
         let options = FormatOptions(importGrouping: .testableFirst)
         testFormatting(for: input, output, rule: .sortImports, options: options)
     }
 
     func testCaseInsensitiveSortImports() {
-        let input = "import Zlib\nimport lib"
-        let output = "import lib\nimport Zlib"
+        let input = """
+        import Zlib
+        import lib
+        """
+        let output = """
+        import lib
+        import Zlib
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testCaseInsensitiveCaseDifferingSortImports() {
-        let input = "import c\nimport B\nimport A.a\nimport A.A"
-        let output = "import A.A\nimport A.a\nimport B\nimport c"
+        let input = """
+        import c
+        import B
+        import A.a
+        import A.A
+        """
+        let output = """
+        import A.A
+        import A.a
+        import B
+        import c
+        """
         testFormatting(for: input, output, rule: .sortImports)
     }
 
     func testNoDeleteCodeBetweenImports() {
-        let input = "import Foo\nfunc bar() {}\nimport Bar"
+        let input = """
+        import Foo
+        func bar() {}
+        import Bar
+        """
         testFormatting(for: input, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }
 
     func testNoDeleteCodeBetweenImports2() {
-        let input = "import Foo\nimport Bar\nfoo = bar\nimport Bar"
-        let output = "import Bar\nimport Foo\nfoo = bar\nimport Bar"
+        let input = """
+        import Foo
+        import Bar
+        foo = bar
+        import Bar
+        """
+        let output = """
+        import Bar
+        import Foo
+        foo = bar
+        import Bar
+        """
         testFormatting(for: input, output, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }
@@ -152,8 +317,20 @@ class SortImportsTests: XCTestCase {
     }
 
     func testSortContiguousImports() {
-        let input = "import Foo\nimport Bar\nfunc bar() {}\nimport Quux\nimport Baz"
-        let output = "import Bar\nimport Foo\nfunc bar() {}\nimport Baz\nimport Quux"
+        let input = """
+        import Foo
+        import Bar
+        func bar() {}
+        import Quux
+        import Baz
+        """
+        let output = """
+        import Bar
+        import Foo
+        func bar() {}
+        import Baz
+        import Quux
+        """
         testFormatting(for: input, output, rule: .sortImports,
                        exclude: [.blankLineAfterImports])
     }

--- a/Tests/Rules/SortTypealiasesTests.swift
+++ b/Tests/Rules/SortTypealiasesTests.swift
@@ -217,27 +217,37 @@ class SortTypealiasesTests: XCTestCase {
     }
 
     func testSortSingleLineTypealiasBeginningWithAny() {
-        let input = "typealias Placeholders = any Bar & Foo"
+        let input = """
+        typealias Placeholders = any Bar & Foo
+        """
         testFormatting(for: input, rule: .sortTypealiases)
     }
 
     func testCollectionTypealiasWithArrayOfExistentialTypes() {
-        let input = "public typealias Parameters = [any Any & Sendable]"
+        let input = """
+        public typealias Parameters = [any Any & Sendable]
+        """
         testFormatting(for: input, rule: .sortTypealiases)
     }
 
     func testCollectionTypealiasWithDictionaryOfExistentialTypes() {
-        let input = "public typealias Parameters = [any Hashable & Sendable: any Any & Sendable]"
+        let input = """
+        public typealias Parameters = [any Hashable & Sendable: any Any & Sendable]
+        """
         testFormatting(for: input, rule: .sortTypealiases)
     }
 
     func testCollectionTypealiasWithOptionalExistentialType() {
-        let input = "public typealias Parameters = (Hashable & Sendable)?"
+        let input = """
+        public typealias Parameters = (Hashable & Sendable)?
+        """
         testFormatting(for: input, rule: .sortTypealiases)
     }
 
     func testCollectionTypealiasWithGenericExistentialType() {
-        let input = "public typealias Parameters = Result<any Hashable & Sendable, any Error & Sendable>"
+        let input = """
+        public typealias Parameters = Result<any Hashable & Sendable, any Error & Sendable>
+        """
         testFormatting(for: input, rule: .sortTypealiases)
     }
 

--- a/Tests/Rules/SpaceAroundBracesTests.swift
+++ b/Tests/Rules/SpaceAroundBracesTests.swift
@@ -11,54 +11,82 @@ import XCTest
 
 class SpaceAroundBracesTests: XCTestCase {
     func testSpaceAroundTrailingClosure() {
-        let input = "if x{ y }else{ z }"
-        let output = "if x { y } else { z }"
+        let input = """
+        if x{ y }else{ z }
+        """
+        let output = """
+        if x { y } else { z }
+        """
         testFormatting(for: input, output, rule: .spaceAroundBraces,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testNoSpaceAroundClosureInsiderParens() {
-        let input = "foo({ $0 == 5 })"
+        let input = """
+        foo({ $0 == 5 })
+        """
         testFormatting(for: input, rule: .spaceAroundBraces,
                        exclude: [.trailingClosures])
     }
 
     func testNoExtraSpaceAroundBracesAtStartOrEndOfFile() {
-        let input = "{ foo }"
+        let input = """
+        { foo }
+        """
         testFormatting(for: input, rule: .spaceAroundBraces)
     }
 
     func testNoSpaceAfterPrefixOperator() {
-        let input = "let foo = ..{ bar }"
+        let input = """
+        let foo = ..{ bar }
+        """
         testFormatting(for: input, rule: .spaceAroundBraces)
     }
 
     func testNoSpaceBeforePostfixOperator() {
-        let input = "let foo = { bar }.."
+        let input = """
+        let foo = { bar }..
+        """
         testFormatting(for: input, rule: .spaceAroundBraces)
     }
 
     func testSpaceAroundBracesAfterOptionalProperty() {
-        let input = "var: Foo?{}"
-        let output = "var: Foo? {}"
+        let input = """
+        var: Foo?{}
+        """
+        let output = """
+        var: Foo? {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBraces)
     }
 
     func testSpaceAroundBracesAfterImplicitlyUnwrappedProperty() {
-        let input = "var: Foo!{}"
-        let output = "var: Foo! {}"
+        let input = """
+        var: Foo!{}
+        """
+        let output = """
+        var: Foo! {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBraces)
     }
 
     func testSpaceAroundBracesAfterNumber() {
-        let input = "if x = 5{}"
-        let output = "if x = 5 {}"
+        let input = """
+        if x = 5{}
+        """
+        let output = """
+        if x = 5 {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBraces)
     }
 
     func testSpaceAroundBracesAfterString() {
-        let input = "if x = \"\"{}"
-        let output = "if x = \"\" {}"
+        let input = """
+        if x = \"\"{}
+        """
+        let output = """
+        if x = \"\" {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBraces)
     }
 }

--- a/Tests/Rules/SpaceAroundBracketsTests.swift
+++ b/Tests/Rules/SpaceAroundBracketsTests.swift
@@ -11,101 +11,157 @@ import XCTest
 
 class SpaceAroundBracketsTests: XCTestCase {
     func testSubscriptNoAddSpacing() {
-        let input = "foo[bar] = baz"
+        let input = """
+        foo[bar] = baz
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 
     func testSubscriptRemoveSpacing() {
-        let input = "foo [bar] = baz"
-        let output = "foo[bar] = baz"
+        let input = """
+        foo [bar] = baz
+        """
+        let output = """
+        foo[bar] = baz
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testArrayLiteralSpacing() {
-        let input = "foo = [bar, baz]"
+        let input = """
+        foo = [bar, baz]
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 
     func testAsArrayCastingSpacing() {
-        let input = "foo as[String]"
-        let output = "foo as [String]"
+        let input = """
+        foo as[String]
+        """
+        let output = """
+        foo as [String]
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testAsOptionalArrayCastingSpacing() {
-        let input = "foo as? [String]"
+        let input = """
+        foo as? [String]
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 
     func testIsArrayTestingSpacing() {
-        let input = "if foo is[String] {}"
-        let output = "if foo is [String] {}"
+        let input = """
+        if foo is[String] {}
+        """
+        let output = """
+        if foo is [String] {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testKeywordAsIdentifierBracketSpacing() {
-        let input = "if foo.is[String] {}"
+        let input = """
+        if foo.is[String] {}
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 
     func testSpaceBeforeTupleIndexSubscript() {
-        let input = "foo.1 [2]"
-        let output = "foo.1[2]"
+        let input = """
+        foo.1 [2]
+        """
+        let output = """
+        foo.1[2]
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testRemoveSpaceBetweenBracketAndParen() {
-        let input = "let foo = bar[5] ()"
-        let output = "let foo = bar[5]()"
+        let input = """
+        let foo = bar[5] ()
+        """
+        let output = """
+        let foo = bar[5]()
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testRemoveSpaceBetweenBracketAndParenInsideClosure() {
-        let input = "let foo = bar { [Int] () }"
-        let output = "let foo = bar { [Int]() }"
+        let input = """
+        let foo = bar { [Int] () }
+        """
+        let output = """
+        let foo = bar { [Int]() }
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testAddSpaceBetweenCaptureListAndParen() {
-        let input = "let foo = bar { [self](foo: Int) in foo }"
-        let output = "let foo = bar { [self] (foo: Int) in foo }"
+        let input = """
+        let foo = bar { [self](foo: Int) in foo }
+        """
+        let output = """
+        let foo = bar { [self] (foo: Int) in foo }
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testAddSpaceBetweenInoutAndStringArray() {
-        let input = "func foo(arg _: inout[String]) {}"
-        let output = "func foo(arg _: inout [String]) {}"
+        let input = """
+        func foo(arg _: inout[String]) {}
+        """
+        let output = """
+        func foo(arg _: inout [String]) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testAddSpaceBetweenConsumingAndStringArray() {
-        let input = "func foo(arg _: consuming[String]) {}"
-        let output = "func foo(arg _: consuming [String]) {}"
+        let input = """
+        func foo(arg _: consuming[String]) {}
+        """
+        let output = """
+        func foo(arg _: consuming [String]) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets,
                        exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenBorrowingAndStringArray() {
-        let input = "func foo(arg _: borrowing[String]) {}"
-        let output = "func foo(arg _: borrowing [String]) {}"
+        let input = """
+        func foo(arg _: borrowing[String]) {}
+        """
+        let output = """
+        func foo(arg _: borrowing [String]) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets,
                        exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenSendingAndStringArray() {
-        let input = "func foo(arg _: sending[String]) {}"
-        let output = "func foo(arg _: sending [String]) {}"
+        let input = """
+        func foo(arg _: sending[String]) {}
+        """
+        let output = """
+        func foo(arg _: sending [String]) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundBrackets)
     }
 
     func testSpaceNotRemovedBetweenAsOperatorAndBracket() {
         // https://github.com/nicklockwood/SwiftFormat/issues/1846
-        let input = "@Test(arguments: [kSecReturnRef, kSecReturnAttributes] as [String])"
+        let input = """
+        @Test(arguments: [kSecReturnRef, kSecReturnAttributes] as [String])
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 
     func testSpaceNotRemovedBetweenTryAndBracket() {
-        let input = "@Test(arguments: try [Identifier(101), nil])"
+        let input = """
+        @Test(arguments: try [Identifier(101), nil])
+        """
         testFormatting(for: input, rule: .spaceAroundBrackets)
     }
 }

--- a/Tests/Rules/SpaceAroundCommentsTests.swift
+++ b/Tests/Rules/SpaceAroundCommentsTests.swift
@@ -11,26 +11,42 @@ import XCTest
 
 class SpaceAroundCommentsTests: XCTestCase {
     func testSpaceAroundCommentInParens() {
-        let input = "(/* foo */)"
-        let output = "( /* foo */ )"
+        let input = """
+        (/* foo */)
+        """
+        let output = """
+        ( /* foo */ )
+        """
         testFormatting(for: input, output, rule: .spaceAroundComments,
                        exclude: [.redundantParens])
     }
 
     func testNoSpaceAroundCommentAtStartAndEndOfFile() {
-        let input = "/* foo */"
+        let input = """
+        /* foo */
+        """
         testFormatting(for: input, rule: .spaceAroundComments)
     }
 
     func testNoSpaceAroundCommentBeforeComma() {
-        let input = "(foo /* foo */ , bar)"
-        let output = "(foo /* foo */, bar)"
+        let input = """
+        (foo /* foo */ , bar)
+        """
+        let output = """
+        (foo /* foo */, bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundComments)
     }
 
     func testSpaceAroundSingleLineComment() {
-        let input = "func foo() {// comment\n}"
-        let output = "func foo() { // comment\n}"
+        let input = """
+        func foo() {// comment
+        }
+        """
+        let output = """
+        func foo() { // comment
+        }
+        """
         testFormatting(for: input, output, rule: .spaceAroundComments)
     }
 }

--- a/Tests/Rules/SpaceAroundGenericsTests.swift
+++ b/Tests/Rules/SpaceAroundGenericsTests.swift
@@ -11,18 +11,26 @@ import XCTest
 
 class SpaceAroundGenericsTests: XCTestCase {
     func testSpaceAroundGenerics() {
-        let input = "Foo <Bar <Baz>>"
-        let output = "Foo<Bar<Baz>>"
+        let input = """
+        Foo <Bar <Baz>>
+        """
+        let output = """
+        Foo<Bar<Baz>>
+        """
         testFormatting(for: input, output, rule: .spaceAroundGenerics)
     }
 
     func testSpaceAroundGenericsFollowedByAndOperator() {
-        let input = "if foo is Foo<Bar> && baz {}"
+        let input = """
+        if foo is Foo<Bar> && baz {}
+        """
         testFormatting(for: input, rule: .spaceAroundGenerics, exclude: [.andOperator])
     }
 
     func testSpaceAroundGenericResultBuilder() {
-        let input = "func foo(@SomeResultBuilder<Self> builder _: () -> Void) {}"
+        let input = """
+        func foo(@SomeResultBuilder<Self> builder _: () -> Void) {}
+        """
         testFormatting(for: input, rule: .spaceAroundGenerics)
     }
 }

--- a/Tests/Rules/SpaceAroundOperatorsTests.swift
+++ b/Tests/Rules/SpaceAroundOperatorsTests.swift
@@ -11,367 +11,584 @@ import XCTest
 
 class SpaceAroundOperatorsTests: XCTestCase {
     func testSpaceAfterColon() {
-        let input = "let foo:Bar = 5"
-        let output = "let foo: Bar = 5"
+        let input = """
+        let foo:Bar = 5
+        """
+        let output = """
+        let foo: Bar = 5
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenOptionalAndDefaultValue() {
-        let input = "let foo: String?=nil"
-        let output = "let foo: String? = nil"
+        let input = """
+        let foo: String?=nil
+        """
+        let output = """
+        let foo: String? = nil
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenImplictlyUnwrappedOptionalAndDefaultValue() {
-        let input = "let foo: String!=nil"
-        let output = "let foo: String! = nil"
+        let input = """
+        let foo: String!=nil
+        """
+        let output = """
+        let foo: String! = nil
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpacePreservedBetweenOptionalTryAndDot() {
-        let input = "let foo: Int = try? .init()"
+        let input = """
+        let foo: Int = try? .init()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpacePreservedBetweenForceTryAndDot() {
-        let input = "let foo: Int = try! .init()"
+        let input = """
+        let foo: Int = try! .init()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenOptionalAndDefaultValueInFunction() {
-        let input = "func foo(bar _: String?=nil) {}"
-        let output = "func foo(bar _: String? = nil) {}"
+        let input = """
+        func foo(bar _: String?=nil) {}
+        """
+        let output = """
+        func foo(bar _: String? = nil) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAddedAfterColonInSelector() {
-        let input = "@objc(foo:bar:)"
+        let input = """
+        @objc(foo:bar:)
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAfterColonInSwitchCase() {
-        let input = "switch x { case .y:break }"
-        let output = "switch x { case .y: break }"
+        let input = """
+        switch x { case .y:break }
+        """
+        let output = """
+        switch x { case .y: break }
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAfterColonInSwitchDefault() {
-        let input = "switch x { default:break }"
-        let output = "switch x { default: break }"
+        let input = """
+        switch x { default:break }
+        """
+        let output = """
+        switch x { default: break }
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAfterComma() {
-        let input = "let foo = [1,2,3]"
-        let output = "let foo = [1, 2, 3]"
+        let input = """
+        let foo = [1,2,3]
+        """
+        let output = """
+        let foo = [1, 2, 3]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenColonAndEnumValue() {
-        let input = "[.Foo:.Bar]"
-        let output = "[.Foo: .Bar]"
+        let input = """
+        [.Foo:.Bar]
+        """
+        let output = """
+        [.Foo: .Bar]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenCommaAndEnumValue() {
-        let input = "[.Foo,.Bar]"
-        let output = "[.Foo, .Bar]"
+        let input = """
+        [.Foo,.Bar]
+        """
+        let output = """
+        [.Foo, .Bar]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoRemoveSpaceAroundEnumInBrackets() {
-        let input = "[ .red ]"
+        let input = """
+        [ .red ]
+        """
         testFormatting(for: input, rule: .spaceAroundOperators,
                        exclude: [.spaceInsideBrackets])
     }
 
     func testSpaceBetweenSemicolonAndEnumValue() {
-        let input = "statement;.Bar"
-        let output = "statement; .Bar"
+        let input = """
+        statement;.Bar
+        """
+        let output = """
+        statement; .Bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpacePreservedBetweenEqualsAndEnumValue() {
-        let input = "foo = .Bar"
+        let input = """
+        foo = .Bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceBeforeColon() {
-        let input = "let foo : Bar = 5"
-        let output = "let foo: Bar = 5"
+        let input = """
+        let foo : Bar = 5
+        """
+        let output = """
+        let foo: Bar = 5
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpacePreservedBeforeColonInTernary() {
-        let input = "foo ? bar : baz"
+        let input = """
+        foo ? bar : baz
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpacePreservedAroundEnumValuesInTernary() {
-        let input = "foo ? .Bar : .Baz"
+        let input = """
+        foo ? .Bar : .Baz
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceBeforeColonInNestedTernary() {
-        let input = "foo ? (hello + a ? b: c) : baz"
-        let output = "foo ? (hello + a ? b : c) : baz"
+        let input = """
+        foo ? (hello + a ? b: c) : baz
+        """
+        let output = """
+        foo ? (hello + a ? b : c) : baz
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceBeforeComma() {
-        let input = "let foo = [1 , 2 , 3]"
-        let output = "let foo = [1, 2, 3]"
+        let input = """
+        let foo = [1 , 2 , 3]
+        """
+        let output = """
+        let foo = [1, 2, 3]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAtStartOfLine() {
-        let input = "print(foo\n      ,bar)"
-        let output = "print(foo\n      , bar)"
+        let input = """
+        print(foo
+              ,bar)
+        """
+        let output = """
+        print(foo
+              , bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators,
                        exclude: [.leadingDelimiters])
     }
 
     func testSpaceAroundInfixMinus() {
-        let input = "foo-bar"
-        let output = "foo - bar"
+        let input = """
+        foo-bar
+        """
+        let output = """
+        foo - bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundPrefixMinus() {
-        let input = "foo + -bar"
+        let input = """
+        foo + -bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundLessThan() {
-        let input = "foo<bar"
-        let output = "foo < bar"
+        let input = """
+        foo<bar
+        """
+        let output = """
+        foo < bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceAroundDot() {
-        let input = "foo . bar"
-        let output = "foo.bar"
+        let input = """
+        foo . bar
+        """
+        let output = """
+        foo.bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundDotOnNewLine() {
-        let input = "foo\n    .bar"
+        let input = """
+        foo
+            .bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundEnumCase() {
-        let input = "case .Foo,.Bar:"
-        let output = "case .Foo, .Bar:"
+        let input = """
+        case .Foo,.Bar:
+        """
+        let output = """
+        case .Foo, .Bar:
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSwitchWithEnumCases() {
-        let input = "switch x {\ncase.Foo:\n    break\ndefault:\n    break\n}"
-        let output = "switch x {\ncase .Foo:\n    break\ndefault:\n    break\n}"
+        let input = """
+        switch x {
+        case.Foo:
+            break
+        default:
+            break
+        }
+        """
+        let output = """
+        switch x {
+        case .Foo:
+            break
+        default:
+            break
+        }
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundEnumReturn() {
-        let input = "return.Foo"
-        let output = "return .Foo"
+        let input = """
+        return.Foo
+        """
+        let output = """
+        return .Foo
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAfterReturnAsIdentifier() {
-        let input = "foo.return.Bar"
+        let input = """
+        foo.return.Bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundCaseLet() {
-        let input = "case let.Foo(bar):"
-        let output = "case let .Foo(bar):"
+        let input = """
+        case let.Foo(bar):
+        """
+        let output = """
+        case let .Foo(bar):
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundEnumArgument() {
-        let input = "foo(with:.Bar)"
-        let output = "foo(with: .Bar)"
+        let input = """
+        foo(with:.Bar)
+        """
+        let output = """
+        foo(with: .Bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceBeforeEnumCaseInsideClosure() {
-        let input = "{ .bar() }"
+        let input = """
+        { .bar() }
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundMultipleOptionalChaining() {
-        let input = "foo??!?!.bar"
+        let input = """
+        foo??!?!.bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundForcedChaining() {
-        let input = "foo!.bar"
+        let input = """
+        foo!.bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAddedInOptionalChaining() {
-        let input = "foo?.bar"
+        let input = """
+        foo?.bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceRemovedInOptionalChaining() {
-        let input = "foo? .bar"
-        let output = "foo?.bar"
+        let input = """
+        foo? .bar
+        """
+        let output = """
+        foo?.bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceRemovedInForcedChaining() {
-        let input = "foo! .bar"
-        let output = "foo!.bar"
+        let input = """
+        foo! .bar
+        """
+        let output = """
+        foo!.bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceRemovedInMultipleOptionalChaining() {
-        let input = "foo??! .bar"
-        let output = "foo??!.bar"
+        let input = """
+        foo??! .bar
+        """
+        let output = """
+        foo??!.bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAfterOptionalInsideTernary() {
-        let input = "x ? foo? .bar() : bar?.baz()"
-        let output = "x ? foo?.bar() : bar?.baz()"
+        let input = """
+        x ? foo? .bar() : bar?.baz()
+        """
+        let output = """
+        x ? foo?.bar() : bar?.baz()
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSplitLineOptionalChaining() {
-        let input = "foo?\n    .bar"
+        let input = """
+        foo?
+            .bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSplitLineMultipleOptionalChaining() {
-        let input = "foo??!\n    .bar"
+        let input = """
+        foo??!
+            .bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceBetweenNullCoalescingAndDot() {
-        let input = "foo ?? .bar()"
+        let input = """
+        foo ?? .bar()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundFailableInit() {
-        let input = "init?()"
+        let input = """
+        init?()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundImplictlyUnwrappedFailableInit() {
-        let input = "init!()"
+        let input = """
+        init!()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundFailableInitWithGenerics() {
-        let input = "init?<T>()"
+        let input = """
+        init?<T>()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundImplictlyUnwrappedFailableInitWithGenerics() {
-        let input = "init!<T>()"
+        let input = """
+        init!<T>()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundInitWithGenericAndSuppressedConstraint() {
-        let input = "init<T: ~Copyable>()"
+        let input = """
+        init<T: ~Copyable>()
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testGenericBracketAroundAttributeNotConfusedWithLessThan() {
-        let input = "Example<(@MainActor () -> Void)?>(nil)"
+        let input = """
+        Example<(@MainActor () -> Void)?>(nil)
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAfterOptionalAs() {
-        let input = "foo as?[String]"
-        let output = "foo as? [String]"
+        let input = """
+        foo as?[String]
+        """
+        let output = """
+        foo as? [String]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAfterForcedAs() {
-        let input = "foo as![String]"
-        let output = "foo as! [String]"
+        let input = """
+        foo as![String]
+        """
+        let output = """
+        foo as! [String]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundGenerics() {
-        let input = "Foo<String>"
+        let input = """
+        Foo<String>
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoSpaceAroundGenericsWithSuppressedConstraint() {
-        let input = "Foo<String: ~Copyable>"
+        let input = """
+        Foo<String: ~Copyable>
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundReturnTypeArrow() {
-        let input = "foo() ->Bool"
-        let output = "foo() -> Bool"
+        let input = """
+        foo() ->Bool
+        """
+        let output = """
+        foo() -> Bool
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceAroundCommentInInfixExpression() {
-        let input = "foo/* hello */-bar"
-        let output = "foo/* hello */ -bar"
+        let input = """
+        foo/* hello */-bar
+        """
+        let output = """
+        foo/* hello */ -bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundCommentsInInfixExpression() {
-        let input = "a/* */+/* */b"
-        let output = "a/* */ + /* */b"
+        let input = """
+        a/* */+/* */b
+        """
+        let output = """
+        a/* */ + /* */b
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundCommentInPrefixExpression() {
-        let input = "a + /* hello */ -bar"
+        let input = """
+        a + /* hello */ -bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testPrefixMinusBeforeMember() {
-        let input = "-.foo"
+        let input = """
+        -.foo
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testPostfixMinusBeforeMember() {
-        let input = "foo-.bar"
+        let input = """
+        foo-.bar
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceBeforeNegativeIndex() {
-        let input = "foo[ -bar]"
-        let output = "foo[-bar]"
+        let input = """
+        foo[ -bar]
+        """
+        let output = """
+        foo[-bar]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoInsertSpaceBeforeUnlabelledAddressArgument() {
-        let input = "foo(&bar)"
+        let input = """
+        foo(&bar)
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceBeforeUnlabelledAddressArgument() {
-        let input = "foo( &bar, baz: &baz)"
-        let output = "foo(&bar, baz: &baz)"
+        let input = """
+        foo( &bar, baz: &baz)
+        """
+        let output = """
+        foo(&bar, baz: &baz)
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceBeforeKeyPath() {
-        let input = "foo( \\.bar)"
-        let output = "foo(\\.bar)"
+        let input = """
+        foo( \\.bar)
+        """
+        let output = """
+        foo(\\.bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceAfterFuncEquals() {
-        let input = "func ==(lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
-        let output = "func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
+        let input = """
+        func ==(lhs: Int, rhs: Int) -> Bool { return lhs === rhs }
+        """
+        let output = """
+        func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceAfterFuncEquals() {
-        let input = "func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
-        let output = "func ==(lhs: Int, rhs: Int) -> Bool { return lhs === rhs }"
+        let input = """
+        func == (lhs: Int, rhs: Int) -> Bool { return lhs === rhs }
+        """
+        let output = """
+        func ==(lhs: Int, rhs: Int) -> Bool { return lhs === rhs }
+        """
         let options = FormatOptions(spaceAroundOperatorDeclarations: .remove)
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
@@ -386,237 +603,360 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testAddSpaceAfterOperatorEquals() {
-        let input = "operator =={}"
-        let output = "operator == {}"
+        let input = """
+        operator =={}
+        """
+        let output = """
+        operator == {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testNoRemoveSpaceAfterOperatorEqualsWhenSpaceAroundOperatorDeclarationsFalse() {
-        let input = "operator == {}"
+        let input = """
+        operator == {}
+        """
         let options = FormatOptions(spaceAroundOperatorDeclarations: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoAddSpaceAfterOperatorEqualsWithAllmanBrace() {
-        let input = "operator ==\n{}"
+        let input = """
+        operator ==
+        {}
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testNoAddSpaceAroundOperatorInsideParens() {
-        let input = "(!=)"
+        let input = """
+        (!=)
+        """
         testFormatting(for: input, rule: .spaceAroundOperators, exclude: [.redundantParens])
     }
 
     func testSpaceAroundPlusBeforeHash() {
-        let input = "\"foo.\"+#file"
-        let output = "\"foo.\" + #file"
+        let input = """
+        \"foo.\"+#file
+        """
+        let output = """
+        \"foo.\" + #file
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceNotAddedAroundStarInAvailableAnnotation() {
-        let input = "@available(*, deprecated, message: \"foo\")"
+        let input = """
+        @available(*, deprecated, message: \"foo\")
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceAroundRange() {
-        let input = "let a = b...c"
-        let output = "let a = b ... c"
+        let input = """
+        let a = b...c
+        """
+        let output = """
+        let a = b ... c
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceRemovedInNestedPropertyWrapper() {
-        let input = "@Encoded .Foo var foo: String"
-        let output = "@Encoded.Foo var foo: String"
+        let input = """
+        @Encoded .Foo var foo: String
+        """
+        let output = """
+        @Encoded.Foo var foo: String
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testSpaceNotAddedInKeyPath() {
-        let input = "let a = b.map(\\.?.something)"
+        let input = """
+        let a = b.map(\\.?.something)
+        """
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
     // noSpaceOperators
 
     func testNoAddSpaceAroundNoSpaceStar() {
-        let input = "let a = b*c+d"
-        let output = "let a = b*c + d"
+        let input = """
+        let a = b*c+d
+        """
+        let output = """
+        let a = b*c + d
+        """
         let options = FormatOptions(noSpaceOperators: ["*"])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceAroundNoSpaceStar() {
-        let input = "let a = b * c + d"
-        let output = "let a = b*c + d"
+        let input = """
+        let a = b * c + d
+        """
+        let output = """
+        let a = b*c + d
+        """
         let options = FormatOptions(noSpaceOperators: ["*"])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoRemoveSpaceAroundNoSpaceStarBeforePrefixOperator() {
-        let input = "let a = b * -c"
+        let input = """
+        let a = b * -c
+        """
         let options = FormatOptions(noSpaceOperators: ["*"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoRemoveSpaceAroundNoSpaceStarAfterPostfixOperator() {
-        let input = "let a = b% * c"
+        let input = """
+        let a = b% * c
+        """
         let options = FormatOptions(noSpaceOperators: ["*"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceAroundNoSpaceStarAfterUnwrapOperator() {
-        let input = "let a = b! * c"
-        let output = "let a = b!*c"
+        let input = """
+        let a = b! * c
+        """
+        let output = """
+        let a = b!*c
+        """
         let options = FormatOptions(noSpaceOperators: ["*"])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoAddSpaceAroundNoSpaceSlash() {
-        let input = "let a = b/c+d"
-        let output = "let a = b/c + d"
+        let input = """
+        let a = b/c+d
+        """
+        let output = """
+        let a = b/c + d
+        """
         let options = FormatOptions(noSpaceOperators: ["/"])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoAddSpaceAroundNoSpaceRange() {
-        let input = "let a = b...c"
+        let input = """
+        let a = b...c
+        """
         let options = FormatOptions(noSpaceOperators: ["..."])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoAddSpaceAroundNoSpaceHalfOpenRange() {
-        let input = "let a = b..<c"
+        let input = """
+        let a = b..<c
+        """
         let options = FormatOptions(noSpaceOperators: ["..<"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceAroundNoSpaceRange() {
-        let input = "let a = b ... c"
-        let output = "let a = b...c"
+        let input = """
+        let a = b ... c
+        """
+        let output = """
+        let a = b...c
+        """
         let options = FormatOptions(noSpaceOperators: ["..."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoRemoveSpaceAroundNoSpaceRangeBeforePrefixOperator() {
-        let input = "let a = b ... -c"
+        let input = """
+        let a = b ... -c
+        """
         let options = FormatOptions(noSpaceOperators: ["..."])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoRemoveSpaceAroundTernaryColon() {
-        let input = "let a = b ? c : d"
-        let output = "let a = b ? c:d"
+        let input = """
+        let a = b ? c : d
+        """
+        let output = """
+        let a = b ? c:d
+        """
         let options = FormatOptions(noSpaceOperators: [":"])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testNoRemoveSpaceAroundTernaryQuestionMark() {
-        let input = "let a = b ? c : d"
+        let input = """
+        let a = b ? c : d
+        """
         let options = FormatOptions(noSpaceOperators: ["?"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceOnOneSideOfPlusMatchedByLinebreakNotRemoved() {
-        let input = "let range = 0 +\n4"
+        let input = """
+        let range = 0 +
+        4
+        """
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceOnOneSideOfPlusMatchedByLinebreakNotRemoved2() {
-        let input = "let range = 0\n+ 4"
+        let input = """
+        let range = 0
+        + 4
+        """
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceAroundPlusWithLinebreakOnOneSideNotRemoved() {
-        let input = "let range = 0 + \n4"
+        let input = """
+        let range = 0 + 
+        4
+        """
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent, .trailingSpace])
     }
 
     func testSpaceAroundPlusWithLinebreakOnOneSideNotRemoved2() {
-        let input = "let range = 0\n + 4"
+        let input = """
+        let range = 0
+         + 4
+        """
         let options = FormatOptions(noSpaceOperators: ["+"])
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testAddSpaceEvenAfterLHSClosure() {
-        let input = "let foo = { $0 }..bar"
-        let output = "let foo = { $0 } .. bar"
+        let input = """
+        let foo = { $0 }..bar
+        """
+        let output = """
+        let foo = { $0 } .. bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceEvenBeforeRHSClosure() {
-        let input = "let foo = bar..{ $0 }"
-        let output = "let foo = bar .. { $0 }"
+        let input = """
+        let foo = bar..{ $0 }
+        """
+        let output = """
+        let foo = bar .. { $0 }
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceEvenAfterLHSArray() {
-        let input = "let foo = [42]..bar"
-        let output = "let foo = [42] .. bar"
+        let input = """
+        let foo = [42]..bar
+        """
+        let output = """
+        let foo = [42] .. bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceEvenBeforeRHSArray() {
-        let input = "let foo = bar..[42]"
-        let output = "let foo = bar .. [42]"
+        let input = """
+        let foo = bar..[42]
+        """
+        let output = """
+        let foo = bar .. [42]
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceEvenAfterLHSParens() {
-        let input = "let foo = (42, 1337)..bar"
-        let output = "let foo = (42, 1337) .. bar"
+        let input = """
+        let foo = (42, 1337)..bar
+        """
+        let output = """
+        let foo = (42, 1337) .. bar
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testAddSpaceEvenBeforeRHSParens() {
-        let input = "let foo = bar..(42, 1337)"
-        let output = "let foo = bar .. (42, 1337)"
+        let input = """
+        let foo = bar..(42, 1337)
+        """
+        let output = """
+        let foo = bar .. (42, 1337)
+        """
         testFormatting(for: input, output, rule: .spaceAroundOperators)
     }
 
     func testRemoveSpaceEvenAfterLHSClosure() {
-        let input = "let foo = { $0 } .. bar"
-        let output = "let foo = { $0 }..bar"
+        let input = """
+        let foo = { $0 } .. bar
+        """
+        let output = """
+        let foo = { $0 }..bar
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceEvenBeforeRHSClosure() {
-        let input = "let foo = bar .. { $0 }"
-        let output = "let foo = bar..{ $0 }"
+        let input = """
+        let foo = bar .. { $0 }
+        """
+        let output = """
+        let foo = bar..{ $0 }
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceEvenAfterLHSArray() {
-        let input = "let foo = [42] .. bar"
-        let output = "let foo = [42]..bar"
+        let input = """
+        let foo = [42] .. bar
+        """
+        let output = """
+        let foo = [42]..bar
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceEvenBeforeRHSArray() {
-        let input = "let foo = bar .. [42]"
-        let output = "let foo = bar..[42]"
+        let input = """
+        let foo = bar .. [42]
+        """
+        let output = """
+        let foo = bar..[42]
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceEvenAfterLHSParens() {
-        let input = "let foo = (42, 1337) .. bar"
-        let output = "let foo = (42, 1337)..bar"
+        let input = """
+        let foo = (42, 1337) .. bar
+        """
+        let output = """
+        let foo = (42, 1337)..bar
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testRemoveSpaceEvenBeforeRHSParens() {
-        let input = "let foo = bar .. (42, 1337)"
-        let output = "let foo = bar..(42, 1337)"
+        let input = """
+        let foo = bar .. (42, 1337)
+        """
+        let output = """
+        let foo = bar..(42, 1337)
+        """
         let options = FormatOptions(noSpaceOperators: [".."])
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
@@ -635,82 +975,112 @@ class SpaceAroundOperatorsTests: XCTestCase {
     // spaceAroundRangeOperators: .remove
 
     func testNoSpaceAroundRangeOperatorsWithCustomOptions() {
-        let input = "foo ..< bar"
-        let output = "foo..<bar"
+        let input = """
+        foo ..< bar
+        """
+        let output = """
+        foo..<bar
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, output, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceNotRemovedBeforeLeadingRangeOperatorWithSpaceAroundRangeOperatorsFalse() {
-        let input = "let range = ..<foo.endIndex"
+        let input = """
+        let range = ..<foo.endIndex
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceOnOneSideOfRangeMatchedByCommentNotRemoved() {
-        let input = "let range = 0 .../* foo */4"
+        let input = """
+        let range = 0 .../* foo */4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByCommentNotRemoved2() {
-        let input = "let range = 0/* foo */... 4"
+        let input = """
+        let range = 0/* foo */... 4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved() {
-        let input = "let range = 0 ... /* foo */4"
+        let input = """
+        let range = 0 ... /* foo */4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceAroundRangeWithCommentOnOneSideNotRemoved2() {
-        let input = "let range = 0/* foo */ ... 4"
+        let input = """
+        let range = 0/* foo */ ... 4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.spaceAroundComments])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved() {
-        let input = "let range = 0 ...\n4"
+        let input = """
+        let range = 0 ...
+        4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceOnOneSideOfRangeMatchedByLinebreakNotRemoved2() {
-        let input = "let range = 0\n... 4"
+        let input = """
+        let range = 0
+        ... 4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved() {
-        let input = "let range = 0 ... \n4"
+        let input = """
+        let range = 0 ... 
+        4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent, .trailingSpace])
     }
 
     func testSpaceAroundRangeWithLinebreakOnOneSideNotRemoved2() {
-        let input = "let range = 0\n ... 4"
+        let input = """
+        let range = 0
+         ... 4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options,
                        exclude: [.indent])
     }
 
     func testSpaceNotRemovedAroundRangeFollowedByPrefixOperator() {
-        let input = "let range = 0 ... -4"
+        let input = """
+        let range = 0 ... -4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
 
     func testSpaceNotRemovedAroundRangePreceededByPostfixOperator() {
-        let input = "let range = 0>> ... 4"
+        let input = """
+        let range = 0>> ... 4
+        """
         let options = FormatOptions(spaceAroundRangeOperators: .remove)
         testFormatting(for: input, rule: .spaceAroundOperators, options: options)
     }
@@ -729,8 +1099,12 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testSpaceAroundDataTypeDelimiterLeadingAdded() {
-        let input = "class Implementation: ImplementationProtocol {}"
-        let output = "class Implementation : ImplementationProtocol {}"
+        let input = """
+        class Implementation: ImplementationProtocol {}
+        """
+        let output = """
+        class Implementation : ImplementationProtocol {}
+        """
         let options = FormatOptions(typeDelimiterSpacing: .spaced)
         testFormatting(
             for: input,
@@ -741,8 +1115,12 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testSpaceAroundDataTypeDelimiterLeadingTrailingAdded() {
-        let input = "class Implementation:ImplementationProtocol {}"
-        let output = "class Implementation : ImplementationProtocol {}"
+        let input = """
+        class Implementation:ImplementationProtocol {}
+        """
+        let output = """
+        class Implementation : ImplementationProtocol {}
+        """
         let options = FormatOptions(typeDelimiterSpacing: .spaced)
         testFormatting(
             for: input,
@@ -753,7 +1131,9 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testSpaceAroundDataTypeDelimiterLeadingTrailingNotModified() {
-        let input = "class Implementation : ImplementationProtocol {}"
+        let input = """
+        class Implementation : ImplementationProtocol {}
+        """
         let options = FormatOptions(typeDelimiterSpacing: .spaced)
         testFormatting(
             for: input,
@@ -763,8 +1143,12 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testSpaceAroundDataTypeDelimiterTrailingAdded() {
-        let input = "class Implementation:ImplementationProtocol {}"
-        let output = "class Implementation: ImplementationProtocol {}"
+        let input = """
+        class Implementation:ImplementationProtocol {}
+        """
+        let output = """
+        class Implementation: ImplementationProtocol {}
+        """
 
         let options = FormatOptions(typeDelimiterSpacing: .spaceAfter)
         testFormatting(
@@ -776,7 +1160,9 @@ class SpaceAroundOperatorsTests: XCTestCase {
     }
 
     func testSpaceAroundDataTypeDelimiterLeadingNotAdded() {
-        let input = "class Implementation: ImplementationProtocol {}"
+        let input = """
+        class Implementation: ImplementationProtocol {}
+        """
         let options = FormatOptions(typeDelimiterSpacing: .spaceAfter)
         testFormatting(
             for: input,

--- a/Tests/Rules/SpaceAroundParensTests.swift
+++ b/Tests/Rules/SpaceAroundParensTests.swift
@@ -11,52 +11,80 @@ import XCTest
 
 class SpaceAroundParensTests: XCTestCase {
     func testSpaceAfterSet() {
-        let input = "private(set)var foo: Int"
-        let output = "private(set) var foo: Int"
+        let input = """
+        private(set)var foo: Int
+        """
+        let output = """
+        private(set) var foo: Int
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndClass() {
-        let input = "@objc(XYZFoo)class foo"
-        let output = "@objc(XYZFoo) class foo"
+        let input = """
+        @objc(XYZFoo)class foo
+        """
+        let output = """
+        @objc(XYZFoo) class foo
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenConventionAndBlock() {
-        let input = "@convention(block)() -> Void"
-        let output = "@convention(block) () -> Void"
+        let input = """
+        @convention(block)() -> Void
+        """
+        let output = """
+        @convention(block) () -> Void
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenConventionAndEscaping() {
-        let input = "@convention(block)@escaping () -> Void"
-        let output = "@convention(block) @escaping () -> Void"
+        let input = """
+        @convention(block)@escaping () -> Void
+        """
+        let output = """
+        @convention(block) @escaping () -> Void
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenAutoclosureEscapingAndBlock() { // Swift 2.3 only
-        let input = "@autoclosure(escaping)() -> Void"
-        let output = "@autoclosure(escaping) () -> Void"
+        let input = """
+        @autoclosure(escaping)() -> Void
+        """
+        let output = """
+        @autoclosure(escaping) () -> Void
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenSendableAndBlock() {
-        let input = "@Sendable (Action) -> Void"
+        let input = """
+        @Sendable (Action) -> Void
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenMainActorAndBlock() {
-        let input = "@MainActor (Action) -> Void"
+        let input = """
+        @MainActor (Action) -> Void
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenMainActorAndBlock2() {
-        let input = "@MainActor (@MainActor (Action) -> Void) async -> Void"
+        let input = """
+        @MainActor (@MainActor (Action) -> Void) async -> Void
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenMainActorAndClosureParams() {
-        let input = "{ @MainActor (foo: Int) in foo }"
+        let input = """
+        { @MainActor (foo: Int) in foo }
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
@@ -70,243 +98,391 @@ class SpaceAroundParensTests: XCTestCase {
     }
 
     func testSpaceBetweenParenAndAs() {
-        let input = "(foo.bar) as? String"
+        let input = """
+        (foo.bar) as? String
+        """
         testFormatting(for: input, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testNoSpaceAfterParenAtEndOfFile() {
-        let input = "(foo.bar)"
+        let input = """
+        (foo.bar)
+        """
         testFormatting(for: input, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testSpaceBetweenParenAndFoo() {
-        let input = "func foo ()"
-        let output = "func foo()"
+        let input = """
+        func foo ()
+        """
+        let output = """
+        func foo()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenParenAndAny() {
-        let input = "func any ()"
-        let output = "func any()"
+        let input = """
+        func any ()
+        """
+        let output = """
+        func any()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenParenAndAnyType() {
-        let input = "let foo: any(A & B).Type"
-        let output = "let foo: any (A & B).Type"
+        let input = """
+        let foo: any(A & B).Type
+        """
+        let output = """
+        let foo: any (A & B).Type
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenParenAndSomeType() {
-        let input = "func foo() -> some(A & B).Type"
-        let output = "func foo() -> some (A & B).Type"
+        let input = """
+        func foo() -> some(A & B).Type
+        """
+        let output = """
+        func foo() -> some (A & B).Type
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenParenAndInit() {
-        let input = "init ()"
-        let output = "init()"
+        let input = """
+        init ()
+        """
+        let output = """
+        init()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenObjcAndSelector() {
-        let input = "@objc (XYZFoo) class foo"
-        let output = "@objc(XYZFoo) class foo"
+        let input = """
+        @objc (XYZFoo) class foo
+        """
+        let output = """
+        @objc(XYZFoo) class foo
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenHashSelectorAndBrace() {
-        let input = "#selector(foo)"
+        let input = """
+        #selector(foo)
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenHashKeyPathAndBrace() {
-        let input = "#keyPath (foo.bar)"
-        let output = "#keyPath(foo.bar)"
+        let input = """
+        #keyPath (foo.bar)
+        """
+        let output = """
+        #keyPath(foo.bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenHashAvailableAndBrace() {
-        let input = "#available (iOS 9.0, *)"
-        let output = "#available(iOS 9.0, *)"
+        let input = """
+        #available (iOS 9.0, *)
+        """
+        let output = """
+        #available(iOS 9.0, *)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenPrivateAndSet() {
-        let input = "private (set) var foo: Int"
-        let output = "private(set) var foo: Int"
+        let input = """
+        private (set) var foo: Int
+        """
+        let output = """
+        private(set) var foo: Int
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenLetAndTuple() {
-        let input = "if let (foo, bar) = baz {}"
+        let input = """
+        if let (foo, bar) = baz {}
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenIfAndCondition() {
-        let input = "if(a || b) == true {}"
-        let output = "if (a || b) == true {}"
+        let input = """
+        if(a || b) == true {}
+        """
+        let output = """
+        if (a || b) == true {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenArrayLiteralAndParen() {
-        let input = "[String] ()"
-        let output = "[String]()"
+        let input = """
+        [String] ()
+        """
+        let output = """
+        [String]()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenCaptureListAndArguments() {
-        let input = "{ [weak self](foo) in print(foo) }"
-        let output = "{ [weak self] (foo) in print(foo) }"
+        let input = """
+        { [weak self](foo) in print(foo) }
+        """
+        let output = """
+        { [weak self] (foo) in print(foo) }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantParens])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments2() {
-        let input = "{ [weak self]() -> Void in }"
-        let output = "{ [weak self] () -> Void in }"
+        let input = """
+        { [weak self]() -> Void in }
+        """
+        let output = """
+        { [weak self] () -> Void in }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments3() {
-        let input = "{ [weak self]() throws -> Void in }"
-        let output = "{ [weak self] () throws -> Void in }"
+        let input = """
+        { [weak self]() throws -> Void in }
+        """
+        let output = """
+        { [weak self] () throws -> Void in }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments4() {
-        let input = "{ [weak self](foo: @escaping(Bar?) -> Void) -> Baz? in foo }"
-        let output = "{ [weak self] (foo: @escaping (Bar?) -> Void) -> Baz? in foo }"
+        let input = """
+        { [weak self](foo: @escaping(Bar?) -> Void) -> Baz? in foo }
+        """
+        let output = """
+        { [weak self] (foo: @escaping (Bar?) -> Void) -> Baz? in foo }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenCaptureListAndArguments5() {
-        let input = "{ [weak self](foo: @autoclosure() -> String) -> Baz? in foo() }"
-        let output = "{ [weak self] (foo: @autoclosure () -> String) -> Baz? in foo() }"
+        let input = """
+        { [weak self](foo: @autoclosure() -> String) -> Baz? in foo() }
+        """
+        let output = """
+        { [weak self] (foo: @autoclosure () -> String) -> Baz? in foo() }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenCaptureListAndArguments6() {
-        let input = "{ [weak self](foo: @Sendable() -> String) -> Baz? in foo() }"
-        let output = "{ [weak self] (foo: @Sendable () -> String) -> Baz? in foo() }"
+        let input = """
+        { [weak self](foo: @Sendable() -> String) -> Baz? in foo() }
+        """
+        let output = """
+        { [weak self] (foo: @Sendable () -> String) -> Baz? in foo() }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenCaptureListAndArguments7() {
-        let input = "Foo<Bar>(0) { [weak self]() -> Void in }"
-        let output = "Foo<Bar>(0) { [weak self] () -> Void in }"
+        let input = """
+        Foo<Bar>(0) { [weak self]() -> Void in }
+        """
+        let output = """
+        Foo<Bar>(0) { [weak self] () -> Void in }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenCaptureListAndArguments8() {
-        let input = "{ [weak self]() throws(Foo) -> Void in }"
-        let output = "{ [weak self] () throws(Foo) -> Void in }"
+        let input = """
+        { [weak self]() throws(Foo) -> Void in }
+        """
+        let output = """
+        { [weak self] () throws(Foo) -> Void in }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantVoidReturnType])
     }
 
     func testAddSpaceBetweenEscapingAndParenthesizedClosure() {
-        let input = "@escaping(() -> Void)"
-        let output = "@escaping (() -> Void)"
+        let input = """
+        @escaping(() -> Void)
+        """
+        let output = """
+        @escaping (() -> Void)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenAutoclosureAndParenthesizedClosure() {
-        let input = "@autoclosure(() -> String)"
-        let output = "@autoclosure (() -> String)"
+        let input = """
+        @autoclosure(() -> String)
+        """
+        let output = """
+        @autoclosure (() -> String)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceBetweenClosingParenAndOpenBrace() {
-        let input = "func foo(){ foo }"
-        let output = "func foo() { foo }"
+        let input = """
+        func foo(){ foo }
+        """
+        let output = """
+        func foo() { foo }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testNoSpaceBetweenClosingBraceAndParens() {
-        let input = "{ block } ()"
-        let output = "{ block }()"
+        let input = """
+        { block } ()
+        """
+        let output = """
+        { block }()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens, exclude: [.redundantClosure])
     }
 
     func testDontRemoveSpaceBetweenOpeningBraceAndParens() {
-        let input = "a = (b + c)"
+        let input = """
+        a = (b + c)
+        """
         testFormatting(for: input, rule: .spaceAroundParens,
                        exclude: [.redundantParens])
     }
 
     func testKeywordAsIdentifierParensSpacing() {
-        let input = "if foo.let (foo, bar) {}"
-        let output = "if foo.let(foo, bar) {}"
+        let input = """
+        if foo.let (foo, bar) {}
+        """
+        let output = """
+        if foo.let(foo, bar) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceAfterInoutParam() {
-        let input = "func foo(bar _: inout(Int, String)) {}"
-        let output = "func foo(bar _: inout (Int, String)) {}"
+        let input = """
+        func foo(bar _: inout(Int, String)) {}
+        """
+        let output = """
+        func foo(bar _: inout (Int, String)) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceAfterEscapingAttribute() {
-        let input = "func foo(bar: @escaping() -> Void)"
-        let output = "func foo(bar: @escaping () -> Void)"
+        let input = """
+        func foo(bar: @escaping() -> Void)
+        """
+        let output = """
+        func foo(bar: @escaping () -> Void)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testSpaceAfterAutoclosureAttribute() {
-        let input = "func foo(bar: @autoclosure () -> Void)"
+        let input = """
+        func foo(bar: @autoclosure () -> Void)
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testSpaceAfterSendableAttribute() {
-        let input = "func foo(bar: @Sendable () -> Void)"
+        let input = """
+        func foo(bar: @Sendable () -> Void)
+        """
         testFormatting(for: input, rule: .spaceAroundParens)
     }
 
     func testSpaceBeforeTupleIndexArgument() {
-        let input = "foo.1 (true)"
-        let output = "foo.1(true)"
+        let input = """
+        foo.1 (true)
+        """
+        let output = """
+        foo.1(true)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testRemoveSpaceBetweenParenAndBracket() {
-        let input = "let foo = bar[5] ()"
-        let output = "let foo = bar[5]()"
+        let input = """
+        let foo = bar[5] ()
+        """
+        let output = """
+        let foo = bar[5]()
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testRemoveSpaceBetweenParenAndBracketInsideClosure() {
-        let input = "let foo = bar { [Int] () }"
-        let output = "let foo = bar { [Int]() }"
+        let input = """
+        let foo = bar { [Int] () }
+        """
+        let output = """
+        let foo = bar { [Int]() }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndCaptureList() {
-        let input = "let foo = bar { [self](foo: Int) in foo }"
-        let output = "let foo = bar { [self] (foo: Int) in foo }"
+        let input = """
+        let foo = bar { [self](foo: Int) in foo }
+        """
+        let output = """
+        let foo = bar { [self] (foo: Int) in foo }
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndAwait() {
-        let input = "let foo = await(bar: 5)"
-        let output = "let foo = await (bar: 5)"
+        let input = """
+        let foo = await(bar: 5)
+        """
+        let output = """
+        let foo = await (bar: 5)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndAwaitForSwift5_5() {
-        let input = "let foo = await(bar: 5)"
-        let output = "let foo = await (bar: 5)"
+        let input = """
+        let foo = await(bar: 5)
+        """
+        let output = """
+        let foo = await (bar: 5)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens,
                        options: FormatOptions(swiftVersion: "5.5"))
     }
 
     func testNoAddSpaceBetweenParenAndAwaitForSwiftLessThan5_5() {
-        let input = "let foo = await(bar: 5)"
+        let input = """
+        let foo = await(bar: 5)
+        """
         testFormatting(for: input, rule: .spaceAroundParens,
                        options: FormatOptions(swiftVersion: "5.4.9"))
     }
 
     func testRemoveSpaceBetweenParenAndConsume() {
-        let input = "let foo = consume (bar)"
-        let output = "let foo = consume(bar)"
+        let input = """
+        let foo = consume (bar)
+        """
+        let output = """
+        let foo = consume(bar)
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
@@ -321,27 +497,43 @@ class SpaceAroundParensTests: XCTestCase {
     }
 
     func testNoAddSpaceAroundTypedThrowsFunctionType() {
-        let input = "func foo() throws (Bar) -> Baz {}"
-        let output = "func foo() throws(Bar) -> Baz {}"
+        let input = """
+        func foo() throws (Bar) -> Baz {}
+        """
+        let output = """
+        func foo() throws(Bar) -> Baz {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndBorrowing() {
-        let input = "func foo(_: borrowing(any Foo)) {}"
-        let output = "func foo(_: borrowing (any Foo)) {}"
+        let input = """
+        func foo(_: borrowing(any Foo)) {}
+        """
+        let output = """
+        func foo(_: borrowing (any Foo)) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens,
                        exclude: [.noExplicitOwnership])
     }
 
     func testAddSpaceBetweenParenAndIsolated() {
-        let input = "func foo(isolation _: isolated(any Actor)) {}"
-        let output = "func foo(isolation _: isolated (any Actor)) {}"
+        let input = """
+        func foo(isolation _: isolated(any Actor)) {}
+        """
+        let output = """
+        func foo(isolation _: isolated (any Actor)) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 
     func testAddSpaceBetweenParenAndSending() {
-        let input = "func foo(_: sending(any Foo)) {}"
-        let output = "func foo(_: sending (any Foo)) {}"
+        let input = """
+        func foo(_: sending(any Foo)) {}
+        """
+        let output = """
+        func foo(_: sending (any Foo)) {}
+        """
         testFormatting(for: input, output, rule: .spaceAroundParens)
     }
 }

--- a/Tests/Rules/SpaceInsideBracesTests.swift
+++ b/Tests/Rules/SpaceInsideBracesTests.swift
@@ -11,23 +11,33 @@ import XCTest
 
 class SpaceInsideBracesTests: XCTestCase {
     func testSpaceInsideBraces() {
-        let input = "foo({bar})"
-        let output = "foo({ bar })"
+        let input = """
+        foo({bar})
+        """
+        let output = """
+        foo({ bar })
+        """
         testFormatting(for: input, output, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoExtraSpaceInsidebraces() {
-        let input = "{ foo }"
+        let input = """
+        { foo }
+        """
         testFormatting(for: input, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoSpaceAddedInsideEmptybraces() {
-        let input = "foo({})"
+        let input = """
+        foo({})
+        """
         testFormatting(for: input, rule: .spaceInsideBraces, exclude: [.trailingClosures])
     }
 
     func testNoSpaceAddedBetweenDoublebraces() {
-        let input = "func foo() -> () -> Void {{ bar() }}"
+        let input = """
+        func foo() -> () -> Void {{ bar() }}
+        """
         testFormatting(for: input, rule: .spaceInsideBraces)
     }
 }

--- a/Tests/Rules/SpaceInsideBracketsTests.swift
+++ b/Tests/Rules/SpaceInsideBracketsTests.swift
@@ -11,20 +11,34 @@ import XCTest
 
 class SpaceInsideBracketsTests: XCTestCase {
     func testSpaceInsideBrackets() {
-        let input = "foo[ 5 ]"
-        let output = "foo[5]"
+        let input = """
+        foo[ 5 ]
+        """
+        let output = """
+        foo[5]
+        """
         testFormatting(for: input, output, rule: .spaceInsideBrackets)
     }
 
     func testSpaceInsideWrappedArray() {
-        let input = "[ foo,\n bar ]"
-        let output = "[foo,\n bar]"
+        let input = """
+        [ foo,
+         bar ]
+        """
+        let output = """
+        [foo,
+         bar]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, output, rule: .spaceInsideBrackets, options: options)
     }
 
     func testSpaceBeforeCommentInsideWrappedArray() {
-        let input = "[ // foo\n    bar,\n]"
+        let input = """
+        [ // foo
+            bar,
+        ]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, rule: .spaceInsideBrackets, options: options)
     }

--- a/Tests/Rules/SpaceInsideCommentsTests.swift
+++ b/Tests/Rules/SpaceInsideCommentsTests.swift
@@ -11,96 +11,163 @@ import XCTest
 
 class SpaceInsideCommentsTests: XCTestCase {
     func testSpaceInsideMultilineComment() {
-        let input = "/*foo\n bar*/"
-        let output = "/* foo\n bar */"
+        let input = """
+        /*foo
+         bar*/
+        """
+        let output = """
+        /* foo
+         bar */
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideSingleLineMultilineComment() {
-        let input = "/*foo*/"
-        let output = "/* foo */"
+        let input = """
+        /*foo*/
+        """
+        let output = """
+        /* foo */
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testNoSpaceInsideEmptyMultilineComment() {
-        let input = "/**/"
+        let input = """
+        /**/
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideSingleLineComment() {
-        let input = "//foo"
-        let output = "// foo"
+        let input = """
+        //foo
+        """
+        let output = """
+        // foo
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideMultilineHeaderdocComment() {
-        let input = "/**foo\n bar*/"
-        let output = "/** foo\n bar */"
+        let input = """
+        /**foo
+         bar*/
+        """
+        let output = """
+        /** foo
+         bar */
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testSpaceInsideMultilineHeaderdocCommentType2() {
-        let input = "/*!foo\n bar*/"
-        let output = "/*! foo\n bar */"
+        let input = """
+        /*!foo
+         bar*/
+        """
+        let output = """
+        /*! foo
+         bar */
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideMultilineSwiftPlaygroundDocComment() {
-        let input = "/*:foo\n bar*/"
-        let output = "/*: foo\n bar */"
+        let input = """
+        /*:foo
+         bar*/
+        """
+        let output = """
+        /*: foo
+         bar */
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testNoExtraSpaceInsideMultilineHeaderdocComment() {
-        let input = "/** foo\n bar */"
+        let input = """
+        /** foo
+         bar */
+        """
         testFormatting(for: input, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testNoExtraSpaceInsideMultilineHeaderdocCommentType2() {
-        let input = "/*! foo\n bar */"
+        let input = """
+        /*! foo
+         bar */
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 
     func testNoExtraSpaceInsideMultilineSwiftPlaygroundDocComment() {
-        let input = "/*: foo\n bar */"
+        let input = """
+        /*: foo
+         bar */
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideSingleLineHeaderdocComment() {
-        let input = "///foo"
-        let output = "/// foo"
+        let input = """
+        ///foo
+        """
+        let output = """
+        /// foo
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideSingleLineHeaderdocCommentType2() {
-        let input = "//!foo"
-        let output = "//! foo"
+        let input = """
+        //!foo
+        """
+        let output = """
+        //! foo
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testSpaceInsideSingleLineSwiftPlaygroundDocComment() {
-        let input = "//:foo"
-        let output = "//: foo"
+        let input = """
+        //:foo
+        """
+        let output = """
+        //: foo
+        """
         testFormatting(for: input, output, rule: .spaceInsideComments)
     }
 
     func testPreformattedMultilineComment() {
-        let input = "/*********************\n *****Hello World*****\n *********************/"
+        let input = """
+        /*********************
+         *****Hello World*****
+         *********************/
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 
     func testPreformattedSingleLineComment() {
-        let input = "/////////ATTENTION////////"
+        let input = """
+        /////////ATTENTION////////
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 
     func testNoSpaceAddedToFirstLineOfDocComment() {
-        let input = "/**\n Comment\n */"
+        let input = """
+        /**
+         Comment
+         */
+        """
         testFormatting(for: input, rule: .spaceInsideComments, exclude: [.docComments])
     }
 
     func testNoSpaceAddedToEmptyDocComment() {
-        let input = "///"
+        let input = """
+        ///
+        """
         testFormatting(for: input, rule: .spaceInsideComments)
     }
 

--- a/Tests/Rules/SpaceInsideGenericsTests.swift
+++ b/Tests/Rules/SpaceInsideGenericsTests.swift
@@ -11,8 +11,12 @@ import XCTest
 
 class SpaceInsideGenericsTests: XCTestCase {
     func testSpaceInsideGenerics() {
-        let input = "Foo< Bar< Baz > >"
-        let output = "Foo<Bar<Baz>>"
+        let input = """
+        Foo< Bar< Baz > >
+        """
+        let output = """
+        Foo<Bar<Baz>>
+        """
         testFormatting(for: input, output, rule: .spaceInsideGenerics)
     }
 }

--- a/Tests/Rules/SpaceInsideParensTests.swift
+++ b/Tests/Rules/SpaceInsideParensTests.swift
@@ -11,14 +11,22 @@ import XCTest
 
 class SpaceInsideParensTests: XCTestCase {
     func testSpaceInsideParens() {
-        let input = "( 1, ( 2, 3 ) )"
-        let output = "(1, (2, 3))"
+        let input = """
+        ( 1, ( 2, 3 ) )
+        """
+        let output = """
+        (1, (2, 3))
+        """
         testFormatting(for: input, output, rule: .spaceInsideParens)
     }
 
     func testSpaceBeforeCommentInsideParens() {
-        let input = "( /* foo */ 1, 2 )"
-        let output = "( /* foo */ 1, 2)"
+        let input = """
+        ( /* foo */ 1, 2 )
+        """
+        let output = """
+        ( /* foo */ 1, 2)
+        """
         testFormatting(for: input, output, rule: .spaceInsideParens)
     }
 }

--- a/Tests/Rules/StrongOutletsTests.swift
+++ b/Tests/Rules/StrongOutletsTests.swift
@@ -11,53 +11,91 @@ import XCTest
 
 class StrongOutletsTests: XCTestCase {
     func testRemoveWeakFromOutlet() {
-        let input = "@IBOutlet weak var label: UILabel!"
-        let output = "@IBOutlet var label: UILabel!"
+        let input = """
+        @IBOutlet weak var label: UILabel!
+        """
+        let output = """
+        @IBOutlet var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 
     func testRemoveWeakFromPrivateOutlet() {
-        let input = "@IBOutlet private weak var label: UILabel!"
-        let output = "@IBOutlet private var label: UILabel!"
+        let input = """
+        @IBOutlet private weak var label: UILabel!
+        """
+        let output = """
+        @IBOutlet private var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 
     func testRemoveWeakFromOutletOnSplitLine() {
-        let input = "@IBOutlet\nweak var label: UILabel!"
-        let output = "@IBOutlet\nvar label: UILabel!"
+        let input = """
+        @IBOutlet
+        weak var label: UILabel!
+        """
+        let output = """
+        @IBOutlet
+        var label: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 
     func testNoRemoveWeakFromNonOutlet() {
-        let input = "weak var label: UILabel!"
+        let input = """
+        weak var label: UILabel!
+        """
         testFormatting(for: input, rule: .strongOutlets)
     }
 
     func testNoRemoveWeakFromNonOutletAfterOutlet() {
-        let input = "@IBOutlet weak var label1: UILabel!\nweak var label2: UILabel!"
-        let output = "@IBOutlet var label1: UILabel!\nweak var label2: UILabel!"
+        let input = """
+        @IBOutlet weak var label1: UILabel!
+        weak var label2: UILabel!
+        """
+        let output = """
+        @IBOutlet var label1: UILabel!
+        weak var label2: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 
     func testNoRemoveWeakFromDelegateOutlet() {
-        let input = "@IBOutlet weak var delegate: UITableViewDelegate?"
+        let input = """
+        @IBOutlet weak var delegate: UITableViewDelegate?
+        """
         testFormatting(for: input, rule: .strongOutlets)
     }
 
     func testNoRemoveWeakFromDataSourceOutlet() {
-        let input = "@IBOutlet weak var dataSource: UITableViewDataSource?"
+        let input = """
+        @IBOutlet weak var dataSource: UITableViewDataSource?
+        """
         testFormatting(for: input, rule: .strongOutlets)
     }
 
     func testRemoveWeakFromOutletAfterDelegateOutlet() {
-        let input = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet weak var label1: UILabel!"
-        let output = "@IBOutlet weak var delegate: UITableViewDelegate?\n@IBOutlet var label1: UILabel!"
+        let input = """
+        @IBOutlet weak var delegate: UITableViewDelegate?
+        @IBOutlet weak var label1: UILabel!
+        """
+        let output = """
+        @IBOutlet weak var delegate: UITableViewDelegate?
+        @IBOutlet var label1: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 
     func testRemoveWeakFromOutletAfterDataSourceOutlet() {
-        let input = "@IBOutlet weak var dataSource: UITableViewDataSource?\n@IBOutlet weak var label1: UILabel!"
-        let output = "@IBOutlet weak var dataSource: UITableViewDataSource?\n@IBOutlet var label1: UILabel!"
+        let input = """
+        @IBOutlet weak var dataSource: UITableViewDataSource?
+        @IBOutlet weak var label1: UILabel!
+        """
+        let output = """
+        @IBOutlet weak var dataSource: UITableViewDataSource?
+        @IBOutlet var label1: UILabel!
+        """
         testFormatting(for: input, output, rule: .strongOutlets)
     }
 }

--- a/Tests/Rules/StrongifiedSelfTests.swift
+++ b/Tests/Rules/StrongifiedSelfTests.swift
@@ -64,7 +64,9 @@ class StrongifiedSelfTests: XCTestCase {
     }
 
     func testBacktickedSelfNotConvertedIfNotConditional() {
-        let input = "nonisolated(unsafe) let `self` = self"
+        let input = """
+        nonisolated(unsafe) let `self` = self
+        """
         let options = FormatOptions(swiftVersion: "4.2")
         testFormatting(for: input, rule: .strongifiedSelf, options: options)
     }

--- a/Tests/Rules/TodosTests.swift
+++ b/Tests/Rules/TodosTests.swift
@@ -11,32 +11,52 @@ import XCTest
 
 class TodosTests: XCTestCase {
     func testMarkIsUpdated() {
-        let input = "// MARK foo"
-        let output = "// MARK: foo"
+        let input = """
+        // MARK foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testTodoIsUpdated() {
-        let input = "// TODO foo"
-        let output = "// TODO: foo"
+        let input = """
+        // TODO foo
+        """
+        let output = """
+        // TODO: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testFixmeIsUpdated() {
-        let input = "//    FIXME foo"
-        let output = "//    FIXME: foo"
+        let input = """
+        //    FIXME foo
+        """
+        let output = """
+        //    FIXME: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testMarkWithColonSeparatedBySpace() {
-        let input = "// MARK : foo"
-        let output = "// MARK: foo"
+        let input = """
+        // MARK : foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testMarkWithTripleSlash() {
-        let input = "/// MARK: foo"
-        let output = "// MARK: foo"
+        let input = """
+        /// MARK: foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
@@ -81,70 +101,110 @@ class TodosTests: XCTestCase {
 
     func testMarkWithNoSpaceAfterColon() {
         // NOTE: this was an unintended side-effect, but I like it
-        let input = "// MARK:foo"
-        let output = "// MARK: foo"
+        let input = """
+        // MARK:foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testMarkInsideMultilineComment() {
-        let input = "/* MARK foo */"
-        let output = "/* MARK: foo */"
+        let input = """
+        /* MARK foo */
+        """
+        let output = """
+        /* MARK: foo */
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testNoExtraSpaceAddedAfterTodo() {
-        let input = "/* TODO: */"
+        let input = """
+        /* TODO: */
+        """
         testFormatting(for: input, rule: .todos)
     }
 
     func testLowercaseMarkColonIsUpdated() {
-        let input = "// mark: foo"
-        let output = "// MARK: foo"
+        let input = """
+        // mark: foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testMixedCaseMarkColonIsUpdated() {
-        let input = "// Mark: foo"
-        let output = "// MARK: foo"
+        let input = """
+        // Mark: foo
+        """
+        let output = """
+        // MARK: foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testLowercaseMarkIsNotUpdated() {
-        let input = "// mark as read"
+        let input = """
+        // mark as read
+        """
         testFormatting(for: input, rule: .todos)
     }
 
     func testMixedCaseMarkIsNotUpdated() {
-        let input = "// Mark as read"
+        let input = """
+        // Mark as read
+        """
         testFormatting(for: input, rule: .todos)
     }
 
     func testLowercaseMarkDashIsUpdated() {
-        let input = "// mark - foo"
-        let output = "// MARK: - foo"
+        let input = """
+        // mark - foo
+        """
+        let output = """
+        // MARK: - foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testSpaceAddedBeforeMarkDash() {
-        let input = "// MARK:- foo"
-        let output = "// MARK: - foo"
+        let input = """
+        // MARK:- foo
+        """
+        let output = """
+        // MARK: - foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testSpaceAddedAfterMarkDash() {
-        let input = "// MARK: -foo"
-        let output = "// MARK: - foo"
+        let input = """
+        // MARK: -foo
+        """
+        let output = """
+        // MARK: - foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testSpaceAddedAroundMarkDash() {
-        let input = "// MARK:-foo"
-        let output = "// MARK: - foo"
+        let input = """
+        // MARK:-foo
+        """
+        let output = """
+        // MARK: - foo
+        """
         testFormatting(for: input, output, rule: .todos)
     }
 
     func testSpaceNotAddedAfterMarkDashAtEndOfString() {
-        let input = "// MARK: -"
+        let input = """
+        // MARK: -
+        """
         testFormatting(for: input, rule: .todos)
     }
 }

--- a/Tests/Rules/TrailingClosuresTests.swift
+++ b/Tests/Rules/TrailingClosuresTests.swift
@@ -11,179 +11,273 @@ import XCTest
 
 class TrailingClosuresTests: XCTestCase {
     func testAnonymousClosureArgumentMadeTrailing() {
-        let input = "foo(foo: 5, { /* some code */ })"
-        let output = "foo(foo: 5) { /* some code */ }"
+        let input = """
+        foo(foo: 5, { /* some code */ })
+        """
+        let output = """
+        foo(foo: 5) { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testNamedClosureArgumentNotMadeTrailing() {
-        let input = "foo(foo: 5, bar: { /* some code */ })"
+        let input = """
+        foo(foo: 5, bar: { /* some code */ })
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testClosureArgumentPassedToFunctionInArgumentsNotMadeTrailing() {
-        let input = "foo(bar { /* some code */ })"
+        let input = """
+        foo(bar { /* some code */ })
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testClosureArgumentInFunctionWithOtherClosureArgumentsNotMadeTrailing() {
-        let input = "foo(foo: { /* some code */ }, { /* some code */ })"
+        let input = """
+        foo(foo: { /* some code */ }, { /* some code */ })
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testClosureArgumentInExpressionNotMadeTrailing() {
-        let input = "if let foo = foo(foo: 5, { /* some code */ }) {}"
+        let input = """
+        if let foo = foo(foo: 5, { /* some code */ }) {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testClosureArgumentInCompoundExpressionNotMadeTrailing() {
-        let input = "if let foo = foo(foo: 5, { /* some code */ }), let bar = bar(bar: 2, { /* some code */ }) {}"
+        let input = """
+        if let foo = foo(foo: 5, { /* some code */ }), let bar = bar(bar: 2, { /* some code */ }) {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testClosureArgumentAfterLinebreakInGuardNotMadeTrailing() {
-        let input = "guard let foo =\n    bar({ /* some code */ })\nelse { return }"
+        let input = """
+        guard let foo =
+            bar({ /* some code */ })
+        else { return }
+        """
         testFormatting(for: input, rule: .trailingClosures,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testClosureMadeTrailingForNumericTupleMember() {
-        let input = "foo.1(5, { bar })"
-        let output = "foo.1(5) { bar }"
+        let input = """
+        foo.1(5, { bar })
+        """
+        let output = """
+        foo.1(5) { bar }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testNoRemoveParensAroundClosureFollowedByOpeningBrace() {
-        let input = "foo({ bar }) { baz }"
+        let input = """
+        foo({ bar }) { baz }
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testRemoveParensAroundClosureWithInnerSpacesFollowedByUnwrapOperator() {
-        let input = "foo( { bar } )?.baz"
-        let output = "foo { bar }?.baz"
+        let input = """
+        foo( { bar } )?.baz
+        """
+        let output = """
+        foo { bar }?.baz
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     // solitary argument
 
     func testParensAroundSolitaryClosureArgumentRemoved() {
-        let input = "foo({ /* some code */ })"
-        let output = "foo { /* some code */ }"
+        let input = """
+        foo({ /* some code */ })
+        """
+        let output = """
+        foo { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testParensAroundNamedSolitaryClosureArgumentNotRemoved() {
-        let input = "foo(foo: { /* some code */ })"
+        let input = """
+        foo(foo: { /* some code */ })
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testParensAroundSolitaryClosureArgumentInExpressionNotRemoved() {
-        let input = "if let foo = foo({ /* some code */ }) {}"
+        let input = """
+        if let foo = foo({ /* some code */ }) {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testParensAroundSolitaryClosureArgumentInCompoundExpressionNotRemoved() {
-        let input = "if let foo = foo({ /* some code */ }), let bar = bar({ /* some code */ }) {}"
+        let input = """
+        if let foo = foo({ /* some code */ }), let bar = bar({ /* some code */ }) {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testParensAroundOptionalTrailingClosureInForLoopNotRemoved() {
-        let input = "for foo in bar?.map({ $0.baz }) ?? [] {}"
+        let input = """
+        for foo in bar?.map({ $0.baz }) ?? [] {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testParensAroundTrailingClosureInGuardCaseLetNotRemoved() {
-        let input = "guard case let .foo(bar) = baz.filter({ $0 == quux }).isEmpty else {}"
+        let input = """
+        guard case let .foo(bar) = baz.filter({ $0 == quux }).isEmpty else {}
+        """
         testFormatting(for: input, rule: .trailingClosures,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testParensAroundTrailingClosureInWhereClauseLetNotRemoved() {
-        let input = "for foo in bar where baz.filter({ $0 == quux }).isEmpty {}"
+        let input = """
+        for foo in bar where baz.filter({ $0 == quux }).isEmpty {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testParensAroundTrailingClosureInSwitchNotRemoved() {
-        let input = "switch foo({ $0 == bar }).count {}"
+        let input = """
+        switch foo({ $0 == bar }).count {}
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testSolitaryClosureMadeTrailingInChain() {
-        let input = "foo.map({ $0.path }).joined()"
-        let output = "foo.map { $0.path }.joined()"
+        let input = """
+        foo.map({ $0.path }).joined()
+        """
+        let output = """
+        foo.map { $0.path }.joined()
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testSpaceNotInsertedAfterClosureBeforeUnwrap() {
-        let input = "let foo = bar.map({ foo($0) })?.baz"
-        let output = "let foo = bar.map { foo($0) }?.baz"
+        let input = """
+        let foo = bar.map({ foo($0) })?.baz
+        """
+        let output = """
+        let foo = bar.map { foo($0) }?.baz
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testSpaceNotInsertedAfterClosureBeforeForceUnwrap() {
-        let input = "let foo = bar.map({ foo($0) })!.baz"
-        let output = "let foo = bar.map { foo($0) }!.baz"
+        let input = """
+        let foo = bar.map({ foo($0) })!.baz
+        """
+        let output = """
+        let foo = bar.map { foo($0) }!.baz
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testSolitaryClosureMadeTrailingForNumericTupleMember() {
-        let input = "foo.1({ bar })"
-        let output = "foo.1 { bar }"
+        let input = """
+        foo.1({ bar })
+        """
+        let output = """
+        foo.1 { bar }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     // dispatch methods
 
     func testDispatchAsyncClosureArgumentMadeTrailing() {
-        let input = "queue.async(execute: { /* some code */ })"
-        let output = "queue.async { /* some code */ }"
+        let input = """
+        queue.async(execute: { /* some code */ })
+        """
+        let output = """
+        queue.async { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testDispatchAsyncGroupClosureArgumentMadeTrailing() {
         // TODO: async(group: , qos: , flags: , execute: )
-        let input = "queue.async(group: g, execute: { /* some code */ })"
-        let output = "queue.async(group: g) { /* some code */ }"
+        let input = """
+        queue.async(group: g, execute: { /* some code */ })
+        """
+        let output = """
+        queue.async(group: g) { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testDispatchAsyncAfterClosureArgumentMadeTrailing() {
-        let input = "queue.asyncAfter(deadline: t, execute: { /* some code */ })"
-        let output = "queue.asyncAfter(deadline: t) { /* some code */ }"
+        let input = """
+        queue.asyncAfter(deadline: t, execute: { /* some code */ })
+        """
+        let output = """
+        queue.asyncAfter(deadline: t) { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testDispatchAsyncAfterWallClosureArgumentMadeTrailing() {
-        let input = "queue.asyncAfter(wallDeadline: t, execute: { /* some code */ })"
-        let output = "queue.asyncAfter(wallDeadline: t) { /* some code */ }"
+        let input = """
+        queue.asyncAfter(wallDeadline: t, execute: { /* some code */ })
+        """
+        let output = """
+        queue.asyncAfter(wallDeadline: t) { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testDispatchSyncClosureArgumentMadeTrailing() {
-        let input = "queue.sync(execute: { /* some code */ })"
-        let output = "queue.sync { /* some code */ }"
+        let input = """
+        queue.sync(execute: { /* some code */ })
+        """
+        let output = """
+        queue.sync { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     func testDispatchSyncFlagsClosureArgumentMadeTrailing() {
-        let input = "queue.sync(flags: f, execute: { /* some code */ })"
-        let output = "queue.sync(flags: f) { /* some code */ }"
+        let input = """
+        queue.sync(flags: f, execute: { /* some code */ })
+        """
+        let output = """
+        queue.sync(flags: f) { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     // autoreleasepool
 
     func testAutoreleasepoolMadeTrailing() {
-        let input = "autoreleasepool(invoking: { /* some code */ })"
-        let output = "autoreleasepool { /* some code */ }"
+        let input = """
+        autoreleasepool(invoking: { /* some code */ })
+        """
+        let output = """
+        autoreleasepool { /* some code */ }
+        """
         testFormatting(for: input, output, rule: .trailingClosures)
     }
 
     // explicit trailing closure methods
 
     func testCustomMethodMadeTrailing() {
-        let input = "foo(bar: 1, baz: { /* some code */ })"
-        let output = "foo(bar: 1) { /* some code */ }"
+        let input = """
+        foo(bar: 1, baz: { /* some code */ })
+        """
+        let output = """
+        foo(bar: 1) { /* some code */ }
+        """
         let options = FormatOptions(trailingClosures: ["foo"])
         testFormatting(for: input, output, rule: .trailingClosures, options: options)
     }
@@ -191,17 +285,23 @@ class TrailingClosuresTests: XCTestCase {
     // explicit non-trailing closure methods
 
     func testPerformBatchUpdatesNotMadeTrailing() {
-        let input = "collectionView.performBatchUpdates({ /* some code */ })"
+        let input = """
+        collectionView.performBatchUpdates({ /* some code */ })
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testNimbleExpectNotMadeTrailing() {
-        let input = "expect({ bar }).to(beNil())"
+        let input = """
+        expect({ bar }).to(beNil())
+        """
         testFormatting(for: input, rule: .trailingClosures)
     }
 
     func testCustomMethodNotMadeTrailing() {
-        let input = "foo({ /* some code */ })"
+        let input = """
+        foo({ /* some code */ })
+        """
         let options = FormatOptions(neverTrailing: ["foo"])
         testFormatting(for: input, rule: .trailingClosures, options: options)
     }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -11,85 +11,161 @@ import XCTest
 
 class TrailingCommasTests: XCTestCase {
     func testCommaAddedToSingleItem() {
-        let input = "[\n    foo\n]"
-        let output = "[\n    foo,\n]"
+        let input = """
+        [
+            foo
+        ]
+        """
+        let output = """
+        [
+            foo,
+        ]
+        """
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
     func testCommaAddedToLastItem() {
-        let input = "[\n    foo,\n    bar\n]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [
+            foo,
+            bar
+        ]
+        """
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
     func testCommaAddedToLastItemCollectionsOnly() {
-        let input = "[\n    foo,\n    bar\n]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [
+            foo,
+            bar
+        ]
+        """
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
         let options = FormatOptions(trailingCommas: .collectionsOnly)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }
 
     func testCommaAddedToDictionary() {
-        let input = "[\n    foo: bar\n]"
-        let output = "[\n    foo: bar,\n]"
+        let input = """
+        [
+            foo: bar
+        ]
+        """
+        let output = """
+        [
+            foo: bar,
+        ]
+        """
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
     func testCommaNotAddedToInlineArray() {
-        let input = "[foo, bar]"
+        let input = """
+        [foo, bar]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testCommaNotAddedToInlineDictionary() {
-        let input = "[foo: bar]"
+        let input = """
+        [foo: bar]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testCommaNotAddedToSubscript() {
-        let input = "foo[bar]"
+        let input = """
+        foo[bar]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testCommaAddedBeforeComment() {
-        let input = "[\n    foo // comment\n]"
-        let output = "[\n    foo, // comment\n]"
+        let input = """
+        [
+            foo // comment
+        ]
+        """
+        let output = """
+        [
+            foo, // comment
+        ]
+        """
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
     func testCommaNotAddedAfterComment() {
-        let input = "[\n    foo, // comment\n]"
+        let input = """
+        [
+            foo, // comment
+        ]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testCommaNotAddedInsideEmptyArrayLiteral() {
-        let input = "foo = [\n]"
+        let input = """
+        foo = [
+        ]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testCommaNotAddedInsideEmptyDictionaryLiteral() {
-        let input = "foo = [:\n]"
+        let input = """
+        foo = [:
+        ]
+        """
         let options = FormatOptions(wrapCollections: .disabled)
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
     func testTrailingCommaRemovedInInlineArray() {
-        let input = "[foo,]"
-        let output = "[foo]"
+        let input = """
+        [foo,]
+        """
+        let output = """
+        [foo]
+        """
         testFormatting(for: input, output, rule: .trailingCommas)
     }
 
     func testTrailingCommaNotAddedToSubscript() {
-        let input = "foo[\n    bar\n]"
+        let input = """
+        foo[
+            bar
+        ]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testTrailingCommaNotAddedToSubscript2() {
-        let input = "foo?[\n    bar\n]"
+        let input = """
+        foo?[
+            bar
+        ]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
     func testTrailingCommaNotAddedToSubscript3() {
-        let input = "foo()[\n    bar\n]"
+        let input = """
+        foo()[
+            bar
+        ]
+        """
         testFormatting(for: input, rule: .trailingCommas)
     }
 
@@ -268,14 +344,29 @@ class TrailingCommasTests: XCTestCase {
     // trailingCommas = false
 
     func testCommaNotAddedToLastItem() {
-        let input = "[\n    foo,\n    bar\n]"
+        let input = """
+        [
+            foo,
+            bar
+        ]
+        """
         let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
 
     func testCommaRemovedFromLastItem() {
-        let input = "[\n    foo,\n    bar,\n]"
-        let output = "[\n    foo,\n    bar\n]"
+        let input = """
+        [
+            foo,
+            bar,
+        ]
+        """
+        let output = """
+        [
+            foo,
+            bar
+        ]
+        """
         let options = FormatOptions(trailingCommas: .never)
         testFormatting(for: input, output, rule: .trailingCommas, options: options)
     }

--- a/Tests/Rules/TrailingSpaceTests.swift
+++ b/Tests/Rules/TrailingSpaceTests.swift
@@ -13,45 +13,97 @@ class TrailingSpaceTests: XCTestCase {
     // truncateBlankLines = true
 
     func testTrailingSpace() {
-        let input = "foo  \nbar"
-        let output = "foo\nbar"
+        let input = """
+        foo\("    ")
+        bar
+        """
+        let output = """
+        foo
+        bar
+        """
         testFormatting(for: input, output, rule: .trailingSpace)
     }
 
     func testTrailingSpaceAtEndOfFile() {
-        let input = "foo  "
-        let output = "foo"
+        let input = """
+        foo\("    ")
+        """
+        let output = """
+        foo
+        """
         testFormatting(for: input, output, rule: .trailingSpace)
     }
 
     func testTrailingSpaceInMultilineComments() {
-        let input = "/* foo  \n bar  */"
-        let output = "/* foo\n bar  */"
+        let input = """
+        /* foo\("    ")
+         bar  */
+        """
+        let output = """
+        /* foo
+         bar  */
+        """
         testFormatting(for: input, output, rule: .trailingSpace)
     }
 
     func testTrailingSpaceInSingleLineComments() {
-        let input = "// foo  \n// bar  "
-        let output = "// foo\n// bar"
+        let input = """
+        // foo\("    ")
+        // bar  
+        """
+        let output = """
+        // foo
+        // bar
+        """
         testFormatting(for: input, output, rule: .trailingSpace)
     }
 
     func testTruncateBlankLine() {
-        let input = "foo {\n    // bar\n    \n    // baz\n}"
-        let output = "foo {\n    // bar\n\n    // baz\n}"
+        let input = """
+        foo {
+            // bar
+        \("    ")
+            // baz
+        }
+        """
+        let output = """
+        foo {
+            // bar
+
+            // baz
+        }
+        """
         testFormatting(for: input, output, rule: .trailingSpace)
     }
 
     func testTrailingSpaceInArray() {
-        let input = "let foo = [\n    1,\n    \n    2,\n]"
-        let output = "let foo = [\n    1,\n\n    2,\n]"
+        let input = """
+        let foo = [
+            1,
+        \("    ")
+            2,
+        ]
+        """
+        let output = """
+        let foo = [
+            1,
+
+            2,
+        ]
+        """
         testFormatting(for: input, output, rule: .trailingSpace, exclude: [.redundantSelf])
     }
 
     // truncateBlankLines = false
 
     func testNoTruncateBlankLine() {
-        let input = "foo {\n    // bar\n    \n    // baz\n}"
+        let input = """
+        foo {
+            // bar
+        \("    ")
+            // baz
+        }
+        """
         let options = FormatOptions(truncateBlankLines: false)
         testFormatting(for: input, rule: .trailingSpace, options: options)
     }

--- a/Tests/Rules/TypeSugarTests.swift
+++ b/Tests/Rules/TypeSugarTests.swift
@@ -13,48 +13,76 @@ class TypeSugarTests: XCTestCase {
     // arrays
 
     func testArrayTypeConvertedToSugar() {
-        let input = "var foo: Array<String>"
-        let output = "var foo: [String]"
+        let input = """
+        var foo: Array<String>
+        """
+        let output = """
+        var foo: [String]
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testSwiftArrayTypeConvertedToSugar() {
-        let input = "var foo: Swift.Array<String>"
-        let output = "var foo: [String]"
+        let input = """
+        var foo: Swift.Array<String>
+        """
+        let output = """
+        var foo: [String]
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testArrayNestedTypeAliasNotConvertedToSugar() {
-        let input = "typealias Indices = Array<Foo>.Indices"
+        let input = """
+        typealias Indices = Array<Foo>.Indices
+        """
         testFormatting(for: input, rule: .typeSugar)
     }
 
     func testArrayTypeReferenceConvertedToSugar() {
-        let input = "let type = Array<Foo>.Type"
-        let output = "let type = [Foo].Type"
+        let input = """
+        let type = Array<Foo>.Type
+        """
+        let output = """
+        let type = [Foo].Type
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testSwiftArrayTypeReferenceConvertedToSugar() {
-        let input = "let type = Swift.Array<Foo>.Type"
-        let output = "let type = [Foo].Type"
+        let input = """
+        let type = Swift.Array<Foo>.Type
+        """
+        let output = """
+        let type = [Foo].Type
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testArraySelfReferenceConvertedToSugar() {
-        let input = "let type = Array<Foo>.self"
-        let output = "let type = [Foo].self"
+        let input = """
+        let type = Array<Foo>.self
+        """
+        let output = """
+        let type = [Foo].self
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testSwiftArraySelfReferenceConvertedToSugar() {
-        let input = "let type = Swift.Array<Foo>.self"
-        let output = "let type = [Foo].self"
+        let input = """
+        let type = Swift.Array<Foo>.self
+        """
+        let output = """
+        let type = [Foo].self
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testArrayDeclarationNotConvertedToSugar() {
-        let input = "struct Array<Element> {}"
+        let input = """
+        struct Array<Element> {}
+        """
         testFormatting(for: input, rule: .typeSugar)
     }
 
@@ -78,82 +106,128 @@ class TypeSugarTests: XCTestCase {
     // dictionaries
 
     func testDictionaryTypeConvertedToSugar() {
-        let input = "var foo: Dictionary<String, Int>"
-        let output = "var foo: [String: Int]"
+        let input = """
+        var foo: Dictionary<String, Int>
+        """
+        let output = """
+        var foo: [String: Int]
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testSwiftDictionaryTypeConvertedToSugar() {
-        let input = "var foo: Swift.Dictionary<String, Int>"
-        let output = "var foo: [String: Int]"
+        let input = """
+        var foo: Swift.Dictionary<String, Int>
+        """
+        let output = """
+        var foo: [String: Int]
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     // optionals
 
     func testOptionalPropertyTypeNotConvertedToSugarByDefault() {
-        let input = "var bar: Optional<String>"
+        let input = """
+        var bar: Optional<String>
+        """
         testFormatting(for: input, rule: .typeSugar)
     }
 
     func testOptionalTypeConvertedToSugar() {
-        let input = "var foo: Optional<String>"
-        let output = "var foo: String?"
+        let input = """
+        var foo: Optional<String>
+        """
+        let output = """
+        var foo: String?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testSwiftOptionalTypeConvertedToSugar() {
-        let input = "var foo: Swift.Optional<String>"
-        let output = "var foo: String?"
+        let input = """
+        var foo: Swift.Optional<String>
+        """
+        let output = """
+        var foo: String?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testOptionalClosureParenthesizedConvertedToSugar() {
-        let input = "var foo: Optional<(Int) -> String>"
-        let output = "var foo: ((Int) -> String)?"
+        let input = """
+        var foo: Optional<(Int) -> String>
+        """
+        let output = """
+        var foo: ((Int) -> String)?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testOptionalTupleWrappedInParensConvertedToSugar() {
-        let input = "let foo: Optional<(foo: Int, bar: String)>"
-        let output = "let foo: (foo: Int, bar: String)?"
+        let input = """
+        let foo: Optional<(foo: Int, bar: String)>
+        """
+        let output = """
+        let foo: (foo: Int, bar: String)?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testOptionalComposedProtocolWrappedInParensConvertedToSugar() {
-        let input = "let foo: Optional<UIView & Foo>"
-        let output = "let foo: (UIView & Foo)?"
+        let input = """
+        let foo: Optional<UIView & Foo>
+        """
+        let output = """
+        let foo: (UIView & Foo)?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testSwiftOptionalClosureParenthesizedConvertedToSugar() {
-        let input = "var foo: Swift.Optional<(Int) -> String>"
-        let output = "var foo: ((Int) -> String)?"
+        let input = """
+        var foo: Swift.Optional<(Int) -> String>
+        """
+        let output = """
+        var foo: ((Int) -> String)?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testStrippingSwiftNamespaceInOptionalTypeWhenConvertedToSugar() {
-        let input = "Swift.Optional<String>"
-        let output = "String?"
+        let input = """
+        Swift.Optional<String>
+        """
+        let output = """
+        String?
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     func testStrippingSwiftNamespaceDoesNotStripPreviousSwiftNamespaceReferences() {
-        let input = "let a: Swift.String = Optional<String>"
-        let output = "let a: Swift.String = String?"
+        let input = """
+        let a: Swift.String = Optional<String>
+        """
+        let output = """
+        let a: Swift.String = String?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testOptionalTypeInsideCaseConvertedToSugar() {
-        let input = "if case .some(Optional<Any>.some(let foo)) = bar else {}"
-        let output = "if case .some(Any?.some(let foo)) = bar else {}"
+        let input = """
+        if case .some(Optional<Any>.some(let foo)) = bar else {}
+        """
+        let output = """
+        if case .some(Any?.some(let foo)) = bar else {}
+        """
         testFormatting(for: input, output, rule: .typeSugar, exclude: [.hoistPatternLet])
     }
 
@@ -167,71 +241,107 @@ class TypeSugarTests: XCTestCase {
     }
 
     func testCaseOptionalNotReplaced2() {
-        let input = "if case Optional<Any>.none = foo {}"
+        let input = """
+        if case Optional<Any>.none = foo {}
+        """
         testFormatting(for: input, rule: .typeSugar)
     }
 
     func testUnwrappedOptionalSomeParenthesized() {
-        let input = "func foo() -> Optional<some Publisher<String, Never>> {}"
-        let output = "func foo() -> (some Publisher<String, Never>)? {}"
+        let input = """
+        func foo() -> Optional<some Publisher<String, Never>> {}
+        """
+        let output = """
+        func foo() -> (some Publisher<String, Never>)? {}
+        """
         testFormatting(for: input, output, rule: .typeSugar)
     }
 
     // swift parser bug
 
     func testAvoidSwiftParserBugWithClosuresInsideArrays() {
-        let input = "var foo = Array<(_ image: Data?) -> Void>()"
+        let input = """
+        var foo = Array<(_ image: Data?) -> Void>()
+        """
         testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyTypes])
     }
 
     func testAvoidSwiftParserBugWithClosuresInsideDictionaries() {
-        let input = "var foo = Dictionary<String, (_ image: Data?) -> Void>()"
+        let input = """
+        var foo = Dictionary<String, (_ image: Data?) -> Void>()
+        """
         testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyTypes])
     }
 
     func testAvoidSwiftParserBugWithClosuresInsideOptionals() {
-        let input = "var foo = Optional<(_ image: Data?) -> Void>()"
+        let input = """
+        var foo = Optional<(_ image: Data?) -> Void>()
+        """
         testFormatting(for: input, rule: .typeSugar, options: FormatOptions(shortOptionals: .always), exclude: [.propertyTypes])
     }
 
     func testDontOverApplyBugWorkaround() {
-        let input = "var foo: Array<(_ image: Data?) -> Void>"
-        let output = "var foo: [(_ image: Data?) -> Void]"
+        let input = """
+        var foo: Array<(_ image: Data?) -> Void>
+        """
+        let output = """
+        var foo: [(_ image: Data?) -> Void]
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testDontOverApplyBugWorkaround2() {
-        let input = "var foo: Dictionary<String, (_ image: Data?) -> Void>"
-        let output = "var foo: [String: (_ image: Data?) -> Void]"
+        let input = """
+        var foo: Dictionary<String, (_ image: Data?) -> Void>
+        """
+        let output = """
+        var foo: [String: (_ image: Data?) -> Void]
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testDontOverApplyBugWorkaround3() {
-        let input = "var foo: Optional<(_ image: Data?) -> Void>"
-        let output = "var foo: ((_ image: Data?) -> Void)?"
+        let input = """
+        var foo: Optional<(_ image: Data?) -> Void>
+        """
+        let output = """
+        var foo: ((_ image: Data?) -> Void)?
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)
     }
 
     func testDontOverApplyBugWorkaround4() {
-        let input = "var foo = Array<(image: Data?) -> Void>()"
-        let output = "var foo = [(image: Data?) -> Void]()"
+        let input = """
+        var foo = Array<(image: Data?) -> Void>()
+        """
+        let output = """
+        var foo = [(image: Data?) -> Void]()
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyTypes])
     }
 
     func testDontOverApplyBugWorkaround5() {
-        let input = "var foo = Array<(Data?) -> Void>()"
-        let output = "var foo = [(Data?) -> Void]()"
+        let input = """
+        var foo = Array<(Data?) -> Void>()
+        """
+        let output = """
+        var foo = [(Data?) -> Void]()
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyTypes])
     }
 
     func testDontOverApplyBugWorkaround6() {
-        let input = "var foo = Dictionary<Int, Array<(_ image: Data?) -> Void>>()"
-        let output = "var foo = [Int: Array<(_ image: Data?) -> Void>]()"
+        let input = """
+        var foo = Dictionary<Int, Array<(_ image: Data?) -> Void>>()
+        """
+        let output = """
+        var foo = [Int: Array<(_ image: Data?) -> Void>]()
+        """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options, exclude: [.propertyTypes])
     }

--- a/Tests/Rules/UnusedArgumentsTests.swift
+++ b/Tests/Rules/UnusedArgumentsTests.swift
@@ -27,66 +27,105 @@ class UnusedArgumentsTests: XCTestCase {
     }
 
     func testUnusedUntypedClosureArguments() {
-        let input = "let foo = { bar, baz in\n    print(\"Hello \\(baz)\")\n}"
-        let output = "let foo = { _, baz in\n    print(\"Hello \\(baz)\")\n}"
+        let input = """
+        let foo = { bar, baz in
+            print(\"Hello \\(baz)\")
+        }
+        """
+        let output = """
+        let foo = { _, baz in
+            print(\"Hello \\(baz)\")
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureReturnType() {
-        let input = "let foo = { () -> Foo.Bar in baz() }"
+        let input = """
+        let foo = { () -> Foo.Bar in baz() }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureThrows() {
-        let input = "let foo = { () throws in }"
+        let input = """
+        let foo = { () throws in }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureTypedThrows() {
-        let input = "let foo = { () throws(Foo) in }"
+        let input = """
+        let foo = { () throws(Foo) in }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureGenericReturnTypes() {
-        let input = "let foo = { () -> Promise<String> in bar }"
+        let input = """
+        let foo = { () -> Promise<String> in bar }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureTupleReturnTypes() {
-        let input = "let foo = { () -> (Int, Int) in (5, 6) }"
+        let input = """
+        let foo = { () -> (Int, Int) in (5, 6) }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveClosureGenericArgumentTypes() {
-        let input = "let foo = { (_: Foo<Bar, Baz>) in }"
+        let input = """
+        let foo = { (_: Foo<Bar, Baz>) in }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testNoRemoveFunctionNameBeforeForLoop() {
-        let input = "{\n    func foo() -> Int {}\n    for a in b {}\n}"
+        let input = """
+        {
+            func foo() -> Int {}
+            for a in b {}
+        }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testClosureTypeInClosureArgumentsIsNotMangled() {
-        let input = "{ (foo: (Int) -> Void) in }"
-        let output = "{ (_: (Int) -> Void) in }"
+        let input = """
+        { (foo: (Int) -> Void) in }
+        """
+        let output = """
+        { (_: (Int) -> Void) in }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedUnnamedClosureArguments() {
-        let input = "{ (_ foo: Int, _ bar: Int) in }"
-        let output = "{ (_: Int, _: Int) in }"
+        let input = """
+        { (_ foo: Int, _ bar: Int) in }
+        """
+        let output = """
+        { (_: Int, _: Int) in }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedInoutClosureArgumentsNotMangled() {
-        let input = "{ (foo: inout Foo, bar: inout Bar) in }"
-        let output = "{ (_: inout Foo, _: inout Bar) in }"
+        let input = """
+        { (foo: inout Foo, bar: inout Bar) in }
+        """
+        let output = """
+        { (_: inout Foo, _: inout Bar) in }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMalformedFunctionNotMisidentifiedAsClosure() {
-        let input = "func foo() { bar(5) {} in }"
+        let input = """
+        func foo() { bar(5) {} in }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
@@ -210,24 +249,36 @@ class UnusedArgumentsTests: XCTestCase {
     }
 
     func testUnusedThrowingClosureArgument() {
-        let input = "foo = { bar throws in \"\" }"
-        let output = "foo = { _ throws in \"\" }"
+        let input = """
+        foo = { bar throws in \"\" }
+        """
+        let output = """
+        foo = { _ throws in \"\" }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedTypedThrowingClosureArgument() {
-        let input = "foo = { bar throws(Foo) in \"\" }"
-        let output = "foo = { _ throws(Foo) in \"\" }"
+        let input = """
+        foo = { bar throws(Foo) in \"\" }
+        """
+        let output = """
+        foo = { _ throws(Foo) in \"\" }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUsedThrowingClosureArgument() {
-        let input = "let foo = { bar throws in bar + \"\" }"
+        let input = """
+        let foo = { bar throws in bar + \"\" }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testUsedTypedThrowingClosureArgument() {
-        let input = "let foo = { bar throws(Foo) in bar + \"\" }"
+        let input = """
+        let foo = { bar throws(Foo) in bar + \"\" }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
@@ -283,7 +334,9 @@ class UnusedArgumentsTests: XCTestCase {
     }
 
     func testTrailingAsyncClosureArgumentAlreadyMarkedUnused() {
-        let input = "app.get { _ async in 5 }"
+        let input = """
+        app.get { _ async in 5 }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
@@ -399,100 +452,188 @@ class UnusedArgumentsTests: XCTestCase {
     // functions
 
     func testMarkUnusedFunctionArgument() {
-        let input = "func foo(bar: Int, baz: String) {\n    print(\"Hello \\(baz)\")\n}"
-        let output = "func foo(bar _: Int, baz: String) {\n    print(\"Hello \\(baz)\")\n}"
+        let input = """
+        func foo(bar: Int, baz: String) {
+            print(\"Hello \\(baz)\")
+        }
+        """
+        let output = """
+        func foo(bar _: Int, baz: String) {
+            print(\"Hello \\(baz)\")
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMarkUnusedArgumentsInNonVoidFunction() {
-        let input = "func foo(bar: Int, baz: String) -> (A<B, C>, D & E, [F: G]) { return baz.quux }"
-        let output = "func foo(bar _: Int, baz: String) -> (A<B, C>, D & E, [F: G]) { return baz.quux }"
+        let input = """
+        func foo(bar: Int, baz: String) -> (A<B, C>, D & E, [F: G]) { return baz.quux }
+        """
+        let output = """
+        func foo(bar _: Int, baz: String) -> (A<B, C>, D & E, [F: G]) { return baz.quux }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMarkUnusedArgumentsInThrowsFunction() {
-        let input = "func foo(bar: Int, baz: String) throws {\n    print(\"Hello \\(baz)\")\n}"
-        let output = "func foo(bar _: Int, baz: String) throws {\n    print(\"Hello \\(baz)\")\n}"
+        let input = """
+        func foo(bar: Int, baz: String) throws {
+            print(\"Hello \\(baz)\")
+        }
+        """
+        let output = """
+        func foo(bar _: Int, baz: String) throws {
+            print(\"Hello \\(baz)\")
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMarkUnusedArgumentsInOptionalReturningFunction() {
-        let input = "func foo(bar: Int, baz: String) -> String? {\n    return \"Hello \\(baz)\"\n}"
-        let output = "func foo(bar _: Int, baz: String) -> String? {\n    return \"Hello \\(baz)\"\n}"
+        let input = """
+        func foo(bar: Int, baz: String) -> String? {
+            return \"Hello \\(baz)\"
+        }
+        """
+        let output = """
+        func foo(bar _: Int, baz: String) -> String? {
+            return \"Hello \\(baz)\"
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testNoMarkUnusedArgumentsInProtocolFunction() {
-        let input = "protocol Foo {\n    func foo(bar: Int) -> Int\n    var bar: Int { get }\n}"
+        let input = """
+        protocol Foo {
+            func foo(bar: Int) -> Int
+            var bar: Int { get }
+        }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testUnusedUnnamedFunctionArgument() {
-        let input = "func foo(_ foo: Int) {}"
-        let output = "func foo(_: Int) {}"
+        let input = """
+        func foo(_ foo: Int) {}
+        """
+        let output = """
+        func foo(_: Int) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedInoutFunctionArgumentIsNotMangled() {
-        let input = "func foo(_ foo: inout Foo) {}"
-        let output = "func foo(_: inout Foo) {}"
+        let input = """
+        func foo(_ foo: inout Foo) {}
+        """
+        let output = """
+        func foo(_: inout Foo) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedInternallyRenamedFunctionArgument() {
-        let input = "func foo(foo bar: Int) {}"
-        let output = "func foo(foo _: Int) {}"
+        let input = """
+        func foo(foo bar: Int) {}
+        """
+        let output = """
+        func foo(foo _: Int) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testNoMarkProtocolFunctionArgument() {
-        let input = "func foo(foo bar: Int)\nvar bar: Bool { get }"
+        let input = """
+        func foo(foo bar: Int)
+        var bar: Bool { get }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testMembersAreNotArguments() {
-        let input = "func foo(bar: Int, baz: String) {\n    print(\"Hello \\(bar.baz)\")\n}"
-        let output = "func foo(bar: Int, baz _: String) {\n    print(\"Hello \\(bar.baz)\")\n}"
+        let input = """
+        func foo(bar: Int, baz: String) {
+            print(\"Hello \\(bar.baz)\")
+        }
+        """
+        let output = """
+        func foo(bar: Int, baz _: String) {
+            print(\"Hello \\(bar.baz)\")
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testLabelsAreNotArguments() {
-        let input = "func foo(bar: Int, baz: String) {\n    bar: while true { print(baz) }\n}"
-        let output = "func foo(bar _: Int, baz: String) {\n    bar: while true { print(baz) }\n}"
+        let input = """
+        func foo(bar: Int, baz: String) {
+            bar: while true { print(baz) }
+        }
+        """
+        let output = """
+        func foo(bar _: Int, baz: String) {
+            bar: while true { print(baz) }
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments, exclude: [.wrapLoopBodies])
     }
 
     func testDictionaryLiteralsRuinEverything() {
-        let input = "func foo(bar: Int, baz: Int) {\n    let quux = [bar: 1, baz: 2]\n}"
+        let input = """
+        func foo(bar: Int, baz: Int) {
+            let quux = [bar: 1, baz: 2]
+        }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testOperatorArgumentsAreUnnamed() {
-        let input = "func == (lhs: Int, rhs: Int) { false }"
-        let output = "func == (_: Int, _: Int) { false }"
+        let input = """
+        func == (lhs: Int, rhs: Int) { false }
+        """
+        let output = """
+        func == (_: Int, _: Int) { false }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testUnusedtFailableInitArgumentsAreNotMangled() {
-        let input = "init?(foo: Bar) {}"
-        let output = "init?(foo _: Bar) {}"
+        let input = """
+        init?(foo: Bar) {}
+        """
+        let output = """
+        init?(foo _: Bar) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testTreatEscapedArgumentsAsUsed() {
-        let input = "func foo(default: Int) -> Int {\n    return `default`\n}"
+        let input = """
+        func foo(default: Int) -> Int {
+            return `default`
+        }
+        """
         testFormatting(for: input, rule: .unusedArguments)
     }
 
     func testPartiallyMarkedUnusedArguments() {
-        let input = "func foo(bar: Bar, baz _: Baz) {}"
-        let output = "func foo(bar _: Bar, baz _: Baz) {}"
+        let input = """
+        func foo(bar: Bar, baz _: Baz) {}
+        """
+        let output = """
+        func foo(bar _: Bar, baz _: Baz) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testPartiallyMarkedUnusedArguments2() {
-        let input = "func foo(bar _: Bar, baz: Baz) {}"
-        let output = "func foo(bar _: Bar, baz _: Baz) {}"
+        let input = """
+        func foo(bar _: Bar, baz: Baz) {}
+        """
+        let output = """
+        func foo(bar _: Bar, baz _: Baz) {}
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
@@ -992,7 +1133,11 @@ class UnusedArgumentsTests: XCTestCase {
     // functions (closure-only)
 
     func testNoMarkFunctionArgument() {
-        let input = "func foo(_ bar: Int, baz: String) {\n    print(\"Hello \\(baz)\")\n}"
+        let input = """
+        func foo(_ bar: Int, baz: String) {
+            print(\"Hello \\(baz)\")
+        }
+        """
         let options = FormatOptions(stripUnusedArguments: .closureOnly)
         testFormatting(for: input, rule: .unusedArguments, options: options)
     }
@@ -1010,14 +1155,20 @@ class UnusedArgumentsTests: XCTestCase {
     }
 
     func testRemoveUnnamedFunctionArgument() {
-        let input = "func foo(_ foo: Int) {}"
-        let output = "func foo(_: Int) {}"
+        let input = """
+        func foo(_ foo: Int) {}
+        """
+        let output = """
+        func foo(_: Int) {}
+        """
         let options = FormatOptions(stripUnusedArguments: .unnamedOnly)
         testFormatting(for: input, output, rule: .unusedArguments, options: options)
     }
 
     func testNoRemoveInternalFunctionArgumentName() {
-        let input = "func foo(foo bar: Int) {}"
+        let input = """
+        func foo(foo bar: Int) {}
+        """
         let options = FormatOptions(stripUnusedArguments: .unnamedOnly)
         testFormatting(for: input, rule: .unusedArguments, options: options)
     }
@@ -1047,20 +1198,44 @@ class UnusedArgumentsTests: XCTestCase {
     // subscript
 
     func testMarkUnusedSubscriptArgument() {
-        let input = "subscript(foo: Int, baz: String) -> String {\n    return get(baz)\n}"
-        let output = "subscript(_: Int, baz: String) -> String {\n    return get(baz)\n}"
+        let input = """
+        subscript(foo: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
+        let output = """
+        subscript(_: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMarkUnusedUnnamedSubscriptArgument() {
-        let input = "subscript(_ foo: Int, baz: String) -> String {\n    return get(baz)\n}"
-        let output = "subscript(_: Int, baz: String) -> String {\n    return get(baz)\n}"
+        let input = """
+        subscript(_ foo: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
+        let output = """
+        subscript(_: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 
     func testMarkUnusedNamedSubscriptArgument() {
-        let input = "subscript(foo foo: Int, baz: String) -> String {\n    return get(baz)\n}"
-        let output = "subscript(foo _: Int, baz: String) -> String {\n    return get(baz)\n}"
+        let input = """
+        subscript(foo foo: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
+        let output = """
+        subscript(foo _: Int, baz: String) -> String {
+            return get(baz)
+        }
+        """
         testFormatting(for: input, output, rule: .unusedArguments)
     }
 

--- a/Tests/Rules/VoidTests.swift
+++ b/Tests/Rules/VoidTests.swift
@@ -11,19 +11,30 @@ import XCTest
 
 class VoidTests: XCTestCase {
     func testEmptyParensReturnValueConvertedToVoid() {
-        let input = "() -> ()"
-        let output = "() -> Void"
+        let input = """
+        () -> ()
+        """
+        let output = """
+        () -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testSpacedParensReturnValueConvertedToVoid() {
-        let input = "() -> ( \n)"
-        let output = "() -> Void"
+        let input = """
+        () -> ( 
+        )
+        """
+        let output = """
+        () -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testParensContainingCommentNotConvertedToVoid() {
-        let input = "() -> ( /* Hello World */ )"
+        let input = """
+        () -> ( /* Hello World */ )
+        """
         testFormatting(for: input, rule: .void)
     }
 
@@ -37,100 +48,152 @@ class VoidTests: XCTestCase {
     }
 
     func testParensRemovedAroundVoid() {
-        let input = "() -> (Void)"
-        let output = "() -> Void"
+        let input = """
+        () -> (Void)
+        """
+        let output = """
+        () -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testVoidArgumentConvertedToEmptyParens() {
-        let input = "Void -> Void"
-        let output = "() -> Void"
+        let input = """
+        Void -> Void
+        """
+        let output = """
+        () -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testVoidArgumentInParensNotConvertedToEmptyParens() {
-        let input = "(Void) -> Void"
+        let input = """
+        (Void) -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testAnonymousVoidArgumentNotConvertedToEmptyParens() {
-        let input = "{ (_: Void) -> Void in }"
+        let input = """
+        { (_: Void) -> Void in }
+        """
         testFormatting(for: input, rule: .void, exclude: [.redundantVoidReturnType])
     }
 
     func testFuncWithAnonymousVoidArgumentNotStripped() {
-        let input = "func foo(_: Void) -> Void"
+        let input = """
+        func foo(_: Void) -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testFunctionThatReturnsAFunction() {
-        let input = "(Void) -> Void -> ()"
-        let output = "(Void) -> () -> Void"
+        let input = """
+        (Void) -> Void -> ()
+        """
+        let output = """
+        (Void) -> () -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testFunctionThatReturnsAFunctionThatThrows() {
-        let input = "(Void) -> Void throws -> ()"
-        let output = "(Void) -> () throws -> Void"
+        let input = """
+        (Void) -> Void throws -> ()
+        """
+        let output = """
+        (Void) -> () throws -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testFunctionThatReturnsAFunctionThatHasTypedThrows() {
-        let input = "(Void) -> Void throws(Foo) -> ()"
-        let output = "(Void) -> () throws(Foo) -> Void"
+        let input = """
+        (Void) -> Void throws(Foo) -> ()
+        """
+        let output = """
+        (Void) -> () throws(Foo) -> Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testChainOfFunctionsIsNotChanged() {
-        let input = "() -> () -> () -> Void"
+        let input = """
+        () -> () -> () -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testChainOfFunctionsWithThrowsIsNotChanged() {
-        let input = "() -> () throws -> () throws -> Void"
+        let input = """
+        () -> () throws -> () throws -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testChainOfFunctionsWithTypedThrowsIsNotChanged() {
-        let input = "() -> () throws(Foo) -> () throws(Foo) -> Void"
+        let input = """
+        () -> () throws(Foo) -> () throws(Foo) -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testVoidThrowsIsNotMangled() {
-        let input = "(Void) throws -> Void"
+        let input = """
+        (Void) throws -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testVoidTypedThrowsIsNotMangled() {
-        let input = "(Void) throws(Foo) -> Void"
+        let input = """
+        (Void) throws(Foo) -> Void
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testEmptyClosureArgsNotMangled() {
-        let input = "{ () in }"
+        let input = """
+        { () in }
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testEmptyClosureReturnValueConvertedToVoid() {
-        let input = "{ () -> () in }"
-        let output = "{ () -> Void in }"
+        let input = """
+        { () -> () in }
+        """
+        let output = """
+        { () -> Void in }
+        """
         testFormatting(for: input, output, rule: .void, exclude: [.redundantVoidReturnType])
     }
 
     func testAnonymousVoidClosureNotChanged() {
-        let input = "{ (_: Void) in }"
+        let input = """
+        { (_: Void) in }
+        """
         testFormatting(for: input, rule: .void, exclude: [.unusedArguments])
     }
 
     func testVoidLiteralConvertedToParens() {
-        let input = "foo(Void())"
-        let output = "foo(())"
+        let input = """
+        foo(Void())
+        """
+        let output = """
+        foo(())
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testVoidLiteralConvertedToParens2() {
-        let input = "let foo = Void()"
-        let output = "let foo = ()"
+        let input = """
+        let foo = Void()
+        """
+        let output = """
+        let foo = ()
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
@@ -149,30 +212,44 @@ class VoidTests: XCTestCase {
     }
 
     func testVoidLiteralReturnValueConvertedToParens2() {
-        let input = "{ _ in Void() }"
-        let output = "{ _ in () }"
+        let input = """
+        { _ in Void() }
+        """
+        let output = """
+        { _ in () }
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testNamespacedVoidLiteralNotConverted() {
         // TODO: it should actually be safe to convert Swift.Void - only unsafe for other namespaces
-        let input = "let foo = Swift.Void()"
+        let input = """
+        let foo = Swift.Void()
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testMalformedFuncDoesNotCauseInvalidOutput() throws {
-        let input = "func baz(Void) {}"
+        let input = """
+        func baz(Void) {}
+        """
         testFormatting(for: input, rule: .void)
     }
 
     func testEmptyParensInGenericsConvertedToVoid() {
-        let input = "Foo<(), ()>"
-        let output = "Foo<Void, Void>"
+        let input = """
+        Foo<(), ()>
+        """
+        let output = """
+        Foo<Void, Void>
+        """
         testFormatting(for: input, output, rule: .void)
     }
 
     func testCaseVoidNotUnwrapped() {
-        let input = "case some(Void)"
+        let input = """
+        case some(Void)
+        """
         testFormatting(for: input, rule: .void)
     }
 
@@ -215,53 +292,77 @@ class VoidTests: XCTestCase {
     // useVoid = false
 
     func testUseVoidOptionFalse() {
-        let input = "(Void) -> Void"
-        let output = "(()) -> ()"
+        let input = """
+        (Void) -> Void
+        """
+        let output = """
+        (()) -> ()
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, output, rule: .void, options: options)
     }
 
     func testNamespacedVoidNotConverted() {
-        let input = "() -> Swift.Void"
+        let input = """
+        () -> Swift.Void
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, rule: .void, options: options)
     }
 
     func testTypealiasVoidNotConverted() {
-        let input = "public typealias Void = ()"
+        let input = """
+        public typealias Void = ()
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, rule: .void, options: options)
     }
 
     func testVoidClosureReturnValueConvertedToEmptyTuple() {
-        let input = "{ () -> Void in }"
-        let output = "{ () -> () in }"
+        let input = """
+        { () -> Void in }
+        """
+        let output = """
+        { () -> () in }
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, output, rule: .void, options: options, exclude: [.redundantVoidReturnType])
     }
 
     func testNoConvertVoidSelfToTuple() {
-        let input = "Void.self"
+        let input = """
+        Void.self
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, rule: .void, options: options)
     }
 
     func testNoConvertVoidTypeToTuple() {
-        let input = "Void.Type"
+        let input = """
+        Void.Type
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, rule: .void, options: options)
     }
 
     func testCaseVoidConvertedToTuple() {
-        let input = "case some(Void)"
-        let output = "case some(())"
+        let input = """
+        case some(Void)
+        """
+        let output = """
+        case some(())
+        """
         let options = FormatOptions(useVoid: false)
         testFormatting(for: input, output, rule: .void, options: options)
     }
 
     func testTypealiasEmptyTupleConvertedToVoid() {
-        let input = "public typealias Dependencies = ()"
-        let output = "public typealias Dependencies = Void"
+        let input = """
+        public typealias Dependencies = ()
+        """
+        let output = """
+        public typealias Dependencies = Void
+        """
         testFormatting(for: input, output, rule: .void)
     }
 }

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -53,7 +53,12 @@ class WrapArgumentsTests: XCTestCase {
     }
 
     func testWrapParametersDoesNotAffectFunctionDeclaration() {
-        let input = "foo(\n    bar _: Int,\n    baz _: String\n)"
+        let input = """
+        foo(
+            bar _: Int,
+            baz _: String
+        )
+        """
         let options = FormatOptions(wrapArguments: .preserve, wrapParameters: .afterFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
@@ -69,22 +74,47 @@ class WrapArgumentsTests: XCTestCase {
     }
 
     func testWrapParametersNotSetWrapArgumentsAfterFirstDefaultsToAfterFirst() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
-        let output = "func foo(bar _: Int,\n         baz _: String) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
         let options = FormatOptions(wrapArguments: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testWrapParametersNotSetWrapArgumentsBeforeFirstDefaultsToBeforeFirst() {
-        let input = "func foo(bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapArguments: .beforeFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testWrapParametersNotSetWrapArgumentsPreserveDefaultsToPreserve() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapArguments: .preserve)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
@@ -232,41 +262,81 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: preserve
 
     func testAfterFirstPreserved() {
-        let input = "func foo(bar _: Int,\n         baz _: String) {}"
+        let input = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
 
     func testAfterFirstPreservedIndentFixed() {
-        let input = "func foo(bar _: Int,\n baz _: String) {}"
-        let output = "func foo(bar _: Int,\n         baz _: String) {}"
+        let input = """
+        func foo(bar _: Int,
+         baz _: String) {}
+        """
+        let output = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testAfterFirstPreservedNewlineRemoved() {
-        let input = "func foo(bar _: Int,\n         baz _: String\n) {}"
-        let output = "func foo(bar _: Int,\n         baz _: String) {}"
+        let input = """
+        func foo(bar _: Int,
+                 baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testBeforeFirstPreserved() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
 
     func testBeforeFirstPreservedIndentFixed() {
-        let input = "func foo(\n    bar _: Int,\n baz _: String\n) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+         baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testBeforeFirstPreservedNewlineAdded() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
@@ -288,15 +358,31 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: afterFirst
 
     func testBeforeFirstConvertedToAfterFirst() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
-        let output = "func foo(bar _: Int,\n         baz _: String) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testNoWrapInnerArguments() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: foo(bar, baz)\n) {}"
-        let output = "func foo(bar _: Int,\n         baz _: foo(bar, baz)) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: foo(bar, baz)
+        ) {}
+        """
+        let output = """
+        func foo(bar _: Int,
+                 baz _: foo(bar, baz)) {}
+        """
         let options = FormatOptions(wrapParameters: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
@@ -468,22 +554,47 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: beforeFirst
 
     func testWrapAfterFirstConvertedToWrapBefore() {
-        let input = "func foo(bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .beforeFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testLinebreakInsertedAtEndOfWrappedFunction() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .beforeFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testAfterFirstConvertedToBeforeFirst() {
-        let input = "func foo(bar _: Int,\n         baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(bar _: Int,
+                 baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapParameters: .beforeFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
@@ -820,28 +931,36 @@ class WrapArgumentsTests: XCTestCase {
     }
 
     func testNoWrapSubscriptWithSingleElement() {
-        let input = "guard let foo = bar[0] {}"
+        let input = """
+        guard let foo = bar[0] {}
+        """
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 20)
         testFormatting(for: input, rule: .wrapArguments, options: options,
                        exclude: [.wrap])
     }
 
     func testNoWrapArrayWithSingleElement() {
-        let input = "let foo = [0]"
+        let input = """
+        let foo = [0]
+        """
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 11)
         testFormatting(for: input, rule: .wrapArguments, options: options,
                        exclude: [.wrap])
     }
 
     func testNoWrapDictionaryWithSingleElement() {
-        let input = "let foo = [bar: baz]"
+        let input = """
+        let foo = [bar: baz]
+        """
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 15)
         testFormatting(for: input, rule: .wrapArguments, options: options,
                        exclude: [.wrap])
     }
 
     func testNoWrapImageLiteral() {
-        let input = "if let image = #imageLiteral(resourceName: \"abc.png\") {}"
+        let input = """
+        if let image = #imageLiteral(resourceName: \"abc.png\") {}
+        """
         let options = FormatOptions(wrapCollections: .beforeFirst, maxWidth: 30)
         testFormatting(for: input, rule: .wrapArguments, options: options,
                        exclude: [.wrap])
@@ -872,22 +991,47 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: closingParenPosition = true
 
     func testParenOnSameLineWhenWrapAfterFirstConvertedToWrapBefore() {
-        let input = "func foo(bar _: Int,\n    baz _: String) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String) {}"
+        let input = """
+        func foo(bar _: Int,
+            baz _: String) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .beforeFirst, closingParenPosition: .sameLine)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testParenOnSameLineWhenWrapBeforeFirstUnchanged() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .beforeFirst, closingParenPosition: .sameLine)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testParenOnSameLineWhenWrapBeforeFirstPreserved() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
-        let output = "func foo(\n    bar _: Int,\n    baz _: String) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
+        let output = """
+        func foo(
+            bar _: Int,
+            baz _: String) {}
+        """
         let options = FormatOptions(wrapParameters: .preserve, closingParenPosition: .sameLine)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
@@ -922,19 +1066,34 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: - wrapArguments --wrapArguments
 
     func testWrapArgumentsDoesNotAffectFunctionDeclaration() {
-        let input = "func foo(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        func foo(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapArguments: .afterFirst, wrapParameters: .preserve)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
 
     func testWrapArgumentsDoesNotAffectInit() {
-        let input = "init(\n    bar _: Int,\n    baz _: String\n) {}"
+        let input = """
+        init(
+            bar _: Int,
+            baz _: String
+        ) {}
+        """
         let options = FormatOptions(wrapArguments: .afterFirst, wrapParameters: .preserve)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
 
     func testWrapArgumentsDoesNotAffectSubscript() {
-        let input = "subscript(\n    bar _: Int,\n    baz _: String\n) -> Int {}"
+        let input = """
+        subscript(
+            bar _: Int,
+            baz _: String
+        ) -> Int {}
+        """
         let options = FormatOptions(wrapArguments: .afterFirst, wrapParameters: .preserve)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
@@ -957,14 +1116,33 @@ class WrapArgumentsTests: XCTestCase {
     }
 
     func testCorrectWrapIndentForNestedArguments() {
-        let input = "foo(\nbar: (\nx: 0,\ny: 0\n),\nbaz: (\nx: 0,\ny: 0\n)\n)"
-        let output = "foo(bar: (x: 0,\n          y: 0),\n    baz: (x: 0,\n          y: 0))"
+        let input = """
+        foo(
+        bar: (
+        x: 0,
+        y: 0
+        ),
+        baz: (
+        x: 0,
+        y: 0
+        )
+        )
+        """
+        let output = """
+        foo(bar: (x: 0,
+                  y: 0),
+            baz: (x: 0,
+                  y: 0))
+        """
         let options = FormatOptions(wrapArguments: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testNoRemoveLinebreakAfterCommentInArguments() {
-        let input = "a(b // comment\n)"
+        let input = """
+        a(b // comment
+        )
+        """
         let options = FormatOptions(wrapArguments: .afterFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
@@ -1010,7 +1188,11 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: beforeFirst
 
     func testClosureInsideParensNotWrappedOntoNextLine() {
-        let input = "foo({\n    bar()\n})"
+        let input = """
+        foo({
+            bar()
+        })
+        """
         let options = FormatOptions(wrapArguments: .beforeFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options,
                        exclude: [.trailingClosures])
@@ -1207,47 +1389,99 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: beforeFirst
 
     func testNoDoubleSpaceAddedToWrappedArray() {
-        let input = "[ foo,\n    bar ]"
-        let output = "[\n    foo,\n    bar\n]"
+        let input = """
+        [ foo,
+            bar ]
+        """
+        let output = """
+        [
+            foo,
+            bar
+        ]
+        """
         let options = FormatOptions(trailingCommas: .never, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .spaceInsideBrackets],
                        options: options)
     }
 
     func testTrailingCommasAddedToWrappedArray() {
-        let input = "[foo,\n    bar]"
-        let output = "[\n    foo,\n    bar,\n]"
+        let input = """
+        [foo,
+            bar]
+        """
+        let output = """
+        [
+            foo,
+            bar,
+        ]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testTrailingCommasAddedToWrappedNestedDictionary() {
-        let input = "[foo: [bar: baz,\n    bar2: baz2]]"
-        let output = "[foo: [\n    bar: baz,\n    bar2: baz2,\n]]"
+        let input = """
+        [foo: [bar: baz,
+            bar2: baz2]]
+        """
+        let output = """
+        [foo: [
+            bar: baz,
+            bar2: baz2,
+        ]]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testTrailingCommasAddedToSingleLineNestedDictionary() {
-        let input = "[\n    foo: [bar: baz, bar2: baz2]]"
-        let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
+        let input = """
+        [
+            foo: [bar: baz, bar2: baz2]]
+        """
+        let output = """
+        [
+            foo: [bar: baz, bar2: baz2],
+        ]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testTrailingCommasAddedToWrappedNestedDictionaries() {
-        let input = "[foo: [bar: baz,\n    bar2: baz2],\n    foo2: [bar: baz,\n    bar2: baz2]]"
-        let output = "[\n    foo: [\n        bar: baz,\n        bar2: baz2,\n    ],\n    foo2: [\n        bar: baz,\n        bar2: baz2,\n    ],\n]"
+        let input = """
+        [foo: [bar: baz,
+            bar2: baz2],
+            foo2: [bar: baz,
+            bar2: baz2]]
+        """
+        let output = """
+        [
+            foo: [
+                bar: baz,
+                bar2: baz2,
+            ],
+            foo2: [
+                bar: baz,
+                bar2: baz2,
+            ],
+        ]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .beforeFirst)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testSpaceAroundEnumValuesInArray() {
-        let input = "[\n    .foo,\n    .bar, .baz,\n]"
+        let input = """
+        [
+            .foo,
+            .bar, .baz,
+        ]
+        """
         let options = FormatOptions(wrapCollections: .beforeFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
@@ -1270,14 +1504,27 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: afterFirst
 
     func testTrailingCommaRemovedInWrappedArray() {
-        let input = "[\n    .foo,\n    .bar,\n    .baz,\n]"
-        let output = "[.foo,\n .bar,\n .baz]"
+        let input = """
+        [
+            .foo,
+            .bar,
+            .baz,
+        ]
+        """
+        let output = """
+        [.foo,
+         .bar,
+         .baz]
+        """
         let options = FormatOptions(wrapCollections: .afterFirst)
         testFormatting(for: input, output, rule: .wrapArguments, options: options)
     }
 
     func testNoRemoveLinebreakAfterCommentInElements() {
-        let input = "[a, // comment\n]"
+        let input = """
+        [a, // comment
+        ]
+        """
         let options = FormatOptions(wrapCollections: .afterFirst)
         testFormatting(for: input, rule: .wrapArguments, options: options)
     }
@@ -1309,24 +1556,44 @@ class WrapArgumentsTests: XCTestCase {
     // MARK: preserve
 
     func testNoBeforeFirstPreservedAndTrailingCommaIgnoredInMultilineNestedDictionary() {
-        let input = "[foo: [bar: baz,\n    bar2: baz2]]"
-        let output = "[foo: [bar: baz,\n       bar2: baz2]]"
+        let input = """
+        [foo: [bar: baz,
+            bar2: baz2]]
+        """
+        let output = """
+        [foo: [bar: baz,
+               bar2: baz2]]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testBeforeFirstPreservedAndTrailingCommaAddedInSingleLineNestedDictionary() {
-        let input = "[\n    foo: [bar: baz, bar2: baz2]]"
-        let output = "[\n    foo: [bar: baz, bar2: baz2],\n]"
+        let input = """
+        [
+            foo: [bar: baz, bar2: baz2]]
+        """
+        let output = """
+        [
+            foo: [bar: baz, bar2: baz2],
+        ]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)
     }
 
     func testBeforeFirstPreservedAndTrailingCommaAddedInSingleLineNestedDictionaryWithOneNestedItem() {
-        let input = "[\n    foo: [bar: baz]]"
-        let output = "[\n    foo: [bar: baz],\n]"
+        let input = """
+        [
+            foo: [bar: baz]]
+        """
+        let output = """
+        [
+            foo: [bar: baz],
+        ]
+        """
         let options = FormatOptions(trailingCommas: .always, wrapCollections: .preserve)
         testFormatting(for: input, [output], rules: [.wrapArguments, .trailingCommas],
                        options: options)

--- a/Tests/Rules/WrapConditionalBodiesTests.swift
+++ b/Tests/Rules/WrapConditionalBodiesTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 class WrapConditionalBodiesTests: XCTestCase {
     func testGuardReturnWraps() {
-        let input = "guard let foo = bar else { return }"
+        let input = """
+        guard let foo = bar else { return }
+        """
         let output = """
         guard let foo = bar else {
             return
@@ -21,19 +23,25 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testEmptyGuardReturnWithSpaceDoesNothing() {
-        let input = "guard let foo = bar else { }"
+        let input = """
+        guard let foo = bar else { }
+        """
         testFormatting(for: input, rule: .wrapConditionalBodies,
                        exclude: [.emptyBraces])
     }
 
     func testEmptyGuardReturnWithoutSpaceDoesNothing() {
-        let input = "guard let foo = bar else {}"
+        let input = """
+        guard let foo = bar else {}
+        """
         testFormatting(for: input, rule: .wrapConditionalBodies,
                        exclude: [.emptyBraces])
     }
 
     func testGuardReturnWithValueWraps() {
-        let input = "guard let foo = bar else { return baz }"
+        let input = """
+        guard let foo = bar else { return baz }
+        """
         let output = """
         guard let foo = bar else {
             return baz
@@ -56,7 +64,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardContinueWithNoSpacesToCleanupWraps() {
-        let input = "guard let foo = bar else {continue}"
+        let input = """
+        guard let foo = bar else {continue}
+        """
         let output = """
         guard let foo = bar else {
             continue
@@ -66,7 +76,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardReturnWrapsSemicolonDelimitedStatements() {
-        let input = "guard let foo = bar else { var baz = 0; let boo = 1; fatalError() }"
+        let input = """
+        guard let foo = bar else { var baz = 0; let boo = 1; fatalError() }
+        """
         let output = """
         guard let foo = bar else {
             var baz = 0; let boo = 1; fatalError()
@@ -76,7 +88,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardReturnWrapsSemicolonDelimitedStatementsWithNoSpaces() {
-        let input = "guard let foo = bar else {var baz=0;let boo=1;fatalError()}"
+        let input = """
+        guard let foo = bar else {var baz=0;let boo=1;fatalError()}
+        """
         let output = """
         guard let foo = bar else {
             var baz=0;let boo=1;fatalError()
@@ -105,7 +119,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardMultilineCommentSameLineUnchanged() {
-        let input = "guard let foo = bar else { /* Test comment */ return }"
+        let input = """
+        guard let foo = bar else { /* Test comment */ return }
+        """
         let output = """
         guard let foo = bar else { /* Test comment */
             return
@@ -115,7 +131,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardTwoMultilineCommentsSameLine() {
-        let input = "guard let foo = bar else { /* Test comment 1 */ return /* Test comment 2 */ }"
+        let input = """
+        guard let foo = bar else { /* Test comment 1 */ return /* Test comment 2 */ }
+        """
         let output = """
         guard let foo = bar else { /* Test comment 1 */
             return /* Test comment 2 */
@@ -125,7 +143,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testNestedGuardElseIfStatementsPutOnNewline() {
-        let input = "guard let foo = bar else { if qux { return quux } else { return quuz } }"
+        let input = """
+        guard let foo = bar else { if qux { return quux } else { return quuz } }
+        """
         let output = """
         guard let foo = bar else {
             if qux {
@@ -139,7 +159,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testNestedGuardElseGuardStatementPutOnNewline() {
-        let input = "guard let foo = bar else { guard qux else { return quux } }"
+        let input = """
+        guard let foo = bar else { guard qux else { return quux } }
+        """
         let output = """
         guard let foo = bar else {
             guard qux else {
@@ -151,7 +173,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testGuardWithClosureOnlyWrapsElseBody() {
-        let input = "guard foo { $0.bar } else { return true }"
+        let input = """
+        guard foo { $0.bar } else { return true }
+        """
         let output = """
         guard foo { $0.bar } else {
             return true
@@ -161,7 +185,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testIfElseReturnsWrap() {
-        let input = "if foo { return bar } else if baz { return qux } else { return quux }"
+        let input = """
+        if foo { return bar } else if baz { return qux } else { return quux }
+        """
         let output = """
         if foo {
             return bar
@@ -175,7 +201,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testIfElseBodiesWrap() {
-        let input = "if foo { bar } else if baz { qux } else { quux }"
+        let input = """
+        if foo { bar } else if baz { qux } else { quux }
+        """
         let output = """
         if foo {
             bar
@@ -189,7 +217,9 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testIfElsesWithClosuresDontWrapClosures() {
-        let input = "if foo { $0.bar } { baz } else if qux { $0.quux } { quuz } else { corge }"
+        let input = """
+        if foo { $0.bar } { baz } else if qux { $0.quux } { quuz } else { corge }
+        """
         let output = """
         if foo { $0.bar } {
             baz
@@ -203,13 +233,17 @@ class WrapConditionalBodiesTests: XCTestCase {
     }
 
     func testEmptyIfElseBodiesWithSpaceDoNothing() {
-        let input = "if foo { } else if baz { } else { }"
+        let input = """
+        if foo { } else if baz { } else { }
+        """
         testFormatting(for: input, rule: .wrapConditionalBodies,
                        exclude: [.emptyBraces])
     }
 
     func testEmptyIfElseBodiesWithoutSpaceDoNothing() {
-        let input = "if foo {} else if baz {} else {}"
+        let input = """
+        if foo {} else if baz {} else {}
+        """
         testFormatting(for: input, rule: .wrapConditionalBodies,
                        exclude: [.emptyBraces])
     }

--- a/Tests/Rules/WrapEnumCasesTests.swift
+++ b/Tests/Rules/WrapEnumCasesTests.swift
@@ -167,7 +167,9 @@ class WrapEnumCasesTests: XCTestCase {
     }
 
     func testNoWrapEnumStatementAllOnOneLine() {
-        let input = "enum Foo { bar, baz }"
+        let input = """
+        enum Foo { bar, baz }
+        """
         testFormatting(for: input, rule: .wrapEnumCases)
     }
 
@@ -223,7 +225,9 @@ class WrapEnumCasesTests: XCTestCase {
     }
 
     func testNoWrapSingleLineEnumCases() {
-        let input = "enum Foo { case foo, bar }"
+        let input = """
+        enum Foo { case foo, bar }
+        """
         testFormatting(for: input, rule: .wrapEnumCases)
     }
 

--- a/Tests/Rules/WrapLoopBodiesTests.swift
+++ b/Tests/Rules/WrapLoopBodiesTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 class WrapLoopBodiesTests: XCTestCase {
     func testWrapForLoop() {
-        let input = "for foo in bar { print(foo) }"
+        let input = """
+        for foo in bar { print(foo) }
+        """
         let output = """
         for foo in bar {
             print(foo)
@@ -21,7 +23,9 @@ class WrapLoopBodiesTests: XCTestCase {
     }
 
     func testWrapWhileLoop() {
-        let input = "while let foo = bar.next() { print(foo) }"
+        let input = """
+        while let foo = bar.next() { print(foo) }
+        """
         let output = """
         while let foo = bar.next() {
             print(foo)
@@ -31,7 +35,9 @@ class WrapLoopBodiesTests: XCTestCase {
     }
 
     func testWrapRepeatWhileLoop() {
-        let input = "repeat { print(foo) } while condition()"
+        let input = """
+        repeat { print(foo) } while condition()
+        """
         let output = """
         repeat {
             print(foo)

--- a/Tests/Rules/WrapTests.swift
+++ b/Tests/Rules/WrapTests.swift
@@ -123,7 +123,9 @@ class WrapTests: XCTestCase {
     }
 
     func testWrapClosure3() {
-        let input = "let foo = bar { $0.baz }"
+        let input = """
+        let foo = bar { $0.baz }
+        """
         let output = """
         let foo = bar {
             $0.baz }
@@ -381,22 +383,31 @@ class WrapTests: XCTestCase {
     }
 
     func testNoWrapAtUnspacedOperator() {
-        let input = "let foo = bar+baz+quux"
-        let output = "let foo =\n    bar+baz+quux"
+        let input = """
+        let foo = bar+baz+quux
+        """
+        let output = """
+        let foo =
+            bar+baz+quux
+        """
         let options = FormatOptions(maxWidth: 15)
         testFormatting(for: input, output, rule: .wrap, options: options,
                        exclude: [.spaceAroundOperators])
     }
 
     func testNoWrapAtUnspacedEquals() {
-        let input = "let foo=bar+baz+quux"
+        let input = """
+        let foo=bar+baz+quux
+        """
         let options = FormatOptions(maxWidth: 15)
         testFormatting(for: input, rule: .wrap, options: options,
                        exclude: [.spaceAroundOperators])
     }
 
     func testNoWrapSingleParameter() {
-        let input = "let fooBar = try unkeyedContainer.decode(FooBar.self)"
+        let input = """
+        let fooBar = try unkeyedContainer.decode(FooBar.self)
+        """
         let output = """
         let fooBar = try unkeyedContainer
             .decode(FooBar.self)
@@ -406,7 +417,9 @@ class WrapTests: XCTestCase {
     }
 
     func testWrapSingleParameter() {
-        let input = "let fooBar = try unkeyedContainer.decode(FooBar.self)"
+        let input = """
+        let fooBar = try unkeyedContainer.decode(FooBar.self)
+        """
         let output = """
         let fooBar = try unkeyedContainer.decode(
             FooBar.self
@@ -417,7 +430,9 @@ class WrapTests: XCTestCase {
     }
 
     func testWrapFunctionArrow() {
-        let input = "func foo() -> Int {}"
+        let input = """
+        func foo() -> Int {}
+        """
         let output = """
         func foo()
             -> Int {}
@@ -427,7 +442,9 @@ class WrapTests: XCTestCase {
     }
 
     func testNoWrapFunctionArrow() {
-        let input = "func foo() -> Int {}"
+        let input = """
+        func foo() -> Int {}
+        """
         let output = """
         func foo(
         ) -> Int {}
@@ -494,7 +511,9 @@ class WrapTests: XCTestCase {
     }
 
     func testWrapImageLiteral() {
-        let input = "if let image = #imageLiteral(resourceName: \"abc.png\") {}"
+        let input = """
+        if let image = #imageLiteral(resourceName: \"abc.png\") {}
+        """
         let options = FormatOptions(maxWidth: 40, assetLiteralWidth: .visualWidth)
         testFormatting(for: input, rule: .wrap, options: options)
     }

--- a/Tests/Rules/YodaConditionsTests.swift
+++ b/Tests/Rules/YodaConditionsTests.swift
@@ -11,275 +11,439 @@ import XCTest
 
 class YodaConditionsTests: XCTestCase {
     func testNumericLiteralEqualYodaCondition() {
-        let input = "5 == foo"
-        let output = "foo == 5"
+        let input = """
+        5 == foo
+        """
+        let output = """
+        foo == 5
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNumericLiteralGreaterYodaCondition() {
-        let input = "5.1 > foo"
-        let output = "foo < 5.1"
+        let input = """
+        5.1 > foo
+        """
+        let output = """
+        foo < 5.1
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testStringLiteralNotEqualYodaCondition() {
-        let input = "\"foo\" != foo"
-        let output = "foo != \"foo\""
+        let input = """
+        \"foo\" != foo
+        """
+        let output = """
+        foo != \"foo\"
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNilNotEqualYodaCondition() {
-        let input = "nil != foo"
-        let output = "foo != nil"
+        let input = """
+        nil != foo
+        """
+        let output = """
+        foo != nil
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testTrueNotEqualYodaCondition() {
-        let input = "true != foo"
-        let output = "foo != true"
+        let input = """
+        true != foo
+        """
+        let output = """
+        foo != true
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testEnumCaseNotEqualYodaCondition() {
-        let input = ".foo != foo"
-        let output = "foo != .foo"
+        let input = """
+        .foo != foo
+        """
+        let output = """
+        foo != .foo
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testArrayLiteralNotEqualYodaCondition() {
-        let input = "[5, 6] != foo"
-        let output = "foo != [5, 6]"
+        let input = """
+        [5, 6] != foo
+        """
+        let output = """
+        foo != [5, 6]
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNestedArrayLiteralNotEqualYodaCondition() {
-        let input = "[5, [6, 7]] != foo"
-        let output = "foo != [5, [6, 7]]"
+        let input = """
+        [5, [6, 7]] != foo
+        """
+        let output = """
+        foo != [5, [6, 7]]
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testDictionaryLiteralNotEqualYodaCondition() {
-        let input = "[foo: 5, bar: 6] != foo"
-        let output = "foo != [foo: 5, bar: 6]"
+        let input = """
+        [foo: 5, bar: 6] != foo
+        """
+        let output = """
+        foo != [foo: 5, bar: 6]
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testSubscriptNotTreatedAsYodaCondition() {
-        let input = "foo[5] != bar"
+        let input = """
+        foo[5] != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfParenthesizedExpressionNotTreatedAsYodaCondition() {
-        let input = "(foo + bar)[5] != baz"
+        let input = """
+        (foo + bar)[5] != baz
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfUnwrappedValueNotTreatedAsYodaCondition() {
-        let input = "foo![5] != bar"
+        let input = """
+        foo![5] != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfExpressionWithInlineCommentNotTreatedAsYodaCondition() {
-        let input = "foo /* foo */ [5] != bar"
+        let input = """
+        foo /* foo */ [5] != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfCollectionNotTreatedAsYodaCondition() {
-        let input = "[foo][5] != bar"
+        let input = """
+        [foo][5] != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfTrailingClosureNotTreatedAsYodaCondition() {
-        let input = "foo { [5] }[0] != bar"
+        let input = """
+        foo { [5] }[0] != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testSubscriptOfRhsNotMangledInYodaCondition() {
-        let input = "[1] == foo[0]"
-        let output = "foo[0] == [1]"
+        let input = """
+        [1] == foo[0]
+        """
+        let output = """
+        foo[0] == [1]
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testTupleYodaCondition() {
-        let input = "(5, 6) != bar"
-        let output = "bar != (5, 6)"
+        let input = """
+        (5, 6) != bar
+        """
+        let output = """
+        bar != (5, 6)
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testLabeledTupleYodaCondition() {
-        let input = "(foo: 5, bar: 6) != baz"
-        let output = "baz != (foo: 5, bar: 6)"
+        let input = """
+        (foo: 5, bar: 6) != baz
+        """
+        let output = """
+        baz != (foo: 5, bar: 6)
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNestedTupleYodaCondition() {
-        let input = "(5, (6, 7)) != baz"
-        let output = "baz != (5, (6, 7))"
+        let input = """
+        (5, (6, 7)) != baz
+        """
+        let output = """
+        baz != (5, (6, 7))
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testFunctionCallNotTreatedAsYodaCondition() {
-        let input = "foo(5) != bar"
+        let input = """
+        foo(5) != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testCallOfParenthesizedExpressionNotTreatedAsYodaCondition() {
-        let input = "(foo + bar)(5) != baz"
+        let input = """
+        (foo + bar)(5) != baz
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testCallOfUnwrappedValueNotTreatedAsYodaCondition() {
-        let input = "foo!(5) != bar"
+        let input = """
+        foo!(5) != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testCallOfExpressionWithInlineCommentNotTreatedAsYodaCondition() {
-        let input = "foo /* foo */ (5) != bar"
+        let input = """
+        foo /* foo */ (5) != bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testCallOfRhsNotMangledInYodaCondition() {
-        let input = "(1, 2) == foo(0)"
-        let output = "foo(0) == (1, 2)"
+        let input = """
+        (1, 2) == foo(0)
+        """
+        let output = """
+        foo(0) == (1, 2)
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testTrailingClosureOnRhsNotMangledInYodaCondition() {
-        let input = "(1, 2) == foo { $0 }"
-        let output = "foo { $0 } == (1, 2)"
+        let input = """
+        (1, 2) == foo { $0 }
+        """
+        let output = """
+        foo { $0 } == (1, 2)
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testYodaConditionInIfStatement() {
-        let input = "if 5 != foo {}"
-        let output = "if foo != 5 {}"
+        let input = """
+        if 5 != foo {}
+        """
+        let output = """
+        if foo != 5 {}
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testSubscriptYodaConditionInIfStatementWithBraceOnNextLine() {
-        let input = "if [0] == foo.bar[0]\n{ baz() }"
-        let output = "if foo.bar[0] == [0]\n{ baz() }"
+        let input = """
+        if [0] == foo.bar[0]
+        { baz() }
+        """
+        let output = """
+        if foo.bar[0] == [0]
+        { baz() }
+        """
         testFormatting(for: input, output, rule: .yodaConditions,
                        exclude: [.wrapConditionalBodies])
     }
 
     func testYodaConditionInSecondClauseOfIfStatement() {
-        let input = "if foo, 5 != bar {}"
-        let output = "if foo, bar != 5 {}"
+        let input = """
+        if foo, 5 != bar {}
+        """
+        let output = """
+        if foo, bar != 5 {}
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testYodaConditionInExpression() {
-        let input = "let foo = 5 < bar\nbaz()"
-        let output = "let foo = bar > 5\nbaz()"
+        let input = """
+        let foo = 5 < bar
+        baz()
+        """
+        let output = """
+        let foo = bar > 5
+        baz()
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testYodaConditionInExpressionWithTrailingClosure() {
-        let input = "let foo = 5 < bar { baz() }"
-        let output = "let foo = bar { baz() } > 5"
+        let input = """
+        let foo = 5 < bar { baz() }
+        """
+        let output = """
+        let foo = bar { baz() } > 5
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testYodaConditionInFunctionCall() {
-        let input = "foo(5 < bar)"
-        let output = "foo(bar > 5)"
+        let input = """
+        foo(5 < bar)
+        """
+        let output = """
+        foo(bar > 5)
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testYodaConditionFollowedByExpression() {
-        let input = "5 == foo + 6"
-        let output = "foo + 6 == 5"
+        let input = """
+        5 == foo + 6
+        """
+        let output = """
+        foo + 6 == 5
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testPrefixExpressionYodaCondition() {
-        let input = "!false == foo"
-        let output = "foo == !false"
+        let input = """
+        !false == foo
+        """
+        let output = """
+        foo == !false
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testPrefixExpressionYodaCondition2() {
-        let input = "true == !foo"
-        let output = "!foo == true"
+        let input = """
+        true == !foo
+        """
+        let output = """
+        !foo == true
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testPostfixExpressionYodaCondition() {
-        let input = "5<*> == foo"
-        let output = "foo == 5<*>"
+        let input = """
+        5<*> == foo
+        """
+        let output = """
+        foo == 5<*>
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testDoublePostfixExpressionYodaCondition() {
-        let input = "5!! == foo"
-        let output = "foo == 5!!"
+        let input = """
+        5!! == foo
+        """
+        let output = """
+        foo == 5!!
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testPostfixExpressionNonYodaCondition() {
-        let input = "5 == 5<*>"
+        let input = """
+        5 == 5<*>
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testPostfixExpressionNonYodaCondition2() {
-        let input = "5<*> == 5"
+        let input = """
+        5<*> == 5
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testStringEqualsStringNonYodaCondition() {
-        let input = "\"foo\" == \"bar\""
+        let input = """
+        \"foo\" == \"bar\"
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testConstantAfterNullCoalescingNonYodaCondition() {
-        let input = "foo.last ?? -1 < bar"
+        let input = """
+        foo.last ?? -1 < bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionFollowedByAndOperator() {
-        let input = "5 <= foo && foo <= 7"
-        let output = "foo >= 5 && foo <= 7"
+        let input = """
+        5 <= foo && foo <= 7
+        """
+        let output = """
+        foo >= 5 && foo <= 7
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionFollowedByOrOperator() {
-        let input = "5 <= foo || foo <= 7"
-        let output = "foo >= 5 || foo <= 7"
+        let input = """
+        5 <= foo || foo <= 7
+        """
+        let output = """
+        foo >= 5 || foo <= 7
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionFollowedByParentheses() {
-        let input = "0 <= (foo + bar)"
-        let output = "(foo + bar) >= 0"
+        let input = """
+        0 <= (foo + bar)
+        """
+        let output = """
+        (foo + bar) >= 0
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionInTernary() {
-        let input = "let z = 0 < y ? 3 : 4"
-        let output = "let z = y > 0 ? 3 : 4"
+        let input = """
+        let z = 0 < y ? 3 : 4
+        """
+        let output = """
+        let z = y > 0 ? 3 : 4
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionInTernary2() {
-        let input = "let z = y > 0 ? 0 < x : 4"
-        let output = "let z = y > 0 ? x > 0 : 4"
+        let input = """
+        let z = y > 0 ? 0 < x : 4
+        """
+        let output = """
+        let z = y > 0 ? x > 0 : 4
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testNoMangleYodaConditionInTernary3() {
-        let input = "let z = y > 0 ? 3 : 0 < x"
-        let output = "let z = y > 0 ? 3 : x > 0"
+        let input = """
+        let z = y > 0 ? 3 : 0 < x
+        """
+        let output = """
+        let z = y > 0 ? 3 : x > 0
+        """
         testFormatting(for: input, output, rule: .yodaConditions)
     }
 
     func testKeyPathNotMangledAndNotTreatedAsYodaCondition() {
-        let input = "\\.foo == bar"
+        let input = """
+        \\.foo == bar
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
     func testEnumCaseLessThanEnumCase() {
-        let input = "XCTAssertFalse(.never < .never)"
+        let input = """
+        XCTAssertFalse(.never < .never)
+        """
         testFormatting(for: input, rule: .yodaConditions)
     }
 
@@ -298,7 +462,9 @@ class YodaConditionsTests: XCTestCase {
     // yodaSwap = literalsOnly
 
     func testNoSwapYodaDotMember() {
-        let input = "foo(where: .bar == baz)"
+        let input = """
+        foo(where: .bar == baz)
+        """
         let options = FormatOptions(yodaSwap: .literalsOnly)
         testFormatting(for: input, rule: .yodaConditions, options: options)
     }


### PR DESCRIPTION
This PR updates the rule test suite to use multi-line strings.

Many older test cases predate multi-line strings, but would be easier to read and modify as multi-line strings.

We could leave existing single-line test cases as standard string literals, but I like using multi-line strings everywhere for consistency and extensibility (easier to add more lines to an existing test case that already uses multi-line strings).