### PR TITLE
Prototype rule to convert single-line strings with escaped newlines to multi-line strings

### DIFF
--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -152,7 +152,11 @@ func printRuleInfo(for name: String, as type: CLI.OutputType) throws {
         return
     }
     if !rule.options.isEmpty {
-        print("\nOptions:\n", as: type)
+        print("""
+        
+        Options:
+        
+        """, as: type)
         print(rule.options.compactMap {
             guard let descriptor = Descriptors.byName[$0], !descriptor.isDeprecated else {
                 return nil
@@ -166,12 +170,22 @@ func printRuleInfo(for name: String, as type: CLI.OutputType) throws {
     }
     if var examples = rule.examples {
         examples = examples
-            .replacingOccurrences(of: "```diff\n", with: "")
-            .replacingOccurrences(of: "```\n", with: "")
+            .replacingOccurrences(of: """
+            ```diff
+            
+            """, with: "")
+            .replacingOccurrences(of: """
+            ```
+            
+            """, with: "")
         if examples.hasSuffix("```") {
             examples = String(examples.dropLast(3))
         }
-        print("\nExamples:\n", as: type)
+        print("""
+        
+        Examples:
+        
+        """, as: type)
         print(examples, as: type)
     }
     print("")

--- a/Sources/GithubActionsLogReporter.swift
+++ b/Sources/GithubActionsLogReporter.swift
@@ -54,7 +54,10 @@ final class GithubActionsLogReporter: Reporter {
     func write() throws -> Data? {
         let output = changes.reduce(into: "") { output, change in
             let file = workspaceRelativePath(filePath: change.filePath ?? "")
-            output += "::warning file=\(file),line=\(change.line)::\(change.help) (\(change.rule.name))\n"
+            output += """
+            ::warning file=\(file),line=\(change.line)::\(change.help) (\(change.rule.name))
+            
+            """
         }
         return Data(output.utf8)
     }

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -54,6 +54,7 @@ let ruleRegistry: [String: FormatRule] = [
     "markTypes": .markTypes,
     "modifierOrder": .modifierOrder,
     "modifiersOnSameLine": .modifiersOnSameLine,
+    "multilineStrings": .multilineStrings,
     "noExplicitOwnership": .noExplicitOwnership,
     "noGuardInTests": .noGuardInTests,
     "numberFormatting": .numberFormatting,

--- a/Sources/Rules/MultilineStrings.swift
+++ b/Sources/Rules/MultilineStrings.swift
@@ -1,0 +1,67 @@
+//
+//  MultilineStrings.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 7/26/2025.
+//  Copyright © 2025 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Convert single-line strings containing escaped newlines to multi-line strings
+    static let multilineStrings = FormatRule(
+        help: "Convert single-line strings containing escaped newlines to multi-line strings.",
+        options: []
+    ) { formatter in
+        formatter.forEach(.startOfScope("\"")) { startIndex, _ in
+            guard let endIndex = formatter.endOfScope(at: startIndex) else {
+                return
+            }
+
+            let stringBodyRange = (startIndex + 1) ..< endIndex
+            let stringContent = formatter.tokens[stringBodyRange].string
+
+            guard stringContent.contains("\\n") else { return }
+
+            let unescapedContent = stringContent
+                .replacingOccurrences(of: "\\n", with: "\n")
+                .replacingOccurrences(of: "\\r", with: "\r")
+                .replacingOccurrences(of: "\\t", with: "\t")
+                .replacingOccurrences(of: "\\0", with: "\0")
+                .replacingOccurrences(of: "\\", with: "")
+
+            // Skip strings that contain only whitespace characters and escape sequences
+            guard !unescapedContent.allSatisfy({ $0.isWhitespace || $0.isNewline }) else { return }
+
+            // Get the current line's indentation
+            let currentIndent = formatter.currentIndentForLine(at: startIndex)
+
+            // Convert escaped newlines to actual newlines
+            let convertedContent = stringContent.replacingOccurrences(of: "\\n", with: "\n\(currentIndent)")
+
+            // Replace with multi-line string tokens
+            let newTokens: [Token] = [
+                .startOfScope("\"\"\""),
+                .linebreak("\n", 0),
+                .space(currentIndent),
+                .stringBody(convertedContent),
+                .linebreak("\n", 0),
+                .space(currentIndent),
+                .endOfScope("\"\"\""),
+            ]
+
+            formatter.replaceTokens(in: startIndex ... endIndex, with: newTokens)
+        }
+    } examples: {
+        """
+        ```diff
+        - let message = "Hello\\nWorld"
+        + let message = \"\"\"
+        + Hello
+        + World
+        + \"\"\"
+        ```
+        """
+    }
+}

--- a/Sources/Rules/MultilineStrings.swift
+++ b/Sources/Rules/MultilineStrings.swift
@@ -38,7 +38,10 @@ public extension FormatRule {
             let currentIndent = formatter.currentIndentForLine(at: startIndex)
 
             // Convert escaped newlines to actual newlines
-            let convertedContent = stringContent.replacingOccurrences(of: "\\n", with: "\n\(currentIndent)")
+            let convertedContent = stringContent.replacingOccurrences(of: "\\n", with: """
+            
+            \(currentIndent)
+            """)
 
             // Replace with multi-line string tokens
             let newTokens: [Token] = [

--- a/Sources/Rules/PreferSwiftTesting.swift
+++ b/Sources/Rules/PreferSwiftTesting.swift
@@ -174,9 +174,15 @@ extension TypeDeclaration {
         // as @MainActor for maximum compatibility.
         let startOfModifiers = formatter.startOfModifiers(at: keywordIndex, includingAttributes: true)
         if !modifiers.contains("@MainActor") {
-            formatter.insert(tokenize("@MainActor @Suite(.serialized)\n"), at: startOfModifiers)
+            formatter.insert(tokenize("""
+            @MainActor @Suite(.serialized)
+            
+            """), at: startOfModifiers)
         } else {
-            formatter.insert(tokenize("@Suite(.serialized)\n"), at: startOfModifiers)
+            formatter.insert(tokenize("""
+            @Suite(.serialized)
+            
+            """), at: startOfModifiers)
         }
 
         let instanceMethods = body.filter { $0.keyword == "func" && !$0.modifiers.contains("static") }

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -594,7 +594,10 @@ extension Collection<Token> where Index == Int {
 extension UnicodeScalar {
     var isDigit: Bool { isdigit(Int32(value)) > 0 }
     var isHexDigit: Bool { isxdigit(Int32(value)) > 0 }
-    var isLinebreak: Bool { "\n\r\u{000B}\u{000C}".unicodeScalars.contains(self) }
+    var isLinebreak: Bool { """
+    
+    \r\u{000B}\u{000C}
+    """.unicodeScalars.contains(self) }
     var isSpace: Bool {
         switch value {
         case 0x0009, 0x0011, 0x0012, 0x0020,

--- a/Sources/XMLReporter.swift
+++ b/Sources/XMLReporter.swift
@@ -48,11 +48,17 @@ final class XMLReporter: Reporter {
     func write() throws -> Data? {
         let fileChanges = Dictionary(grouping: changes, by: { $0.filePath ?? "<nopath>" })
         let report = [
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">",
+            """
+            <?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <checkstyle version=\"4.3\">
+            """,
             fileChanges
                 .sorted(by: { $0.key < $1.key })
                 .map(generateChangeForFile).joined(),
-            "\n</checkstyle>",
+            """
+            
+            </checkstyle>
+            """,
         ].joined()
 
         return Data(report.utf8)
@@ -62,7 +68,13 @@ final class XMLReporter: Reporter {
 private extension XMLReporter {
     func generateChangeForFile(_ file: String, fileChanges: [Formatter.Change]) -> String {
         [
-            "\n\t<file name=\"", file, "\">\n",
+            """
+            
+            \t<file name=\"
+            """, file, """
+            \">
+            
+            """,
             fileChanges.map(generateChange).joined(),
             "\t</file>",
         ].joined()
@@ -79,7 +91,10 @@ private extension XMLReporter {
             "column=\"\(col)\" ",
             "severity=\"", severity, "\" ",
             "message=\"", reason, "\" ",
-            "source=\"\(rule)\"/>\n",
+            """
+            source=\"\(rule)\"/>
+            
+            """,
         ].joined()
     }
 }

--- a/Tests/ArgumentsTests.swift
+++ b/Tests/ArgumentsTests.swift
@@ -48,7 +48,10 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testParseEscapedN() {
-        let input = "hello\\nworld"
+        let input = """
+        hello\
+        world
+        """
         let output = ["", "hellonworld"]
         XCTAssertEqual(parseArguments(input), output)
     }
@@ -72,8 +75,14 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testParseQuotedEscapedN() {
-        let input = "\"hello\\nworld\""
-        let output = ["", "hello\\nworld"]
+        let input = """
+        \"hello\
+        world\"
+        """
+        let output = ["", """
+        hello\
+        world
+        """]
         XCTAssertEqual(parseArguments(input), output)
     }
 
@@ -323,9 +332,15 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testFileHeaderOptionToArguments() throws {
-        let options = FormatOptions(fileHeader: "//  Hello World\n//  Goodbye World")
+        let options = FormatOptions(fileHeader: """
+        //  Hello World
+        //  Goodbye World
+        """)
         let args = argumentsFor(Options(formatOptions: options), excludingDefaults: true)
-        XCTAssertEqual(args["header"], "//  Hello World\\n//  Goodbye World")
+        XCTAssertEqual(args["header"], """
+        //  Hello World\
+        //  Goodbye World
+        """)
     }
 
     // TODO: should this go in OptionDescriptorTests instead?
@@ -437,11 +452,17 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testParseArgumentsContainingEscapedCharacters() throws {
-        let config = "--header hello\\ world\\ngoodbye\\ world"
+        let config = """
+        --header hello\\ world\
+        goodbye\\ world
+        """
         let data = Data(config.utf8)
         let args = try parseConfigFile(data)
         XCTAssertEqual(args.count, 1)
-        XCTAssertEqual(args["header"], "hello world\\ngoodbye world")
+        XCTAssertEqual(args["header"], """
+        hello world\
+        goodbye world
+        """)
     }
 
     func testParseArgumentsContainingQuotedCharacters() throws {
@@ -451,7 +472,10 @@ class ArgumentsTests: XCTestCase {
         let data = Data(config.utf8)
         let args = try parseConfigFile(data)
         XCTAssertEqual(args.count, 1)
-        XCTAssertEqual(args["header"], "hello world\\ngoodbye world")
+        XCTAssertEqual(args["header"], """
+        hello world\
+        goodbye world
+        """)
     }
 
     func testParseIgnoreFileHeader() throws {
@@ -522,15 +546,27 @@ class ArgumentsTests: XCTestCase {
     }
 
     func testSerializeFileHeaderContainingLinebreak() throws {
-        let options = Options(formatOptions: FormatOptions(fileHeader: "//hello\nworld"))
+        let options = Options(formatOptions: FormatOptions(fileHeader: """
+        //hello
+        world
+        """))
         let config = serialize(options: options, excludingDefaults: true)
-        XCTAssertEqual(config, "--header //hello\\nworld")
+        XCTAssertEqual(config, """
+        --header //hello\
+        world
+        """)
     }
 
     func testSerializeFileHeaderContainingLinebreakAndSpaces() throws {
-        let options = Options(formatOptions: FormatOptions(fileHeader: "// hello\n// world"))
+        let options = Options(formatOptions: FormatOptions(fileHeader: """
+        // hello
+        // world
+        """))
         let config = serialize(options: options, excludingDefaults: true)
-        XCTAssertEqual(config, "--header \"// hello\\n// world\"")
+        XCTAssertEqual(config, """
+        --header \"// hello\
+        // world\"
+        """)
     }
 
     func testSerializeOptionsWithPoundCharacter() throws {

--- a/Tests/CodeOrganizationTests.swift
+++ b/Tests/CodeOrganizationTests.swift
@@ -206,7 +206,10 @@ class CodeOrganizationTests: XCTestCase {
 
                 let stringContent = formatter.tokens[stringBodyRange].map(\.string).joined()
                 let currentIndent = formatter.currentIndentForLine(at: startOfString)
-                let convertedContent = stringContent.replacingOccurrences(of: "\\n", with: "\n\(currentIndent)")
+                let convertedContent = stringContent.replacingOccurrences(of: "\\n", with: """
+                
+                \(currentIndent)
+                """)
 
                 let newTokens: [Token] = [
                     .startOfScope("\"\"\""),

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -77,7 +77,12 @@ class CommandLineTests: XCTestCase {
         CLI.print = { message, type in
             switch type {
             case .raw, .content:
-                XCTAssertEqual(message, "func foo() {\n    bar()\n}\n")
+                XCTAssertEqual(message, """
+                func foo() {
+                    bar()
+                }
+                
+                """)
             case .error, .warning:
                 XCTFail()
             case .info, .success:
@@ -89,11 +94,20 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo()\n"
+                return """
+                func foo()
+                
+                """
             case 2:
-                return "{\n"
+                return """
+                {
+                
+                """
             case 3:
-                return "bar()\n"
+                return """
+                bar()
+                
+                """
             case 4:
                 return "}"
             default:
@@ -149,11 +163,20 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo()\n"
+                return """
+                func foo()
+                
+                """
             case 2:
-                return "{\n"
+                return """
+                {
+                
+                """
             case 3:
-                return "bar() + baaz() + 25\n"
+                return """
+                bar() + baaz() + 25
+                
+                """
             case 4:
                 return "}"
             default:
@@ -168,7 +191,11 @@ class CommandLineTests: XCTestCase {
         CLI.print = { message, type in
             switch type {
             case .raw, .content:
-                XCTAssertEqual(message, "func foo() {\n}\n")
+                XCTAssertEqual(message, """
+                func foo() {
+                }
+                
+                """)
             case .error, .warning:
                 XCTFail()
             case .info, .success:
@@ -180,9 +207,15 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo() {\n"
+                return """
+                func foo() {
+                
+                """
             case 2:
-                return "}\n"
+                return """
+                }
+                
+                """
             default:
                 return nil
             }
@@ -201,7 +234,11 @@ class CommandLineTests: XCTestCase {
         CLI.print = { message, type in
             switch type {
             case .raw, .content:
-                XCTAssertEqual(message, "func foo() {\n}\n")
+                XCTAssertEqual(message, """
+                func foo() {
+                }
+                
+                """)
             case .error, .warning:
                 XCTFail()
             case .info, .success:
@@ -213,9 +250,15 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo() {\n"
+                return """
+                func foo() {
+                
+                """
             case 2:
-                return "}\n"
+                return """
+                }
+                
+                """
             default:
                 return nil
             }
@@ -236,7 +279,11 @@ class CommandLineTests: XCTestCase {
         CLI.print = { message, type in
             switch type {
             case .raw, .content:
-                XCTAssertEqual(message, "func foo() {\n}\n")
+                XCTAssertEqual(message, """
+                func foo() {
+                }
+                
+                """)
             case .error, .warning:
                 XCTFail()
             case .info, .success:
@@ -248,9 +295,15 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo() {\n"
+                return """
+                func foo() {
+                
+                """
             case 2:
-                return "}\n"
+                return """
+                }
+                
+                """
             default:
                 return nil
             }
@@ -271,7 +324,10 @@ class CommandLineTests: XCTestCase {
         CLI.print = { message, type in
             switch type {
             case .raw, .content:
-                XCTAssertEqual(message, "func foo() {}\n")
+                XCTAssertEqual(message, """
+                func foo() {}
+                
+                """)
             case .error, .warning:
                 XCTFail()
             case .info, .success:
@@ -283,9 +339,15 @@ class CommandLineTests: XCTestCase {
             readCount += 1
             switch readCount {
             case 1:
-                return "func foo() {\n"
+                return """
+                func foo() {
+                
+                """
             case 2:
-                return "}\n"
+                return """
+                }
+                
+                """
             default:
                 return nil
             }
@@ -409,13 +471,19 @@ class CommandLineTests: XCTestCase {
 
     func testCacheMiss() throws {
         let input = "let foo = bar"
-        let output = "let foo = bar\n"
+        let output = """
+        let foo = bar
+        
+        """
         XCTAssertNotEqual(computeHash(input), computeHash(output))
     }
 
     func testCachePotentialFalsePositive() throws {
         let input = "let foo = bar;"
-        let output = "let foo = bar\n"
+        let output = """
+        let foo = bar
+        
+        """
         XCTAssertNotEqual(computeHash(input), computeHash(output))
     }
 
@@ -636,7 +704,11 @@ class CommandLineTests: XCTestCase {
 
     func testJSONReporterEndToEnd() throws {
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { message, type in
                 switch type {
@@ -663,7 +735,11 @@ class CommandLineTests: XCTestCase {
     func testJSONReporterInferredFromURL() throws {
         let outputURL = try createTmpFile("report.json", contents: "")
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { _, _ in }
             _ = processArguments([
@@ -680,7 +756,11 @@ class CommandLineTests: XCTestCase {
 
     func testGithubActionsLogReporterEndToEnd() throws {
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { message, type in
                 switch type {
@@ -708,7 +788,11 @@ class CommandLineTests: XCTestCase {
 
     func testGithubActionsLogReporterMisspelled() throws {
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { message, type in
                 switch type {
@@ -732,7 +816,11 @@ class CommandLineTests: XCTestCase {
 
     func testXMLReporterEndToEnd() throws {
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { message, type in
                 switch type {
@@ -759,7 +847,11 @@ class CommandLineTests: XCTestCase {
     func testXMLReporterInferredFromURL() throws {
         let outputURL = try createTmpFile("report.xml", contents: "")
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { _, _ in }
             _ = processArguments([
@@ -776,7 +868,11 @@ class CommandLineTests: XCTestCase {
 
     func testSARIFReporterEndToEnd() throws {
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { message, type in
                 switch type {
@@ -803,7 +899,11 @@ class CommandLineTests: XCTestCase {
     func testSARIFReporterInferredFromURL() throws {
         let outputURL = try createTmpFile("report.sarif", contents: "")
         try withTmpFiles([
-            "foo.swift": "func foo() {\n}\n",
+            "foo.swift": """
+            func foo() {
+            }
+            
+            """,
         ]) { url in
             CLI.print = { _, _ in }
             _ = processArguments([

--- a/Tests/FormatterTests.swift
+++ b/Tests/FormatterTests.swift
@@ -115,14 +115,28 @@ class FormatterTests: XCTestCase {
     // MARK: enable/disable directives
 
     func testDisableRule() {
-        let input = "//swiftformat:disable spaceAroundOperators\nlet foo : Int=5;"
-        let output = "// swiftformat:disable spaceAroundOperators\nlet foo : Int=5\n"
+        let input = """
+        //swiftformat:disable spaceAroundOperators
+        let foo : Int=5;
+        """
+        let output = """
+        // swiftformat:disable spaceAroundOperators
+        let foo : Int=5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testDirectiveInMiddleOfComment() {
-        let input = "//fixme: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5;"
-        let output = "// FIXME: swiftformat:disable spaceAroundOperators - bug\nlet foo : Int=5\n"
+        let input = """
+        //fixme: swiftformat:disable spaceAroundOperators - bug
+        let foo : Int=5;
+        """
+        let output = """
+        // FIXME: swiftformat:disable spaceAroundOperators - bug
+        let foo : Int=5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
@@ -163,7 +177,10 @@ class FormatterTests: XCTestCase {
     }
 
     func testDisableAllRules() {
-        let input = "//swiftformat:disable all\nlet foo : Int=5;"
+        let input = """
+        //swiftformat:disable all
+        let foo : Int=5;
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, input)
     }
 
@@ -204,38 +221,84 @@ class FormatterTests: XCTestCase {
     }
 
     func testDisableAllRulesAndReEnableOneRule() {
-        let input = "//swiftformat:disable all\nlet foo : Int=5;\n//swiftformat:enable linebreakAtEndOfFile"
-        let output = "//swiftformat:disable all\nlet foo : Int=5;\n//swiftformat:enable linebreakAtEndOfFile\n"
+        let input = """
+        //swiftformat:disable all
+        let foo : Int=5;
+        //swiftformat:enable linebreakAtEndOfFile
+        """
+        let output = """
+        //swiftformat:disable all
+        let foo : Int=5;
+        //swiftformat:enable linebreakAtEndOfFile
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testDisableNext() {
-        let input = "//swiftformat:disable:next all\nlet foo : Int=5;\nlet foo : Int=5;"
-        let output = "// swiftformat:disable:next all\nlet foo : Int=5;\nlet foo: Int = 5\n"
+        let input = """
+        //swiftformat:disable:next all
+        let foo : Int=5;
+        let foo : Int=5;
+        """
+        let output = """
+        // swiftformat:disable:next all
+        let foo : Int=5;
+        let foo: Int = 5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testEnableNext() {
-        let input = "//swiftformat:disable all\n//swiftformat:enable:next all\nlet foo : Int=5;\nlet foo : Int=5;"
-        let output = "//swiftformat:disable all\n//swiftformat:enable:next all\nlet foo: Int = 5\nlet foo : Int=5;"
+        let input = """
+        //swiftformat:disable all
+        //swiftformat:enable:next all
+        let foo : Int=5;
+        let foo : Int=5;
+        """
+        let output = """
+        //swiftformat:disable all
+        //swiftformat:enable:next all
+        let foo: Int = 5
+        let foo : Int=5;
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testDisableThis() {
-        let input = "let foo : Int=5; // swiftformat:disable:this all\nlet foo : Int=5;"
-        let output = "let foo : Int=5; // swiftformat:disable:this all\nlet foo: Int = 5\n"
+        let input = """
+        let foo : Int=5; // swiftformat:disable:this all
+        let foo : Int=5;
+        """
+        let output = """
+        let foo : Int=5; // swiftformat:disable:this all
+        let foo: Int = 5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testEnableThis() {
-        let input = "//swiftformat:disable all\nlet foo : Int=5; //swiftformat:enable:this all\nlet foo : Int=5;"
-        let output = "//swiftformat:disable all\nlet foo: Int = 5 // swiftformat:enable:this all\nlet foo : Int=5;"
+        let input = """
+        //swiftformat:disable all
+        let foo : Int=5; //swiftformat:enable:this all
+        let foo : Int=5;
+        """
+        let output = """
+        //swiftformat:disable all
+        let foo: Int = 5 // swiftformat:enable:this all
+        let foo : Int=5;
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testDisableRuleWithMultilineComment() {
         let input = "/*swiftformat:disable spaceAroundOperators*/let foo : Int=5;"
-        let output = "/* swiftformat:disable spaceAroundOperators */ let foo : Int=5\n"
+        let output = """
+        /* swiftformat:disable spaceAroundOperators */ let foo : Int=5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
@@ -257,14 +320,33 @@ class FormatterTests: XCTestCase {
     }
 
     func testDisableNextWithMultilineComment() {
-        let input = "/*swiftformat:disable:next all*/\nlet foo : Int=5;\nlet foo : Int=5;"
-        let output = "/* swiftformat:disable:next all */\nlet foo : Int=5;\nlet foo: Int = 5\n"
+        let input = """
+        /*swiftformat:disable:next all*/
+        let foo : Int=5;
+        let foo : Int=5;
+        """
+        let output = """
+        /* swiftformat:disable:next all */
+        let foo : Int=5;
+        let foo: Int = 5
+        
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
     func testEnableNextWithMultilineComment() {
-        let input = "//swiftformat:disable all\n/*swiftformat:enable:next all*/\nlet foo : Int=5;\nlet foo : Int=5;"
-        let output = "//swiftformat:disable all\n/*swiftformat:enable:next all*/\nlet foo: Int = 5\nlet foo : Int=5;"
+        let input = """
+        //swiftformat:disable all
+        /*swiftformat:enable:next all*/
+        let foo : Int=5;
+        let foo : Int=5;
+        """
+        let output = """
+        //swiftformat:disable all
+        /*swiftformat:enable:next all*/
+        let foo: Int = 5
+        let foo : Int=5;
+        """
         XCTAssertEqual(try format(input, rules: FormatRules.default).output, output)
     }
 
@@ -570,7 +652,10 @@ class FormatterTests: XCTestCase {
     // MARK: change tracking
 
     func testTrackChangesInFirstLine() {
-        let formatter = Formatter(tokenize("foo bar\nbaz"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo bar
+        baz
+        """), trackChanges: true)
         let tokens = formatter.tokens
         formatter.removeLastToken()
         XCTAssertNotEqual(formatter.tokens, tokens)
@@ -579,7 +664,11 @@ class FormatterTests: XCTestCase {
     }
 
     func testTrackChangesInSecondLine() {
-        let formatter = Formatter(tokenize("foo\nbar\nbaz"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo
+        bar
+        baz
+        """), trackChanges: true)
         let tokens = formatter.tokens
         formatter.removeToken(at: formatter.tokens.firstIndex(of: .identifier("bar"))!)
         XCTAssertNotEqual(formatter.tokens, tokens)
@@ -588,7 +677,11 @@ class FormatterTests: XCTestCase {
     }
 
     func testTrackChangesInLastLine() {
-        let formatter = Formatter(tokenize("foo\nbar\nbaz"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo
+        bar
+        baz
+        """), trackChanges: true)
         let tokens = formatter.tokens
         formatter.removeLastToken()
         XCTAssertNotEqual(formatter.tokens, tokens)
@@ -614,7 +707,12 @@ class FormatterTests: XCTestCase {
     }
 
     func testTrackRemovalOfBlankLineFollowedByBlankLine() {
-        let formatter = Formatter(tokenize("foo\n\n\n"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo
+        
+        
+        
+        """), trackChanges: true)
         let tokens = formatter.tokens
         formatter.removeToken(at: 2)
         XCTAssertNotEqual(formatter.tokens, tokens)
@@ -623,7 +721,12 @@ class FormatterTests: XCTestCase {
     }
 
     func testTrackRemovalOfBlankLineAfterBlankLine() {
-        let formatter = Formatter(tokenize("foo\n\n\n"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo
+        
+        
+        
+        """), trackChanges: true)
         let tokens = formatter.tokens
         formatter.removeLastToken()
         XCTAssertNotEqual(formatter.tokens, tokens)
@@ -632,17 +735,33 @@ class FormatterTests: XCTestCase {
     }
 
     func testMoveTokensToEarlierPositionTrackedAsMoves() {
-        let formatter = Formatter(tokenize("foo()\nbar()\n"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo()
+        bar()
+        
+        """), trackChanges: true)
         formatter.moveTokens(in: 4 ... 7, to: 0)
-        XCTAssertEqual(sourceCode(for: formatter.tokens), "bar()\nfoo()\n")
+        XCTAssertEqual(sourceCode(for: formatter.tokens), """
+        bar()
+        foo()
+        
+        """)
         XCTAssert(!formatter.changes.isEmpty)
         XCTAssert(formatter.changes.allSatisfy(\.isMove))
     }
 
     func testMoveTokensToFollowingPositionTrackedAsMoves() {
-        let formatter = Formatter(tokenize("foo()\nbar()\n"), trackChanges: true)
+        let formatter = Formatter(tokenize("""
+        foo()
+        bar()
+        
+        """), trackChanges: true)
         formatter.moveTokens(in: 0 ... 3, to: 8)
-        XCTAssertEqual(sourceCode(for: formatter.tokens), "bar()\nfoo()\n")
+        XCTAssertEqual(sourceCode(for: formatter.tokens), """
+        bar()
+        foo()
+        
+        """)
         XCTAssert(!formatter.changes.isEmpty)
         XCTAssert(formatter.changes.allSatisfy(\.isMove))
     }

--- a/Tests/InferenceTests.swift
+++ b/Tests/InferenceTests.swift
@@ -104,7 +104,12 @@ class InferenceTests: XCTestCase {
     // MARK: linebreak
 
     func testInferLinebreaks() {
-        let input = "foo\nbar\r\nbaz\rquux\r\n"
+        let input = """
+        foo
+        bar\r
+        baz\rquux\r
+        
+        """
         let output = "\r\n"
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.linebreak, output)
@@ -119,13 +124,19 @@ class InferenceTests: XCTestCase {
     }
 
     func testInferNoAllowInlineSemicolons() {
-        let input = "let foo = 5\nlet bar = 6"
+        let input = """
+        let foo = 5
+        let bar = 6
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.semicolons, .never)
     }
 
     func testNoInferAllowInlineSemicolonsFromTerminatingSemicolon() {
-        let input = "let foo = 5;\nlet bar = 6"
+        let input = """
+        let foo = 5;
+        let bar = 6
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.semicolons, .never)
     }
@@ -147,13 +158,27 @@ class InferenceTests: XCTestCase {
     // MARK: trailingCommas
 
     func testInferTrailingCommas() {
-        let input = "let foo = [\nbar,\n]\n let baz = [\nquux\n]"
+        let input = """
+        let foo = [
+        bar,
+        ]
+         let baz = [
+        quux
+        ]
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.trailingCommas, .always)
     }
 
     func testInferNoTrailingCommas() {
-        let input = "let foo = [\nbar\n]\n let baz = [\nquux\n]"
+        let input = """
+        let foo = [
+        bar
+        ]
+         let baz = [
+        quux
+        ]
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.trailingCommas, .never)
     }
@@ -161,7 +186,17 @@ class InferenceTests: XCTestCase {
     // MARK: truncateBlankLines
 
     func testInferNoTruncateBlanklines() {
-        let input = "class Foo {\n    \nfunc bar() {\n        \n        //baz\n\n}\n    \n}"
+        let input = """
+        class Foo {
+            
+        func bar() {
+                
+                //baz
+        
+        }
+            
+        }
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertFalse(options.truncateBlankLines)
     }
@@ -169,7 +204,18 @@ class InferenceTests: XCTestCase {
     // MARK: allmanBraces
 
     func testInferAllmanComments() {
-        let input = "func foo()\n{\n}\n\nfunc bar() {\n}\n\nfunc baz()\n{\n}"
+        let input = """
+        func foo()
+        {
+        }
+        
+        func bar() {
+        }
+        
+        func baz()
+        {
+        }
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertTrue(options.allmanBraces)
     }
@@ -177,35 +223,67 @@ class InferenceTests: XCTestCase {
     // MARK: ifdefIndent
 
     func testInferIfdefIndent() {
-        let input = "#if foo\n    //foo\n#endif"
+        let input = """
+        #if foo
+            //foo
+        #endif
+        """
         let output = IndentMode.indent
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.ifdefIndent, output)
     }
 
     func testInferIdententIfdefIndent() {
-        let input = "{\n    {\n#    if foo\n        //foo\n    #endif\n    }\n}"
+        let input = """
+        {
+            {
+        #    if foo
+                //foo
+            #endif
+            }
+        }
+        """
         let output = IndentMode.indent
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.ifdefIndent, output)
     }
 
     func testInferIfdefNoIndent() {
-        let input = "#if foo\n//foo\n#endif"
+        let input = """
+        #if foo
+        //foo
+        #endif
+        """
         let output = IndentMode.noIndent
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.ifdefIndent, output)
     }
 
     func testInferIdententIfdefNoIndent() {
-        let input = "{\n    {\n    #if foo\n    //foo\n    #endif\n    }\n}"
+        let input = """
+        {
+            {
+            #if foo
+            //foo
+            #endif
+            }
+        }
+        """
         let output = IndentMode.noIndent
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.ifdefIndent, output)
     }
 
     func testInferIndentedIfdefOutdent() {
-        let input = "{\n    {\n#if foo\n        //foo\n#endif\n    }\n}"
+        let input = """
+        {
+            {
+        #if foo
+                //foo
+        #endif
+            }
+        }
+        """
         let output = IndentMode.outdent
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.ifdefIndent, output)
@@ -281,13 +359,19 @@ class InferenceTests: XCTestCase {
     // MARK: wrapCollections
 
     func testInferWrapElementsAfterFirstArgument() {
-        let input = "[foo: 1,\n    bar: 2, baz: 3]"
+        let input = """
+        [foo: 1,
+            bar: 2, baz: 3]
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.wrapCollections, .afterFirst)
     }
 
     func testInferWrapElementsAfterSecondArgument() {
-        let input = "[foo, bar,\n]"
+        let input = """
+        [foo, bar,
+        ]
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.wrapCollections, .afterFirst)
     }
@@ -295,13 +379,30 @@ class InferenceTests: XCTestCase {
     // MARK: closingParenPosition
 
     func testInferParenOnSameLine() {
-        let input = "func foo(\n    bar: Int,\n    baz: String) {\n}\nfunc foo(\n    bar: Int,\n    baz: String)"
+        let input = """
+        func foo(
+            bar: Int,
+            baz: String) {
+        }
+        func foo(
+            bar: Int,
+            baz: String)
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.closingParenPosition, .sameLine)
     }
 
     func testInferParenOnNextLine() {
-        let input = "func foo(\n    bar: Int,\n    baz: String) {\n}\nfunc foo(\n    bar: Int,\n    baz: String\n)"
+        let input = """
+        func foo(
+            bar: Int,
+            baz: String) {
+        }
+        func foo(
+            bar: Int,
+            baz: String
+        )
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.closingParenPosition, .balanced)
     }
@@ -579,19 +680,31 @@ class InferenceTests: XCTestCase {
     // MARK: elseOnNextLine
 
     func testInferElseOnNextLine() {
-        let input = "if foo {\n}\nelse {}"
+        let input = """
+        if foo {
+        }
+        else {}
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.elsePosition, .nextLine)
     }
 
     func testInferElseOnSameLine() {
-        let input = "if foo {\n} else {}"
+        let input = """
+        if foo {
+        } else {}
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.elsePosition, .sameLine)
     }
 
     func testIgnoreInlineIfElse() {
-        let input = "if foo {} else {}\nif foo {\n}\nelse {}"
+        let input = """
+        if foo {} else {}
+        if foo {
+        }
+        else {}
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertEqual(options.elsePosition, .nextLine)
     }
@@ -599,13 +712,21 @@ class InferenceTests: XCTestCase {
     // MARK: indentCase
 
     func testInferIndentCase() {
-        let input = "switch {\n    case foo: break\n}"
+        let input = """
+        switch {
+            case foo: break
+        }
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertTrue(options.indentCase)
     }
 
     func testInferNoIndentCase() {
-        let input = "switch {\ncase foo: break\n}"
+        let input = """
+        switch {
+        case foo: break
+        }
+        """
         let options = inferFormatOptions(from: tokenize(input))
         XCTAssertFalse(options.indentCase)
     }

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -36,42 +36,86 @@ class MetadataTests: XCTestCase {
 
     // NOTE: if test fails, just run it again locally to update rules file
     func testGenerateRulesDocumentation() throws {
-        var result = "# Default Rules (enabled by default)\n"
+        var result = """
+        # Default Rules (enabled by default)
+        
+        """
         for rule in FormatRules.default {
-            result += "\n* [\(rule.name)](#\(rule.name))"
+            result += """
+            
+            * [\(rule.name)](#\(rule.name))
+            """
         }
 
-        result += "\n\n# Opt-in Rules (disabled by default)\n"
+        result += """
+        
+        
+        # Opt-in Rules (disabled by default)
+        
+        """
         for rule in FormatRules.disabledByDefault {
             guard !rule.isDeprecated else {
                 continue
             }
-            result += "\n* [\(rule.name)](#\(rule.name))"
+            result += """
+            
+            * [\(rule.name)](#\(rule.name))
+            """
         }
 
         let deprecatedRules = FormatRules.all.filter(\.isDeprecated)
         if !deprecatedRules.isEmpty {
-            result += "\n\n# Deprecated Rules (do not use)\n"
+            result += """
+            
+            
+            # Deprecated Rules (do not use)
+            
+            """
             for rule in deprecatedRules {
-                result += "\n* [\(rule.name)](#\(rule.name))"
+                result += """
+                
+                * [\(rule.name)](#\(rule.name))
+                """
             }
         }
 
-        result += "\n\n----------"
+        result += """
+        
+        
+        ----------
+        """
         for rule in FormatRules.all {
-            result += "\n\n## \(rule.name)\n\n\(rule.help)"
+            result += """
+            
+            
+            ## \(rule.name)
+            
+            \(rule.help)
+            """
             if let message = rule.deprecationMessage {
-                result += "\n\n*Note: \(rule.name) rule is deprecated. \(message)*"
+                result += """
+                
+                
+                *Note: \(rule.name) rule is deprecated. \(message)*
+                """
                 continue
             }
             if !rule.options.isEmpty {
-                result += "\n\nOption | Description\n--- | ---"
+                result += """
+                
+                
+                Option | Description
+                --- | ---
+                """
                 for option in rule.options {
                     let descriptor = Descriptors.byName[option]!
                     guard !descriptor.isDeprecated else {
                         continue
                     }
-                    result += "\n`--\(option)` | \(descriptor.help)"
+                    result += """
+                    
+                    `--\(option)` | \(descriptor.help)
+                    """
                 }
             }
             if let examples = rule.examples {

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -200,27 +200,99 @@ class OptionDescriptorTests: XCTestCase {
         let validations: [FreeTextValidationExpectation] = [
             (input: "tab", isValid: true),
             (input: "", isValid: true),
-            (input: "// Bob \n\n// {year}\n", isValid: true),
-            (input: "/*\n\n\n*/", isValid: true),
+            (input: """
+            // Bob 
+            
+            // {year}
+            
+            """, isValid: true),
+            (input: """
+            /*
+            
+            
+            */
+            """, isValid: true),
             (input: "\n\n\n", isValid: true),
         ]
         let fromOptionExpectations: [OptionArgumentMapping<FileHeaderMode>] = [
             (optionValue: "", argumentValue: "strip"),
             (optionValue: "// Header", argumentValue: "// Header"),
             (optionValue: .ignore, argumentValue: "ignore"),
-            (optionValue: "/*\n\n\n*/", argumentValue: "/*\\n\\n\\n*/"),
+            (optionValue: """
+            /*
+            
+            
+            */
+            """, argumentValue: """
+            /*\
+            \
+            \
+            */
+            """),
         ]
         let fromArgumentExpectations: [OptionArgumentMapping<FileHeaderMode>] = [
             (optionValue: "", argumentValue: "strip"),
             (optionValue: "// Header", argumentValue: "// Header"),
             (optionValue: .ignore, argumentValue: "ignore"),
             (optionValue: "// {year}", argumentValue: "{year}"),
-            (optionValue: "/*\n\n\n*/", argumentValue: "/*\\n\\n\\n*/"),
-            (optionValue: "//\n//\n//\n//\n//", argumentValue: "\\n\\n\\n\\n"),
-            (optionValue: "//\n//\n// a\n//\n//", argumentValue: "\\n\\na\\n\\n"),
-            (optionValue: "//\n// a\n//\n// a\n//", argumentValue: "\\na\\n\\na\\n"),
-            (optionValue: "// a\n//", argumentValue: "a\\n"),
-            (optionValue: "//a\n//b", argumentValue: "//a\\n//b"),
+            (optionValue: """
+            /*
+            
+            
+            */
+            """, argumentValue: """
+            /*\
+            \
+            \
+            */
+            """),
+            (optionValue: """
+            //
+            //
+            //
+            //
+            //
+            """, argumentValue: "\\n\\n\\n\\n"),
+            (optionValue: """
+            //
+            //
+            // a
+            //
+            //
+            """, argumentValue: """
+            \
+            \
+            a\
+            \
+            
+            """),
+            (optionValue: """
+            //
+            // a
+            //
+            // a
+            //
+            """, argumentValue: """
+            \
+            a\
+            \
+            a\
+            
+            """),
+            (optionValue: """
+            // a
+            //
+            """, argumentValue: """
+            a\
+            
+            """),
+            (optionValue: """
+            //a
+            //b
+            """, argumentValue: """
+            //a\
+            //b
+            """),
         ]
 
         validateArgumentsFreeTextType(descriptor, expectations: validations)

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -190,7 +190,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testNonVoidFunctionAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("func foo() -> Int\n{\n    return 5\n}"))
+        let formatter = Formatter(tokenize("""
+        func foo() -> Int
+        {
+            return 5
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 10))
     }
 
@@ -215,7 +220,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testFunctionAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("func foo()\n{\n    bar = 5\n}"))
+        let formatter = Formatter(tokenize("""
+        func foo()
+        {
+            bar = 5
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 6))
     }
 
@@ -262,7 +272,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testInitAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("init()\n{\n    foo = 5\n}"))
+        let formatter = Formatter(tokenize("""
+        init()
+        {
+            foo = 5
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 4))
     }
 
@@ -272,7 +287,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testOptionalInitAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("init?()\n{\n    return nil\n}"))
+        let formatter = Formatter(tokenize("""
+        init?()
+        {
+            return nil
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 5))
     }
 
@@ -282,7 +302,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testDeinitAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("deinit\n{\n    foo = nil\n}"))
+        let formatter = Formatter(tokenize("""
+        deinit
+        {
+            foo = nil
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 2))
     }
 
@@ -292,7 +317,12 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testSubscriptAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("subscript(i: Int) -> Int\n{\n    foo[i]\n}"))
+        let formatter = Formatter(tokenize("""
+        subscript(i: Int) -> Int
+        {
+            foo[i]
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 12))
     }
 
@@ -304,12 +334,20 @@ class ParsingHelpersTests: XCTestCase {
     }
 
     func testComputedVarAllmanBracesNotTreatedAsClosure() {
-        let formatter = Formatter(tokenize("var foo: Int\n{\n    return 5\n}"))
+        let formatter = Formatter(tokenize("""
+        var foo: Int
+        {
+            return 5
+        }
+        """))
         XCTAssertFalse(formatter.isStartOfClosure(at: 7))
     }
 
     func testVarFollowedByBracesOnNextLineTreatedAsClosure() {
-        let formatter = Formatter(tokenize("var foo: Int\nfoo { return 5 }"))
+        let formatter = Formatter(tokenize("""
+        var foo: Int
+        foo { return 5 }
+        """))
         XCTAssert(formatter.isStartOfClosure(at: 9))
     }
 
@@ -1669,14 +1707,20 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(barDeclarationRange, 6 ... 16)
         XCTAssertEqual(
             formatter.tokens[barDeclarationRange].string,
-            "    let bar = \"bar\"\n"
+            """
+                let bar = \"bar\"
+            
+            """
         )
 
         let baazDeclarationRange = declarations[0].body![1].range
         XCTAssertEqual(baazDeclarationRange, 17 ... 27)
         XCTAssertEqual(
             formatter.tokens[baazDeclarationRange].string,
-            "    let baaz = \"baaz\"\n"
+            """
+                let baaz = \"baaz\"
+            
+            """
         )
     }
 
@@ -1701,14 +1745,20 @@ class ParsingHelpersTests: XCTestCase {
         XCTAssertEqual(barDeclarationRange, 4 ... 13)
         XCTAssertEqual(
             formatter.tokens[barDeclarationRange].string,
-            "let bar = \"bar\"\n"
+            """
+            let bar = \"bar\"
+            
+            """
         )
 
         let baazDeclarationRange = declarations[0].body![1].range
         XCTAssertEqual(baazDeclarationRange, 14 ... 23)
         XCTAssertEqual(
             formatter.tokens[baazDeclarationRange].string,
-            "let baaz = \"baaz\"\n"
+            """
+            let baaz = \"baaz\"
+            
+            """
         )
     }
 

--- a/Tests/Rules/FileHeaderTests.swift
+++ b/Tests/Rules/FileHeaderTests.swift
@@ -207,7 +207,10 @@ class FileHeaderTests: XCTestCase {
         /// func
         func foo() {}
         """
-        let options = FormatOptions(fileHeader: "// Hello\n// World")
+        let options = FormatOptions(fileHeader: """
+        // Hello
+        // World
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -231,7 +234,10 @@ class FileHeaderTests: XCTestCase {
         /// func
         func foo() {}
         """
-        let options = FormatOptions(fileHeader: "/*--- Hello ---*/\n/*--- World ---*/")
+        let options = FormatOptions(fileHeader: """
+        /*--- Hello ---*/
+        /*--- World ---*/
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -297,7 +303,11 @@ class FileHeaderTests: XCTestCase {
 
         class Foo {}
         """
-        let options = FormatOptions(fileHeader: "// Copyright (c) 2010-2024 Foobar\n//\n// SPDX-License-Identifier: EPL-2.0")
+        let options = FormatOptions(fileHeader: """
+        // Copyright (c) 2010-2024 Foobar
+        //
+        // SPDX-License-Identifier: EPL-2.0
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -316,7 +326,11 @@ class FileHeaderTests: XCTestCase {
 
         class Foo {}
         """
-        let options = FormatOptions(fileHeader: "// Copyright (c) 2010-2024 Foobar\n//\n// swiftformat:disable all")
+        let options = FormatOptions(fileHeader: """
+        // Copyright (c) 2010-2024 Foobar
+        //
+        // swiftformat:disable all
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -327,7 +341,11 @@ class FileHeaderTests: XCTestCase {
         let output: String = {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy"
-            return "// Copyright © \(formatter.string(from: Date()))\n\nlet foo = bar"
+            return """
+            // Copyright © \(formatter.string(from: Date()))
+            
+            let foo = bar
+            """
         }()
         let options = FormatOptions(fileHeader: "// Copyright © {year}")
         testFormatting(for: input, output, rule: .fileHeader, options: options)
@@ -341,7 +359,11 @@ class FileHeaderTests: XCTestCase {
         let output: String = {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy"
-            return "// Copyright © \(formatter.string(from: date))\n\nlet foo = bar"
+            return """
+            // Copyright © \(formatter.string(from: date))
+            
+            let foo = bar
+            """
         }()
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// Copyright © {created.year}", fileInfo: fileInfo)
@@ -399,7 +421,10 @@ class FileHeaderTests: XCTestCase {
         let foo = bar
         """
         let fileInfo = FileInfo(replacements: [.authorName: .constant(name)])
-        let options = FormatOptions(fileHeader: "// Copyright © {author.name}\n// Created by {author.name}", fileInfo: fileInfo)
+        let options = FormatOptions(fileHeader: """
+        // Copyright © {author.name}
+        // Created by {author.name}
+        """, fileInfo: fileInfo)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -412,7 +437,11 @@ class FileHeaderTests: XCTestCase {
             let formatter = DateFormatter()
             formatter.dateStyle = .short
             formatter.timeStyle = .none
-            return "// Created by Nick Lockwood on \(formatter.string(from: date)).\n\nlet foo = bar"
+            return """
+            // Created by Nick Lockwood on \(formatter.string(from: date)).
+            
+            let foo = bar
+            """
         }()
         let fileInfo = FileInfo(creationDate: date)
         let options = FormatOptions(fileHeader: "// Created by Nick Lockwood on {created}.", fileInfo: fileInfo)
@@ -514,7 +543,10 @@ class FileHeaderTests: XCTestCase {
 
         class Foo {}
         """
-        let options = FormatOptions(fileHeader: "// Header line1\n// Header line2")
+        let options = FormatOptions(fileHeader: """
+        // Header line1
+        // Header line2
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 
@@ -526,7 +558,11 @@ class FileHeaderTests: XCTestCase {
 
         // Something else...
         """
-        let options = FormatOptions(fileHeader: "//\n// Header\n//")
+        let options = FormatOptions(fileHeader: """
+        //
+        // Header
+        //
+        """)
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
@@ -540,7 +576,11 @@ class FileHeaderTests: XCTestCase {
         // Something else...
         //
         """
-        let options = FormatOptions(fileHeader: "//\n// Header\n//")
+        let options = FormatOptions(fileHeader: """
+        //
+        // Header
+        //
+        """)
         testFormatting(for: input, rule: .fileHeader, options: options)
     }
 
@@ -576,7 +616,10 @@ class FileHeaderTests: XCTestCase {
 
         let foo = 5
         """
-        let options = FormatOptions(fileHeader: "// Header line1\n// Header line2")
+        let options = FormatOptions(fileHeader: """
+        // Header line1
+        // Header line2
+        """)
         testFormatting(for: input, output, rule: .fileHeader, options: options)
     }
 

--- a/Tests/Rules/MultilineStringsTests.swift
+++ b/Tests/Rules/MultilineStringsTests.swift
@@ -1,0 +1,164 @@
+//
+//  MultilineStringsTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 7/26/2025.
+//  Copyright © 2025 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class MultilineStringsTests: XCTestCase {
+    func testConvertsStringWithEscapedNewline() {
+        let input = """
+        let message = "Hello\\nWorld"
+        """
+        let output = """
+        let message = \"\"\"
+        Hello
+        World
+        \"\"\"
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testConvertsStringWithMultipleEscapedNewlines() {
+        let input = """
+        let text = "Line 1\\nLine 2\\nLine 3"
+        """
+        let output = """
+        let text = \"\"\"
+        Line 1
+        Line 2
+        Line 3
+        \"\"\"
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testPreservesIndentation() {
+        let input = """
+        func test() {
+            let message = "Hello\\nWorld"
+        }
+        """
+        let output = """
+        func test() {
+            let message = \"\"\"
+            Hello
+            World
+            \"\"\"
+        }
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testDoesNotAffectStringsWithoutNewlines() {
+        let input = """
+        let message = "Hello World"
+        """
+        testFormatting(for: input, rule: .multilineStrings)
+    }
+
+    func testDoesNotAffectExistingMultilineStrings() {
+        let input = """
+        let message = \"\"\"
+        Hello
+        World
+        \"\"\"
+        """
+        testFormatting(for: input, rule: .multilineStrings)
+    }
+
+    func testConvertsStringInFunctionCall() {
+        let input = """
+        print("First line\\nSecond line")
+        """
+        let output = """
+        print(\"\"\"
+        First line
+        Second line
+        \"\"\")
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testConvertsStringWithMixedContent() {
+        let input = """
+        let error = "Error occurred at line \\(lineNumber)\\nPlease check your input"
+        """
+        let output = """
+        let error = \"\"\"
+        Error occurred at line \\(lineNumber)
+        Please check your input
+        \"\"\"
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testConvertsNestedString() {
+        let input = """
+        struct Config {
+            let template = "Header\\nBody\\nFooter"
+        }
+        """
+        let output = """
+        struct Config {
+            let template = \"\"\"
+            Header
+            Body
+            Footer
+            \"\"\"
+        }
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testDoesNotConvertWhitespaceOnlyStrings() {
+        let input = #"""
+        let newline = "\\n"
+        let newlines = "\n\n"
+        let whitespace = "\r\n\t"
+        let mixed = "Content\nMore content"
+        """#
+        let output = #"""
+        let newline = "\\n"
+        let newlines = "\n\n"
+        let whitespace = "\r\n\t"
+        let mixed = """
+        Content
+        More content
+        """
+        """#
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent])
+    }
+
+    func testConvertsIndentedStringInStruct() {
+        let input = """
+        struct APIClient {
+            private let baseURL = "https://api.example.com"
+
+            func fetchData() {
+                let request = "GET /users\\nHost: api.example.com\\nAuthorization: Bearer token"
+                send(request)
+            }
+        }
+        """
+        let output = """
+        struct APIClient {
+            private let baseURL = "https://api.example.com"
+
+            func fetchData() {
+                let request = \"\"\"
+                GET /users
+                Host: api.example.com
+                Authorization: Bearer token
+                \"\"\"
+                send(request)
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .multilineStrings, exclude: [.indent, .trailingSpace])
+    }
+}

--- a/Tests/TokenizerTests.swift
+++ b/Tests/TokenizerTests.swift
@@ -128,7 +128,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testHashbangAtStartOfFile() {
-        let input = "#!/usr/bin/swift \n"
+        let input = """
+        #!/usr/bin/swift 
+        
+        """
         let output: [Token] = [
             .startOfScope("#!"),
             .commentBody("/usr/bin/swift"),
@@ -139,7 +142,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testHashbangAfterFirstLine() {
-        let input = "//Hello World\n#!/usr/bin/swift \n"
+        let input = """
+        //Hello World
+        #!/usr/bin/swift 
+        
+        """
         let output: [Token] = [
             .startOfScope("//"),
             .commentBody("Hello World"),
@@ -184,8 +191,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testUnescapeLinebreak() {
-        let input = Token.stringBody("Hello\\nWorld")
-        let output = "Hello\nWorld"
+        let input = Token.stringBody("""
+        Hello\
+        World
+        """)
+        let output = """
+        Hello
+        World
+        """
         XCTAssertEqual(input.unescaped(), output)
     }
 
@@ -320,7 +333,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testUnterminatedString2() {
-        let input = "\"foo\nbar"
+        let input = """
+        \"foo
+        bar
+        """
         let output: [Token] = [
             .startOfScope("\""),
             .stringBody("foo"),
@@ -332,7 +348,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testUnterminatedString3() {
-        let input = "\"foo\n\""
+        let input = """
+        \"foo
+        \"
+        """
         let output: [Token] = [
             .startOfScope("\""),
             .stringBody("foo"),
@@ -347,7 +366,12 @@ class TokenizerTests: XCTestCase {
     // MARK: Multiline strings
 
     func testSimpleMultilineString() {
-        let input = "\"\"\"\n    hello\n    world\n    \"\"\""
+        let input = """
+        \"\"\"
+            hello
+            world
+            \"\"\"
+        """
         let output: [Token] = [
             .startOfScope("\"\"\""),
             .linebreak("\n", 1),
@@ -364,7 +388,12 @@ class TokenizerTests: XCTestCase {
     }
 
     func testIndentedSimpleMultilineString() {
-        let input = "\"\"\"\n    hello\n    world\n\"\"\""
+        let input = """
+        \"\"\"
+            hello
+            world
+        \"\"\"
+        """
         let output: [Token] = [
             .startOfScope("\"\"\""),
             .linebreak("\n", 1),
@@ -378,7 +407,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testEmptyMultilineString() {
-        let input = "\"\"\"\n\"\"\""
+        let input = """
+        \"\"\"
+        \"\"\"
+        """
         let output: [Token] = [
             .startOfScope("\"\"\""),
             .linebreak("\n", 1),
@@ -388,7 +420,12 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineStringWithEscapedLinebreak() {
-        let input = "\"\"\"\n    hello \\\n    world\n\"\"\""
+        let input = """
+        \"\"\"
+            hello \\
+            world
+        \"\"\"
+        """
         let output: [Token] = [
             .startOfScope("\"\"\""),
             .linebreak("\n", 1),
@@ -402,7 +439,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineStringStartingWithInterpolation() {
-        let input = "    \"\"\"\n    \\(String(describing: 1))\n    \"\"\""
+        let input = """
+            \"\"\"
+            \\(String(describing: 1))
+            \"\"\"
+        """
         let output: [Token] = [
             .space("    "),
             .startOfScope("\"\"\""),
@@ -539,7 +580,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineStringWithEscapedTripleQuote() {
-        let input = "\"\"\"\n\\\"\"\"\n\"\"\""
+        let input = """
+        \"\"\"
+        \\\"\"\"
+        \"\"\"
+        """
         let output: [Token] = [
             .startOfScope("\"\"\""),
             .linebreak("\n", 1),
@@ -686,7 +731,12 @@ class TokenizerTests: XCTestCase {
     // MARK: Multiline raw strings
 
     func testSimpleMultilineRawString() {
-        let input = "#\"\"\"\n    hello\n    world\n    \"\"\"#"
+        let input = """
+        #\"\"\"
+            hello
+            world
+            \"\"\"#
+        """
         let output: [Token] = [
             .startOfScope("#\"\"\""),
             .linebreak("\n", 1),
@@ -703,7 +753,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineRawStringContainingUnhashedInterpolation() {
-        let input = "#\"\"\"\n    \\(5)\n    \"\"\"#"
+        let input = """
+        #\"\"\"
+            \\(5)
+            \"\"\"#
+        """
         let output: [Token] = [
             .startOfScope("#\"\"\""),
             .linebreak("\n", 1),
@@ -717,7 +771,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineRawStringContainingHashedInterpolation() {
-        let input = "#\"\"\"\n    \\#(5)\n    \"\"\"#"
+        let input = """
+        #\"\"\"
+            \\#(5)
+            \"\"\"#
+        """
         let output: [Token] = [
             .startOfScope("#\"\"\""),
             .linebreak("\n", 1),
@@ -734,7 +792,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineRawStringContainingUnderhashedInterpolation() {
-        let input = "##\"\"\"\n    \\#(5)\n    \"\"\"##"
+        let input = """
+        ##\"\"\"
+            \\#(5)
+            \"\"\"##
+        """
         let output: [Token] = [
             .startOfScope("##\"\"\""),
             .linebreak("\n", 1),
@@ -1048,7 +1110,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testCasePathTreatedAsOperator2() {
-        let input = "let foo = /Foo.bar\nbaz"
+        let input = """
+        let foo = /Foo.bar
+        baz
+        """
         let output: [Token] = [
             .keyword("let"),
             .space(" "),
@@ -1081,7 +1146,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testDivideOperatorInParenthesesTreatedAsOperator() {
-        let input = "return (/)\n"
+        let input = """
+        return (/)
+        
+        """
         let output: [Token] = [
             .keyword("return"),
             .space(" "),
@@ -1205,7 +1273,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSingleLineCommentWithLinebreak() {
-        let input = "//foo\nbar"
+        let input = """
+        //foo
+        bar
+        """
         let output: [Token] = [
             .startOfScope("//"),
             .commentBody("foo"),
@@ -1240,7 +1311,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineComment() {
-        let input = "/*foo\nbar*/"
+        let input = """
+        /*foo
+        bar*/
+        """
         let output: [Token] = [
             .startOfScope("/*"),
             .commentBody("foo"),
@@ -1252,7 +1326,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineCommentWithSpace() {
-        let input = "/*foo\n  bar*/"
+        let input = """
+        /*foo
+          bar*/
+        """
         let output: [Token] = [
             .startOfScope("/*"),
             .commentBody("foo"),
@@ -1265,7 +1342,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testCommentIndentingWithTrailingClose() {
-        let input = "/* foo\n */"
+        let input = """
+        /* foo
+         */
+        """
         let output: [Token] = [
             .startOfScope("/*"),
             .space(" "),
@@ -2230,7 +2310,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testInfixOperatorBeforeLinebreak() {
-        let input = "foo +\nbar"
+        let input = """
+        foo +
+        bar
+        """
         let output: [Token] = [
             .identifier("foo"),
             .space(" "),
@@ -2242,7 +2325,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testInfixOperatorAfterLinebreak() {
-        let input = "foo\n+ bar"
+        let input = """
+        foo
+        + bar
+        """
         let output: [Token] = [
             .identifier("foo"),
             .linebreak("\n", 1),
@@ -3021,7 +3107,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testGenericFollowedByGreaterThan() {
-        let input = "Foo<T>\na=b>c"
+        let input = """
+        Foo<T>
+        a=b>c
+        """
         let output: [Token] = [
             .identifier("Foo"),
             .startOfScope("<"),
@@ -3275,7 +3364,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testHalfOpenRangeFollowedByComment() {
-        let input = "1..<5\n//comment"
+        let input = """
+        1..<5
+        //comment
+        """
         let output: [Token] = [
             .number("1", .integer),
             .operator("..<", .infix),
@@ -3352,7 +3444,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testIfLessThanIfGreaterThan() {
-        let input = "if x < 0 {}\nif y > (0) {}"
+        let input = """
+        if x < 0 {}
+        if y > (0) {}
+        """
         let output: [Token] = [
             .keyword("if"),
             .space(" "),
@@ -3565,7 +3660,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSplitLineOptionalChaining() {
-        let input = "foo?\n    .bar"
+        let input = """
+        foo?
+            .bar
+        """
         let output: [Token] = [
             .identifier("foo"),
             .operator("?", .postfix),
@@ -3621,7 +3719,12 @@ class TokenizerTests: XCTestCase {
     }
 
     func testMultilineLineEnum() {
-        let input = "enum Foo {\ncase Bar\ncase Baz\n}"
+        let input = """
+        enum Foo {
+        case Bar
+        case Baz
+        }
+        """
         let output: [Token] = [
             .keyword("enum"),
             .space(" "),
@@ -3643,7 +3746,16 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchStatement() {
-        let input = "switch x {\ncase 1:\nbreak\ncase 2:\nbreak\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        break
+        case 2:
+        break
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3676,7 +3788,15 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchStatementWithEnumCases() {
-        let input = "switch x {\ncase.foo,\n.bar:\nbreak\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case.foo,
+        .bar:
+        break
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3706,7 +3826,11 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingDictionaryDefault() {
-        let input = "switch x {\ncase y: foo[\"z\", default: []]\n}"
+        let input = """
+        switch x {
+        case y: foo[\"z\", default: []]
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3739,7 +3863,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseIsDictionaryStatement() {
-        let input = "switch x {\ncase foo is [Key: Value]:\nbreak\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case foo is [Key: Value]:
+        break
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3774,7 +3905,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingCaseIdentifier() {
-        let input = "switch x {\ncase 1:\nfoo.case\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        foo.case
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3802,7 +3940,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingDefaultIdentifier() {
-        let input = "switch x {\ncase 1:\nfoo.default\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        foo.default
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3830,7 +3975,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingIfCase() {
-        let input = "switch x {\ncase 1:\nif case x = y {}\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        if case x = y {}
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3867,7 +4019,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingIfCaseCommaCase() {
-        let input = "switch x {\ncase 1:\nif case w = x, case y = z {}\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        if case w = x, case y = z {}
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3913,7 +4072,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingGuardCase() {
-        let input = "switch x {\ncase 1:\nguard case x = y else {}\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 1:
+        guard case x = y else {}
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3952,7 +4118,15 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchFollowedByEnum() {
-        let input = "switch x {\ncase y: break\ndefault: break\n}\nenum Foo {\ncase z\n}"
+        let input = """
+        switch x {
+        case y: break
+        default: break
+        }
+        enum Foo {
+        case z
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -3990,7 +4164,17 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingSwitchIdentifierFollowedByEnum() {
-        let input = "switch x {\ncase 1:\nfoo.switch\ndefault:\nbreak\n}\nenum Foo {\ncase z\n}"
+        let input = """
+        switch x {
+        case 1:
+        foo.switch
+        default:
+        break
+        }
+        enum Foo {
+        case z
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4030,7 +4214,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchCaseContainingRangeOperator() {
-        let input = "switch x {\ncase 0 ..< 2:\nbreak\ndefault:\nbreak\n}"
+        let input = """
+        switch x {
+        case 0 ..< 2:
+        break
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4060,7 +4251,16 @@ class TokenizerTests: XCTestCase {
     }
 
     func testEnumDeclarationInsideSwitchCase() {
-        let input = "switch x {\ncase y:\nenum Foo {\ncase z\n}\nbreak\ndefault: break\n}"
+        let input = """
+        switch x {
+        case y:
+        enum Foo {
+        case z
+        }
+        break
+        default: break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4098,7 +4298,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testDefaultAfterWhereCondition() {
-        let input = "switch foo {\ncase _ where baz < quux:\nbreak\ndefault:\nbreak\n}"
+        let input = """
+        switch foo {
+        case _ where baz < quux:
+        break
+        default:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4132,7 +4339,14 @@ class TokenizerTests: XCTestCase {
     }
 
     func testEnumWithConditionalCase() {
-        let input = "enum Foo {\ncase bar\n#if baz\ncase baz\n#endif\n}"
+        let input = """
+        enum Foo {
+        case bar
+        #if baz
+        case baz
+        #endif
+        }
+        """
         let output: [Token] = [
             .keyword("enum"),
             .space(" "),
@@ -4160,7 +4374,16 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchWithConditionalCase() {
-        let input = "switch foo {\ncase bar:\nbreak\n#if baz\ndefault:\nbreak\n#endif\n}"
+        let input = """
+        switch foo {
+        case bar:
+        break
+        #if baz
+        default:
+        break
+        #endif
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4192,7 +4415,17 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchWithConditionalCase2() {
-        let input = "switch foo {\n#if baz\ndefault:\nbreak\n#else\ncase bar:\nbreak\n#endif\n}"
+        let input = """
+        switch foo {
+        #if baz
+        default:
+        break
+        #else
+        case bar:
+        break
+        #endif
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4226,7 +4459,16 @@ class TokenizerTests: XCTestCase {
     }
 
     func testSwitchWithConditionalCase3() {
-        let input = "switch foo {\n#if baz\ncase foo:\nbreak\n#endif\ncase bar:\nbreak\n}"
+        let input = """
+        switch foo {
+        #if baz
+        case foo:
+        break
+        #endif
+        case bar:
+        break
+        }
+        """
         let output: [Token] = [
             .keyword("switch"),
             .space(" "),
@@ -4439,7 +4681,10 @@ class TokenizerTests: XCTestCase {
     // MARK: linebreaks
 
     func testLF() {
-        let input = "foo\nbar"
+        let input = """
+        foo
+        bar
+        """
         let output: [Token] = [
             .identifier("foo"),
             .linebreak("\n", 1),
@@ -4459,7 +4704,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testCRLF() {
-        let input = "foo\r\nbar"
+        let input = """
+        foo\r
+        bar
+        """
         let output: [Token] = [
             .identifier("foo"),
             .linebreak("\r\n", 1),
@@ -4469,7 +4717,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testCRLFAfterComment() {
-        let input = "//foo\r\n//bar"
+        let input = """
+        //foo\r
+        //bar
+        """
         let output: [Token] = [
             .startOfScope("//"),
             .commentBody("foo"),
@@ -4481,7 +4732,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testCRLFInMultilineComment() {
-        let input = "/*foo\r\nbar*/"
+        let input = """
+        /*foo\r
+        bar*/
+        """
         let output: [Token] = [
             .startOfScope("/*"),
             .commentBody("foo"),
@@ -4971,7 +5225,10 @@ class TokenizerTests: XCTestCase {
     }
 
     func testActorVariable() {
-        let input = "let foo = actor\nlet bar = foo"
+        let input = """
+        let foo = actor
+        let bar = foo
+        """
         let output: [Token] = [
             .keyword("let"),
             .space(" "),

--- a/Tests/XCTestCase+testFormatting.swift
+++ b/Tests/XCTestCase+testFormatting.swift
@@ -109,7 +109,10 @@ extension XCTestCase {
                            output, file: file, line: line)
             if !input.hasPrefix("#!") {
                 for rule in rules {
-                    let disabled = "// swiftformat:disable \(rule)\n\(input)"
+                    let disabled = """
+                    // swiftformat:disable \(rule)
+                    \(input)
+                    """
                     XCTAssertEqual(try format(disabled, rules: [rule], options: options).output,
                                    disabled, "Failed to disable \(rule) rule", file: file, line: line)
                 }


### PR DESCRIPTION
This PR prototypes a rule to convert single-line strings with escaped newlines to multi-line strings.

Lots of edge cases still left to be dealt with before we could ship it, and there are a lot of examples in the codebase that I don't really love the look of after being converted.