### PR TITLE
Add `--type-body-marks remove` option to `organizeDeclarations`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1768,6 +1768,7 @@ Option | Description
 `--mark-enum-threshold` | Minimum line count to add MARK comments in enum body. Defaults to 0
 `--mark-extension-threshold` | Minimum line count to add MARK comments in extension body. Defaults to 0
 `--organization-mode` | Organize declarations by: "visibility" (default) or "type"
+`--type-body-marks` | MARK comments in type bodies: "preserve" (default) or "remove"
 `--visibility-order` | Order for visibility groups inside declaration
 `--type-order` | Order for declaration type groups inside declaration
 `--visibility-marks` | Marks for visibility groups (public:Public Fields,..)

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1100,6 +1100,12 @@ struct _Descriptors {
         help: "Organize declarations by:",
         keyPath: \.organizationMode
     )
+    let typeBodyMarks = OptionDescriptor(
+        argumentName: "type-body-marks",
+        displayName: "Type Body Mark Comments",
+        help: "MARK comments in type bodies: \"preserve\" (default) or \"remove\"",
+        keyPath: \.typeBodyMarks
+    )
     let visibilityOrder = OptionDescriptor(
         argumentName: "visibility-order",
         displayName: "Organization Order For Visibility",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -497,6 +497,14 @@ public enum DeclarationOrganizationMode: String, CaseIterable {
     case type
 }
 
+/// Treatment of MARK comments in type bodies
+public enum TypeBodyMarks: String, CaseIterable {
+    /// Preserve all existing MARK comments in type bodies
+    case preserve
+    /// Remove MARK comments that don't match expected visibility/declaration kind marks
+    case remove
+}
+
 /// Whether to insert or remove blank lines from the start / end of type bodies
 public enum TypeBlankLines: String, CaseIterable {
     case remove
@@ -781,6 +789,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var markEnumThreshold: Int
     public var markExtensionThreshold: Int
     public var organizationMode: DeclarationOrganizationMode
+    public var typeBodyMarks: TypeBodyMarks
     public var visibilityOrder: [String]?
     public var typeOrder: [String]?
     public var customVisibilityMarks: Set<String>
@@ -920,6 +929,7 @@ public struct FormatOptions: CustomStringConvertible {
                 markEnumThreshold: Int = 0,
                 markExtensionThreshold: Int = 0,
                 organizationMode: DeclarationOrganizationMode = .visibility,
+                typeBodyMarks: TypeBodyMarks = .preserve,
                 visibilityOrder: [String]? = nil,
                 typeOrder: [String]? = nil,
                 customVisibilityMarks: Set<String> = [],
@@ -1048,6 +1058,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.markEnumThreshold = markEnumThreshold
         self.markExtensionThreshold = markExtensionThreshold
         self.organizationMode = organizationMode
+        self.typeBodyMarks = typeBodyMarks
         self.visibilityOrder = visibilityOrder
         self.typeOrder = typeOrder
         self.customVisibilityMarks = customVisibilityMarks


### PR DESCRIPTION
This PR adds a `--type-body-marks remove` option to the `organizeDeclarations` rule.

When enabled, it removes MARK comments in type bodies, other than the ones added automatically: 
 - `// MARK: Lifecycle`
 - `// MARK: Public`
 - `// MARK: Internal`
 - `// MARK: Private`
 - etc