### PR TITLE
Add support for file-specific options and configs

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -33,6 +33,7 @@ import Foundation
 
 extension Options {
     init(_ args: [String: String], in directory: String) throws {
+        let (args, fileSpecificOptions) = processGlobArguments(args)
         fileOptions = try fileOptionsFor(args, in: directory)
         formatOptions = try formatOptionsFor(args)
         configURLs = args["config"].map {
@@ -41,6 +42,7 @@ extension Options {
         let lint = args.keys.contains("lint")
         self.lint = lint
         rules = try rulesFor(args, lint: lint)
+        self.fileSpecificOptions = fileSpecificOptions
     }
 
     mutating func addArguments(_ args: [String: String], in directory: String) throws {
@@ -52,6 +54,29 @@ extension Options {
         }
         newOptions.configURLs = configURLs
         self = newOptions
+    }
+
+    mutating func addFileSpecificArguments(path: String) throws {
+        var relevantOptions = [String: String]()
+
+        for (globKey, value) in fileSpecificOptions {
+            guard let (key, glob) = parseFileGlobArgument(globKey) else { continue }
+
+            let globExpansionPaths = ["/"]
+                + (configURLs ?? []).map { $0.deletingLastPathComponent().path }
+
+            for globExpansionPath in globExpansionPaths {
+                for glob in expandGlobs(glob, in: globExpansionPath) {
+                    if glob.matches(path) {
+                        relevantOptions[key] = value
+                        break
+                    }
+                }
+            }
+        }
+
+        guard !relevantOptions.isEmpty else { return }
+        try applyArguments(relevantOptions, lint: lint, to: &self)
     }
 }
 
@@ -232,9 +257,18 @@ func preprocessArguments(_ args: [String], _ names: [String]) throws -> [String:
     var name = ""
     for arg in args {
         if arg.hasPrefix("--") {
-            let key = String(arg.unicodeScalars.dropFirst(2)).lowercased()
+            var key = String(arg.unicodeScalars.dropFirst(2))
+            var keyToValidate = key
 
-            if names.contains(key) {
+            // Ensure the option itself is lowercase
+            if let (globKey, glob) = parseFileGlobArgument(key) {
+                key = "\(globKey.lowercased())(\(glob))"
+                keyToValidate = globKey.lowercased()
+            } else {
+                key = key.lowercased()
+            }
+
+            if names.contains(keyToValidate) {
                 name = key
             }
 
@@ -295,6 +329,37 @@ func preprocessArguments(_ args: [String], _ names: [String]) throws -> [String:
         }
     }
     return namedArgs
+}
+
+func parseFileGlobArgument(_ key: String) -> (key: String, glob: String)? {
+    // If this is an option like --arg(glob), parse the glob that the option applies to.
+    guard let openParenIndex = key.firstIndex(of: "("),
+          let closeParenIndex = key.firstIndex(of: ")")
+    else { return nil }
+
+    let indexAfterOpenParen = key.index(after: openParenIndex)
+    guard indexAfterOpenParen < closeParenIndex else { return nil }
+
+    let fileGlob = String(key[indexAfterOpenParen ..< closeParenIndex])
+    let keyWithoutGlob = key.replacingOccurrences(of: "(\(fileGlob))", with: "")
+    return (keyWithoutGlob, fileGlob)
+}
+
+func processGlobArguments(_ arguments: [String: String]) -> (
+    baseOptions: [String: String],
+    fileSpecificOptions: [String: String]
+) {
+    var baseOptions = arguments
+    var fileSpecificOptions = [String: String]()
+
+    for (key, value) in arguments {
+        if parseFileGlobArgument(key) != nil {
+            baseOptions[key] = nil
+            fileSpecificOptions[key] = value
+        }
+    }
+
+    return (baseOptions, fileSpecificOptions)
 }
 
 /// Parse a comma-delimited list of items
@@ -585,6 +650,9 @@ func argumentsFor(_ options: Options, excludingDefaults: Bool = false) -> [Strin
         if !disabled.isEmpty {
             args["disable"] = disabled.sorted().joined(separator: ",")
         }
+    }
+    for (key, value) in options.fileSpecificOptions {
+        args[key] = value
     }
     return args
 }

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -1198,6 +1198,7 @@ public struct Options {
     public var rules: Set<String>?
     public var configURLs: [URL]?
     public var lint: Bool
+    public var fileSpecificOptions: [String: String]
 
     public static let `default` = Options(
         fileOptions: .default,
@@ -1211,13 +1212,15 @@ public struct Options {
                 formatOptions: FormatOptions? = nil,
                 rules: Set<String>? = nil,
                 configURLs: [URL]? = nil,
-                lint: Bool = false)
+                lint: Bool = false,
+                fileSpecificOptions: [String: String] = [:])
     {
         self.fileOptions = fileOptions
         self.formatOptions = formatOptions
         self.rules = rules
         self.configURLs = configURLs
         self.lint = lint
+        self.fileSpecificOptions = fileSpecificOptions
     }
 
     public func shouldSkipFile(_ inputURL: URL) -> Bool {

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -1124,4 +1124,180 @@ class CommandLineTests: XCTestCase {
         // Should not contain the deprecation warning about --commas
         XCTAssertEqual(warnings, [])
     }
+
+    func testFileSpecificOptions() throws {
+        var errors = [String]()
+
+        CLI.print = { message, type in
+            if type == .error {
+                errors.append(message)
+            }
+        }
+
+        try withTmpFiles([
+            "FooModule/Sources/Foo.swift": """
+            func foo() {
+            print("bar")
+            }
+            """,
+
+            "FooModule/Tests/FooTests.swift": """
+            func foo() {
+            print("bar")
+            }
+            """,
+
+            "BarModule/Tests/BarTests.swift": """
+            func bar() {
+            print("baaz")
+            }
+            """,
+        ]) { url in
+            _ = processArguments([
+                "",
+                url.path,
+                "--indent", "4",
+                "--indent(**/Tests/*)", "2",
+                "--disable(**/Tests/*)", "linebreakAtEndOfFile",
+            ], in: "")
+
+            let fileContents = try String(contentsOf: url, encoding: .utf8)
+            if url.lastPathComponent == "Foo.swift" {
+                XCTAssertEqual(fileContents, """
+                func foo() {
+                    print("bar")
+                }
+
+                """)
+            } else if url.lastPathComponent == "FooTests.swift" {
+                XCTAssertEqual(fileContents, """
+                func foo() {
+                  print("bar")
+                }
+                """)
+            } else if url.lastPathComponent == "BarTests.swift" {
+                XCTAssertEqual(fileContents, """
+                func bar() {
+                  print("baaz")
+                }
+                """)
+            }
+        }
+
+        XCTAssertEqual(errors, [])
+    }
+
+    func testFileSpecificOptionsInConfigFile() throws {
+        var errors = [String]()
+
+        CLI.print = { message, type in
+            if type == .error {
+                errors.append(message)
+            }
+        }
+
+        let configURL = try createTmpFile("\(#function)/config.swiftformat", contents: """
+        --indent 4
+        --indent(Tests/**) 2 # glob evaluated relative to config file
+        """)
+
+        let nonTestFile = try createTmpFile("\(#function)/Sources/Foo.swift", contents: """
+        func foo() {
+        print("bar")
+        }
+        """)
+
+        let testFile = try createTmpFile("\(#function)/Tests/FooTests.swift", contents: """
+        func foo() {
+        print("bar")
+        }
+        """)
+
+        _ = processArguments([
+            "",
+            configURL.deletingLastPathComponent().path,
+            "--config", configURL.path,
+        ], in: "")
+
+        XCTAssertEqual(try String(contentsOf: nonTestFile, encoding: .utf8), """
+        func foo() {
+            print("bar")
+        }
+
+        """)
+
+        XCTAssertEqual(try String(contentsOf: testFile, encoding: .utf8), """
+        func foo() {
+          print("bar")
+        }
+
+        """)
+
+        let tempFiles = [configURL, nonTestFile, testFile]
+        for tempFile in tempFiles {
+            try FileManager.default.removeItem(at: tempFile)
+        }
+
+        XCTAssertEqual(errors, [])
+    }
+
+    func testFileSpecificConfigs() throws {
+        var errors = [String]()
+
+        CLI.print = { message, type in
+            if type == .error {
+                errors.append(message)
+            }
+        }
+
+        let configURL = try createTmpFile("\(#function)/config.swiftformat", contents: """
+        --indent 4
+        """)
+
+        let testConfigURL = try createTmpFile("\(#function)/testConfig.swiftformat", contents: """
+        --indent 2
+        --allman true
+        """)
+
+        let nonTestFile = try createTmpFile("\(#function)/Sources/Foo.swift", contents: """
+        func foo() {
+        print("bar")
+        }
+        """)
+
+        let testFile = try createTmpFile("\(#function)/Tests/FooTests.swift", contents: """
+        func foo() {
+        print("bar")
+        }
+        """)
+
+        _ = processArguments([
+            "",
+            configURL.deletingLastPathComponent().path,
+            "--config", configURL.path,
+            "--config(**/Tests/**)", testConfigURL.path,
+        ], in: "")
+
+        XCTAssertEqual(try String(contentsOf: nonTestFile, encoding: .utf8), """
+        func foo() {
+            print("bar")
+        }
+
+        """)
+
+        XCTAssertEqual(try String(contentsOf: testFile, encoding: .utf8), """
+        func foo()
+        {
+          print("bar")
+        }
+
+        """)
+
+        let tempFiles = [configURL, testConfigURL, nonTestFile, testFile]
+        for tempFile in tempFiles {
+            try FileManager.default.removeItem(at: tempFile)
+        }
+
+        XCTAssertEqual(errors, [])
+    }
 }


### PR DESCRIPTION
This PR adds support for file-specific options and configs.

In `--config` options or rule configuration options, you can specify a file glob in parenthesis. This causes the option to only apply to that files matching the glob pattern.

Some use cases that we have:
 - You may want to apply different rules to all test code. In our repo every module has a `Sources` folder and a `Tests` directory. You can now specify `--config(**/Tests/**) tests.swiftformat` to apply a config file only to test directories.
 - In our `apps` repo, most of our code live in `apps/ios`, but we also have code in `apps/tools/ios`. We have to disable some rules in the tools directory (e.g. our `#URL` macro is in a module not accessible to code in `tools/ios`). This can be handled easily within the main config file with `--disable(**/tools/ios/**) urlMacro`.

This also simplifies #2066.

What do you think @nicklockwood?


