### PR TITLE
Add option to disallow partial wrapping of functions and collections

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3673,6 +3673,7 @@ Option | Description
 `--wrap-type-aliases` | Typealias wrapping: "before-first", "after-first", "preserve" (default), "disabled" or "default"
 `--wrap-effects` | Function effects (throws, async) wrapping: "preserve" (default), "if-multiline" or "never"
 `--wrap-string-interpolation` | String interpolation wrapping: "default" (wrap if needed) or "preserve"
+`--allow-partial-wrapping` | Allow partial argument wrapping: "true" (default) or "false"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -426,7 +426,8 @@ extension Formatter {
                         endOfScope += insertSpace(indent + options.indent, at: linebreakIndex + 1)
                     } else if !allowGrouping || (maxWidth > 0 &&
                         lineLength(at: linebreakIndex) > maxWidth &&
-                        lineLength(upTo: linebreakIndex) <= maxWidth)
+                        lineLength(upTo: linebreakIndex) <= maxWidth),
+                        !tokens[linebreakIndex].isLinebreak
                     {
                         insertLinebreak(at: linebreakIndex)
                         endOfScope += 1 + insertSpace(indent + options.indent, at: linebreakIndex + 1)
@@ -594,15 +595,15 @@ extension Formatter {
                 case .beforeFirst:
                     wrapArgumentsBeforeFirst(startOfScope: i,
                                              endOfScope: endOfScope,
-                                             allowGrouping: firstIdentifierIndex > firstLinebreakIndex)
+                                             allowGrouping: options.allowPartialWrapping && firstIdentifierIndex > firstLinebreakIndex)
                 case .preserve where firstIdentifierIndex > firstLinebreakIndex:
                     wrapArgumentsBeforeFirst(startOfScope: i,
                                              endOfScope: endOfScope,
-                                             allowGrouping: true)
+                                             allowGrouping: options.allowPartialWrapping)
                 case .afterFirst, .preserve:
                     wrapArgumentsAfterFirst(startOfScope: i,
                                             endOfScope: endOfScope,
-                                            allowGrouping: true)
+                                            allowGrouping: options.allowPartialWrapping)
                 case .disabled, .default:
                     assertionFailure() // Shouldn't happen
                 }

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1412,6 +1412,12 @@ struct _Descriptors {
         help: "Insert line After switch cases:",
         keyPath: \.blankLineAfterSwitchCase
     )
+    let allowPartialWrapping = OptionDescriptor(
+        argumentName: "allow-partial-wrapping",
+        displayName: "Allow Partial Wrapping",
+        help: "Allow partial argument wrapping:",
+        keyPath: \.allowPartialWrapping
+    )
 
     // MARK: - Internal
 

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -828,6 +828,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var preferFileMacro: Bool
     public var lineBetweenConsecutiveGuards: Bool
     public var blankLineAfterSwitchCase: BlankLineAfterSwitchCase
+    public var allowPartialWrapping: Bool
 
     /// Deprecated
     public var indentComments: Bool
@@ -968,6 +969,7 @@ public struct FormatOptions: CustomStringConvertible {
                 preferFileMacro: Bool = true,
                 lineBetweenConsecutiveGuards: Bool = false,
                 blankLineAfterSwitchCase: BlankLineAfterSwitchCase = .multilineOnly,
+                allowPartialWrapping: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -1097,6 +1099,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.preferFileMacro = preferFileMacro
         self.lineBetweenConsecutiveGuards = lineBetweenConsecutiveGuards
         self.blankLineAfterSwitchCase = blankLineAfterSwitchCase
+        self.allowPartialWrapping = allowPartialWrapping
         self.indentComments = indentComments
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules/Wrap.swift
+++ b/Sources/Rules/Wrap.swift
@@ -14,7 +14,7 @@ public extension FormatRule {
         options: ["max-width", "no-wrap-operators", "asset-literals", "wrap-ternary", "wrap-string-interpolation"],
         sharedOptions: ["wrap-arguments", "wrap-parameters", "wrap-collections", "closing-paren", "call-site-paren", "indent",
                         "trim-whitespace", "linebreaks", "tab-width", "max-width", "smart-tabs", "wrap-return-type",
-                        "wrap-conditions", "wrap-type-aliases", "wrap-ternary", "wrap-effects"]
+                        "wrap-conditions", "wrap-type-aliases", "wrap-ternary", "wrap-effects", "allow-partial-wrapping"]
     ) { formatter in
         let maxWidth = formatter.options.maxWidth
         guard maxWidth > 0 else { return }

--- a/Sources/Rules/WrapArguments.swift
+++ b/Sources/Rules/WrapArguments.swift
@@ -14,7 +14,7 @@ public extension FormatRule {
         help: "Align wrapped function arguments or collection elements.",
         orderAfter: [.wrap],
         options: ["wrap-arguments", "wrap-parameters", "wrap-collections", "closing-paren", "call-site-paren",
-                  "wrap-return-type", "wrap-conditions", "wrap-type-aliases", "wrap-effects", "wrap-string-interpolation"],
+                  "wrap-return-type", "wrap-conditions", "wrap-type-aliases", "wrap-effects", "wrap-string-interpolation", "allow-partial-wrapping"],
         sharedOptions: ["indent", "trim-whitespace", "linebreaks",
                         "tab-width", "max-width", "smart-tabs", "asset-literals", "wrap-ternary"]
     ) { formatter in

--- a/Tests/MetadataTests.swift
+++ b/Tests/MetadataTests.swift
@@ -238,7 +238,7 @@ class MetadataTests: XCTestCase {
                             Descriptors.indent, Descriptors.tabWidth, Descriptors.smartTabs, Descriptors.maxWidth,
                             Descriptors.assetLiteralWidth, Descriptors.wrapReturnType, Descriptors.wrapEffects,
                             Descriptors.wrapConditions, Descriptors.wrapTypealiases, Descriptors.wrapTernaryOperators,
-                            Descriptors.wrapStringInterpolation,
+                            Descriptors.wrapStringInterpolation, Descriptors.allowPartialWrapping,
                         ]
                     case .identifier("wrapStatementBody"):
                         referencedOptions += [Descriptors.indent, Descriptors.linebreak]

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -2948,4 +2948,120 @@ class WrapArgumentsTests: XCTestCase {
             exclude: [.wrapConditionalBodies]
         )
     }
+
+    func testWrapPartiallyWrappedFunctionCall() {
+        let input = """
+        func foo(
+            bar: Bar, baaz: Baaz,
+            quux: Quux,
+        ) {
+            print(
+                bar, baaz,
+            )
+        }
+        """
+
+        let output = """
+        func foo(
+            bar: Bar,
+            baaz: Baaz,
+            quux: Quux,
+        ) {
+            print(
+                bar,
+                baaz,
+            )
+        }
+        """
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: FormatOptions(wrapArguments: .beforeFirst, allowPartialWrapping: false), exclude: [.unusedArguments])
+    }
+
+    func testWrapPartiallyWrappedFunctionCallTwoLines() {
+        let input = """
+        func foo(
+            foo: Foo, bar: Bar,
+            baaz: Baaz, quux: Quux,
+        ) {
+            print(
+                foo, bar,
+                baaz, quux,
+            )
+        }
+        """
+
+        let output = """
+        func foo(
+            foo: Foo,
+            bar: Bar,
+            baaz: Baaz,
+            quux: Quux,
+        ) {
+            print(
+                foo,
+                bar,
+                baaz,
+                quux,
+            )
+        }
+        """
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: FormatOptions(wrapArguments: .beforeFirst, allowPartialWrapping: false))
+    }
+
+    func testWrapPartiallyWrappedArray() {
+        let input = """
+        let foo = [
+            foo, bar,
+            baaz, quux,
+        ]
+        """
+
+        let output = """
+        let foo = [
+            foo,
+            bar,
+            baaz,
+            quux,
+        ]
+        """
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: FormatOptions(wrapArguments: .beforeFirst, allowPartialWrapping: false))
+    }
+
+    func testArrayWithBlankLine() {
+        let input = """
+        let foo = [
+            foo,
+            bar,
+
+            baaz,
+            quux,
+        ]
+        """
+
+        testFormatting(for: input, rule: .wrapArguments, options: FormatOptions(wrapArguments: .beforeFirst, allowPartialWrapping: false))
+    }
+
+    func testPartiallyWrappedArrayWithBlankLine() {
+        let input = """
+        let foo = [
+            foo, bar,
+
+            baaz, quux,
+        ]
+        """
+
+        let output = """
+        let foo = [
+            foo,
+            bar,
+
+            baaz,
+            quux,
+        ]
+        """
+
+        testFormatting(for: input, output, rule: .wrapArguments, options: FormatOptions(wrapArguments: .beforeFirst, allowPartialWrapping: false))
+    }
 }


### PR DESCRIPTION
This PR adds a `--allow-partial-wrapping false` option that lets you specify function arguments and collection elements should all be wrapped to a single line

```diff
  func foo(
-   foo: Foo, bar: Bar,
-   baaz: Baaz, quux: Quux,
+   foo: Foo,
+   bar: Bar,
+   baaz: Baaz,
+   quux: Quux,
  ) { }
```