### PR TITLE
Improve type-related helpers by adding `TypeName` type

### DIFF
--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -329,7 +329,7 @@ extension TypeDeclaration {
     }
 
     /// The list of conformances of this type, not including any constraints following a `where` clause.
-    var conformances: [(conformance: String, index: Int)] {
+    var conformances: [(conformance: TypeName, index: Int)] {
         formatter.parseConformancesOfType(atKeywordIndex: keywordIndex)
     }
 }

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1982,7 +1982,7 @@ extension Formatter {
                 currentIndex = equalsIndex
             }
 
-            var rhsType: (name: String, range: ClosedRange<Int>)?
+            var rhsType: TypeName?
             if let rhsTypeIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: currentIndex),
                let type = parseType(at: rhsTypeIndex)
             {
@@ -2018,7 +2018,7 @@ extension Formatter {
             // `Foo.Element == Fooable`, etc. Create a reference to this specific
             // generic parameter (`Foo` in all of these examples) that can store
             // the constraints and conformances that we encounter later.
-            let fullGenericTypeName = qualifyGenericTypeName(lhsType.name)
+            let fullGenericTypeName = qualifyGenericTypeName(lhsType.string)
 
             let baseGenericTypeName: String
             if fullGenericTypeName.contains(".") {
@@ -2040,8 +2040,8 @@ extension Formatter {
 
             if let rhsType, let conformanceType {
                 genericType.conformances.append(.init(
-                    name: rhsType.name,
-                    typeName: qualifyGenericTypeName(lhsType.name),
+                    name: rhsType.string,
+                    typeName: qualifyGenericTypeName(lhsType.string),
                     type: conformanceType,
                     sourceRange: lhsType.range.lowerBound ... currentIndex
                 ))
@@ -2931,7 +2931,7 @@ extension Formatter {
     /// by adding a blank line to the end of this declaration if not already present.
     func addTrailingBlankLineIfNeeded(in range: ClosedRange<Int>) {
         let range = range.autoUpdating(in: self)
-        while tokens[range.range].numberOfTrailingLinebreaks() < 2 {
+        while tokens[range].numberOfTrailingLinebreaks() < 2 {
             insertLinebreak(at: range.upperBound)
         }
     }
@@ -2951,7 +2951,7 @@ extension Formatter {
     /// by adding blank like to the start of this declaration if not already present.
     func addLeadingBlankLineIfNeeded(in range: ClosedRange<Int>) {
         let range = range.autoUpdating(in: self)
-        while tokens[range.range].numberOfLeadingLinebreaks() < 2 {
+        while tokens[range].numberOfLeadingLinebreaks() < 2 {
             insertLinebreak(at: range.lowerBound)
         }
     }
@@ -2960,7 +2960,7 @@ extension Formatter {
     /// by removing any trailing blank lines.
     func removeLeadingBlankLinesIfPresent(in range: ClosedRange<Int>) {
         let range = range.autoUpdating(in: self)
-        while tokens[range.range].numberOfLeadingLinebreaks() > 1 {
+        while tokens[range].numberOfLeadingLinebreaks() > 1 {
             guard let firstNewlineIndex = index(of: .linebreak, in: Range(range.range)) else { break }
             removeTokens(in: range.lowerBound ... firstNewlineIndex)
         }

--- a/Sources/Rules/EnvironmentEntry.swift
+++ b/Sources/Rules/EnvironmentEntry.swift
@@ -70,7 +70,7 @@ extension Formatter {
         for declaration in declarations {
             guard let typeDeclaration = declaration.asTypeDeclaration,
                   typeDeclaration.keyword == "struct" || typeDeclaration.keyword == "enum",
-                  typeDeclaration.conformances.contains(where: { $0.conformance == "EnvironmentKey" }),
+                  typeDeclaration.conformances.contains(where: { $0.conformance.string == "EnvironmentKey" }),
                   let keyName = typeDeclaration.name,
                   typeDeclaration.body.count == 1,
                   let defaultValueDeclaration = typeDeclaration.body.first(where: {

--- a/Sources/Rules/MarkTypes.swift
+++ b/Sources/Rules/MarkTypes.swift
@@ -96,7 +96,7 @@ public extension FormatRule {
             if declaration.keyword == "extension" {
                 let conformances = typeDeclaration.conformances.map(\.conformance)
                 if !conformances.isEmpty {
-                    conformanceNames = conformances.joined(separator: ", ")
+                    conformanceNames = conformances.map(\.string).joined(separator: ", ")
                 }
             }
 

--- a/Sources/Rules/NoExplicitOwnership.swift
+++ b/Sources/Rules/NoExplicitOwnership.swift
@@ -30,7 +30,7 @@ public extension FormatRule {
             }
 
             else if let type = formatter.parseType(at: nextTokenIndex),
-                    type.name.first?.isLowercase == false
+                    type.string.first?.isLowercase == false
             {
                 isValidOwnershipModifier = true
             }

--- a/Sources/Rules/NoGuardInTests.swift
+++ b/Sources/Rules/NoGuardInTests.swift
@@ -156,9 +156,9 @@ public extension FormatRule {
                         ])
 
                         // Add type annotation if present
-                        if let typeInfo = property.type {
+                        if let colonIndex = property.colonIndex, let type = property.type {
                             // Include from colon to end of type
-                            let typeTokens = formatter.tokens[typeInfo.colonIndex ... typeInfo.range.upperBound]
+                            let typeTokens = formatter.tokens[colonIndex ... type.range.upperBound]
                             replacementStatements.append(contentsOf: typeTokens)
                         }
 

--- a/Sources/Rules/OpaqueGenericParameters.swift
+++ b/Sources/Rules/OpaqueGenericParameters.swift
@@ -110,8 +110,8 @@ public extension FormatRule {
                 // but with `-> some Fooable` the generic type is specified by the function implementation.
                 // Because those represent different concepts, we can't convert between them,
                 // so have to mark the generic type as ineligible if it appears in the return type.
-                if let returnType = declaration.returnType?.name,
-                   tokenize(returnType).contains(where: { $0.string == genericType.name })
+                if let returnType = declaration.returnType,
+                   returnType.tokens.contains(where: { $0.string == genericType.name })
                 {
                     genericType.eligibleToRemove = false
                     continue
@@ -198,7 +198,7 @@ public extension FormatRule {
                 if let tokenAfterWhereKeyword = formatter.index(of: .nonSpaceOrLinebreak, after: whereClauseRange.lowerBound),
                    whereClauseRange.upperBound <= tokenAfterWhereKeyword
                 {
-                    formatter.removeTokens(in: whereClauseRange.range)
+                    formatter.removeTokens(in: whereClauseRange)
                 }
 
                 // remove trailing comma

--- a/Sources/Rules/PreferSwiftTesting.swift
+++ b/Sources/Rules/PreferSwiftTesting.swift
@@ -25,7 +25,7 @@ public extension FormatRule {
 
         let xcTestSuites = declarations
             .compactMap(\.asTypeDeclaration)
-            .filter { $0.conformances.contains(where: { $0.conformance == "XCTestCase" }) }
+            .filter { $0.conformances.contains(where: { $0.conformance.string == "XCTestCase" }) }
 
         guard !xcTestSuites.isEmpty,
               !xcTestSuites.contains(where: { $0.hasUnsupportedXCTestFunctionality() })
@@ -154,7 +154,7 @@ extension TypeDeclaration {
     /// Converts this XCTestCase implementation to a Swift Testing test suite
     func convertXCTestCaseToSwiftTestingSuite() {
         // Remove the XCTestCase conformance
-        if let xcTestCaseConformance = conformances.first(where: { $0.conformance == "XCTestCase" }) {
+        if let xcTestCaseConformance = conformances.first(where: { $0.conformance.string == "XCTestCase" }) {
             formatter.removeConformance(at: xcTestCaseConformance.index)
         }
 

--- a/Sources/Rules/RedundantEquatable.swift
+++ b/Sources/Rules/RedundantEquatable.swift
@@ -47,7 +47,7 @@ public extension FormatRule {
             // as long as all of the properties are themselves Equatable. This is usually true
             //
             if equatableType.typeDeclaration.keyword == "struct",
-               !storedInstanceProperties.contains(where: { $0.parsePropertyDeclaration()?.type?.name.isKnownNonEquatableType == true })
+               !storedInstanceProperties.contains(where: { $0.parsePropertyDeclaration()?.type?.isKnownNonEquatableType == true })
             {
                 equatableType.equatableFunction.remove()
             }
@@ -57,7 +57,7 @@ public extension FormatRule {
             else if case let .macro(macro, module: module) = formatter.options.equatableMacro {
                 let declarationWithEquatableConformance = equatableType.declarationWithEquatableConformance
 
-                guard let equatableConformance = formatter.parseConformancesOfType(atKeywordIndex: declarationWithEquatableConformance.keywordIndex).first(where: { $0.conformance == "Equatable" || $0.conformance == "Hashable" })
+                guard let equatableConformance = formatter.parseConformancesOfType(atKeywordIndex: declarationWithEquatableConformance.keywordIndex).first(where: { $0.conformance.string == "Equatable" || $0.conformance.string == "Hashable" })
                 else { continue }
 
                 // Exclude cases where the Equatable conformance is defined in an extension with a where clause,
@@ -73,7 +73,7 @@ public extension FormatRule {
 
                 // Remove the `: Equatable` conformance.
                 //  - If this type uses as `: Hashable` conformance, we have to preserve that.
-                if equatableConformance.conformance == "Equatable" {
+                if equatableConformance.conformance.string == "Equatable" {
                     formatter.removeConformance(at: equatableConformance.index)
                 }
 
@@ -166,7 +166,7 @@ extension Formatter {
 
                 // Both an Equatable and Hashable conformance will cause the Equatable conformance to be synthesized
                 if conformances.contains(where: {
-                    $0.conformance == "Equatable" || $0.conformance == "Hashable"
+                    $0.conformance.string == "Equatable" || $0.conformance.string == "Hashable"
                 }) {
                     typesWithEquatableConformances.append((
                         fullyQualifiedTypeName: fullyQualifiedName,
@@ -188,7 +188,7 @@ extension Formatter {
                    functionArguments[1].internalLabel == "rhs",
                    functionArguments[0].type == functionArguments[1].type
                 {
-                    var comparedTypeName = functionArguments[0].type
+                    var comparedTypeName = functionArguments[0].type.string
 
                     if let parentDeclaration = declaration.parent {
                         // If the function uses `Self`, resolve that to the name of the parent type
@@ -296,10 +296,10 @@ extension Formatter {
     }
 }
 
-extension String {
+extension TypeName {
     /// Whether or not this type name is known to be non-Equatable
     var isKnownNonEquatableType: Bool {
         let knownNonEquatableTypes = ["AnyClass"]
-        return knownNonEquatableTypes.contains(self) || isTupleType
+        return knownNonEquatableTypes.contains(string) || isTuple
     }
 }

--- a/Sources/Rules/RedundantInit.swift
+++ b/Sources/Rules/RedundantInit.swift
@@ -37,7 +37,7 @@ public extension FormatRule {
             let type = formatter.parseType(at: startOfTypeIndex),
             // Filter out values that start with a lowercase letter.
             // This covers edge cases like `super.init()`, where the `init` is not redundant.
-            let firstChar = type.name.components(separatedBy: ".").last?.first,
+            let firstChar = type.string.components(separatedBy: ".").last?.first,
             firstChar != "$",
             String(firstChar).uppercased() == String(firstChar)
             else { return }

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -37,15 +37,15 @@ public extension FormatRule {
             }
 
             // Collect stored properties from the struct body
-            var storedProperties = [(name: String, type: String)]()
+            var storedProperties = [(name: String, type: TypeName)]()
 
             for childDeclaration in structDeclaration.body {
                 guard ["var", "let"].contains(childDeclaration.keyword),
                       let property = formatter.parsePropertyDeclaration(atIntroducerIndex: childDeclaration.keywordIndex),
-                      let typeInfo = property.type,
+                      let type = property.type,
                       childDeclaration.isStoredInstanceProperty
                 else { continue }
-                storedProperties.append((name: property.identifier, type: typeInfo.name))
+                storedProperties.append((name: property.identifier, type: type))
             }
 
             guard !storedProperties.isEmpty else { continue }
@@ -160,7 +160,7 @@ public extension FormatRule {
                 else { continue }
 
                 // Check if parameters match stored properties exactly
-                let parameters = functionDecl.arguments.compactMap { arg -> (name: String, type: String, externalLabel: String?, hasDefaultValue: Bool)? in
+                let parameters = functionDecl.arguments.compactMap { arg -> (name: String, type: TypeName, externalLabel: String?, hasDefaultValue: Bool)? in
                     guard let name = arg.internalLabel else { return nil }
 
                     // Check for default value by looking for '=' after the type

--- a/Sources/Rules/RedundantNilInit.swift
+++ b/Sources/Rules/RedundantNilInit.swift
@@ -36,7 +36,7 @@ public extension FormatRule {
             if let parentType = declaration.parentType {
                 // Check if this is in a Codable type
                 if parentType.conformances.contains(where: {
-                    ["Codable", "Decodable"].contains($0.conformance)
+                    ["Codable", "Decodable"].contains($0.conformance.string)
                 }) {
                     return
                 }
@@ -53,7 +53,7 @@ public extension FormatRule {
 
             guard let propertyDeclaration = formatter.parsePropertyDeclaration(atIntroducerIndex: varIndex),
                   let type = propertyDeclaration.type,
-                  type.name.hasSuffix("?") || type.name.hasSuffix("!")
+                  type.string.hasSuffix("?") || type.string.hasSuffix("!")
             else { return }
 
             switch formatter.options.nilInit {

--- a/Sources/TypeName.swift
+++ b/Sources/TypeName.swift
@@ -1,0 +1,116 @@
+//
+//  TypeName.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 8/22/25.
+//  Copyright © 2025 Nick Lockwood. All rights reserved.
+//
+
+// MARK: - TypeName
+
+/// A Swift type parsed by the `formatter.parseType(at:)` parsing helper
+struct TypeName {
+    var range: AutoUpdatingRange
+    let formatter: Formatter
+
+    init(range: ClosedRange<Int>, formatter: Formatter) {
+        self.range = AutoUpdatingRange(range: range, formatter: formatter)
+        self.formatter = formatter
+    }
+
+    /// The string representation of this type, excluding linebreaks or comments
+    var string: String {
+        formatter.tokens[range].stringExcludingLinebreaksAndComments
+    }
+
+    var tokens: ArraySlice<Token> {
+        formatter.tokens[range]
+    }
+}
+
+extension TypeName: Equatable {
+    static func == (lhs: TypeName, rhs: TypeName) -> Bool {
+        lhs.tokens == rhs.tokens
+    }
+}
+
+extension TypeName: CustomDebugStringConvertible {
+    var debugDescription: String {
+        """
+        /* Type at \(range) */
+        \(tokens.string)
+        """
+    }
+}
+
+// MARK: Helpers
+
+extension TypeName {
+    /// Whether or not this type is a tuple.
+    var isTuple: Bool {
+        // Tuple types start and end with parens and have a comma-separated list of elements.
+        // (There are no single-element tuples).
+        guard let openParen = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: range.lowerBound - 1),
+              formatter.tokens[openParen] == .startOfScope("("),
+              let closingParen = formatter.endOfScope(at: openParen),
+              openParen + 1 != closingParen
+        else { return false }
+
+        // The tuple could be optional, but otherwise the closing paren should be the last token.
+        if let tokenAfterClosingParen = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closingParen) {
+            guard tokenAfterClosingParen > range.upperBound || formatter.tokens[tokenAfterClosingParen] == .operator("?", .postfix) else {
+                return false
+            }
+        }
+
+        let hasCommaInParens = formatter.index(of: .delimiter(","), in: (openParen + 1) ..< closingParen) != nil
+        return hasCommaInParens
+    }
+
+    /// Whether or not this type is an array.
+    var isArray: Bool {
+        guard let openBrace = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: range.lowerBound - 1),
+              formatter.tokens[openBrace] == .startOfScope("["),
+              let closingBrace = formatter.endOfScope(at: openBrace),
+              openBrace + 1 != closingBrace
+        else { return false }
+
+        // [:] would be a dictionary, not an array
+        let hasColonInBraces = formatter.index(of: .delimiter(":"), in: (openBrace + 1) ..< closingBrace) != nil
+        return !hasColonInBraces
+    }
+
+    /// Whether or not this type is an array.
+    var isDictionary: Bool {
+        guard let openBrace = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: range.lowerBound - 1),
+              formatter.tokens[openBrace] == .startOfScope("["),
+              let closingBrace = formatter.endOfScope(at: openBrace),
+              openBrace + 1 != closingBrace
+        else { return false }
+
+        // [] would be a dictionary, not an array
+        let hasColonInBraces = formatter.index(of: .delimiter(":"), in: (openBrace + 1) ..< closingBrace) != nil
+        return hasColonInBraces
+    }
+
+    /// Whether or not this type is a closure
+    var isClosure: Bool {
+        formatter.isStartOfClosureType(at: range.lowerBound)
+    }
+
+    /// If this type is wrapped in redundant parens, returns the inner type.
+    func withoutParens() -> TypeName {
+        /// If this type is a tuple, then the parens aren't redundant
+        if isTuple { return self }
+
+        guard formatter.tokens[range.lowerBound] == .startOfScope("("),
+              formatter.tokens[range.upperBound] == .endOfScope(")"),
+              let tokenAfterFirst = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: range.lowerBound),
+              let tokenBeforeLast = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: range.upperBound),
+              tokenAfterFirst <= tokenBeforeLast
+        else { return self }
+
+        let newType = TypeName(range: tokenAfterFirst ... tokenBeforeLast, formatter: formatter)
+        return newType.withoutParens()
+    }
+}

--- a/SwiftFormat.xcodeproj/project.pbxproj
+++ b/SwiftFormat.xcodeproj/project.pbxproj
@@ -86,6 +86,10 @@
 		2EDC9DDC2CCE9A7C0085DBE2 /* Declaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */; };
 		2EDC9DDD2CCE9A7C0085DBE2 /* Declaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */; };
 		2EDC9DDF2CCE9BC70085DBE2 /* DeclarationV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDC9DDE2CCE9BC70085DBE2 /* DeclarationV2Tests.swift */; };
+		2EE4007A2E595B7200CF8D5A /* TypeName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE400792E595B7000CF8D5A /* TypeName.swift */; };
+		2EE4007B2E595B7200CF8D5A /* TypeName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE400792E595B7000CF8D5A /* TypeName.swift */; };
+		2EE4007C2E595B7200CF8D5A /* TypeName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE400792E595B7000CF8D5A /* TypeName.swift */; };
+		2EE4007D2E595B7200CF8D5A /* TypeName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE400792E595B7000CF8D5A /* TypeName.swift */; };
 		2EF737522C5E881C00128F91 /* CodeOrganizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */; };
 		2EF737542C5E897800128F91 /* ProjectFilePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF737532C5E897800128F91 /* ProjectFilePaths.swift */; };
 		2EF8BF1B2D1E0D4F00D6F12F /* DeclarationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */; };
@@ -248,6 +252,7 @@
 		2E7D30A32A7940C500C32174 /* Singularize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Singularize.swift; sourceTree = "<group>"; };
 		2EDC9DD92CCE9A7C0085DBE2 /* Declaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Declaration.swift; sourceTree = "<group>"; };
 		2EDC9DDE2CCE9BC70085DBE2 /* DeclarationV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationV2Tests.swift; sourceTree = "<group>"; };
+		2EE400792E595B7000CF8D5A /* TypeName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeName.swift; sourceTree = "<group>"; };
 		2EF737512C5E881C00128F91 /* CodeOrganizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeOrganizationTests.swift; sourceTree = "<group>"; };
 		2EF737532C5E897800128F91 /* ProjectFilePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFilePaths.swift; sourceTree = "<group>"; };
 		2EF8BF1A2D1E0D4F00D6F12F /* DeclarationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarationType.swift; sourceTree = "<group>"; };
@@ -402,6 +407,7 @@
 		01A0EAA61D5DB4CF00A0A8E3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				2EE400792E595B7000CF8D5A /* TypeName.swift */,
 				2E3A24EE2DDD621600407419 /* Rules */,
 				2E2BAB8B2C57F6B600590239 /* RuleRegistry.generated.swift */,
 				01F17E811E25870700DCD359 /* CommandLine.swift */,
@@ -884,6 +890,7 @@
 				DD9AD39E2999FCC8001C2C0E /* GithubActionsLogReporter.swift in Sources */,
 				01045A91211988F100D2BE3D /* Inference.swift in Sources */,
 				DD9AD3A32999FCC8001C2C0E /* Reporter.swift in Sources */,
+				2EE4007C2E595B7200CF8D5A /* TypeName.swift in Sources */,
 				E4FABAD5202FEF060065716E /* OptionDescriptor.swift in Sources */,
 				2EDC9DDA2CCE9A7C0085DBE2 /* Declaration.swift in Sources */,
 				01BBD85921DAA2A000457380 /* Globs.swift in Sources */,
@@ -951,6 +958,7 @@
 				01A8320724EC7F7600A9D0EB /* FormattingHelpers.swift in Sources */,
 				01F17E831E25870700DCD359 /* CommandLine.swift in Sources */,
 				015243E22B04B0A600F65221 /* Singularize.swift in Sources */,
+				2EE4007B2E595B7200CF8D5A /* TypeName.swift in Sources */,
 				6E954FF42E0DEACC004EE019 /* SARIFReporter.swift in Sources */,
 				C2FFD1832BD13C9E00774F55 /* XMLReporter.swift in Sources */,
 				01A0EACD1D5DB5F500A0A8E3 /* main.swift in Sources */,
@@ -978,6 +986,7 @@
 				2E2611C92DD94FE900FFFE09 /* XMLReporter.swift in Sources */,
 				2E2611CA2DD94FE900FFFE09 /* GithubActionsLogReporter.swift in Sources */,
 				2E2611CB2DD94FE900FFFE09 /* Reporter.swift in Sources */,
+				2EE4007A2E595B7200CF8D5A /* TypeName.swift in Sources */,
 				2E26108E2DD92CB400FFFE09 /* CommandLine.swift in Sources */,
 				015D3A562995A0340065B2D9 /* AboutViewController.swift in Sources */,
 				E41CB5C52027700100C1BEDE /* FreeTextTableCellView.swift in Sources */,
@@ -1017,6 +1026,7 @@
 				01045A9F2119D30D00D2BE3D /* Inference.swift in Sources */,
 				01A95BD2225BEDE300744931 /* ParsingHelpers.swift in Sources */,
 				90C4B6E51DA4B059009EB000 /* SourceEditorExtension.swift in Sources */,
+				2EE4007D2E595B7200CF8D5A /* TypeName.swift in Sources */,
 				0142C77023C3FB6D005D5832 /* LintFileCommand.swift in Sources */,
 				E4E4D3CC2033F17C000D7CB1 /* EnumAssociable.swift in Sources */,
 				E4FABAD8202FEF060065716E /* OptionDescriptor.swift in Sources */,

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2016,28 +2016,28 @@ class ParsingHelpersTests: XCTestCase {
         let formatter = Formatter(tokenize("""
         let foo: Foo = .init()
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo")
     }
 
     func testParseOptionalType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo? = .init()
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo?")
     }
 
     func testParseIOUType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo! = .init()
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo!")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo!")
     }
 
     func testDoesntParseTernaryOperatorAsType() {
         let formatter = Formatter(tokenize("""
         Foo.bar ? .foo : .bar
         """))
-        XCTAssertEqual(formatter.parseType(at: 0)?.name, "Foo.bar")
+        XCTAssertEqual(formatter.parseType(at: 0)?.string, "Foo.bar")
     }
 
     func testDoesntParseMacroInvocationAsType() {
@@ -2072,161 +2072,161 @@ class ParsingHelpersTests: XCTestCase {
         let formatter = Formatter(tokenize("""
         let foo = [Foo]()
         """))
-        XCTAssertEqual(formatter.parseType(at: 6)?.name, "[Foo]")
+        XCTAssertEqual(formatter.parseType(at: 6)?.string, "[Foo]")
     }
 
     func testParsesDictionaryAsType() {
         let formatter = Formatter(tokenize("""
         let foo = [Foo: Bar]()
         """))
-        XCTAssertEqual(formatter.parseType(at: 6)?.name, "[Foo: Bar]")
+        XCTAssertEqual(formatter.parseType(at: 6)?.string, "[Foo: Bar]")
     }
 
     func testParseGenericType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo<Bar, Baaz> = .init()
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo<Bar, Baaz>")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo<Bar, Baaz>")
     }
 
     func testParseOptionalGenericType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo<Bar, Baaz>? = .init()
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo<Bar, Baaz>?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo<Bar, Baaz>?")
     }
 
     func testParseDictionaryType() {
         let formatter = Formatter(tokenize("""
         let foo: [Foo: Bar] = [:]
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "[Foo: Bar]")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "[Foo: Bar]")
     }
 
     func testParseOptionalDictionaryType() {
         let formatter = Formatter(tokenize("""
         let foo: [Foo: Bar]? = [:]
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "[Foo: Bar]?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "[Foo: Bar]?")
     }
 
     func testParseTupleType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) = (Foo(), Bar())
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar)")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar)")
     }
 
     func testParseClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) -> (Foo, Bar) = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) -> (Foo, Bar)")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) -> (Foo, Bar)")
     }
 
     func testParseThrowingClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) throws -> Void
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) throws -> Void")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) throws -> Void")
     }
 
     func testParseTypedThrowingClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) throws(MyFeatureError) -> Void
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) throws(MyFeatureError) -> Void")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) throws(MyFeatureError) -> Void")
     }
 
     func testParseAsyncClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) async -> Void
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) async -> Void")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) async -> Void")
     }
 
     func testParseAsyncThrowsClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) async throws -> Void
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) async throws -> Void")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) async throws -> Void")
     }
 
     func testParseTypedAsyncThrowsClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) async throws(MyCustomError) -> Void
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) async throws(MyCustomError) -> Void")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) async throws(MyCustomError) -> Void")
     }
 
     func testParseClosureTypeWithOwnership() {
         let formatter = Formatter(tokenize("""
         let foo: (consuming Foo, borrowing Bar) -> (Foo, Bar) = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(consuming Foo, borrowing Bar) -> (Foo, Bar)")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(consuming Foo, borrowing Bar) -> (Foo, Bar)")
     }
 
     func testParseOptionalReturningClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: (Foo, Bar) -> (Foo, Bar)? = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(Foo, Bar) -> (Foo, Bar)?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(Foo, Bar) -> (Foo, Bar)?")
     }
 
     func testParseOptionalClosureType() {
         let formatter = Formatter(tokenize("""
         let foo: ((Foo, Bar) -> (Foo, Bar)?)? = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "((Foo, Bar) -> (Foo, Bar)?)?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "((Foo, Bar) -> (Foo, Bar)?)?")
     }
 
     func testParseOptionalClosureTypeWithOwnership() {
         let formatter = Formatter(tokenize("""
         let foo: ((consuming Foo, borrowing Bar) -> (Foo, Bar)?)? = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "((consuming Foo, borrowing Bar) -> (Foo, Bar)?)?")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "((consuming Foo, borrowing Bar) -> (Foo, Bar)?)?")
     }
 
     func testParseExistentialAny() {
         let formatter = Formatter(tokenize("""
         let foo: any Foo
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "any Foo")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "any Foo")
     }
 
     func testParseCompoundType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo.Bar.Baaz
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo.Bar.Baaz")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo.Bar.Baaz")
     }
 
     func testDoesntParseLeadingDotAsType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo = .Bar.baaz
         """))
-        XCTAssertEqual(formatter.parseType(at: 9)?.name, nil)
+        XCTAssertEqual(formatter.parseType(at: 9)?.string, nil)
     }
 
     func testParseCompoundGenericType() {
         let formatter = Formatter(tokenize("""
         let foo: Foo<Bar>.Bar.Baaz<Quux.V2>
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "Foo<Bar>.Bar.Baaz<Quux.V2>")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "Foo<Bar>.Bar.Baaz<Quux.V2>")
     }
 
     func testParseExistentialTypeWithSubtype() {
         let formatter = Formatter(tokenize("""
         let foo: (any Foo).Bar.Baaz
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(any Foo).Bar.Baaz")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(any Foo).Bar.Baaz")
     }
 
     func testParseOpaqueReturnType() {
         let formatter = Formatter(tokenize("""
         var body: some View { EmptyView() }
         """))
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "some View")
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "some View")
     }
 
     func testParameterPackTypes() {
@@ -2239,19 +2239,19 @@ class ParsingHelpersTests: XCTestCase {
             return (repeat (each item).first)
         }
         """))
-        XCTAssertEqual(formatter.parseType(at: 4)?.name, "each T")
-        XCTAssertEqual(formatter.parseType(at: 13)?.name, "repeat each T")
-        XCTAssertEqual(formatter.parseType(at: 62)?.name, "repeat (each T).Element?")
+        XCTAssertEqual(formatter.parseType(at: 4)?.string, "each T")
+        XCTAssertEqual(formatter.parseType(at: 13)?.string, "repeat each T")
+        XCTAssertEqual(formatter.parseType(at: 62)?.string, "repeat (each T).Element?")
     }
 
     func testParseInvalidType() {
         let formatter = Formatter(tokenize("""
         let foo = { foo, bar in (foo, bar) }
         """))
-        XCTAssertEqual(formatter.parseType(at: 4)?.name, nil)
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, nil)
-        XCTAssertEqual(formatter.parseType(at: 6)?.name, nil)
-        XCTAssertEqual(formatter.parseType(at: 7)?.name, nil)
+        XCTAssertEqual(formatter.parseType(at: 4)?.string, nil)
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, nil)
+        XCTAssertEqual(formatter.parseType(at: 6)?.string, nil)
+        XCTAssertEqual(formatter.parseType(at: 7)?.string, nil)
     }
 
     func testMultilineType() {
@@ -2263,7 +2263,7 @@ class ParsingHelpersTests: XCTestCase {
         { }
         """))
 
-        XCTAssertEqual(formatter.parseType(at: 2)?.name, "Foo.Bar.Baaz.Quux.InnerType1.InnerType2")
+        XCTAssertEqual(formatter.parseType(at: 2)?.string, "Foo.Bar.Baaz.Quux.InnerType1.InnerType2")
     }
 
     func testParseTuples() {
@@ -2280,20 +2280,20 @@ class ParsingHelpersTests: XCTestCase {
 
         let formatter = Formatter(tokenize(input))
 
-        XCTAssertEqual(formatter.parseType(at: 5)?.name, "(foo: Foo, bar: Bar)")
-        XCTAssertTrue(formatter.isStartOfTupleType(at: 5))
+        XCTAssertEqual(formatter.parseType(at: 5)?.string, "(foo: Foo, bar: Bar)")
+        XCTAssert(formatter.parseType(at: 5)?.isTuple == true)
 
-        XCTAssertEqual(formatter.parseType(at: 23)?.name, "(foo: Foo, bar: Bar) -> Void")
-        XCTAssertFalse(formatter.isStartOfTupleType(at: 23))
+        XCTAssertEqual(formatter.parseType(at: 23)?.string, "(foo: Foo, bar: Bar) -> Void")
+        XCTAssert(formatter.parseType(at: 23)?.isTuple == false)
 
-        XCTAssertEqual(formatter.parseType(at: 45)?.name, "(Foo)")
-        XCTAssertFalse(formatter.isStartOfTupleType(at: 45))
+        XCTAssertEqual(formatter.parseType(at: 45)?.string, "(Foo)")
+        XCTAssert(formatter.parseType(at: 45)?.isTuple == false)
 
-        XCTAssertEqual(formatter.parseType(at: 54)?.name, "()")
-        XCTAssertFalse(formatter.isStartOfTupleType(at: 54))
+        XCTAssertEqual(formatter.parseType(at: 54)?.string, "()")
+        XCTAssert(formatter.parseType(at: 54)?.isTuple == false)
 
-        XCTAssertTrue(formatter.isStartOfTupleType(at: 62))
-        XCTAssertEqual(formatter.parseType(at: 62)?.name, "(bar: String,  quux: String  )")
+        XCTAssert(formatter.parseType(at: 62)?.isTuple == true)
+        XCTAssertEqual(formatter.parseType(at: 62)?.string, "(bar: String,  quux: String  )")
     }
 
     // MARK: - parseExpressionRange
@@ -2615,15 +2615,37 @@ class ParsingHelpersTests: XCTestCase {
 
         let formatter = Formatter(tokenize(input))
 
-        XCTAssertEqual(
-            formatter.parseFunctionDeclarationArguments(startOfScope: 3), // foo(...)
-            [
-                Formatter.FunctionArgument(externalLabel: nil, internalLabel: "foo", externalLabelIndex: 4, internalLabelIndex: 6, type: "Foo"),
-                Formatter.FunctionArgument(externalLabel: "bar", internalLabel: "bar", externalLabelIndex: nil, internalLabelIndex: 12, type: "Bar"),
-                Formatter.FunctionArgument(externalLabel: "quux", internalLabel: nil, externalLabelIndex: 18, internalLabelIndex: 20, type: "Quux"),
-                Formatter.FunctionArgument(externalLabel: "last", internalLabel: "baaz", externalLabelIndex: 26, internalLabelIndex: 28, type: "Baaz"),
-            ]
-        )
+        let arguments = formatter.parseFunctionDeclarationArguments(startOfScope: 3) // foo(...)
+
+        XCTAssertEqual(arguments.count, 4)
+
+        // First argument: _ foo: Foo
+        XCTAssertNil(arguments[0].externalLabel)
+        XCTAssertEqual(arguments[0].internalLabel, "foo")
+        XCTAssertEqual(arguments[0].externalLabelIndex, 4)
+        XCTAssertEqual(arguments[0].internalLabelIndex, 6)
+        XCTAssertEqual(arguments[0].type.string, "Foo")
+
+        // Second argument: bar: Bar
+        XCTAssertEqual(arguments[1].externalLabel, "bar")
+        XCTAssertEqual(arguments[1].internalLabel, "bar")
+        XCTAssertNil(arguments[1].externalLabelIndex)
+        XCTAssertEqual(arguments[1].internalLabelIndex, 12)
+        XCTAssertEqual(arguments[1].type.string, "Bar")
+
+        // Third argument: quux _: Quux
+        XCTAssertEqual(arguments[2].externalLabel, "quux")
+        XCTAssertNil(arguments[2].internalLabel)
+        XCTAssertEqual(arguments[2].externalLabelIndex, 18)
+        XCTAssertEqual(arguments[2].internalLabelIndex, 20)
+        XCTAssertEqual(arguments[2].type.string, "Quux")
+
+        // Fourth argument: last baaz: Baaz
+        XCTAssertEqual(arguments[3].externalLabel, "last")
+        XCTAssertEqual(arguments[3].internalLabel, "baaz")
+        XCTAssertEqual(arguments[3].externalLabelIndex, 26)
+        XCTAssertEqual(arguments[3].internalLabelIndex, 28)
+        XCTAssertEqual(arguments[3].type.string, "Baaz")
 
         XCTAssertEqual(
             formatter.parseFunctionDeclarationArguments(startOfScope: 40), // bar()


### PR DESCRIPTION
This PR improves some of our various type-related helpers by adding a `TypeName` type, with a similar structure to the `Declaration` type.

`parseType(at:)` returns this value now instead of a tuple.

I moved some of the type-related helpers defined on `String` to instead be defined on `TypeName`.