### PR TITLE
Fix bug where `markTypes` rule wouldn't add marks after extensions

### DIFF
--- a/Sources/Rules/MarkTypes.swift
+++ b/Sources/Rules/MarkTypes.swift
@@ -152,7 +152,7 @@ public extension FormatRule {
             }
 
             guard let expectedCommentBody = markForType else {
-                return
+                continue
             }
 
             // When inserting a mark before the first declaration,

--- a/Tests/Rules/MarkTypesTests.swift
+++ b/Tests/Rules/MarkTypesTests.swift
@@ -996,4 +996,34 @@ class MarkTypesTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .markTypes)
     }
+
+    func testMarksTypeAfterExtension() {
+        let input = """
+        extension Foo {
+            var foo: Foo { Foo() }
+            var bar: Bar { Bar() }
+        }
+
+        struct Baaz {
+            let foo: Foo
+            let bar: Bar
+        }
+        """
+
+        let output = """
+        extension Foo {
+            var foo: Foo { Foo() }
+            var bar: Bar { Bar() }
+        }
+
+        // MARK: - Baaz
+
+        struct Baaz {
+            let foo: Foo
+            let bar: Bar
+        }
+        """
+
+        testFormatting(for: input, output, rule: .markTypes)
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where the `markTypes` rule wouldn't add mark comments after extensions