### PR TITLE
Add `--default-test-suite-attributes` option to `preferSwiftTesting` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1984,6 +1984,7 @@ Prefer the Swift Testing library over XCTest.
 Option | Description
 --- | ---
 `--xctest-symbols` | Comma-delimited list of symbols that depend on XCTest
+`--default-test-suite-attributes` | Comma-delimited list of attributes to add when converting from XCTest. e.g. "@MainActor,@Suite(.serialized)"
 
 <details>
 <summary>Examples</summary>
@@ -2003,7 +2004,6 @@ Option | Description
 -         XCTAssertNil(myFeature.crashReport)
 -     }
 - }
-+ @MainActor @Suite(.serialized)
 + final class MyFeatureTests { 
 +     @Test func myFeatureHasNoBugs() {
 +         let myFeature = MyFeature()
@@ -2031,7 +2031,6 @@ Option | Description
 -         XCTAssertEqual(myFeature.screens.count, 8)
 -     }
 - }
-+ @MainActor
 + final class MyFeatureTests {
 +     var myFeature: MyFeature!
 + 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1374,6 +1374,19 @@ struct _Descriptors {
         help: "Comma-delimited list of symbols that depend on XCTest",
         keyPath: \.additionalXCTestSymbols
     )
+    let defaultTestSuiteAttributes = OptionDescriptor(
+        argumentName: "default-test-suite-attributes",
+        displayName: "Default test suite attributes",
+        help: "Comma-delimited list of attributes to add when converting from XCTest. e.g. \"@MainActor,@Suite(.serialized)\"",
+        keyPath: \.defaultTestSuiteAttributes,
+        validateArray: { array in
+            for attribute in array {
+                guard attribute.starts(with: "@"), !tokenize(attribute).contains(where: \.isError) else {
+                    throw FormatError.options("Invalid attribute: \"\(attribute)\"")
+                }
+            }
+        }
+    )
     let swiftUIPropertiesSortMode = OptionDescriptor(
         argumentName: "sort-swiftui-properties",
         displayName: "Sort SwiftUI Dynamic Properties",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -823,6 +823,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var nilInit: NilInitType
     public var preservedPrivateDeclarations: Set<String>
     public var additionalXCTestSymbols: Set<String>
+    public var defaultTestSuiteAttributes: [String]
     public var equatableMacro: EquatableMacro
     public var urlMacro: URLMacro
     public var preferFileMacro: Bool
@@ -964,6 +965,7 @@ public struct FormatOptions: CustomStringConvertible {
                 nilInit: NilInitType = .remove,
                 preservedPrivateDeclarations: Set<String> = [],
                 additionalXCTestSymbols: Set<String> = [],
+                defaultTestSuiteAttributes: [String] = [],
                 equatableMacro: EquatableMacro = .none,
                 urlMacro: URLMacro = .none,
                 preferFileMacro: Bool = true,
@@ -1094,6 +1096,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.nilInit = nilInit
         self.preservedPrivateDeclarations = preservedPrivateDeclarations
         self.additionalXCTestSymbols = additionalXCTestSymbols
+        self.defaultTestSuiteAttributes = defaultTestSuiteAttributes
         self.equatableMacro = equatableMacro
         self.urlMacro = urlMacro
         self.preferFileMacro = preferFileMacro

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -38,7 +38,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         @testable import MyFeatureLib
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func myFeatureWorks() {
                 let myFeature = MyFeature()
@@ -93,7 +92,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         @testable import MyFeatureLib
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             var myFeature: MyFeature!
 
@@ -178,7 +176,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         class HelperConversionTests {
             @Test func convertsSimpleXCTestHelpers() throws {
                 #expect(foo)
@@ -285,7 +282,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         class HelperConversionTests {
             @Test func converts_multiline_XCTest_helpers() {
                 #expect(foo.bar(
@@ -463,7 +459,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         @testable import MyFeatureLib
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func myFeatureWorks() {
                 let myFeature = MyFeature()
@@ -528,7 +523,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func test123() {
                 #expect((1 + 2) == 3)
@@ -552,7 +546,7 @@ final class PreferSwiftTestingTests: XCTestCase {
         testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports], options: options)
     }
 
-    func testDoesntUpTestNameToExistingFunctionName() {
+    func testDoesntUpdateTestNameToExistingFunctionName() {
         let input = """
         import XCTest
 
@@ -571,7 +565,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func testOnePlusTwo() {
                 #expect(onePlusTwo() == 3)
@@ -607,7 +600,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func myFeatureWorks() {
                 testMyFeatureWorks(MyFeature())
@@ -648,7 +640,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Foundation
         import Testing
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func myFeatureWorks() throws {
                 let myFeature = MyFeature()
@@ -725,7 +716,6 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Testing
         import UIKit
 
-        @MainActor @Suite(.serialized)
         final class MyFeatureTests {
             @Test func myFeatureWorks() {
                 let viewController = UIViewController()
@@ -735,6 +725,64 @@ final class PreferSwiftTestingTests: XCTestCase {
         """
 
         let options = FormatOptions(swiftVersion: "6.0")
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports], options: options)
+    }
+
+    func testAppliesCustomTestSuiteAttribute() {
+        let input = """
+        import XCTest
+
+        final class MyFeatureTests: XCTestCase {
+            func testMyFeatureWorks() {
+                let myFeature = MyFeature()
+                XCTAssertTrue(myFeature.worksProperly)
+            }
+        }
+        """
+
+        let output = """
+        import Foundation
+        import Testing
+
+        @MainActor
+        final class MyFeatureTests {
+            @Test func myFeatureWorks() {
+                let myFeature = MyFeature()
+                #expect(myFeature.worksProperly)
+            }
+        }
+        """
+
+        let options = FormatOptions(defaultTestSuiteAttributes: ["@MainActor"], swiftVersion: "6.0")
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports], options: options)
+    }
+
+    func testAppliesMultipleTestSuiteAttributes() {
+        let input = """
+        import XCTest
+
+        final class MyFeatureTests: XCTestCase {
+            func testMyFeatureWorks() {
+                let myFeature = MyFeature()
+                XCTAssertTrue(myFeature.worksProperly)
+            }
+        }
+        """
+
+        let output = """
+        import Foundation
+        import Testing
+
+        @MainActor @Suite(.serialized)
+        final class MyFeatureTests {
+            @Test func myFeatureWorks() {
+                let myFeature = MyFeature()
+                #expect(myFeature.worksProperly)
+            }
+        }
+        """
+
+        let options = FormatOptions(defaultTestSuiteAttributes: ["@MainActor", "@Suite(.serialized)"], swiftVersion: "6.0")
         testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports], options: options)
     }
 }


### PR DESCRIPTION
This PR adds a `--default-test-suite-attributes` option to the `preferSwiftTesting` rule.

Instead of adding `@MainActor @Suite(.serialized)` to new test suites by default, allow the user to specify what attributes should be used.