### PR TITLE
Add `preferFinalClasses` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -38,6 +38,7 @@
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferCountWhere](#preferCountWhere)
+* [preferFinalClasses](#preferFinalClasses)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
 * [redundantBackticks](#redundantBackticks)
@@ -1912,6 +1913,36 @@ Prefer `count(where:)` over `filter(_:).count`.
 +         moon.hasAtmosphere
 +     }) > 1
 + })
+```
+
+</details>
+<br/>
+
+## preferFinalClasses
+
+Add final modifier to classes that are not open.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- class Foo {}
++ final class Foo {}
+```
+
+```diff
+- public class Bar {}
++ public final class Bar {}
+```
+
+```diff
+// Does not modify open classes
+open class Baz {}
+```
+
+```diff
+// Does not modify classes that are already final
+final class Qux {}
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -38,7 +38,6 @@
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferCountWhere](#preferCountWhere)
-* [preferFinalClasses](#preferFinalClasses)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
 * [redundantBackticks](#redundantBackticks)
@@ -112,6 +111,7 @@
 * [noExplicitOwnership](#noExplicitOwnership)
 * [noGuardInTests](#noGuardInTests)
 * [organizeDeclarations](#organizeDeclarations)
+* [preferFinalClasses](#preferFinalClasses)
 * [preferSwiftTesting](#preferSwiftTesting)
 * [privateStateVariables](#privateStateVariables)
 * [propertyTypes](#propertyTypes)
@@ -1920,7 +1920,7 @@ Prefer `count(where:)` over `filter(_:).count`.
 
 ## preferFinalClasses
 
-Add final modifier to classes that are not open.
+Prefer defining `final` classes. To suppress this rule, add "Base" to the class name, make the class `open`, add a doc comment with mentioning "base class", or use a `// swiftformat:disable:next preferFinalClasses` directive.
 
 <details>
 <summary>Examples</summary>
@@ -1936,13 +1936,16 @@ Add final modifier to classes that are not open.
 ```
 
 ```diff
-// Does not modify open classes
-open class Baz {}
-```
+  // Preserved classes:
+  open class Baz {}
 
-```diff
-// Does not modify classes that are already final
-final class Qux {}
+  class BaseClass {}
+
+  class MyClass {} // Subclassed in this file
+  class MySubclass: MyClass {}
+
+  /// Base class to be subclassed by other features
+  class MyCustomizationPoint {}
 ```
 
 </details>

--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -176,6 +176,11 @@ extension Declaration {
         }
     }
 
+    /// The range of the doc comment or regular comment immediately preceding this declaration
+    var docCommentRange: ClosedRange<Int>? {
+        formatter.parseDocCommentRange(forDeclarationAt: keywordIndex)
+    }
+
     /// The `CustomDebugStringConvertible` representation of this declaration
     var debugDescription: String {
         guard isValid else {

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2612,6 +2612,29 @@ extension Formatter {
         return matches
     }
 
+    /// Parses the range of the doc comment or regular comment immediately preceding the declaration
+    func parseDocCommentRange(forDeclarationAt keywordIndex: Int) -> ClosedRange<Int>? {
+        let startOfModifiers = startOfModifiers(at: keywordIndex, includingAttributes: true)
+
+        var parseIndex = startOfModifiers
+        var endOfComment: Int?
+
+        while let endOfPreviousLine = index(of: .linebreak, before: parseIndex),
+              let endOfPreviousLineContent = index(of: .nonSpace, before: endOfPreviousLine),
+              tokens[endOfPreviousLineContent].isComment,
+              let startOfScope = startOfScope(at: endOfPreviousLineContent)
+        {
+            parseIndex = startOfScope
+
+            if endOfComment == nil {
+                endOfComment = endOfPreviousLineContent
+            }
+        }
+
+        guard let endOfComment else { return nil }
+        return parseIndex ... endOfComment
+    }
+
     /// Parses the prorocol composition typealias declaration starting at the given `typealias` keyword index.
     /// Returns `nil` if the given index isn't a protocol composition typealias.
     func parseProtocolCompositionTypealias(at typealiasIndex: Int)

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -60,6 +60,7 @@ let ruleRegistry: [String: FormatRule] = [
     "opaqueGenericParameters": .opaqueGenericParameters,
     "organizeDeclarations": .organizeDeclarations,
     "preferCountWhere": .preferCountWhere,
+    "preferFinalClasses": .preferFinalClasses,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
     "preferSwiftTesting": .preferSwiftTesting,

--- a/Sources/Rules/PreferFinalClasses.swift
+++ b/Sources/Rules/PreferFinalClasses.swift
@@ -1,0 +1,128 @@
+//
+//  PreferFinalClasses.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 2025-08-25.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Add the `final` keyword to all classes that are not declared as `open`
+    static let preferFinalClasses = FormatRule(
+        help: """
+        Prefer defining `final` classes. To suppress this rule, add "Base" to the class name, \
+        make the class `open`, or use a `// swiftformat:disable:next` directive. 
+        """
+    ) { formatter in
+        // Parse all declarations to understand inheritance relationships
+        let declarations = formatter.parseDeclarations()
+
+        // Find all class names that are inherited from in this file
+        var classesWithSubclasses = Set<String>()
+        declarations.forEachRecursiveDeclaration { declaration in
+            guard declaration.keyword == "class" else { return }
+
+            // Check all conformances - any of them could be a superclass
+            let conformances = formatter.parseConformancesOfType(atKeywordIndex: declaration.keywordIndex)
+            for conformance in conformances {
+                // Extract base class name from generic types like "Container<String>" -> "Container"
+                let baseClassName = conformance.conformance.components(separatedBy: "<").first ?? conformance.conformance
+                classesWithSubclasses.insert(baseClassName)
+            }
+        }
+
+        // Now process each class declaration
+        declarations.forEachRecursiveDeclaration { declaration in
+            guard declaration.keyword == "class",
+                  let className = declaration.name else { return }
+
+            let keywordIndex = declaration.keywordIndex
+
+            // Check if class already has final or open modifiers
+            let hasFinalModifier = formatter.modifiersForDeclaration(at: keywordIndex, contains: "final")
+            let hasOpenModifier = formatter.modifiersForDeclaration(at: keywordIndex, contains: "open")
+
+            // Only add final if the class doesn't already have final or open
+            guard !hasFinalModifier, !hasOpenModifier else { return }
+
+            // Don't add final if this class is inherited from in the same file
+            guard !classesWithSubclasses.contains(className) else { return }
+
+            // Don't add final to classes that contain "Base" (they're likely meant to be subclassed)
+            guard !className.contains("Base") else { return }
+
+            // Insert final before the class keyword
+            formatter.insert([.keyword("final"), .space(" ")], at: keywordIndex)
+
+            // Convert any open direct child declarations to public (since final classes can't have open members)
+            if let classBody = declaration.body {
+                for childDeclaration in classBody {
+                    guard formatter.modifiersForDeclaration(at: childDeclaration.keywordIndex, contains: "open") else { continue }
+
+                    // Replace "open" with "public" for direct child declarations
+                    if let openIndex = formatter.indexOfModifier("open", forDeclarationAt: childDeclaration.keywordIndex) {
+                        formatter.replaceToken(at: openIndex, with: .keyword("public"))
+                    }
+                }
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - class Foo {}
+        + final class Foo {}
+        ```
+
+        ```diff
+        - public class Bar {}
+        + public final class Bar {}
+        ```
+
+        ```diff
+        // Does not modify open classes
+        open class Baz {}
+        ```
+
+        ```diff
+        // Does not modify classes that are already final
+        final class Qux {}
+        ```
+
+        ```diff
+        // Does not modify classes that have subclasses in the same file
+        class BaseClass {}
+        - class SubClass: BaseClass {}
+        + final class SubClass: BaseClass {}
+        ```
+
+        ```diff
+        // Handles generic classes correctly
+        class Container<T> {}
+        - class StringContainer: Container<String> {}
+        + final class StringContainer: Container<String> {}
+        ```
+
+        ```diff
+        // Does not modify classes with "Base" prefix or suffix
+        class BaseClass {}
+        class UtilityBase {}
+        - class RegularClass {}
+        + final class RegularClass {}
+        ```
+
+        ```diff
+        // Converts open members to public when making class final
+        - class MyClass {
+        -     open var property: String = ""
+        -     open func method() {}
+        - }
+        + final class MyClass {
+        +     public var property: String = ""
+        +     public func method() {}
+        + }
+        ```
+        """
+    }
+}

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -2965,4 +2965,33 @@ class ParsingHelpersTests: XCTestCase {
             "baaz: baaz.quux",
         ])
     }
+
+    func testParseCommentRange() throws {
+        let input = """
+        import FooLib
+
+        // Class declaration
+        class MyClass {}
+
+        // Other comment
+
+        /// Foo bar
+        /// baaz quux
+        @Foo
+        struct MyStruct {}
+        """
+
+        let formatter = Formatter(tokenize(input))
+        let classCommentRange = try XCTUnwrap(formatter.parseDocCommentRange(forDeclarationAt: 9)) // class
+        let structCommentRange = try XCTUnwrap(formatter.parseDocCommentRange(forDeclarationAt: 30)) // struct
+
+        XCTAssertEqual(formatter.tokens[classCommentRange].string, """
+        // Class declaration
+        """)
+
+        XCTAssertEqual(formatter.tokens[structCommentRange].string, """
+        /// Foo bar
+        /// baaz quux
+        """)
+    }
 }

--- a/Tests/Rules/PreferFinalClassesTests.swift
+++ b/Tests/Rules/PreferFinalClassesTests.swift
@@ -371,4 +371,16 @@ class PreferFinalClassesTests: XCTestCase {
         """
         testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.blankLinesBetweenScopes])
     }
+
+    func testNonFinalClassWithBaseCommentPreserved() {
+        let input = """
+        /// Base class to be subclassed by other features
+        public class Foo {}
+
+        //base class to be subclassed by other features
+        public class Bar {}
+        """
+
+        testFormatting(for: input, rule: .preferFinalClasses, exclude: [.docComments, .spaceInsideComments])
+    }
 }

--- a/Tests/Rules/PreferFinalClassesTests.swift
+++ b/Tests/Rules/PreferFinalClassesTests.swift
@@ -1,0 +1,374 @@
+//
+//  PreferFinalClassesTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 2025-08-25.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class PreferFinalClassesTests: XCTestCase {
+    func testBasicClassMadesFinal() {
+        let input = """
+        class Foo {}
+        """
+        let output = """
+        final class Foo {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testPublicClassMadesFinal() {
+        let input = """
+        public class Bar {}
+        """
+        let output = """
+        public final class Bar {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testPrivateClassMadesFinal() {
+        let input = """
+        private class Baz {}
+        """
+        let output = """
+        private final class Baz {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testInternalClassMadesFinal() {
+        let input = """
+        internal class Qux {}
+        """
+        let output = """
+        internal final class Qux {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.redundantInternal])
+    }
+
+    func testOpenClassLeftUnchanged() {
+        let input = """
+        open class OpenClass {}
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testAlreadyFinalClassLeftUnchanged() {
+        let input = """
+        final class FinalClass {}
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testPublicFinalClassLeftUnchanged() {
+        let input = """
+        public final class PublicFinalClass {}
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testPublicOpenClassLeftUnchanged() {
+        let input = """
+        public open class PublicOpenClass {}
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testClassFunctionNotAffected() {
+        let input = """
+        struct Foo {
+            class func bar() {}
+        }
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testClassVariableNotAffected() {
+        let input = """
+        struct Foo {
+            class var bar: String { "bar" }
+        }
+        """
+        testFormatting(for: input, rule: .preferFinalClasses)
+    }
+
+    func testNestedClass() {
+        let input = """
+        class OuterClass {
+            class InnerClass {}
+        }
+        """
+        let output = """
+        final class OuterClass {
+            final class InnerClass {}
+        }
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.enumNamespaces])
+    }
+
+    func testClassWithInheritance() {
+        let input = """
+        class Child: Parent {}
+        """
+        let output = """
+        final class Child: Parent {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testClassWithProtocolConformance() {
+        let input = """
+        class MyClass: SomeProtocol {}
+        """
+        let output = """
+        final class MyClass: SomeProtocol {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testClassWithMultipleModifiers() {
+        let input = """
+        @objc public class MyClass {}
+        """
+        let output = """
+        @objc public final class MyClass {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testMultipleClasses() {
+        let input = """
+        class FirstClass {}
+        class SecondClass {}
+        open class ThirdClass {}
+        final class FourthClass {}
+        """
+        let output = """
+        final class FirstClass {}
+        final class SecondClass {}
+        open class ThirdClass {}
+        final class FourthClass {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testClassWithComments() {
+        let input = """
+        // This is a class
+        class MyClass {
+            // Some content
+        }
+        """
+        let output = """
+        // This is a class
+        final class MyClass {
+            // Some content
+        }
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.docComments])
+    }
+
+    func testClassWithSubclassNotMadeFinal() {
+        let input = """
+        class BaseClass {}
+        class SubClass: BaseClass {}
+        """
+        let output = """
+        class BaseClass {}
+        final class SubClass: BaseClass {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testMultipleInheritanceLevels() {
+        let input = """
+        class GrandParent {}
+        class Parent: GrandParent {}
+        class Child: Parent {}
+        """
+        let output = """
+        class GrandParent {}
+        class Parent: GrandParent {}
+        final class Child: Parent {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testClassWithProtocolConformanceStillMadeFinal() {
+        let input = """
+        protocol SomeProtocol {}
+        class MyClass: SomeProtocol {}
+        """
+        let output = """
+        protocol SomeProtocol {}
+        final class MyClass: SomeProtocol {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testClassInheritingFromExternalClassMadeFinal() {
+        let input = """
+        class MyViewController: UIViewController {}
+        """
+        let output = """
+        final class MyViewController: UIViewController {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testMixedScenario() {
+        let input = """
+        class BaseClass {}
+        final class AlreadyFinalClass {}
+        open class OpenClass {}
+        class SubClass: BaseClass {}
+        class IndependentClass {}
+        """
+        let output = """
+        class BaseClass {}
+        final class AlreadyFinalClass {}
+        open class OpenClass {}
+        final class SubClass: BaseClass {}
+        final class IndependentClass {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testGenericClassWithSubclass() {
+        let input = """
+        class Container<T> {}
+        class StringContainer: Container<String> {}
+        """
+        let output = """
+        class Container<T> {}
+        final class StringContainer: Container<String> {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testGenericClassWithGenericSubclass() {
+        let input = """
+        class BaseContainer<T> {}
+        class SpecialContainer<U>: BaseContainer<U> {}
+        """
+        let output = """
+        class BaseContainer<T> {}
+        final class SpecialContainer<U>: BaseContainer<U> {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testMultipleGenericParameters() {
+        let input = """
+        class GenericClass<T, U> {}
+        class ConcreteClass: GenericClass<String, Int> {}
+        """
+        let output = """
+        class GenericClass<T, U> {}
+        final class ConcreteClass: GenericClass<String, Int> {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testComplexGenericInheritanceChain() {
+        let input = """
+        class BaseContainer<T> {}
+        class MiddleContainer<T>: BaseContainer<T> {}
+        class FinalContainer: MiddleContainer<String> {}
+        """
+        let output = """
+        class BaseContainer<T> {}
+        class MiddleContainer<T>: BaseContainer<T> {}
+        final class FinalContainer: MiddleContainer<String> {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testBaseClassNotMadeFinal() {
+        let input = """
+        class BaseClass {}
+        class ClassBase {}
+        class SomeBase {}
+        class BaseSomething {}
+        class ViewControllerBase {}
+        class RegularClass {}
+        """
+        let output = """
+        class BaseClass {}
+        class ClassBase {}
+        class SomeBase {}
+        class BaseSomething {}
+        class ViewControllerBase {}
+        final class RegularClass {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testConvertOpenMembersToPublic() {
+        let input = """
+        public class MyClass {
+            open var property1: String = ""
+            open let property2: Int = 0
+            open func method1() {}
+            private var privateProperty: String = ""
+            public func publicMethod() {}
+        }
+        """
+        let output = """
+        public final class MyClass {
+            public var property1: String = ""
+            public let property2: Int = 0
+            public func method1() {}
+            private var privateProperty: String = ""
+            public func publicMethod() {}
+        }
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses)
+    }
+
+    func testNestedClassWithOpenMembersNotConverted() {
+        let input = """
+        public class OuterClass {
+            open var outerProperty: String = ""
+
+            public class InnerClass {
+                open var innerProperty: String = ""
+            }
+        }
+        """
+        let output = """
+        public final class OuterClass {
+            public var outerProperty: String = ""
+
+            public final class InnerClass {
+                public var innerProperty: String = ""
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.enumNamespaces])
+    }
+
+    func testMixedScenarioWithBaseAndOpen() {
+        let input = """
+        class BaseController {}
+        public class MyController {
+            open var title: String = ""
+            open func setup() {}
+        }
+        class UtilityBase {}
+        """
+        let output = """
+        class BaseController {}
+        public final class MyController {
+            public var title: String = ""
+            public func setup() {}
+        }
+        class UtilityBase {}
+        """
+        testFormatting(for: input, output, rule: .preferFinalClasses, exclude: [.blankLinesBetweenScopes])
+    }
+}

--- a/Tests/XCTestCase+testFormatting.swift
+++ b/Tests/XCTestCase+testFormatting.swift
@@ -82,6 +82,7 @@ extension XCTestCase {
             .markTypes,
             .blockComments,
             .unusedPrivateDeclarations,
+            .preferFinalClasses,
         ]
         let exclude = exclude + defaultExclusions.filter { !rules.contains($0) }
         let formatResult: (output: String, changes: [SwiftFormat.Formatter.Change])


### PR DESCRIPTION
This PR adds a new `preferFinalClasses` rule that adds the `final` keyword to non-`open` classes.

The rule includes some heuristics to avoid adding `final` in cases where they may be existing subclasses:
 1. We check if there are any subclasses within the file itself
 2. We check if the type name contains "Base" -- this is a common pattern for indicating that the type will be subclasses