### PR TITLE
Fix bug where `--type-body-marks remove` wouldn't be respected on declarations with expected mark comment

### DIFF
--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -4204,4 +4204,49 @@ class OrganizeDeclarationsTests: XCTestCase {
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
+
+    func testRemovesAllUnnecessaryMarkAfterStandardMark() {
+        let input = """
+        public class Foo {
+
+            // MARK: Public
+
+            public func bar() {}
+
+            // MARK: Internal
+
+            // MARK: Implementation
+
+            func method() {}
+
+            // MARK: Testing
+
+            func testMethod() {}
+
+        }
+        """
+
+        let output = """
+        public class Foo {
+
+            // MARK: Public
+
+            public func bar() {}
+
+            // MARK: Internal
+
+            func method() {}
+
+            func testMethod() {}
+
+        }
+        """
+
+        testFormatting(
+            for: input, output,
+            rule: .organizeDeclarations,
+            options: FormatOptions(typeBodyMarks: .remove),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
 }


### PR DESCRIPTION
This PR fixes a bug I noticed where `--type-body-marks remove` wouldn't be respected on declarations with expected mark comment.

For example, it would preserve the unexpected mark comment in this case:

```swift
public class Foo {

    // MARK: Public

    public func bar() {}

    // MARK: Internal

    // MARK: Implementation

    func method() {}

    func testMethod() {}

}
```