### PR TITLE
Fix `blankLinesAroundMark` not ignoring trailing comments at start of scope

### DIFF
--- a/Sources/Rules/BlankLinesAroundMark.swift
+++ b/Sources/Rules/BlankLinesAroundMark.swift
@@ -28,7 +28,7 @@ public extension FormatRule {
             }
             if formatter.options.insertBlankLines,
                let lastIndex = formatter.index(of: .linebreak, before: startIndex),
-               let lastToken = formatter.last(.nonSpace, before: lastIndex),
+               let lastToken = formatter.last(.nonSpaceOrComment, before: lastIndex),
                !lastToken.isLinebreak, lastToken != .startOfScope("{")
             {
                 formatter.insertLinebreak(at: lastIndex)

--- a/Tests/Rules/BlankLinesAroundMarkTests.swift
+++ b/Tests/Rules/BlankLinesAroundMarkTests.swift
@@ -74,6 +74,17 @@ class BlankLinesAroundMarkTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesAroundMark)
     }
 
+    func testNoInsertBlankLineBeforeMarkAtStartOfScopeWithTrailingComment() {
+        let input = """
+        struct Foo { // some comment here
+            // MARK: bar
+
+            let string: String
+        }
+        """
+        testFormatting(for: input, rule: .blankLinesAroundMark)
+    }
+
     func testNoInsertBlankLineAfterMarkAtEndOfScope() {
         let input = """
         do {


### PR DESCRIPTION
Fixes #2202 

This fixes an issue where `blankLinesAroundMark` wouldn't ignore trailing comments at the start of scope. 

`blankLinesAroundMark` is configured to not add a blank line at the start of scope, so this wouldn't produce a lint warning:
```
struct Example {
    // MARK: Properties

    let value: String
}
```

However, if there's a trailing comment at the start of scope, this would produce a lint warning.
```
struct Example { // some comment
    // MARK: Properties

    let value: String
}
```

The trailing comment at the start of scope shouldn't affect whether a blank line is required before the mark. This fixes that by ignoring any comments after the start of scope.