### PR TITLE
Rename `throwingTests` rule to `noForceTryInTests`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -109,6 +109,7 @@
 * [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
 * [noExplicitOwnership](#noExplicitOwnership)
+* [noForceTryInTests](#noForceTryInTests)
 * [noForceUnwrapInTests](#noForceUnwrapInTests)
 * [noGuardInTests](#noGuardInTests)
 * [organizeDeclarations](#organizeDeclarations)
@@ -121,7 +122,6 @@
 * [redundantProperty](#redundantProperty)
 * [singlePropertyPerLine](#singlePropertyPerLine)
 * [sortSwitchCases](#sortSwitchCases)
-* [throwingTests](#throwingTests)
 * [unusedPrivateDeclarations](#unusedPrivateDeclarations)
 * [urlMacro](#urlMacro)
 * [wrapConditionalBodies](#wrapConditionalBodies)
@@ -135,6 +135,7 @@
 * [sortedImports](#sortedImports)
 * [sortedSwitchCases](#sortedSwitchCases)
 * [specifiers](#specifiers)
+* [throwingTests](#throwingTests)
 
 ----------
 
@@ -1629,6 +1630,38 @@ Don't use explicit ownership modifiers (borrowing / consuming).
 ```diff
 - borrowing func foo(_ bar: consuming Bar) { ... }
 + func foo(_ bar: Bar) { ... }
+```
+
+</details>
+<br/>
+
+## noForceTryInTests
+
+Write tests that use `throws` instead of using `try!`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+    import Testing
+
+    struct MyFeatureTests {
+-       @Test func doSomething() {
++       @Test func doSomething() throws {
+-           try! MyFeature().doSomething()
++           try MyFeature().doSomething()
+      }
+    }
+
+    import XCTeset
+
+    class MyFeatureTests: XCTestCase {
+-       func test_doSomething() {
++       func test_doSomething() throws {
+-           try! MyFeature().doSomething()
++           try MyFeature().doSomething()
+      }
+    }
 ```
 
 </details>
@@ -3409,33 +3442,7 @@ In Swift Testing, don't prefix @Test methods with 'test'.
 
 Write tests that use `throws` instead of using `try!`.
 
-<details>
-<summary>Examples</summary>
-
-```diff
-    import Testing
-
-    struct MyFeatureTests {
--       @Test func doSomething() {
-+       @Test func doSomething() throws {
--           try! MyFeature().doSomething()
-+           try MyFeature().doSomething()
-      }
-    }
-
-    import XCTeset
-
-    class MyFeatureTests: XCTestCase {
--       func test_doSomething() {
-+       func test_doSomething() throws {
--           try! MyFeature().doSomething()
-+           try MyFeature().doSomething()
-      }
-    }
-```
-
-</details>
-<br/>
+*Note: throwingTests rule is deprecated. Renamed to `noForceTryInTests`.*
 
 ## todos
 

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -55,6 +55,7 @@ let ruleRegistry: [String: FormatRule] = [
     "modifierOrder": .modifierOrder,
     "modifiersOnSameLine": .modifiersOnSameLine,
     "noExplicitOwnership": .noExplicitOwnership,
+    "noForceTryInTests": .noForceTryInTests,
     "noForceUnwrapInTests": .noForceUnwrapInTests,
     "noGuardInTests": .noGuardInTests,
     "numberFormatting": .numberFormatting,

--- a/Sources/Rules/NoForceTryInTests.swift
+++ b/Sources/Rules/NoForceTryInTests.swift
@@ -1,0 +1,75 @@
+// Created by Andy Bartholomew on 5/30/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+public extension FormatRule {
+    static let noForceTryInTests = FormatRule(
+        help: "Write tests that use `throws` instead of using `try!`.",
+        disabledByDefault: true
+    ) { formatter in
+        guard let testFramework = formatter.detectTestingFramework() else {
+            return
+        }
+
+        formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
+            guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)
+            else { return }
+
+            switch testFramework {
+            case .xcTest:
+                guard functionDecl.name?.starts(with: "test") == true else { return }
+            case .swiftTesting:
+                guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") else { return }
+            }
+
+            guard let bodyRange = functionDecl.bodyRange else { return }
+
+            // Find all `try!` and remove the `!`
+            var foundAnyTryExclamationMarks = false
+            for index in bodyRange.reversed() {
+                guard formatter.tokens[index] == .keyword("try") else { continue }
+                guard let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index)
+                else { return }
+                let nextToken = formatter.tokens[nextTokenIndex]
+                if nextToken != .operator("!", .postfix) { continue }
+
+                // Only remove the `!` if we are not within a closure or nested function,
+                // where it's not safe to just remove the `!` and make our function throw.
+                guard formatter.isInFunctionBody(of: functionDecl, at: index) else { continue }
+
+                formatter.removeToken(at: nextTokenIndex)
+                foundAnyTryExclamationMarks = true
+            }
+
+            // If we found any `!`s, add a `throws` if it doesn't already exist.
+            guard foundAnyTryExclamationMarks else { return }
+
+            formatter.addThrowsEffect(to: functionDecl)
+        }
+    } examples: {
+        """
+        ```diff
+            import Testing
+
+            struct MyFeatureTests {
+        -       @Test func doSomething() {
+        +       @Test func doSomething() throws {
+        -           try! MyFeature().doSomething()
+        +           try MyFeature().doSomething()
+              }
+            }
+
+            import XCTeset
+
+            class MyFeatureTests: XCTestCase {
+        -       func test_doSomething() {
+        +       func test_doSomething() throws {
+        -           try! MyFeature().doSomething()
+        +           try MyFeature().doSomething()
+              }
+            }
+        ```
+        """
+    }
+}

--- a/Sources/Rules/NoForceTryInTests.swift
+++ b/Sources/Rules/NoForceTryInTests.swift
@@ -13,7 +13,8 @@ public extension FormatRule {
         }
 
         formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
-            guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)
+            guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex),
+                  functionDecl.returnType == nil
             else { return }
 
             switch testFramework {

--- a/Sources/Rules/NoForceUnwrapInTests.swift
+++ b/Sources/Rules/NoForceUnwrapInTests.swift
@@ -7,7 +7,7 @@ public extension FormatRule {
     static let noForceUnwrapInTests = FormatRule(
         help: "Use XCTUnwrap or #require in test cases, rather than force unwrapping.",
         disabledByDefault: true,
-        orderAfter: [.urlMacro, .throwingTests]
+        orderAfter: [.urlMacro, .noForceTryInTests, .throwingTests]
     ) { formatter in
         guard let testFramework = formatter.detectTestingFramework() else {
             return
@@ -57,7 +57,7 @@ public extension FormatRule {
                     continue
                 }
 
-                // Preserve `try!`s, this is handled separately by the `throwingTests` rule
+                // Preserve `try!`s, this is handled separately by the `noForceTryInTests` rule
                 if let previousToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: forceUnwrapOperator),
                    formatter.tokens[previousToken] == .keyword("try")
                 {

--- a/Sources/Rules/ThrowingTests.swift
+++ b/Sources/Rules/ThrowingTests.swift
@@ -6,70 +6,11 @@ import Foundation
 public extension FormatRule {
     static let throwingTests = FormatRule(
         help: "Write tests that use `throws` instead of using `try!`.",
+        deprecationMessage: "Renamed to `noForceTryInTests`.",
         disabledByDefault: true
     ) { formatter in
-        guard let testFramework = formatter.detectTestingFramework() else {
-            return
-        }
-
-        formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
-            guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: funcKeywordIndex)
-            else { return }
-
-            switch testFramework {
-            case .xcTest:
-                guard functionDecl.name?.starts(with: "test") == true else { return }
-            case .swiftTesting:
-                guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") else { return }
-            }
-
-            guard let bodyRange = functionDecl.bodyRange else { return }
-
-            // Find all `try!` and remove the `!`
-            var foundAnyTryExclamationMarks = false
-            for index in bodyRange.reversed() {
-                guard formatter.tokens[index] == .keyword("try") else { continue }
-                guard let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index)
-                else { return }
-                let nextToken = formatter.tokens[nextTokenIndex]
-                if nextToken != .operator("!", .postfix) { continue }
-
-                // Only remove the `!` if we are not within a closure or nested function,
-                // where it's not safe to just remove the `!` and make our function throw.
-                guard formatter.isInFunctionBody(of: functionDecl, at: index) else { continue }
-
-                formatter.removeToken(at: nextTokenIndex)
-                foundAnyTryExclamationMarks = true
-            }
-
-            // If we found any `!`s, add a `throws` if it doesn't already exist.
-            guard foundAnyTryExclamationMarks else { return }
-
-            formatter.addThrowsEffect(to: functionDecl)
-        }
+        FormatRule.noForceTryInTests.apply(with: formatter)
     } examples: {
-        """
-        ```diff
-            import Testing
-
-            struct MyFeatureTests {
-        -       @Test func doSomething() {
-        +       @Test func doSomething() throws {
-        -           try! MyFeature().doSomething()
-        +           try MyFeature().doSomething()
-              }
-            }
-
-            import XCTeset
-
-            class MyFeatureTests: XCTestCase {
-        -       func test_doSomething() {
-        +       func test_doSomething() throws {
-        -           try! MyFeature().doSomething()
-        +           try MyFeature().doSomething()
-              }
-            }
-        ```
-        """
+        nil
     }
 }

--- a/Tests/Rules/NoForceTryInTestsTests.swift
+++ b/Tests/Rules/NoForceTryInTestsTests.swift
@@ -69,6 +69,10 @@ final class NoForceTryInTestsTests: XCTestCase {
             func something() {
                 try! somethingThatThrows()
             }
+
+            func testHelper() -> String {
+                try! generateString()
+            }
         }
         """
         testFormatting(for: input, rule: .noForceTryInTests)

--- a/Tests/Rules/NoForceTryInTestsTests.swift
+++ b/Tests/Rules/NoForceTryInTestsTests.swift
@@ -3,7 +3,7 @@
 
 import XCTest
 
-final class ThrowingTestsTests: XCTestCase {
+final class NoForceTryInTestsTests: XCTestCase {
     func testTestCaseIsUpdated_for_Testing() throws {
         let input = """
         import Testing
@@ -19,7 +19,7 @@ final class ThrowingTestsTests: XCTestCase {
             try somethingThatThrows()
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func test_nonTestCaseFunction_IsNotUpdated_for_Testing() throws {
@@ -36,7 +36,7 @@ final class ThrowingTestsTests: XCTestCase {
             try! somethingThatThrows()
         }
         """
-        testFormatting(for: input, rule: .throwingTests)
+        testFormatting(for: input, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsUpdated_for_XCTest() throws {
@@ -58,7 +58,7 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func test_nonTestCaseFunction_IsNotUpdated_for_XCTest() throws {
@@ -71,7 +71,7 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .throwingTests)
+        testFormatting(for: input, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsUpdated_for_async_test() throws {
@@ -89,7 +89,7 @@ final class ThrowingTestsTests: XCTestCase {
             try somethingThatThrows()
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsUpdated_for_already_throws() throws {
@@ -107,7 +107,7 @@ final class ThrowingTestsTests: XCTestCase {
             try somethingThatThrows()
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsUpdated_for_multiple_try_exclamationMarks() throws {
@@ -127,7 +127,7 @@ final class ThrowingTestsTests: XCTestCase {
             try somethingThatThrows()
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsNotUpdated_for_try_exclamationMark_in_closoure() throws {
@@ -140,7 +140,7 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .throwingTests)
+        testFormatting(for: input, rule: .noForceTryInTests)
     }
 
     func testTestCaseIsUpdated_for_try_exclamationMark_in_if_statement() throws {
@@ -162,7 +162,7 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .throwingTests)
+        testFormatting(for: input, output, rule: .noForceTryInTests)
     }
 
     func testCaseIsNotUpdated_for_try_exclamationMark_in_closure_inside_if_statement() throws {
@@ -177,7 +177,7 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .throwingTests)
+        testFormatting(for: input, rule: .noForceTryInTests)
     }
 
     func testCaseIsNotUpdated_for_try_exclamationMark_in_closure_inside_nested_function() throws {
@@ -192,6 +192,6 @@ final class ThrowingTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, rule: .throwingTests)
+        testFormatting(for: input, rule: .noForceTryInTests)
     }
 }

--- a/Tests/Rules/NoForceUnwrapInTestsTests.swift
+++ b/Tests/Rules/NoForceUnwrapInTestsTests.swift
@@ -542,7 +542,7 @@ final class NoForceUnwrapInTestsTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, output, rule: .noForceUnwrapInTests, exclude: [.hoistTry, .throwingTests])
+        testFormatting(for: input, output, rule: .noForceUnwrapInTests, exclude: [.hoistTry, .noForceTryInTests])
     }
 
     func testForceUnwrapInAssignmentLHS() {

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -229,7 +229,7 @@ final class PreferSwiftTestingTests: XCTestCase {
         """
 
         let options = FormatOptions(swiftVersion: "6.0")
-        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .wrapArguments, .indent, .redundantParens, .hoistTry], options: options, exclude: [.throwingTests])
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .wrapArguments, .indent, .redundantParens, .hoistTry], options: options, exclude: [.noForceTryInTests])
     }
 
     func testConvertsMultilineXCTestHelpers() {


### PR DESCRIPTION
This PR renames the `throwingTests` rule to `noForceTryInTests`, to match `noForceUnwrapInTests`.

In theory we could merge the two rules, but it's conceivable that somebody could want one but not the other.