### PR TITLE
Add `redundantThrows` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -60,6 +60,7 @@
 * [redundantReturn](#redundantReturn)
 * [redundantSelf](#redundantSelf)
 * [redundantStaticSelf](#redundantStaticSelf)
+* [redundantThrows](#redundantThrows)
 * [redundantType](#redundantType)
 * [redundantTypedThrows](#redundantTypedThrows)
 * [redundantVoidReturnType](#redundantVoidReturnType)
@@ -2830,6 +2831,54 @@ Remove explicit `Self` where applicable.
 +         bar()
       }
   }
+```
+
+</details>
+<br/>
+
+## redundantThrows
+
+Remove redundant `throws` keyword from function declarations that don't throw any errors.
+
+Option | Description
+--- | ---
+`--redundant-throws` | Remove redundant throws from functions: "tests-only" (default) or "always"
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  // With --redundant-throws tests-only (default)
+  import Testing
+
+- @Test func myFeature() throws {
++ @Test func myFeature() throws {
+      #expect(foo == 1)
+  }
+
+  import XCTest
+
+  class TestCase: XCTestCase {
+-     func testMyFeature() throws {
++     func testMyFeature() {
+          XCTAssertEqual(foo, 1)
+      }
+  }
+```
+
+Also supports `--redundant-throws always`.
+This will cause warnings anywhere the updated method is called with `try`, since `try` is now redundant at the callsite.
+
+```diff
+  // With --redundant-throws always
+- func myNonThrowingMethod() throws -> Int {
++ func myNonThrowingMethod() -> Int {
+      return 0
+  }
+
+  // Possibly elsewhere in codebase:
+  let value = try myNonThrowingMethod()
++             `- warning: no calls to throwing functions occur within 'try' expression
 ```
 
 </details>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1425,6 +1425,12 @@ struct _Descriptors {
         help: "Insert line After switch cases:",
         keyPath: \.blankLineAfterSwitchCase
     )
+    let redundantThrows = OptionDescriptor(
+        argumentName: "redundant-throws",
+        displayName: "Redundant Throws",
+        help: "Remove redundant throws from functions:",
+        keyPath: \.redundantThrows
+    )
     let allowPartialWrapping = OptionDescriptor(
         argumentName: "allow-partial-wrapping",
         displayName: "Allow Partial Wrapping",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -829,6 +829,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var preferFileMacro: Bool
     public var lineBetweenConsecutiveGuards: Bool
     public var blankLineAfterSwitchCase: BlankLineAfterSwitchCase
+    public var redundantThrows: RedundantThrowsMode
     public var allowPartialWrapping: Bool
 
     /// Deprecated
@@ -971,6 +972,7 @@ public struct FormatOptions: CustomStringConvertible {
                 preferFileMacro: Bool = true,
                 lineBetweenConsecutiveGuards: Bool = false,
                 blankLineAfterSwitchCase: BlankLineAfterSwitchCase = .multilineOnly,
+                redundantThrows: RedundantThrowsMode = .testsOnly,
                 allowPartialWrapping: Bool = true,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
@@ -1102,6 +1104,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.preferFileMacro = preferFileMacro
         self.lineBetweenConsecutiveGuards = lineBetweenConsecutiveGuards
         self.blankLineAfterSwitchCase = blankLineAfterSwitchCase
+        self.redundantThrows = redundantThrows
         self.allowPartialWrapping = allowPartialWrapping
         self.indentComments = indentComments
         self.fragment = fragment
@@ -1146,6 +1149,14 @@ public struct FormatOptions: CustomStringConvertible {
             return "\(value);".addingPercentEncoding(withAllowedCharacters: allowedCharacters)
         }.joined()
     }
+}
+
+/// Whether to remove redundant throws from test functions only or from all functions
+public enum RedundantThrowsMode: String, CaseIterable {
+    /// Only remove redundant throws from test functions (default)
+    case testsOnly = "tests-only"
+    /// Remove redundant throws from all functions (can cause build failures)
+    case always
 }
 
 public enum MarkdownFormattingMode: String, CaseIterable {

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -91,6 +91,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantReturn": .redundantReturn,
     "redundantSelf": .redundantSelf,
     "redundantStaticSelf": .redundantStaticSelf,
+    "redundantThrows": .redundantThrows,
     "redundantType": .redundantType,
     "redundantTypedThrows": .redundantTypedThrows,
     "redundantVoidReturnType": .redundantVoidReturnType,

--- a/Sources/Rules/RedundantThrows.swift
+++ b/Sources/Rules/RedundantThrows.swift
@@ -1,0 +1,140 @@
+//
+//  RedundantThrows.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 2025-09-16.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let redundantThrows = FormatRule(
+        help: "Remove redundant `throws` keyword from function declarations that don't throw any errors.",
+        orderAfter: [.noForceUnwrapInTests, .noForceTryInTests, .noGuardInTests, .throwingTests],
+        options: ["redundant-throws"]
+    ) { formatter in
+        let testFramework = formatter.detectTestingFramework()
+        if formatter.options.redundantThrows == .testsOnly, testFramework == nil {
+            return
+        }
+
+        formatter.forEach(.keyword) { keywordIndex, keyword in
+            guard ["func", "init", "subscript"].contains(keyword.string),
+                  let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: keywordIndex),
+                  functionDecl.effects.contains(where: { $0.hasPrefix("throws") }),
+                  let bodyRange = functionDecl.bodyRange
+            else { return }
+
+            // Don't modify override functions - they need to match their parent's signature
+            if formatter.modifiersForDeclaration(at: keywordIndex, contains: "override") {
+                return
+            }
+
+            if formatter.options.redundantThrows == .testsOnly {
+                // Only process test functions
+                guard let testFramework, functionDecl.returnType == nil else { return }
+
+                switch testFramework {
+                case .xcTest:
+                    guard functionDecl.name?.starts(with: "test") == true else { return }
+                case .swiftTesting:
+                    guard formatter.modifiersForDeclaration(at: keywordIndex, contains: "@Test") else { return }
+                }
+            }
+
+            // Check if the function body contains any try keywords (excluding try! and try?) or throw statements
+            var bodyContainsThrowingCode = false
+            for index in bodyRange {
+                if formatter.tokens[index] == .keyword("try") {
+                    // Check if this try is followed by ! or ? (which means it doesn't need throws)
+                    if let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
+                       formatter.tokens[nextTokenIndex].isUnwrapOperator
+                    {
+                        continue // Skip try! and try?
+                    }
+
+                    // Only count try keywords that are directly in this function's body
+                    // (not in nested closures or functions)
+                    if formatter.isInFunctionBody(of: functionDecl, at: index) {
+                        bodyContainsThrowingCode = true
+                        break
+                    }
+                } else if formatter.tokens[index] == .keyword("throw") {
+                    // Only count throw statements that are directly in this function's body
+                    // (not in nested closures or functions)
+                    if formatter.isInFunctionBody(of: functionDecl, at: index) {
+                        bodyContainsThrowingCode = true
+                        break
+                    }
+                }
+            }
+
+            // If the body doesn't contain any throwing code, remove the throws
+            if !bodyContainsThrowingCode {
+                guard let effectsRange = functionDecl.effectsRange else { return }
+
+                // Find the throws keyword in the effects range
+                for index in effectsRange {
+                    if formatter.tokens[index] == .keyword("throws") {
+                        var endIndex = index
+
+                        // Check if there's typed throws (throws(...))
+                        if let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
+                           formatter.tokens[nextTokenIndex] == .startOfScope("("),
+                           let endOfScope = formatter.endOfScope(at: nextTokenIndex)
+                        {
+                            endIndex = endOfScope
+                        }
+
+                        // Include trailing whitespace if present
+                        if endIndex + 1 < formatter.tokens.count,
+                           formatter.tokens[endIndex + 1].isSpace
+                        {
+                            endIndex += 1
+                        }
+
+                        formatter.removeTokens(in: index ... endIndex)
+                        break // Only remove the first throws found
+                    }
+                }
+            }
+        }
+    } examples: {
+        """
+        ```diff
+          // With --redundant-throws tests-only (default)
+          import Testing
+
+        - @Test func myFeature() throws {
+        + @Test func myFeature() throws {
+              #expect(foo == 1)
+          }
+
+          import XCTest
+
+          class TestCase: XCTestCase {
+        -     func testMyFeature() throws {
+        +     func testMyFeature() {
+                  XCTAssertEqual(foo, 1)
+              }
+          }
+        ```
+
+        Also supports `--redundant-throws always`.
+        This will cause warnings anywhere the updated method is called with `try`, since `try` is now redundant at the callsite.
+
+        ```diff
+          // With --redundant-throws always
+        - func myNonThrowingMethod() throws -> Int {
+        + func myNonThrowingMethod() -> Int {
+              return 0
+          }
+
+          // Possibly elsewhere in codebase:
+          let value = try myNonThrowingMethod()
+        +             `- warning: no calls to throwing functions occur within 'try' expression
+        ```
+        """
+    }
+}

--- a/Tests/Rules/RedundantThrowsTests.swift
+++ b/Tests/Rules/RedundantThrowsTests.swift
@@ -1,0 +1,233 @@
+//
+//  RedundantThrowsTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 2025-09-16.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+class RedundantThrowsTests: XCTestCase {
+    func testRemovesThrowsFromXCTestFunction() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() throws {
+                XCTAssertEqual(1, 1)
+            }
+        }
+        """
+        let output = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                XCTAssertEqual(1, 1)
+            }
+        }
+        """
+        let options = FormatOptions(redundantThrows: .testsOnly)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testRemovesThrowsFromSwiftTestingFunction() {
+        let input = """
+        import Testing
+
+        @Test func something() throws {
+            #expect(1 == 1)
+        }
+        """
+        let output = """
+        import Testing
+
+        @Test func something() {
+            #expect(1 == 1)
+        }
+        """
+        let options = FormatOptions(redundantThrows: .testsOnly)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testIgnoresNonTestFunctionsInTestsOnlyMode() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func helper() throws {
+                // This is not a test function, should not be modified
+            }
+
+            func testHelper() throws -> Bool {
+                // This is not a test function, should not be modified
+                false
+            }
+
+            func test_something() throws {
+                XCTAssertEqual(1, 1)
+            }
+        }
+        """
+        let output = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func helper() throws {
+                // This is not a test function, should not be modified
+            }
+
+            func testHelper() throws -> Bool {
+                // This is not a test function, should not be modified
+                false
+            }
+
+            func test_something() {
+                XCTAssertEqual(1, 1)
+            }
+        }
+        """
+        let options = FormatOptions(redundantThrows: .testsOnly)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testRemovesThrowsFromAnyFunctionInAlwaysMode() {
+        let input = """
+        func foo() throws -> Int {
+            return 0
+        }
+
+        init() throws -> Int {
+            return 0
+        }
+
+        subscript(_: String) throws -> Int {
+            return 0
+        }
+        """
+        let output = """
+        func foo() -> Int {
+            return 0
+        }
+
+        init() -> Int {
+            return 0
+        }
+
+        subscript(_: String) -> Int {
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testRemovesTypedThrowsInAlwaysMode() {
+        let input = """
+        func foo() throws(MyError) -> Int {
+            return 0
+        }
+        """
+        let output = """
+        func foo() -> Int {
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testDoesNotModifyOverrideFunctions() {
+        let input = """
+        class TestCase {
+            override func setUpWithError() throws {
+                // Setup code that doesn't actually throw
+            }
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, rule: .redundantThrows, options: options)
+    }
+
+    func testPreservesThrowsWhenFunctionContainsTry() {
+        let input = """
+        func baz() throws -> Int {
+            try somethingThatThrows()
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, rule: .redundantThrows, options: options)
+    }
+
+    func testPreservesThrowsWhenFunctionContainsThrowStatement() {
+        let input = """
+        func foo() throws -> Int {
+            guard someCondition else {
+                throw MyError.invalidInput
+            }
+
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, rule: .redundantThrows, options: options)
+    }
+
+    func testRemovesThrowsWhenOnlyTryExclamationAndTryQuestion() {
+        let input = """
+        func foo() throws -> Int {
+            try! nonThrowingCall()
+            try? anotherCall()
+            return 0
+        }
+        """
+        let output = """
+        func foo() -> Int {
+            try! nonThrowingCall()
+            try? anotherCall()
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    // MARK: - Scoping
+
+    func testRemovesThrowsWhenTryInNestedClosure() {
+        let input = """
+        func foo() throws -> Int {
+            let closure = {
+                try somethingThatThrows()
+            }
+            return 0
+        }
+        """
+        let output = """
+        func foo() -> Int {
+            let closure = {
+                try somethingThatThrows()
+            }
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, output, rule: .redundantThrows, options: options)
+    }
+
+    func testPreservesThrowsWhenTryInControlFlow() {
+        let input = """
+        func foo() throws -> Int {
+            if someCondition {
+                try somethingThatThrows()
+            }
+            return 0
+        }
+        """
+        let options = FormatOptions(redundantThrows: .always)
+        testFormatting(for: input, rule: .redundantThrows, options: options)
+    }
+}


### PR DESCRIPTION
This PR adds a new `redundantThrows` rule.

If a function body doesn't include `try` or `throw`, then any `throws` keyword is redundant.

It's always safe to remove `throws` from test case methods, since those are never called directly:

```diff
  // With --redundant-throws tests-only (default)
  import Testing

- @Test func myFeature() throws {
+ @Test func myFeature() throws {
      #expect(foo == 1)
  }

  import XCTest

  class TestCase: XCTestCase {
-     func testMyFeature() throws {
+     func testMyFeature() {
          XCTAssertEqual(foo, 1)
      }
  }
```

We can also apply this outside of tests, but this will cause additional warnings anywhere the now-non-throwing function is called with a redundant `try` keyword:

```diff
  // With --redundant-throws always
- func myNonThrowingMethod() throws -> Int {
+ func myNonThrowingMethod() -> Int {
      return 0
  }

  // Possibly elsewhere in codebase:
  let value = try myNonThrowingMethod()
+             `- warning: no calls to throwing functions occur within 'try' expression
```

The rule defaults to `--redundant-throws tests-only`, but you can use `--redundant-throws always` if you don't mind the additional warnings, or plan to address them.