### PR TITLE
Improve support for `XCTAssertEqual` and `XCTAssertNil` in `noForceUnwrapInTests`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1683,12 +1683,12 @@ Use XCTUnwrap or #require in test cases, rather than force unwrapping.
 -           let myValue = foo.bar!.value as! Value
 -           let otherValue = (foo! as! Other).bar
 -           otherValue.manager!.prepare()
--           #expect(myValue.property! == other)
+-           #expect(myValue!.property! == other)
 +       @Test func myFeature() throws {
 +           let myValue = try #require(foo.bar?.value as? Value)
 +           let otherValue = try #require((foo as? Other)?.bar)
 +           otherValue.manager?.prepare()
-+           #expect(try #require(myValue.property) == other)
++           #expect(myValue?.property == other)
       }
     }
 
@@ -1698,11 +1698,11 @@ Use XCTUnwrap or #require in test cases, rather than force unwrapping.
 -       func testMyFeature() {
 -           let myValue = foo.bar!.value as! Value
 -           let otherValue = (foo! as! Other).bar
--           XCTAssertEqual(myValue.property, "foo")
+-           XCTAssertEqual(myValue!.property!, "foo")
 +       func testMyFeature() throws {
 +           let myValue = try XCTUnwrap(foo.bar?.value as? Value)
 +           let otherValue = try XCTUnwrap((foo as? Other)?.bar)
-+           XCTAssertEqual(try XCTUnwrap(myValue.property), otherValue)
++           XCTAssertEqual(myValue?.property, otherValue)
       }
     }
 ```

--- a/Tests/CodeOrganizationTests.swift
+++ b/Tests/CodeOrganizationTests.swift
@@ -106,7 +106,9 @@ class CodeOrganizationTests: XCTestCase {
                 // If this is a function call, parse the labels to disambiguate
                 // between methods with the same base name
                 var functionCallArguments: [String?]?
-                if let functionCallStartOfScope = formatter.index(of: .startOfScope("("), after: index) {
+                if let functionCallStartOfScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: index),
+                   formatter.tokens[functionCallStartOfScope] == .startOfScope("(")
+                {
                     functionCallArguments = formatter.parseFunctionCallArguments(startOfScope: functionCallStartOfScope).map(\.label)
                 }
 


### PR DESCRIPTION
This PR improves support for `XCTAssertEqual` /`XCTAssertNil` / `#expect(value == ...)` in `noForceUnwrapInTests`:

`XCTUnwrap` / `#require` is unnecessary in these cases, and omitting it results in more idiomatic code:

 - `XCTAssertEqual(try XCTUnwrap(foo?.bar), baaz)` can just be `XCTAssertEqual(foo?.bar, baaz)`
 - `XCTAssertNil(try XCTUnwrap(foo?.bar))` would cause a runtime test failure, and should just be `XCTAssertNil(foo?.bar)`
 - Same for `#expect(foo?.bar == baaz)` and `#expect(foo?.bar == nil)`

