### PR TITLE
Update `singlePropertyPerLine` to preserve `async let` declarations

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -3493,6 +3493,7 @@ extension _FormatRules {
         ["static", "class"],
         mutatingModifiers,
         ["prefix", "infix", "postfix"],
+        ["async"],
     ]
 
     /// Global swift functions

--- a/Sources/Rules/SinglePropertyPerLine.swift
+++ b/Sources/Rules/SinglePropertyPerLine.swift
@@ -22,6 +22,11 @@ public extension FormatRule {
                 return
             }
 
+            // Skip `async let` declarations
+            if formatter.modifiersForDeclaration(at: i, contains: "async") {
+                return
+            }
+
             // If this property is within a parenthesis scope, this is probably
             // within a switch case like `case (let foo, bar):`
             if let startOfScope = formatter.startOfScope(at: i),

--- a/Tests/Rules/SinglePropertyPerLineTests.swift
+++ b/Tests/Rules/SinglePropertyPerLineTests.swift
@@ -1112,4 +1112,12 @@ class SinglePropertyPerLineTests: XCTestCase {
         """
         testFormatting(for: input, rule: .singlePropertyPerLine)
     }
+
+    func testAsyncLetPreserved() {
+        let input = """
+        async let (one, two) = (performOne(), performTwo())
+        let (oneResult, twoResult) = await (one, two)
+        """
+        testFormatting(for: input, rule: .singlePropertyPerLine)
+    }
 }


### PR DESCRIPTION
This PR fixes #2209