### PR TITLE
Update `trailingCommas` rule to support bug fixes in Swift 6.2

### DIFF
--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -45,7 +45,7 @@ public let swiftVersionFile = ".swift-version"
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
-    "6.0", "6.1", "6.2",
+    "6.0", "6.1", "6.2", "6.3",
 ]
 
 /// Supported Swift language modes

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -2106,4 +2106,1443 @@ class TrailingCommasTests: XCTestCase {
         let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.1")
         testFormatting(for: input, rule: .trailingCommas, options: options)
     }
+
+    func testTrailingCommasAddedToFunctionParametersSwift6_2() {
+        let input = """
+        struct Foo {
+            func foo(
+                bar: Int,
+                baaz: Int
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let output = """
+        struct Foo {
+            func foo(
+                bar: Int,
+                baaz: Int,
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToGenericFunctionParametersSwift6_2() {
+        let input = """
+        struct Foo {
+            func foo<
+                Bar,
+                Baaz
+            >(
+                bar: Bar,
+                baaz: Baaz
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let output = """
+        struct Foo {
+            func foo<
+                Bar,
+                Baaz,
+            >(
+                bar: Bar,
+                baaz: Baaz,
+            ) -> Int {
+                bar + baaz
+            }
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.opaqueGenericParameters])
+    }
+
+    func testTrailingCommasAddedToFunctionArgumentsSwift6_2() {
+        let input = """
+        foo(
+            bar _: Int
+        ) {}
+        """
+        let output = """
+        foo(
+            bar _: Int,
+        ) {}
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToEnumCaseAssociatedValueSwift6_2() {
+        let input = """
+        enum Foo {
+            case bar(
+                baz: String
+            )
+        }
+        """
+        let output = """
+        enum Foo {
+            case bar(
+                baz: String,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToInitializerSwift6_2() {
+        let input = """
+        let foo: Foo = .init(
+            1
+        )
+        """
+        let output = """
+        let foo: Foo = .init(
+            1,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToTupleSwift6_2() {
+        let input = """
+        var foo = (
+            bar: 0,
+            baz: 1
+        )
+
+        foo = (
+            bar: 1,
+            baz: 2
+        )
+        """
+        let output = """
+        var foo = (
+            bar: 0,
+            baz: 1,
+        )
+
+        foo = (
+            bar: 1,
+            baz: 2,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToTupleReturnedFromFunctionSwift6_2() {
+        let input = """
+        func foo() -> (bar: Int, baz: Int) {
+            (
+                bar: 0,
+                baz: 1
+            )
+        }
+
+        func bar() -> (bar: Int, baz: Int) {
+            return (
+                bar: 0,
+                baz: 1
+            )
+        }
+        """
+        let output = """
+        func foo() -> (bar: Int, baz: Int) {
+            (
+                bar: 0,
+                baz: 1,
+            )
+        }
+
+        func bar() -> (bar: Int, baz: Int) {
+            return (
+                bar: 0,
+                baz: 1,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn])
+    }
+
+    func testTrailingCommasAddedToTupleInFunctionCallSwift6_2() {
+        let input = """
+        foo(
+            bar: bar,
+            baaz: (
+                quux: quux,
+                foobar: foobar
+            )
+        )
+        """
+
+        let output = """
+        foo(
+            bar: bar,
+            baaz: (
+                quux: quux,
+                foobar: foobar,
+            ),
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn])
+    }
+
+    func testTrailingCommasAddedToTupleInGenericInitCallSwift6_2() {
+        let input = """
+        let setModeSwizzle = Swizzle<AVAudioSession>(
+            instance: instance,
+            original: #selector(AVAudioSession.setMode(_:)),
+            swizzled: #selector(AVAudioSession.swizzled_setMode(_:))
+        )
+        """
+
+        let output = """
+        let setModeSwizzle = Swizzle<AVAudioSession>(
+            instance: instance,
+            original: #selector(AVAudioSession.setMode(_:)),
+            swizzled: #selector(AVAudioSession.swizzled_setMode(_:)),
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantReturn, .propertyTypes])
+    }
+
+    func testTrailingCommasAddedToParensAroundSingleValueSwift6_2() {
+        let input = """
+        let foo = (
+            0
+        )
+        """
+
+        let output = """
+        let foo = (
+            0,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.redundantParens])
+    }
+
+    func testTrailingCommasAddedToTupleWithNoArgumentsSwift6_2() {
+        let input = """
+        let foo = (
+            0,
+            1
+        )
+        """
+        let output = """
+        let foo = (
+            0,
+            1,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToTupleTypesInSwift6_2() {
+        // Trailing commas are now supported in tuple types in Swift 6.2
+        let input = """
+        let foo: (
+            bar: String,
+            quux: String
+        )
+        """
+        let output = """
+        let foo: (
+            bar: String,
+            quux: String,
+        )
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToTupleTypesInSwift6_2_multiElementLists() {
+        // Trailing commas are now supported in tuple types in Swift 6.2
+        let input = """
+        let foo: (
+            bar: String,
+            quux: String
+        )
+        """
+        let output = """
+        let foo: (
+            bar: String,
+            quux: String,
+        )
+        """
+
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToTupleTypeInArrayInSwift6_2() {
+        // Trailing commas are now supported in tuple types in Swift 6.2
+        let input = """
+        let foo: [[(
+            bar: String,
+            quux: String
+        )]]
+
+        let foo = [[(
+            bar: String,
+            quux: String
+        )]]()
+        """
+        let output = """
+        let foo: [[(
+            bar: String,
+            quux: String,
+        )]]
+
+        let foo = [[(
+            bar: String,
+            quux: String,
+        )]]()
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.propertyTypes])
+    }
+
+    func testTrailingCommasAddedToTupleTypeInGenericBracketsInSwift6_2() {
+        // Trailing commas are now supported in tuple types in Swift 6.2
+        let input = """
+        let foo: Array<(
+            bar: String,
+            quux: String
+        )>
+
+        let foo = Array<(
+            bar: String,
+            quux: String
+        )>()
+        """
+        let output = """
+        let foo: Array<(
+            bar: String,
+            quux: String,
+        )>
+
+        let foo = Array<(
+            bar: String,
+            quux: String,
+        )>()
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
+    }
+
+    func testTrailingCommasAddedToTupleFunctionArgumentInSwift6_2() {
+        let input = """
+        func updateBackgroundMusic(
+            inputs _: (
+                isFullyVisible: Bool,
+                currentLevel: LevelsService.Level?,
+                isAudioEngineRunningInForeground: Bool,
+                cameraMode: EnvironmentCameraMode
+            ),
+        ) {}
+        """
+        let output = """
+        func updateBackgroundMusic(
+            inputs _: (
+                isFullyVisible: Bool,
+                currentLevel: LevelsService.Level?,
+                isAudioEngineRunningInForeground: Bool,
+                cameraMode: EnvironmentCameraMode,
+            ),
+        ) {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToClosureTypeInSwift6_2() {
+        // Trailing commas are now supported in closure types in Swift 6.2
+        let input = """
+        let closure: (
+            String,
+            String
+        ) -> (
+            bar: String,
+            quux: String
+        )
+
+        let closure: @Sendable (
+            String,
+            String
+        ) -> (
+            bar: String,
+            quux: String
+        )
+
+        let closure: (
+            String,
+            String
+        ) async -> (
+            bar: String,
+            quux: String
+        )
+
+        let closure: (
+            String,
+            String
+        ) async throws -> (
+            bar: String,
+            quux: String
+        )
+
+        func foo(_: @escaping (
+            String,
+            String
+        ) -> Void) {}
+        """
+        let output = """
+        let closure: (
+            String,
+            String,
+        ) -> (
+            bar: String,
+            quux: String,
+        )
+
+        let closure: @Sendable (
+            String,
+            String,
+        ) -> (
+            bar: String,
+            quux: String,
+        )
+
+        let closure: (
+            String,
+            String,
+        ) async -> (
+            bar: String,
+            quux: String,
+        )
+
+        let closure: (
+            String,
+            String,
+        ) async throws -> (
+            bar: String,
+            quux: String,
+        )
+
+        func foo(_: @escaping (
+            String,
+            String,
+        ) -> Void) {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToClosureTypeInSwift6_2_multiElementList() {
+        // Trailing commas are now supported in closure types in Swift 6.2
+        let input = """
+        let closure: (
+            String,
+            String
+        ) -> (
+            bar: String,
+            quux: String
+        )
+
+        let closure: @Sendable (
+            String
+        ) -> (
+            bar: String,
+            quux: String
+        )
+        """
+        let output = """
+        let closure: (
+            String,
+            String,
+        ) -> (
+            bar: String,
+            quux: String,
+        )
+
+        let closure: @Sendable (
+            String
+        ) -> (
+            bar: String,
+            quux: String,
+        )
+        """
+
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToOptionalClosureTypeInSwift6_2() {
+        let input = """
+        public func requestLocationAuthorizationAndAccuracy(completion _: (
+            (
+                _ authorizationStatus: CLAuthorizationStatus?,
+                _ accuracyAuthorization: CLAccuracyAuthorization?,
+                _ error: LocationServiceError?
+            ) -> Void
+        )?) {}
+        """
+        let output = """
+        public func requestLocationAuthorizationAndAccuracy(completion _: (
+            (
+                _ authorizationStatus: CLAuthorizationStatus?,
+                _ accuracyAuthorization: CLAccuracyAuthorization?,
+                _ error: LocationServiceError?,
+            ) -> Void
+        )?) {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToClosureTupleTypealiasesInSwift6_2() {
+        let input = """
+        public typealias StringToInt = (
+            String
+        ) -> Int
+
+        public enum Toster {
+            public typealias StringToInt = ((
+                String
+            ) -> Int)?
+        }
+
+        public typealias Tuple = (
+            foo: String,
+            bar: Int
+        )
+
+        public typealias OptionalTuple = (
+            foo: String,
+            bar: Int,
+            baaz: Bool
+        )?
+        """
+        let output = """
+        public typealias StringToInt = (
+            String,
+        ) -> Int
+
+        public enum Toster {
+            public typealias StringToInt = ((
+                String,
+            ) -> Int)?
+        }
+
+        public typealias Tuple = (
+            foo: String,
+            bar: Int,
+        )
+
+        public typealias OptionalTuple = (
+            foo: String,
+            bar: Int,
+            baaz: Bool,
+        )?
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToReturnTupleSwift6_2() {
+        let input = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz
+            )
+        }
+        """
+        let output = """
+        func foo() -> (Int, Int) {
+            let bar = 0
+            let baz = 1
+
+            return (
+                bar,
+                baz,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToThrowSwift6_2() {
+        let input = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar
+            )
+        }
+        """
+
+        let output = """
+        enum FooError: Error {
+            case bar
+        }
+
+        func baz() throws {
+            throw (
+                FooError.bar,
+            )
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToSwitchSwift6_2() {
+        let input = """
+        let foo = (
+            bar: 0,
+            baz: 1
+        )
+        switch (
+            foo.bar,
+            foo.baz
+        ) {
+        case (
+            0,
+            1
+        ): break
+        default: break
+        }
+        """
+        let output = """
+        let foo = (
+            bar: 0,
+            baz: 1,
+        )
+        switch (
+            foo.bar,
+            foo.baz,
+        ) {
+        case (
+            0,
+            1,
+        ): break
+        default: break
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToAttributeSwift6_2() {
+        let input = """
+        @Foo(
+            "bar",
+            "baz"
+        )
+        struct Qux {}
+        """
+        let output = """
+        @Foo(
+            "bar",
+            "baz",
+        )
+        struct Qux {}
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasNotAddedToBuiltInAttributesInSwift6_2() {
+        let input = """
+        @available(
+            *,
+            deprecated,
+            renamed: "bar"
+        )
+        func foo() {}
+
+        @backDeployed(
+            before: iOS 17
+        )
+        public func foo() {}
+
+        @objc(
+            custom_objc_name
+        )
+        class MyClass: NSObject()
+
+        @freestanding(
+            declaration,
+            names: named(CodingKeys)
+        )
+        macro FreestandingMacro() = #externalMacro(module: "Macros", type: "")
+
+        @attached(
+            extension,
+            names: arbitrary
+        )
+        macro AttachedMacro() = #externalMacro(module: "Macros", type: "")
+
+        @_originallyDefinedIn(
+            module: "Foo",
+            macOS 10.0
+        )
+        extension CoreFoundation.CGFloat: Swift.SignedNumeric {}
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToMacroSwift6_2() {
+        let input = """
+        #foo(
+            "bar",
+            "baz"
+        )
+        """
+        let output = """
+        #foo(
+            "bar",
+            "baz",
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToGenericListSwift6_2() {
+        let input = """
+        struct S<
+            T1,
+            T2,
+            T3
+        > {}
+
+        typealias T<
+            T1,
+            T2
+        > = S<T1, T2, Bool>
+
+        func foo<
+            T1,
+            T2,
+        >() -> (T1, T2) {}
+        """
+        let output = """
+        struct S<
+            T1,
+            T2,
+            T3,
+        > {}
+
+        typealias T<
+            T1,
+            T2,
+        > = S<T1, T2, Bool>
+
+        func foo<
+            T1,
+            T2,
+        >() -> (T1, T2) {}
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToGenericTypesInSwift6_2() {
+        // Trailing commas are now supported in generic types in Swift 6.2
+        let input = """
+        public final class TestThing: GenericThing<
+            Test1,
+            Test2,
+            Test3
+        > {}
+
+        func foo(_: GenericThing<
+            Test1,
+            Test2,
+            Test3
+        >) {}
+
+        typealias T<
+            T1,
+            T2,
+        > = S<
+            T1,
+            T2,
+            Bool
+        >
+
+        extension Dictionary<
+            String,
+            Any
+        > {}
+
+        protocol MyProtocolWithAssociatedTypes<
+            Foo,
+            Bar
+        > {}
+        """
+        let output = """
+        public final class TestThing: GenericThing<
+            Test1,
+            Test2,
+            Test3,
+        > {}
+
+        func foo(_: GenericThing<
+            Test1,
+            Test2,
+            Test3,
+        >) {}
+
+        typealias T<
+            T1,
+            T2,
+        > = S<
+            T1,
+            T2,
+            Bool,
+        >
+
+        extension Dictionary<
+            String,
+            Any,
+        > {}
+
+        protocol MyProtocolWithAssociatedTypes<
+            Foo,
+            Bar,
+        > {}
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.emptyExtensions, .typeSugar])
+    }
+
+    func testTrailingCommasRemovedFromSingleLineGenericListSwift6_2() {
+        let input = """
+        struct S<T1, T2, T3,> {}
+        """
+        let output = """
+        struct S<T1, T2, T3> {}
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToCaptureListSwift6_2() {
+        let input = """
+        { [
+            capturedValue1,
+            capturedValue2
+        ] in
+        }
+        """
+        let output = """
+        { [
+            capturedValue1,
+            capturedValue2,
+        ] in
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromSingleElementCaptureListSwift6_2() {
+        let input = """
+        { [
+            capturedValue1,
+        ] in
+        }
+        """
+        let output = """
+        { [
+            capturedValue1
+        ] in
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromSingleLineCaptureListSwift6_2() {
+        let input = """
+        { [capturedValue1, capturedValue2,] in
+            print(capturedValue1, capturedValue2)
+        }
+        """
+        let output = """
+        { [capturedValue1, capturedValue2] in
+            print(capturedValue1, capturedValue2)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToSubscriptSwift6_2() {
+        let input = """
+        let value = m[
+            x,
+            y
+        ]
+        """
+        let output = """
+        let value = m[
+            x,
+            y,
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemoveFromSubscriptWhenCollectionsOnlySwift6_2() {
+        let input = """
+        let value = m[
+            x,
+            y,
+        ]
+        """
+        let output = """
+        let value = m[
+            x,
+            y
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .collectionsOnly, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasRemovedFromSingleLineSubscriptSwift6_2() {
+        let input = """
+        let value = m[x, y,]
+        """
+        let output = """
+        let value = m[x, y]
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testAddingTrailingCommaDoesntConflictWithOpaqueGenericParametersRuleSwift6_2() {
+        let input = """
+        private func foo<
+            Foo: Bar,
+            Bar: Baaz
+        >(a: Foo, b: Foo)
+            where Foo == Bar
+        {
+            print(a, b)
+        }
+        """
+
+        let output = """
+        private func foo<
+            Foo: Bar,
+            Bar: Baaz,
+        >(a: Foo, b: Foo)
+            where Foo == Bar
+        {
+            print(a, b)
+        }
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testCollectionsOnlyAddsCollectionCommasAndRemovesNonCollectionCommasSwift6_2() {
+        let input = """
+        let array = [
+            1,
+            2
+        ]
+
+        func foo(
+            a: Int,
+            b: Int,
+        ) {
+            print(a, b)
+        }
+        """
+        let output = """
+        let array = [
+            1,
+            2,
+        ]
+
+        func foo(
+            a: Int,
+            b: Int
+        ) {
+            print(a, b)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .collectionsOnly, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasNotRemovedFromInitParametersWithAlwaysOptionSwift6_2() {
+        let input = """
+        public init(
+            parameter: Parameter,
+        ) {
+            // test
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.unusedArguments])
+    }
+
+    func testTrailingCommasAddedToInitParametersWithAlwaysOptionSwift6_2() {
+        let input = """
+        public init(
+            parameter: Parameter
+        ) {
+            // test
+        }
+        """
+        let output = """
+        public init(
+            parameter: Parameter,
+        ) {
+            // test
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.unusedArguments])
+    }
+
+    func testMultiElementListsAddsCommaToMultiElementArraySwift6_2() {
+        let input = """
+        let array = [
+            1,
+            2
+        ]
+        """
+        let output = """
+        let array = [
+            1,
+            2,
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsDoesNotAddCommaToSingleElementArraySwift6_2() {
+        let input = """
+        let array = [
+            1
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsAddsCommaToMultiElementFunctionSwift6_2() {
+        let input = """
+        func foo(
+            a: Int,
+            b: Int
+        ) {
+            print(a, b)
+        }
+        """
+        let output = """
+        func foo(
+            a: Int,
+            b: Int,
+        ) {
+            print(a, b)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsDoesNotAddCommaToSingleElementFunctionSwift6_2() {
+        let input = """
+        func foo(
+            a: Int
+        ) {
+            print(a)
+        }
+
+        init(
+            a: Int
+        ) {
+            print(a)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsAddsCommaToMultiElementFunctionCallSwift6_2() {
+        let input = """
+        foo(
+            a: 1,
+            b: 2
+        )
+        """
+        let output = """
+        foo(
+            a: 1,
+            b: 2,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsDoesNotAddCommaToSingleElementFunctionCallSwift6_2() {
+        let input = """
+        foo(
+            a: 1
+        )
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsAddsCommaToMultiElementGenericListSwift6_2() {
+        let input = """
+        struct Foo<
+            T,
+            U
+        > {}
+        """
+        let output = """
+        struct Foo<
+            T,
+            U,
+        > {}
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsDoesNotAddCommaToSingleElementGenericListSwift6_2() {
+        let input = """
+        struct Foo<
+            T
+        > {}
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsRemovesCommaFromSingleElementArraySwift6_2() {
+        let input = """
+        let array = [
+            1,
+        ]
+        """
+        let output = """
+        let array = [
+            1
+        ]
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsRemovesCommaFromSingleElementFunctionSwift6_2() {
+        let input = """
+        func foo(
+            a: Int,
+        ) {
+            print(a)
+        }
+        """
+        let output = """
+        func foo(
+            a: Int
+        ) {
+            print(a)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsRemovesCommaFromSingleElementInitSwift6_2() {
+        let input = """
+        public init(
+            a: Int,
+        ) {
+            print(a)
+        }
+        """
+        let output = """
+        public init(
+            a: Int
+        ) {
+            print(a)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsAddCommaToInitSwift6_2() {
+        let input = """
+        public init(
+            a: Int,
+            b: Int
+        ) {
+            print(a, b)
+        }
+        """
+        let output = """
+        public init(
+            a: Int,
+            b: Int,
+        ) {
+            print(a, b)
+        }
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommaAddedToTupleAndClosureTypesSwift6_2() {
+        let input = """
+        let foo: (
+            bar: String,
+            quux: String
+        )
+
+        let bar: (
+            bar: String,
+            baaz: String
+        ) -> Void
+
+        public func testClosureArgumentInTuple() {
+            _ = object.methodWithTupleArgument((
+                closureArgument: { capturedObject in
+                    _ = capturedObject
+                },
+            ))
+        }
+        """
+        let output = """
+        let foo: (
+            bar: String,
+            quux: String,
+        )
+
+        let bar: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+
+        public func testClosureArgumentInTuple() {
+            _ = object.methodWithTupleArgument((
+                closureArgument: { capturedObject in
+                    _ = capturedObject
+                },
+            ))
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsTrailingCommasAddedToClosureTypeSwift6_2() {
+        let input = """
+        let foo: (
+            bar: String
+        ) -> Void
+
+        let foo: (
+            bar: String,
+            baaz: String
+        ) -> Void
+        """
+        let output = """
+        let foo: (
+            bar: String
+        ) -> Void
+
+        let foo: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testMultiElementListsTrailingCommasAddedToTupleAndClosureTypesSwift6_2() {
+        let input = """
+        let bar: (
+            bar: String,
+            baaz: String
+        )
+
+        let bar: (
+            bar: String,
+            baaz: String
+        ) -> Void
+        """
+        let output = """
+        let bar: (
+            bar: String,
+            baaz: String,
+        )
+
+        let bar: (
+            bar: String,
+            baaz: String,
+        ) -> Void
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToOptionalClosureCallSwift6_2() {
+        let input = """
+        myClosure?(
+            foo: 5,
+            bar: 10
+        )
+        """
+        let output = """
+        myClosure?(
+            foo: 5,
+            bar: 10,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasAddedToOptionalClosureCallSingleParameterSwift6_2() {
+        let input = """
+        myClosure?(
+            foo: 5
+        )
+        """
+        let output = """
+        myClosure?(
+            foo: 5,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasMultiElementListsOptionalClosureCallSwift6_2() {
+        let input = """
+        myClosure?(
+            foo: 5,
+        )
+
+        otherClosure?(
+            foo: 5,
+            bar: 10
+        )
+        """
+        let output = """
+        myClosure?(
+            foo: 5
+        )
+
+        otherClosure?(
+            foo: 5,
+            bar: 10,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .multiElementLists, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testTrailingCommasInTupleTypeCastAddedSwift6_2() {
+        // Now supported in Swift 6.2
+        let input = """
+        let foo = bar as? (
+            Foo,
+            Bar
+        )
+        """
+        let output = """
+        let foo = bar as? (
+            Foo,
+            Bar,
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options)
+    }
+
+    func testIssue2142Swift6_2() {
+        let input = """
+        public func bindExitButton<T: Presenter>(
+            action: T.Action,
+            withIdentifier identifier: UIAction.Identifier? = nil,
+            on controlEvents: UIControl.Event = .primaryActionTriggered,
+            to presenter: T,
+        ) {
+            _ = action
+            _ = identifier
+            _ = controlEvents
+            _ = presenter
+        }
+
+        let setModeSwizzle = Swizzle<AVAudioSession>(
+            instance: instance,
+            original: #selector(AVAudioSession.setMode(_:)),
+            swizzled: #selector(AVAudioSession.swizzled_setMode(_:)),
+        )
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.propertyTypes])
+    }
+
+    func testIssue2143Swift6_2() {
+        let input = """
+        public func testClosureArgumentInTuple() {
+            _ = object.methodWithTupleArgument((
+                closureArgument: { capturedObject in
+                    _ = capturedObject
+                },
+            ))
+        }
+        """
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options)
+    }
 }

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -2418,32 +2418,36 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.propertyTypes])
     }
 
-    func testTrailingCommasAddedToTupleTypeInGenericBracketsInSwift6_2() {
-        // Trailing commas are now supported in tuple types in Swift 6.2
+    func testTrailingCommasNotAddedToTupleTypeInGenericBracketsInSwift6_2() {
+        // In Swift 6.2, trailing commas are unexpectedly not supported in tuple types
+        // within generic arguments: https://github.com/swiftlang/swift-syntax/pull/3153
         let input = """
         let foo: Array<(
             bar: String,
             quux: String
         )>
+        """
 
-        let foo = Array<(
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
+    }
+
+    func testTrailingCommasAddedToTupleTypeInGenericBracketsInSwift6_3() {
+        let input = """
+        let foo: Array<(
             bar: String,
             quux: String
-        )>()
+        )>
         """
+
         let output = """
         let foo: Array<(
             bar: String,
             quux: String,
         )>
-
-        let foo = Array<(
-            bar: String,
-            quux: String,
-        )>()
         """
 
-        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.3")
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
     }
 


### PR DESCRIPTION
Swift 6.1 had bugs that unexpectedly disallowed trailing commas in a few places, like tuple values and generic argument lists (https://github.com/swiftlang/swift/pull/81612).

This PR updates the `trailingCommas` rule to add trailing commas in these places with using Swift 6.2.

I found a remaining edge case in Swift 6.2 where trailing commas are still not supported in tuple values _within generic argument lists_. Working on landing a fix for that in Swift 6.3: https://github.com/swiftlang/swift-syntax/pull/3153.

I'll release a new SwiftFormat version including this change after verifying that the Airbnb codebase compiles properly in Swift 6.2 after applying the updated `trailingCommas` functionality.