### PR TITLE
Handle Swift 6.2 bug where trailing commas are not allowed in closure literal tuple return types

### DIFF
--- a/Sources/Rules/TrailingCommas.swift
+++ b/Sources/Rules/TrailingCommas.swift
@@ -77,8 +77,8 @@ public extension FormatRule {
                 {
                     trailingCommaSupported = true
 
-                    // However, this is one bug in Swift 6.2 where trailing commas are unexpectedly
-                    // not allowed  in tuple types within generic type argument lists.
+                    // However, this is a bug in Swift 6.2 where trailing commas are unexpectedly
+                    // not allowed in tuple types within generic type argument lists.
                     // https://github.com/swiftlang/swift-syntax/pull/3153
                     if formatter.options.swiftVersion == "6.2" {
                         var startOfScope = startOfScope
@@ -90,6 +90,15 @@ public extension FormatRule {
 
                             startOfScope = outerScope
                         }
+                    }
+
+                    // There is also a bug in Swift 6.2 where closure tuple return types don't support trailing commas.
+                    if formatter.options.swiftVersion == "6.2",
+                       let tokenBeforeStartOfScope = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: startOfScope),
+                       formatter.tokens[tokenBeforeStartOfScope] == .operator("->", .infix),
+                       formatter.isInClosureArguments(at: tokenBeforeStartOfScope)
+                    {
+                        trailingCommaSupported = false
                     }
                 }
 

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -2451,6 +2451,81 @@ class TrailingCommasTests: XCTestCase {
         testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
     }
 
+    func testTrailingCommasNotAddedToClosureTupleReturnType() {
+        // Trailing commas are unexpectedly not allowed here in Swift 6.2
+        let input = """
+        let closure = { () -> (
+            foo: String,
+            bar: String
+        ) in
+            (foo: "foo", bar: "bar")
+        }
+
+        func foo() -> (
+            foo: String,
+            bar: String
+        ) {
+            (foo: "foo", bar: "bar")
+        }
+        """
+
+        let output = """
+        let closure = { () -> (
+            foo: String,
+            bar: String
+        ) in
+            (foo: "foo", bar: "bar")
+        }
+
+        func foo() -> (
+            foo: String,
+            bar: String,
+        ) {
+            (foo: "foo", bar: "bar")
+        }
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.2")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
+    }
+
+    func testTrailingCommasAddedToClosureTupleReturnTypeSwift6_3() {
+        let input = """
+        let closure = { () -> (
+            foo: String,
+            bar: String
+        ) in
+            (foo: "foo", bar: "bar")
+        }
+
+        func foo() -> (
+            foo: String,
+            bar: String
+        ) {
+            (foo: "foo", bar: "bar")
+        }
+        """
+
+        let output = """
+        let closure = { () -> (
+            foo: String,
+            bar: String,
+        ) in
+            (foo: "foo", bar: "bar")
+        }
+
+        func foo() -> (
+            foo: String,
+            bar: String,
+        ) {
+            (foo: "foo", bar: "bar")
+        }
+        """
+
+        let options = FormatOptions(trailingCommas: .always, swiftVersion: "6.3")
+        testFormatting(for: input, output, rule: .trailingCommas, options: options, exclude: [.typeSugar, .propertyTypes])
+    }
+
     func testTrailingCommasAddedToTupleFunctionArgumentInSwift6_2() {
         let input = """
         func updateBackgroundMusic(


### PR DESCRIPTION
This PR updates the `trailingCommas` rule to handle a Swift 6.2 bug where trailing commas are unexpectedly not allowed in closure literal tuple return types.

This example does not compile in Swift 6.2:

```swift
let closure = { () -> (
  foo: String,
  bar: String,
) in
  (foo: "foo", bar: "bar")
}
```

I confirmed this fix also fixes this issue, so this should be supported in Swift 6.3: https://github.com/swiftlang/swift/pull/84421