### PR TITLE
Fix `parseDeclarations` parsing bug

### DIFF
--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -4282,4 +4282,43 @@ class OrganizeDeclarationsTests: XCTestCase {
             exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
         )
     }
+
+    func testHandlesMalformedPropertyType() {
+        let input = """
+        extension Foo {
+            /// Invalid type, should still get handled properly
+            private var foo: FooBar++ {
+                guard
+                    let foo = foo.bar,
+                    let bar = foo.bar
+                else {
+                    return nil
+                }
+
+                return bar
+            }
+        }
+
+        extension Foo {
+            /// Invalid type, should still get handled properly
+            func foo() -> FooBar++ {
+                guard
+                    let foo = foo.bar,
+                    let bar = foo.bar
+                else {
+                    return nil
+                }
+
+                return bar
+            }
+        }
+        """
+
+        testFormatting(
+            for: input,
+            rule: .organizeDeclarations,
+            options: FormatOptions(organizeTypes: ["extension"]),
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
 }


### PR DESCRIPTION
This PR fixes a `parseDeclarations` bug where a property declaration with an invalid / unknown / unsupported type could be parsed incorrectly.

Also fixed a `parseType` bug where it didn't support types with multiple layers of optionals, like `Foo???`.