### PR TITLE
Fix issue where `async` effect could be confused for `async` modifier, breaking `docCommentsBeforeModifiers` rule in protocol body with `async` functions

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -403,6 +403,11 @@ extension Formatter {
     /// Returns true if the modifiers list for the given declaration contain a
     /// modifier matching the specified predicate
     func modifiersForDeclaration(at index: Int, contains: (Int, String) -> Bool) -> Bool {
+        var declarationType: String?
+        if tokens[index].isDeclarationTypeKeyword {
+            declarationType = tokens[index].string
+        }
+
         var index = index
         while var prevIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: index) {
             switch tokens[prevIndex] {
@@ -414,6 +419,12 @@ extension Formatter {
                     // Part of previous declaration
                     return false
                 }
+
+                // Async is only a valid modifier on local let/var declarations.
+                if token == .identifier("async"), !["let", "var"].contains(declarationType) {
+                    return false
+                }
+
                 if contains(prevIndex, token.string) {
                     return true
                 }

--- a/Tests/Rules/DocCommentsBeforeModifiersTests.swift
+++ b/Tests/Rules/DocCommentsBeforeModifiersTests.swift
@@ -304,4 +304,20 @@ class DocCommentsBeforeModifiersTests: XCTestCase {
 
         testFormatting(for: input, rule: .docCommentsBeforeModifiers, exclude: [.propertyTypes])
     }
+
+    func testIssue2216() {
+        let input = """
+        protocol TestIssue2216() {
+            /// Documentation comment explaining the function
+            /// with multiple lines of explanation
+            func method1(value: String) async
+
+            /// Documentation comment explaining the function
+            /// with multiple lines of explanation
+            func method2(value: String) async
+        }
+        """
+
+        testFormatting(for: input, rule: .docCommentsBeforeModifiers)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/nicklockwood/SwiftFormat/issues/2216