### PR TITLE
Improve `trailingClosures` support for multiple trailing closures, fix bug where trailing closures could be applied to ineligible function calls

### DIFF
--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -354,7 +354,17 @@ public extension Formatter {
 
     /// Returns the token at the specified index, or nil if index is invalid
     func token(at index: AnyIndex) -> Token? {
-        tokens.indices.contains(index.index) ? tokens[index.index] : nil
+        guard tokens.indices.contains(index.index) else { return nil }
+        return tokens[index.index]
+    }
+
+    /// Returns the tokens at the specified range, or nil if range is invalid
+    func tokens(in range: AnyClosedRange) -> ArraySlice<Token>? {
+        guard tokens.indices.contains(range.lowerBound),
+              tokens.indices.contains(range.upperBound)
+        else { return nil }
+
+        return tokens[range.range]
     }
 
     /// Replaces the token at the specified index with one or more new tokens

--- a/Tests/Rules/TrailingClosuresTests.swift
+++ b/Tests/Rules/TrailingClosuresTests.swift
@@ -470,19 +470,25 @@ class TrailingClosuresTests: XCTestCase {
     func testMultipleTrailingClosuresWithTrailingComma() {
         let input = """
         withAnimationIfNeeded(
-            .linear,
+            .foo,
+            .bar,
             { didAppear = true },
             completion: { animateText = true },
         )
+
         """
         let output = """
         withAnimationIfNeeded(
-            .linear
-        ) { didAppear = true }
-            completion: { animateText = true }
+            .foo,
+            .bar
+        ) {
+            didAppear = true
+        } completion: {
+            animateText = true
+        }
 
         """
-        testFormatting(for: input, [output], rules: [.trailingClosures, .indent])
+        testFormatting(for: input, [output], rules: [.trailingClosures, .indent, .wrapArguments, .wrap])
     }
 
     func testMultipleUnlabeledClosuresNotTransformed() {
@@ -493,5 +499,69 @@ class TrailingClosuresTests: XCTestCase {
         )
         """
         testFormatting(for: input, rule: .trailingClosures)
+    }
+
+    func testMultipleClosuresWithNonClosureArgumentInMiddle() {
+        let input = """
+        withObservationTracking(
+            {
+                _ = self[keyPath: keyPath]
+            },
+            token: {
+                guard !isCancelled.value else {
+                    return nil
+                }
+
+                return ""
+            },
+            willChange: nil,
+            didChange: { [weak cancellable] in
+                action(self[keyPath: keyPath])
+                cancellable?.cancel()
+            }
+        )
+        """
+
+        testFormatting(for: input, rule: .trailingClosures)
+    }
+
+    func testMethodWithOnlyClosureArguments() {
+        let input = """
+        withObservationTracking(
+            {
+                _ = self[keyPath: keyPath]
+            },
+            token: {
+                guard !isCancelled.value else {
+                    return nil
+                }
+
+                return ""
+            },
+            didChange: { [weak cancellable] in
+                action(self[keyPath: keyPath])
+                cancellable?.cancel()
+            }
+        )
+
+        """
+
+        let output = """
+        withObservationTracking {
+            _ = self[keyPath: keyPath]
+        } token: {
+            guard !isCancelled.value else {
+                return nil
+            }
+
+            return ""
+        } didChange: { [weak cancellable] in
+            action(self[keyPath: keyPath])
+            cancellable?.cancel()
+        }
+
+        """
+
+        testFormatting(for: input, [output], rules: [.trailingClosures, .indent])
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/nicklockwood/SwiftFormat/issues/2223