### PR TITLE
Fix bug where `acronyms` rule would incorrectly always capitalize potentially matching acronyms one letter before end of identifier

### DIFF
--- a/Sources/Rules/Acronyms.swift
+++ b/Sources/Rules/Acronyms.swift
@@ -27,7 +27,7 @@ public extension FormatRule {
                 for replaceCandidateRange in token.string.ranges(of: find) {
                     let acronymShouldBeCapitalized: Bool
 
-                    if replaceCandidateRange.upperBound < token.string.indices.last! {
+                    if replaceCandidateRange.upperBound <= token.string.indices.last! {
                         let indexAfterMatch = replaceCandidateRange.upperBound
                         let characterAfterMatch = token.string[indexAfterMatch]
 

--- a/Tests/Rules/AcronymsTests.swift
+++ b/Tests/Rules/AcronymsTests.swift
@@ -90,4 +90,20 @@ class AcronymsTests: XCTestCase {
         let options = FormatOptions(preserveAcronyms: ["externallyProvidedUrl", "toUrl"])
         testFormatting(for: input, output, rule: .acronyms, options: options)
     }
+
+    func testAcronymMatchesPartOfOtherWordAtEndOfIdentifier() {
+        let input = """
+        struct MasKit {}
+        struct Mask {}
+        struct MaskView {}
+        """
+
+        let output = """
+        struct MASKit {}
+        struct Mask {}
+        struct MaskView {}
+        """
+
+        testFormatting(for: input, output, rule: .acronyms, options: FormatOptions(acronyms: ["MAS"]))
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/nicklockwood/SwiftFormat/issues/2218