### PR TITLE
Fix issue where `.swift-version` file was ignored if not also using config file

### DIFF
--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -353,10 +353,15 @@ private func processDirectory(_ inputURL: URL, with options: inout Options, logg
             logger?("Ignoring swift-version file at \(versionFile.path)")
         } else if Version(rawValue: versionString) != nil {
             logger?("Reading swift-version file at \(versionFile.path) (version \(versionString))")
-            args = args.map {
-                var args = $0
-                args["swift-version"] = versionString
-                return args
+
+            if args.isEmpty {
+                args = [["swift-version": versionString]]
+            } else {
+                args = args.map {
+                    var args = $0
+                    args["swift-version"] = versionString
+                    return args
+                }
             }
         } else {
             // Don't treat as error, per: https://github.com/nicklockwood/SwiftFormat/issues/639


### PR DESCRIPTION
This PR fixes an issue where any `.swift-version` file was ignored if not also using a config file. Fixes https://github.com/nicklockwood/SwiftFormat/issues/2221.