### PR TITLE
Update `redundantLet` rule to handle `#Preview` macro

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1218,6 +1218,11 @@ extension Formatter {
                     break
                 }
             }
+
+            if tokens[prevIndex].string == "#Preview" {
+                return true
+            }
+
             if tokens[prevIndex].isStartOfScope, i != startIndex {
                 i = startIndex
             } else {

--- a/Tests/Rules/RedundantLetTests.swift
+++ b/Tests/Rules/RedundantLetTests.swift
@@ -102,7 +102,7 @@ class RedundantLetTests: XCTestCase {
 
     func testNoRemoveLetInIfStatementInViewBuilder() {
         let input = """
-        VStack {
+        VStack(spacing: 0) {
             if visible == "YES" {
                 let _ = print("")
             }
@@ -170,6 +170,21 @@ class RedundantLetTests: XCTestCase {
         let input = """
         let foo = bar { @Sendable
             let _ = try await baz()
+        }
+        """
+        testFormatting(for: input, rule: .redundantLet)
+    }
+
+    func testPreserveLetInPreviewMacro() {
+        let input = """
+        #Preview {
+            let _ = 1234
+            Text("Test")
+        }
+
+        #Preview(name: "Test") {
+            let _ = 1234
+            Text("Test")
         }
         """
         testFormatting(for: input, rule: .redundantLet)


### PR DESCRIPTION
Fixes https://github.com/nicklockwood/SwiftFormat/issues/2222