### PR TITLE
Update `redundantInit` rule to support function calls with single trailing closure argument

### DIFF
--- a/Sources/Rules/RedundantInit.swift
+++ b/Sources/Rules/RedundantInit.swift
@@ -17,10 +17,10 @@ public extension FormatRule {
         formatter.forEach(.identifier("init")) { initIndex, _ in
             guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: initIndex, if: {
                 $0.isOperator(".")
-            }), let openParenIndex = formatter.index(of: .nonSpaceOrLinebreak, after: initIndex, if: {
-                $0 == .startOfScope("(")
-            }), let closeParenIndex = formatter.index(of: .endOfScope(")"), after: openParenIndex),
-            formatter.last(.nonSpaceOrCommentOrLinebreak, before: closeParenIndex) != .delimiter(":"),
+            }), let openParenOrOpenBraceIndex = formatter.index(of: .nonSpaceOrLinebreak, after: initIndex, if: {
+                $0 == .startOfScope("(") || $0 == .startOfScope("{")
+            }), let closeParenOrCloseBraceIndex = formatter.endOfScope(at: openParenOrOpenBraceIndex),
+            formatter.last(.nonSpaceOrCommentOrLinebreak, before: closeParenOrCloseBraceIndex) != .delimiter(":"),
             let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: dotIndex),
             let prevToken = formatter.token(at: prevIndex),
             formatter.isValidEndOfType(at: prevIndex),
@@ -61,7 +61,11 @@ public extension FormatRule {
                     return
                 }
             }
-            formatter.removeTokens(in: initIndex + 1 ..< openParenIndex)
+
+            if formatter.tokens[openParenOrOpenBraceIndex] == .startOfScope("(") {
+                formatter.removeTokens(in: initIndex + 1 ..< openParenOrOpenBraceIndex)
+            }
+
             formatter.removeTokens(in: dotIndex ... initIndex)
         }
     } examples: {

--- a/Tests/Rules/RedundantInitTests.swift
+++ b/Tests/Rules/RedundantInitTests.swift
@@ -246,4 +246,14 @@ class RedundantInitTests: XCTestCase {
         """
         testFormatting(for: input, rule: .redundantInit)
     }
+
+    func testRemoveRedundantInitBeforeTrailingClosure() {
+        let input = """
+        Handler.init { print("foo") }
+        """
+        let output = """
+        Handler { print("foo") }
+        """
+        testFormatting(for: input, output, rule: .redundantInit)
+    }
 }


### PR DESCRIPTION
This PR updates the `redundantInit` rule to support function calls with single trailing closure arguments.

```diff
- Handler.init { print("foo") }
+ Handler { print("foo") }
```