### PR TITLE
Fix issue where `opaqueGenericParameters` rule could cause `'some' types cannot be used in constraints on existential types` build error

### DIFF
--- a/Sources/Rules/OpaqueGenericParameters.swift
+++ b/Sources/Rules/OpaqueGenericParameters.swift
@@ -150,6 +150,16 @@ public extension FormatRule {
                     }
                 }
 
+                // If the generic is used as a generic argument in an `any` existential type,
+                // it can't be replaced with a `some` type.
+                for argument in declaration.arguments {
+                    if argument.type.tokens.contains(where: { $0.string == "any" }),
+                       argument.type.tokens.contains(where: { $0.string == genericType.name })
+                    {
+                        genericType.eligibleToRemove = false
+                    }
+                }
+
                 // Extract the comma-separated list of function parameters,
                 // so we can check conditions on the individual parameters
                 let parameterListTokenIndices = (declaration.argumentsRange.lowerBound + 1) ..< declaration.argumentsRange.upperBound

--- a/Tests/Rules/OpaqueGenericParametersTests.swift
+++ b/Tests/Rules/OpaqueGenericParametersTests.swift
@@ -756,4 +756,16 @@ final class OpaqueGenericParametersTests: XCTestCase {
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, output, rule: .opaqueGenericParameters, options: options)
     }
+
+    func testPreservesGenericInProtocolPrimaryAssociatedType() {
+        // Can't be converted to `any Collection<some StringProtocol>`:
+        // error: 'some' types cannot be used in constraints on existential types
+        let input = """
+        func foo<T: StringProtocol>(_ collection: any Collection<T>) {
+            print(collection)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .opaqueGenericParameters, options: options)
+    }
 }


### PR DESCRIPTION
Fixes #2239