### PR TITLE
Update SimplifyGenericConstraints for edge cases

### DIFF
--- a/Tests/Rules/SimplifyGenericConstraintsTests.swift
+++ b/Tests/Rules/SimplifyGenericConstraintsTests.swift
@@ -361,7 +361,7 @@ final class SimplifyGenericConstraintsTests: XCTestCase {
     }
 
     func testMultilineWhereClauseWithLineBreaksAfterAmpersand() {
-        // Multiline where clause with line breaks after & should produce correct spacing
+        // Don't simplify multiline where clauses with line breaks after & - too error prone
         let input = """
         enum Section<Context>: Component
           where Context: ProviderA & ProviderB &
@@ -369,11 +369,7 @@ final class SimplifyGenericConstraintsTests: XCTestCase {
           ProviderD
         {}
         """
-        let output = """
-        enum Section<Context: ProviderA & ProviderB & ProviderC & ProviderD>: Component
-          {}
-        """
-        testFormatting(for: input, output, rule: .simplifyGenericConstraints, exclude: [.indent])
+        testFormatting(for: input, rule: .simplifyGenericConstraints, exclude: [.indent])
     }
 
     func testProtocolMethodWithWhereClause() {


### PR DESCRIPTION
<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->

Bug fixes and edge cases. Best way to review this PR is by looking at each commit individually.

---
## Commit: https://github.com/nicklockwood/SwiftFormat/pull/2246/commits/b2ef43ad5696c031c4c271854cad5445e97a6d24

#### Problem

The simplifyGenericConstraints rule was removing where clause constraints for generic types that aren't declared in the
function's generic parameter list (e.g., generics from an enclosing extension), causing build failures.

#### Example

```diff
// Before fix: rule incorrectly removed where clause
- func process<T>(value: T) where U: Hashable {
-     print(U.self)
- }

+ func process<T>(value: T) {
+     print(U.self)
+ }
```

#### Root Cause

The rule would:
1. Remove ALL constraints from where clause
2. Try to add them back inline in <...> brackets
3. If generic type not found in brackets (like T from enclosing type), just give up
4. Result: constraint removed but never restored → build failure

#### Solution

Added isGenericTypeDeclared() check to only move constraints for generic types that are actually declared in the function's
generic parameter list. Constraints for enclosing type generics are now preserved in the where clause.

#### Changes

- Added guard condition to verify generic type exists in parameter list before marking constraint as movable
- Added isGenericTypeDeclared() helper function
- Added test case to cover generic types that aren't declared in the function's generic parameter list

---

## Commit https://github.com/nicklockwood/SwiftFormat/pull/2246/commits/12c090a78372a069fb4a97ef64351ebe7c784b78

#### Problem

When a generic type had both an inline constraint and a where clause constraint, the rule produced invalid Swift syntax by
using `:` instead of `&` to combine them:

```swift
// Before fix
struct Config<T: Hashable> where T: Codable {}
// Incorrectly formatted to:
struct Config<T: Hashable: Codable> {}  // ❌ Invalid syntax

// After fix
struct Config<T: Hashable & Codable> {}  // ✅ Valid syntax
```

#### Solution

Added detection for existing inline constraints:
- Check if a `:` token exists after the type name
- If yes, append new constraints with `&`
- If no, add constraints with `:`

#### Changes

- Added logic to detect existing inline constraints before adding new ones
- Added 2 test cases covering single and multiple generics with combined constraints

---

## Commit https://github.com/nicklockwood/SwiftFormat/pull/2246/commits/a729b858d43199e2df2b64c57f0eb57705e44a76

#### Problem
When applied to protocol methods, the rule would move constraints inline but leave behind an empty `where` keyword, since it only handled cases where the where clause was followed by an opening brace `{`, creating invalid Swift syntax.

```swift
protocol Foo {
    func bar<T>(_ value: T) async throws -> T where T: Codable
}

// Buggy output (invalid syntax)
protocol Foo {
    func bar<T: Codable>(_ value: T) async throws -> T where
}

// Fixed output
protocol Foo {
    func bar<T: Codable>(_ value: T) async throws -> T
}
```

#### Solution

Updated where clause removal logic to handle declarations without opening braces (protocol methods, property requirements, etc.) by detecting when the where clause ends at a linebreak instead of `{`.