### PR TITLE
SimplifyGenericConstraints : 40 character limit to protocol composition

### DIFF
--- a/Sources/Rules/SimplifyGenericConstraints.swift
+++ b/Sources/Rules/SimplifyGenericConstraints.swift
@@ -134,6 +134,16 @@ extension Formatter {
             constraintsByType[item.genericType.name, default: []].append(item.conformance)
         }
 
+        // Check if any combined protocol composition is over 40 characters
+        // If so, skip simplification for the entire declaration
+        for conformances in constraintsByType.values {
+            let protocolNames = conformances.map(\.name)
+            let combinedComposition = protocolNames.joined(separator: " & ")
+            if combinedComposition.count > 40 {
+                return
+            }
+        }
+
         // We perform modifications in reverse order to avoid invalidating indices
 
         // First, remove constraints from the where clause


### PR DESCRIPTION
<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->

Updates SimplifyGenericConstraints rule to skip any protocol compositions over the 40 character limit because anything longer than this looks cluttered and awkward.