### PR TITLE
Update `typeSugar` to only preserve optionals in structs with a synthesized memberwise initializer

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3767,10 +3767,15 @@ Prefer shorthand syntax for Arrays, Dictionaries and Optionals.
 
 Option | Description
 --- | ---
-`--short-optionals` | Prefer ? shorthand for optionals: "except-properties" (default) or "always"
+`--short-optionals` | Prefer ? shorthand for optionals: "preserve-struct-inits" (default) or "always"
 
 <details>
 <summary>Examples</summary>
+
+```diff
+- var foo: Optional<String>
++ var foo: String?
+```
 
 ```diff
 - var foo: Array<String>
@@ -3782,10 +3787,15 @@ Option | Description
 + var foo: [String: Int]
 ```
 
-```diff
-- var foo: Optional<(Int) -> Void>
-+ var foo: ((Int) -> Void)?
+By default, preserves `Optional` types that affect a struct's synthesized memberwise initializer:
+
+```swift
+struct Foo {
+    var bar: Optional<String>
+}
 ```
+
+With `var bar: Optional<String>`, `Foo`'s initializer is `init(bar: String?)`. If updated to `var bar String?`, `Foo`'s initializer would become `init(bar: String? = nil)`, which may be unexpected.
 
 </details>
 <br/>

--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -377,6 +377,25 @@ extension Collection<Declaration> {
             (declaration.body ?? []).forEachRecursiveDeclaration(operation)
         }
     }
+
+    /// Searches for and returns the inner-most declaration that contains the given index
+    func declaration(containing index: Int) -> Declaration? {
+        var containingDeclaration: Declaration?
+
+        forEachRecursiveDeclaration { declaration in
+            guard declaration.range.contains(index) else { return }
+
+            if let containingDeclaration,
+               !containingDeclaration.range.contains(declaration.range)
+            {
+                return
+            }
+
+            containingDeclaration = declaration
+        }
+
+        return containingDeclaration
+    }
 }
 
 extension Declaration {

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -983,7 +983,7 @@ struct _Descriptors {
     let shortOptionals = OptionDescriptor(
         argumentName: "short-optionals",
         displayName: "Short Optional Syntax",
-        help: "Prefer ? shorthand for optionals:",
+        help: "Prefer ? shorthand for optionals: \"preserve-struct-inits\" (default) or \"always\"",
         keyPath: \.shortOptionals
     )
     let markTypes = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -453,7 +453,8 @@ public enum SelfMode: String, CaseIterable {
 
 /// Optionals mode
 public enum OptionalsMode: String, CaseIterable {
-    case exceptProperties = "except-properties"
+    case preserveStructInits = "preserve-struct-inits"
+    case exceptPropertiesDeprecated = "except-properties"
     case always
 }
 
@@ -906,7 +907,7 @@ public struct FormatOptions: CustomStringConvertible {
                 noSpaceOperators: Set<String> = [],
                 noWrapOperators: Set<String> = [],
                 modifierOrder: [String] = [],
-                shortOptionals: OptionalsMode = .exceptProperties,
+                shortOptionals: OptionalsMode = .preserveStructInits,
                 funcAttributes: AttributeMode = .preserve,
                 typeAttributes: AttributeMode = .preserve,
                 varAttributes: AttributeMode = .preserve,

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1904,6 +1904,16 @@ extension Formatter {
 
     /// Parses the declarations in the given range.
     func parseDeclarations(in range: Range<Int>) -> [Declaration] {
+        parseDeclarations(in: range, _useForEachToken: true)
+    }
+
+    /// Parses the declarations in the given range.
+    ///
+    /// Uses `forEachToken` to iterate through the tokens in the given range.
+    /// This enables declarations to read the `isEnabled` state from comment directives.
+    /// This can be disabled with `_useForEachToken: false` to avoid reentrancy if you
+    /// need to call `parseDeclarations` from within an existing `forEachToken` call.
+    private func parseDeclarations(in range: Range<Int>, _useForEachToken: Bool) -> [Declaration] {
         // A temporary declaration value. We can't create a `DeclarationV2` directly
         // within the `forEachToken` call, since `forEachToken` doesn't support reentrancy.
         struct _Declaration {
@@ -1916,7 +1926,7 @@ extension Formatter {
         var startOfDeclaration = range.lowerBound
         let startOfScopeAtDeclaration = startOfScope(at: startOfDeclaration)
 
-        forEachToken(onlyWhereEnabled: false) { index, token in
+        let handleIndex = { [self] (index: Int, token: Token) in
             guard range.contains(index),
                   index >= startOfDeclaration,
                   token.isDeclarationTypeKeyword || token == .startOfScope("#if"),
@@ -1927,7 +1937,7 @@ extension Formatter {
 
             let keywordIndex = index
             let declarationKeyword = declarationType(at: keywordIndex) ?? "#if"
-            let endOfDeclaration = self._endOfDeclarationInTypeBody(atDeclarationKeyword: keywordIndex)
+            let endOfDeclaration = _endOfDeclarationInTypeBody(atDeclarationKeyword: keywordIndex)
 
             let declarationRange = startOfDeclaration ... min(endOfDeclaration ?? .max, range.upperBound - 1)
             startOfDeclaration = declarationRange.upperBound + 1
@@ -1941,6 +1951,16 @@ extension Formatter {
                     keywordIndex: keywordIndex,
                     range: declarationRange
                 ))
+            }
+        }
+
+        if _useForEachToken {
+            forEachToken(onlyWhereEnabled: false) { index, token in
+                handleIndex(index, token)
+            }
+        } else {
+            for (index, token) in tokens.enumerated() {
+                handleIndex(index, token)
             }
         }
 
@@ -2081,7 +2101,7 @@ extension Formatter {
         }
 
         // Prefer keeping linebreaks at the end of a declaration's tokens,
-        // instead of the start of the next delaration's tokens.
+        // instead of the start of the next declaration's tokens.
         //  - This includes any spaces on blank lines, but doesn't include the
         //    indentation associated with the next declaration.
         while let linebreakSearchIndex = endOfDeclaration,
@@ -2098,6 +2118,30 @@ extension Formatter {
         }
 
         return endOfDeclaration
+    }
+
+    /// Parses the inner-most type that contains the given index.
+    func parseEnclosingType(containing index: Int) -> TypeDeclaration? {
+        guard let startOfScope = startOfScope(at: index) else { return nil }
+
+        if let typeKeyword = indexOfLastSignificantKeyword(at: startOfScope, excluding: ["where"]),
+           Token.swiftTypeKeywords.contains(tokens[typeKeyword].string),
+           let bodyOpenBrace = self.index(of: .startOfScope("{"), after: typeKeyword),
+           let endOfScope = endOfScope(at: bodyOpenBrace)
+        {
+            // When parsing the body, use `_useForEachToken: false` to enable
+            // `parseEnclosingType` to be called from within `forEachToken` loops.
+            return TypeDeclaration(
+                keyword: tokens[typeKeyword].string,
+                range: startOfModifiers(at: typeKeyword, includingAttributes: true) ... endOfScope,
+                body: parseDeclarations(in: (bodyOpenBrace + 1) ..< endOfScope, _useForEachToken: false),
+                formatter: self
+            )
+        }
+
+        else {
+            return parseEnclosingType(containing: startOfScope)
+        }
     }
 
     /// Whether or not the body within this scope is a single expression

--- a/Tests/Rules/SinglePropertyPerLineTests.swift
+++ b/Tests/Rules/SinglePropertyPerLineTests.swift
@@ -90,7 +90,7 @@ final class SinglePropertyPerLineTests: XCTestCase {
         var optional: Optional<String>
         var result: Result<Int, Error>
         """
-        testFormatting(for: input, output, rule: .singlePropertyPerLine)
+        testFormatting(for: input, output, rule: .singlePropertyPerLine, exclude: [.typeSugar])
     }
 
     func testSeparateDeclarationsWithClosureTypes() {

--- a/Tests/Rules/TypeSugarTests.swift
+++ b/Tests/Rules/TypeSugarTests.swift
@@ -129,17 +129,49 @@ final class TypeSugarTests: XCTestCase {
 
     func testOptionalPropertyTypeNotConvertedToSugarByDefault() {
         let input = """
-        var bar: Optional<String>
+        struct Bar {
+            var bar: Optional<String>
+        }
         """
         testFormatting(for: input, rule: .typeSugar)
     }
 
     func testOptionalTypeConvertedToSugar() {
         let input = """
-        var foo: Optional<String>
+        struct Bar {
+            init() {
+                foo = "foo"
+            }
+
+            var foo: Optional<String>
+        }
+
+        struct Baaz {
+            var bar: Optional<String> = nil
+            let bar: Optional<String>
+        }
+
+        struct Quuz {
+            let bar: Optional<String>
+        }
         """
         let output = """
-        var foo: String?
+        struct Bar {
+            init() {
+                foo = "foo"
+            }
+
+            var foo: String?
+        }
+
+        struct Baaz {
+            var bar: String? = nil
+            let bar: String?
+        }
+
+        struct Quuz {
+            let bar: String?
+        }
         """
         let options = FormatOptions(shortOptionals: .always)
         testFormatting(for: input, output, rule: .typeSugar, options: options)


### PR DESCRIPTION
This PR updates `typeSugar` to only preserve `Optional<T>` types inside structs where:
 1. the struct has a synthesized memberwise initializer (no explicit initializer)
 2. the property is a `var` and doesn't have a default `= nil`

Discussion: #2259