### PR TITLE
Fix preserve ifdef indentation in nested chains

### DIFF
--- a/Sources/Inference.swift
+++ b/Sources/Inference.swift
@@ -304,15 +304,6 @@ private struct Inference {
     let ifdefIndent = OptionInferrer { formatter, options in
         var indented = 0, notIndented = 0, outdented = 0, preserveCandidates = 0
 
-        func recordPreserveCandidate(after linebreakIndex: Int) {
-            guard let token = formatter.next(.nonSpaceOrCommentOrLinebreak, after: linebreakIndex) else {
-                return
-            }
-            if case .operator(".", _) = token {
-                preserveCandidates += 1
-            }
-        }
-
         formatter.forEach(.startOfScope("#if")) { i, _ in
             if let indent = formatter.token(at: i - 1), case let .space(string) = indent,
                !string.isEmpty
@@ -328,7 +319,11 @@ private struct Inference {
                             return
                         } else if innerString == string {
                             notIndented += 1
-                            recordPreserveCandidate(after: nextLineIndex)
+                            if let token = formatter.next(.nonSpaceOrCommentOrLinebreak, after: nextLineIndex),
+                               case .operator(".", _) = token
+                            {
+                                preserveCandidates += 1
+                            }
                         } else {
                             // Assume more indented, as less would be a mistake
                             indented += 1

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -4662,6 +4662,24 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, rule: .indent, options: options)
     }
 
+    func testIfDefPreserveWithinIndentedChain() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                VStack {
+                    Text("Hello World")
+                }
+                .foregroundStyle(Color.white)
+                #if os(iOS)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .preserve)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
     // indent #if/#else/#elseif/#endif (mode: outdent)
 
     func testIfEndifOutdenting() {


### PR DESCRIPTION
<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->

I missed one other scenario causing issues. I've fixed it and written a test for it :)