### PR TITLE
Update `preferForLoop` rule to support optional `forEach` calls with `--optional-for-each convert`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2040,6 +2040,7 @@ Option | Description
 --- | ---
 `--anonymous-for-each` | Convert anonymous forEach closures to for loops: "ignore" or "convert" (default)
 `--single-line-for-each` | Convert single-line forEach closures to for loops: "ignore" (default) or "convert"
+`--optional-for-each` | Convert optional forEach calls to for loops: "convert" or "ignore" (default)
 
 <details>
 <summary>Examples</summary>
@@ -2062,6 +2063,12 @@ Option | Description
 + for baazValue in foo.item().bar[2].baazValues(option: true) {
 -     print($0)
 +     print(baazValue)
+  }
+
+  // --optional-for-each convert
+- foo?.bar?.forEach { item in
++ for item in foo?.bar ?? [] {
+      print(item)
   }
 
   // Doesn't affect long multiline functional chains

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1314,6 +1314,14 @@ struct _Descriptors {
         trueValues: ["ignore", "preserve"],
         falseValues: ["convert"]
     )
+    let convertOptionalForEach = OptionDescriptor(
+        argumentName: "optional-for-each",
+        displayName: "Optional forEach closures",
+        help: "Convert optional forEach calls to for loops:",
+        keyPath: \.convertOptionalForEach,
+        trueValues: ["convert"],
+        falseValues: ["ignore", "preserve"]
+    )
     let preserveDocComments = OptionDescriptor(
         argumentName: "doc-comments",
         displayName: "Doc comments",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -859,6 +859,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var wrapEffects: WrapEffects
     public var preserveAnonymousForEach: Bool
     public var preserveSingleLineForEach: Bool
+    public var convertOptionalForEach: Bool
     public var preserveDocComments: Bool
     public var conditionalAssignmentOnlyAfterNewProperties: Bool
     public var typeDelimiterSpacing: DelimiterSpacing
@@ -1004,6 +1005,7 @@ public struct FormatOptions: CustomStringConvertible {
                 wrapEffects: WrapEffects = .preserve,
                 preserveAnonymousForEach: Bool = false,
                 preserveSingleLineForEach: Bool = true,
+                convertOptionalForEach: Bool = false,
                 preserveDocComments: Bool = false,
                 conditionalAssignmentOnlyAfterNewProperties: Bool = true,
                 typeDelimiterSpacing: DelimiterSpacing = .spaceAfter,
@@ -1138,6 +1140,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.wrapEffects = wrapEffects
         self.preserveAnonymousForEach = preserveAnonymousForEach
         self.preserveSingleLineForEach = preserveSingleLineForEach
+        self.convertOptionalForEach = convertOptionalForEach
         self.preserveDocComments = preserveDocComments
         self.conditionalAssignmentOnlyAfterNewProperties = conditionalAssignmentOnlyAfterNewProperties
         self.typeDelimiterSpacing = typeDelimiterSpacing

--- a/Tests/Rules/PreferForLoopTests.swift
+++ b/Tests/Rules/PreferForLoopTests.swift
@@ -414,4 +414,175 @@ final class PreferForLoopTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .preferForLoop, exclude: [.wrapConditionalBodies, .blankLinesAfterGuardStatements])
     }
+
+    func testConvertsOptionalForEachToForLoop() {
+        let input = """
+        foo?.forEach { item in
+            print(item)
+        }
+        """
+
+        let output = """
+        for item in foo ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testConvertsMultipleOptionalChainingForEach() {
+        let input = """
+        foo?.bar?.baaz?.forEach { item in
+            print(item)
+        }
+        """
+
+        let output = """
+        for item in foo?.bar?.baaz ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testConvertsMixedChainWithOptionalForEach() {
+        let input = """
+        foo.bar?.baaz.forEach { item in
+            print(item)
+        }
+        """
+
+        let output = """
+        for item in foo.bar?.baaz ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testConvertsOptionalForEachWithAnonymousClosure() {
+        let input = """
+        items?.forEach {
+            print($0)
+        }
+        """
+
+        let output = """
+        for item in items ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testConvertsOptionalFunctionCallForEach() {
+        let input = """
+        foo?.getItems()?.forEach { item in
+            print(item)
+        }
+        """
+
+        let output = """
+        for item in foo?.getItems() ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testConvertsOptionalInMiddleOfChainForEach() {
+        let input = """
+        node.body?.statements.forEach { statement in
+            print(statement)
+        }
+        """
+
+        let output = """
+        for statement in node.body?.statements ?? [] {
+            print(statement)
+        }
+        """
+
+        // Note: redundantParens must be excluded because the parens around the
+        // nil-coalescing expression are required for the output to be valid Swift
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, output, rule: .preferForLoop, options: options)
+    }
+
+    func testOptionalForEachParensNotRemovedByRedundantParens() {
+        // Verify that when both rules run together, the parens are preserved
+        let input = """
+        foo?.forEach { item in
+            print(item)
+        }
+        """
+
+        let output = """
+        for item in foo ?? [] {
+            print(item)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, [output], rules: [.preferForLoop, .redundantParens], options: options)
+    }
+
+    func testOptionalForEachWithMultipleClosureArgumentsNotConverted() {
+        // When optional chaining is present and the closure has multiple arguments,
+        // we can't determine the correct empty collection type for `?? []`
+        let input = """
+        dict?.forEach { key, value in
+            print(key, value)
+        }
+
+        array?.enumerated().forEach { index, item in
+            print(index, item)
+        }
+
+        foo.bar?.enumerated().forEach { (index, value) in
+            print(index, value)
+        }
+        """
+
+        let options = FormatOptions(convertOptionalForEach: true)
+        testFormatting(for: input, rule: .preferForLoop, options: options, exclude: [.redundantParens])
+    }
+
+    func testOptionalForEachNotConvertedByDefault() {
+        // By default, optional forEach should not be converted
+        let input = """
+        foo?.forEach { item in
+            print(item)
+        }
+        """
+
+        testFormatting(for: input, rule: .preferForLoop)
+    }
+
+    func testNonOptionalForEachWithMultipleClosureArgumentsConverted() {
+        // Without optional chaining, multiple closure arguments should still convert
+        let input = """
+        dict.forEach { key, value in
+            print(key, value)
+        }
+        """
+
+        let output = """
+        for (key, value) in dict {
+            print(key, value)
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferForLoop)
+    }
 }


### PR DESCRIPTION
This PR updates the `preferForLoop` rule to support optional `forEach` calls with a new `--optional-for-each convert` option.

```diff
  // --optional-for-each convert
- foo?.bar?.forEach { item in
+ for item in foo?.bar ?? [] {
      print(item)
  }
```