### PR TITLE
Prototype `redundantSwiftUIGroup` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -70,6 +70,7 @@
 * [redundantReturn](#redundantReturn)
 * [redundantSelf](#redundantSelf)
 * [redundantStaticSelf](#redundantStaticSelf)
+* [redundantSwiftUIGroup](#redundantSwiftUIGroup)
 * [redundantThrows](#redundantThrows)
 * [redundantType](#redundantType)
 * [redundantTypedThrows](#redundantTypedThrows)
@@ -2914,6 +2915,39 @@ Remove explicit `Self` where applicable.
 -         Self.bar()
 +         bar()
       }
+  }
+```
+
+</details>
+<br/>
+
+## redundantSwiftUIGroup
+
+Remove redundant SwiftUI Group when @ViewBuilder is implied.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  struct MyView: View {
+    var body: some View {
+-     Group {
+        Text("foo")
+        Text("bar")
+-     }
+    }
+  }
+```
+
+```diff
+  struct MyView: View {
++   @ViewBuilder
+    var content: some View {
+-     Group {
+        Text("foo")
+        Text("bar")
+-     }
+    }
   }
 ```
 

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -92,6 +92,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantReturn": .redundantReturn,
     "redundantSelf": .redundantSelf,
     "redundantStaticSelf": .redundantStaticSelf,
+    "redundantSwiftUIGroup": .redundantSwiftUIGroup,
     "redundantThrows": .redundantThrows,
     "redundantType": .redundantType,
     "redundantTypedThrows": .redundantTypedThrows,

--- a/Sources/Rules/RedundantSwiftUIGroup.swift
+++ b/Sources/Rules/RedundantSwiftUIGroup.swift
@@ -1,0 +1,248 @@
+//
+//  RedundantSwiftUIGroup.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 2025-12-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Remove redundant SwiftUI Group when @ViewBuilder is implied
+    static let redundantSwiftUIGroup = FormatRule(
+        help: "Remove redundant SwiftUI Group when @ViewBuilder is implied."
+    ) { formatter in
+        // Collect all Groups to remove (to avoid re-entrancy issues)
+        var groupsToRemove = [(
+            groupStartIndex: Int,
+            groupEndIndex: Int,
+            closureBodyRange: ClosedRange<Int>,
+            addViewBuilderAt: Int?
+        )]()
+
+        formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
+            let bodyScope: ClosedRange<Int>?
+            let isBodyMember: Bool
+            let isInsideViewType: Bool
+
+            // Parse the declaration to get body scope and check if it's a body member
+            if declaration.keyword == "var" || declaration.keyword == "let",
+               let property = declaration.parsePropertyDeclaration()
+            {
+                bodyScope = property.body?.scopeRange
+                // A var named "body" is only the protocol body if it's on a View
+                // (ViewModifier.body must be a function, not a property)
+                let isViewType = formatter.isViewType(declaration.parentType)
+                let isViewModifierType = formatter.isViewModifierType(declaration.parentType)
+                isBodyMember = property.identifier == "body" && isViewType
+                isInsideViewType = isViewType || isViewModifierType
+            } else if declaration.keyword == "func",
+                      let function = formatter.parseFunctionDeclaration(keywordIndex: declaration.keywordIndex)
+            {
+                bodyScope = function.bodyRange
+                // A func named "body" is only the protocol body if it's on a ViewModifier
+                // (View.body must be a property, not a function)
+                let isViewType = formatter.isViewType(declaration.parentType)
+                let isViewModifierType = formatter.isViewModifierType(declaration.parentType)
+                isBodyMember = function.name == "body" && isViewModifierType
+                isInsideViewType = isViewType || isViewModifierType
+            } else {
+                return
+            }
+
+            guard let bodyScope else { return }
+
+            // Only process declarations inside View/ViewModifier types
+            // (we need @ViewBuilder to be valid for the replacement)
+            guard isInsideViewType else { return }
+
+            // Check if the body contains a single Group { } expression with no modifiers
+            guard let groupInfo = formatter.topLevelGroupWithoutModifiers(in: bodyScope) else { return }
+
+            // Determine if we need @ViewBuilder after removing the Group
+            // - If it's the body protocol requirement, @ViewBuilder is implied
+            // - If the Group body is a single non-conditional expression, @ViewBuilder is not needed
+            let hasExistingViewBuilder = formatter.indexOfViewBuilderAttribute(for: declaration) != nil
+            let needsViewBuilder = !isBodyMember
+                && !formatter.scopeBodyIsSingleNonConditionalExpression(at: groupInfo.closureStartIndex)
+
+            // Determine where to add @ViewBuilder if needed
+            let addViewBuilderAt: Int?
+            if needsViewBuilder, !hasExistingViewBuilder {
+                // Insert before modifiers but after any comments
+                addViewBuilderAt = formatter.startOfModifiers(at: declaration.keywordIndex, includingAttributes: true)
+            } else {
+                addViewBuilderAt = nil
+            }
+
+            groupsToRemove.append((
+                groupStartIndex: groupInfo.groupStartIndex,
+                groupEndIndex: groupInfo.groupEndIndex,
+                closureBodyRange: groupInfo.closureBodyRange,
+                addViewBuilderAt: addViewBuilderAt
+            ))
+        }
+
+        // Remove groups in reverse order to not invalidate indices
+        for group in groupsToRemove.reversed() {
+            formatter.removeRedundantGroup(
+                groupStartIndex: group.groupStartIndex,
+                groupEndIndex: group.groupEndIndex,
+                closureBodyRange: group.closureBodyRange
+            )
+
+            // Add @ViewBuilder if needed
+            if let addViewBuilderAt = group.addViewBuilderAt {
+                formatter.insertViewBuilderAttribute(at: addViewBuilderAt)
+            }
+        }
+    } examples: {
+        """
+        ```diff
+          struct MyView: View {
+            var body: some View {
+        -     Group {
+                Text("foo")
+                Text("bar")
+        -     }
+            }
+          }
+        ```
+
+        ```diff
+          struct MyView: View {
+        +   @ViewBuilder
+            var content: some View {
+        -     Group {
+                Text("foo")
+                Text("bar")
+        -     }
+            }
+          }
+        ```
+        """
+    }
+}
+
+extension Formatter {
+    /// Information about a top-level Group without modifiers
+    struct GroupInfo {
+        let groupStartIndex: Int
+        let groupEndIndex: Int
+        let closureStartIndex: Int
+        let closureBodyRange: ClosedRange<Int>
+    }
+
+    /// Finds a top-level Group { } call without modifiers in the given scope
+    func topLevelGroupWithoutModifiers(in bodyScope: ClosedRange<Int>) -> GroupInfo? {
+        // Find the first non-space/comment/linebreak token in the body
+        guard let firstTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: bodyScope.lowerBound),
+              firstTokenIndex < bodyScope.upperBound
+        else { return nil }
+
+        // Check if it's "Group"
+        guard tokens[firstTokenIndex] == .identifier("Group") else { return nil }
+
+        // Find the Group call structure and closure
+        guard let groupCallInfo = parseGroupCall(startingAt: firstTokenIndex) else { return nil }
+
+        // Check that the Group is the only thing in the body (no modifiers after)
+        guard let tokenAfterGroup = index(of: .nonSpaceOrCommentOrLinebreak, after: groupCallInfo.groupEndIndex),
+              tokenAfterGroup == bodyScope.upperBound
+        else { return nil }
+
+        // Get the body range inside the closure
+        guard let closureBodyRange = closureBodyRange(closureStartIndex: groupCallInfo.closureStartIndex) else { return nil }
+
+        return GroupInfo(
+            groupStartIndex: firstTokenIndex,
+            groupEndIndex: groupCallInfo.groupEndIndex,
+            closureStartIndex: groupCallInfo.closureStartIndex,
+            closureBodyRange: closureBodyRange
+        )
+    }
+
+    /// Parses a Group call and returns information about its structure
+    private func parseGroupCall(startingAt groupIndex: Int) -> (groupEndIndex: Int, closureStartIndex: Int)? {
+        guard let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: groupIndex) else { return nil }
+
+        // Case 1: Group { } - trailing closure directly after identifier
+        if tokens[nextToken] == .startOfScope("{"),
+           let endOfClosure = endOfScope(at: nextToken)
+        {
+            return (groupEndIndex: endOfClosure, closureStartIndex: nextToken)
+        }
+
+        // Case 2: Group() { } or Group(content: { }) - parentheses first
+        if tokens[nextToken] == .startOfScope("("),
+           let endOfParens = endOfScope(at: nextToken)
+        {
+            // Check for trailing closure after parentheses: Group() { }
+            if let afterParens = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfParens),
+               tokens[afterParens] == .startOfScope("{"),
+               let endOfClosure = endOfScope(at: afterParens)
+            {
+                return (groupEndIndex: endOfClosure, closureStartIndex: afterParens)
+            }
+
+            // Check for content closure inside parentheses: Group(content: { })
+            if let contentLabel = index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken),
+               tokens[contentLabel] == .identifier("content"),
+               let colon = index(of: .nonSpaceOrCommentOrLinebreak, after: contentLabel),
+               tokens[colon] == .delimiter(":"),
+               let closureStart = index(of: .nonSpaceOrCommentOrLinebreak, after: colon),
+               tokens[closureStart] == .startOfScope("{")
+            {
+                // The end of the group expression is the closing paren
+                return (groupEndIndex: endOfParens, closureStartIndex: closureStart)
+            }
+        }
+
+        return nil
+    }
+
+    /// Gets the range of the body inside a closure (excluding braces)
+    private func closureBodyRange(closureStartIndex: Int) -> ClosedRange<Int>? {
+        guard let closureEndIndex = endOfScope(at: closureStartIndex),
+              closureStartIndex + 1 < closureEndIndex
+        else { return nil }
+
+        guard let firstToken = index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex),
+              let lastToken = index(of: .nonSpaceOrCommentOrLinebreak, before: closureEndIndex),
+              firstToken <= lastToken
+        else { return nil }
+
+        return firstToken ... lastToken
+    }
+
+    /// Removes a redundant Group, replacing it with its closure body contents
+    func removeRedundantGroup(
+        groupStartIndex: Int,
+        groupEndIndex: Int,
+        closureBodyRange: ClosedRange<Int>
+    ) {
+        // Extract the closure body tokens
+        let bodyTokens = Array(tokens[closureBodyRange])
+
+        // Remove the entire Group expression
+        removeTokens(in: groupStartIndex ... groupEndIndex)
+
+        // Insert the body tokens (indent rule will fix indentation)
+        insert(bodyTokens, at: groupStartIndex)
+    }
+
+    /// Inserts @ViewBuilder attribute at the given index
+    func insertViewBuilderAttribute(at index: Int) {
+        let currentIndent = currentIndentForLine(at: index)
+
+        // Check if there's already indentation before the insertion point
+        let hasExistingIndent = index > 0 && tokens[index - 1].isSpace
+
+        var tokensToInsert: [Token] = [.identifier("@ViewBuilder"), linebreakToken(for: index)]
+        if !hasExistingIndent {
+            tokensToInsert.append(.space(currentIndent))
+        }
+        insert(tokensToInsert, at: index)
+    }
+}

--- a/Tests/Rules/RedundantSwiftUIGroupTests.swift
+++ b/Tests/Rules/RedundantSwiftUIGroupTests.swift
@@ -1,0 +1,408 @@
+//
+//  RedundantSwiftUIGroupTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 2025-12-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class RedundantSwiftUIGroupTests: XCTestCase {
+    func testRemoveRedundantGroupInViewBody() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveRedundantGroupInViewModifierBody() {
+        let input = """
+        struct MyModifier: ViewModifier {
+            func body(content: Content) -> some View {
+                Group {
+                    content
+                    Text("overlay")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyModifier: ViewModifier {
+            func body(content: Content) -> some View {
+                content
+                Text("overlay")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testKeepGroupWithModifiers() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+                .foregroundColor(.red)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testKeepGroupWithPaddingModifier() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+                .padding()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testRemoveGroupWithSingleExpression() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupInHelperPropertyWithViewBuilder() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderWhenRemovingGroupFromHelper() {
+        // Without @ViewBuilder, we need to add it when removing Group with multiple views
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderAfterComment() {
+        // @ViewBuilder should be added after comments, not before
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            // MARK: Private
+
+            private var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            // MARK: Private
+
+            @ViewBuilder
+            private var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupInHelperPropertyWithSingleExpression() {
+        // Single expression doesn't need @ViewBuilder, so Group can be removed
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Text("Hello")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithParentheses() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group() {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithContentLabel() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group(content: {
+                    Text("foo")
+                    Text("bar")
+                })
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testKeepGroupWhenNotTopLevel() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Group {
+                        Text("foo")
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testKeepGroupInNonViewType() {
+        let input = """
+        struct MyHelper {
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testRemoveGroupInNestedView() {
+        let input = """
+        struct OuterView: View {
+            var body: some View {
+                InnerView()
+            }
+
+            struct InnerView: View {
+                var body: some View {
+                    Group {
+                        Text("Inner")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct OuterView: View {
+            var body: some View {
+                InnerView()
+            }
+
+            struct InnerView: View {
+                var body: some View {
+                    Text("Inner")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderWhenRemovingGroupWithConditional() {
+        // Conditional expressions need @ViewBuilder, so add it when removing Group
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    if condition {
+                        Text("foo")
+                    } else {
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                if condition {
+                    Text("foo")
+                } else {
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithConditionalInViewBody() {
+        // View.body has implied @ViewBuilder, so Group can be removed
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    if condition {
+                        Text("foo")
+                    } else {
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                if condition {
+                    Text("foo")
+                } else {
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+}


### PR DESCRIPTION
Quick prototype for a rule to remove redundant SwiftUI `Group`s:

```diff
  struct MyView: View {
    var body: some View {
-     Group {
        Text("foo")
        Text("bar")
-     }
    }
  }
```

```diff
  struct MyView: View {
+   @ViewBuilder
    var content: some View {
-     Group {
        Text("foo")
        Text("bar")
-     }
    }
  }
```

Code by Claude, I haven't reviewed or polished it, but did test it on our codebase as a proof of concept. It finds and updates lots of examples.