### PR TITLE
Update `redundantMemberwiseInit` rule to support result builder attributes

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2585,6 +2585,21 @@ Option | Description
   }
 ```
 
+```diff
+  struct MyView<Content: View>: View {
++     @ViewBuilder let content: Content
+-     let content: Content
+-
+-     init(@ViewBuilder content: () -> Content) {
+-         self.content = content()
+-     }
+
+      var body: some View {
+          content
+      }
+  }
+```
+
 `--prefer-synthesized-init-for-internal-structs View,ViewModifier`:
 
 ```diff

--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -133,6 +133,11 @@ extension Declaration {
         return allModifiers
     }
 
+    /// Whether or not this declaration has the given modifier
+    func hasModifier(_ modifier: String) -> Bool {
+        formatter.modifiersForDeclaration(at: keywordIndex, contains: modifier)
+    }
+
     /// Whether or not this declaration represents a stored instance property
     var isStoredInstanceProperty: Bool {
         // A static property is not an instance property
@@ -336,6 +341,17 @@ extension TypeDeclaration {
     /// The list of conformances of this type, not including any constraints following a `where` clause.
     var conformances: [(conformance: TypeName, index: Int)] {
         formatter.parseConformancesOfType(atKeywordIndex: keywordIndex)
+    }
+
+    /// The generic parameters of this type, e.g. between angle brackets `Foo<Bar, Baaz>`.
+    var genericParameters: (types: [Formatter.GenericType], range: ClosedRange<Int>)? {
+        guard let identifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: keywordIndex),
+              tokens[identifierIndex].isIdentifier,
+              let openAngleBracketIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: identifierIndex),
+              tokens[openAngleBracketIndex] == .startOfScope("<")
+        else { return nil }
+
+        return formatter.parseGenericTypes(from: openAngleBracketIndex)
     }
 }
 

--- a/Sources/DeclarationType.swift
+++ b/Sources/DeclarationType.swift
@@ -262,10 +262,10 @@ extension Declaration {
         }
     }
 
+    /// The SwiftUI property wrapper type attached to this declaration, if present.
+    /// Only returns the base attribute name, e.g. `@Environment`, not `@Environment(\.type)`
     var swiftUIPropertyWrapper: String? {
-        modifiers.first { modifier in
-            swiftUIPropertyWrappers.contains(modifier)
-        }
+        swiftUIPropertyWrappers.first(where: { hasModifier($0) })
     }
 
     /// Represents all the native SwiftUI property wrappers that conform to `DynamicProperty` and cause a SwiftUI view to re-render.

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -312,7 +312,7 @@ extension Formatter {
 
         // @Environment properties are not part of the synthesized memberwise init
         // because they get their value from the SwiftUI environment.
-        if declaration.modifiers.contains("@Environment") {
+        if declaration.hasModifier("@Environment") {
             return false
         }
 

--- a/Sources/Rules/RedundantPublic.swift
+++ b/Sources/Rules/RedundantPublic.swift
@@ -50,7 +50,7 @@ public extension FormatRule {
                 return
             }
 
-            if declaration.modifiers.contains("@_spi") {
+            if declaration.hasModifier("@_spi") {
                 return
             }
 

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -45,7 +45,7 @@ public let swiftVersionFile = ".swift-version"
 public let swiftVersions = [
     "3.x", "4.0", "4.1", "4.2",
     "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10",
-    "6.0", "6.1", "6.2", "6.3",
+    "6.0", "6.1", "6.2", "6.3", "6.4",
 ]
 
 /// Supported Swift language modes

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -1989,11 +1989,11 @@ public func tokenize(_ source: String) -> [Token] {
                    let prevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: count - 1),
                    tokens[prevIndex].isIdentifierOrKeyword
                 {
-                    if case let .keyword(name) = tokens[prevIndex] {
+                    if case let .keyword(name) = tokens[prevIndex], !name.isAttribute {
                         tokens[prevIndex] = .identifier(name)
                     }
                     if let prevPrevIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex),
-                       case let .keyword(name) = tokens[prevPrevIndex]
+                       case let .keyword(name) = tokens[prevPrevIndex], !name.isAttribute
                     {
                         tokens[prevPrevIndex] = .identifier(name)
                     }


### PR DESCRIPTION
This PR updates the `redundantMemberwiseInit` rule to support result builder attributes. For example:

```diff
  struct MyView<Content: View>: View {
+     @ViewBuilder let content: Content
-     let content: Content
-
-     init(@ViewBuilder content: () -> Content) {
-         self.content = content()
-     }

      var body: some View {
          content
      }
  }
```

I only just recently learned about this syntax! Pretty nice.