### PR TITLE
Update `organizeDeclarations` rule to handle that private property wrapper variables with a default value don't affect memberwise initializer

### DIFF
--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -1781,6 +1781,7 @@ final class RedundantMemberwiseInitTests: XCTestCase {
             // MARK: Private
 
             @Environment(\\.colorScheme) private var colorScheme
+            @State private var foo = "default"
             private let user: User
             private let settings: Settings
         }
@@ -1797,6 +1798,7 @@ final class RedundantMemberwiseInitTests: XCTestCase {
             // MARK: Private
 
             @Environment(\\.colorScheme) private var colorScheme
+            @State private var foo = "default"
         }
         """
         let options = FormatOptions(preferSynthesizedInitForInternalStructs: .always)


### PR DESCRIPTION
This PR updates the `organizeDeclarations` rule to know that private property wrapper variables with a default value (e.g. `@State private var foo = "bar"`) don't affect the memberwise initializer of a struct. This is a special case in the compiler for property wrappers.