### PR TITLE
Update docComments rule to preserve formatting of comments with directives

### DIFF
--- a/Sources/Rules/DocComments.swift
+++ b/Sources/Rules/DocComments.swift
@@ -51,7 +51,9 @@ public extension FormatRule {
                 }
             }
 
-            let useDocComment = formatter.shouldBeDocComment(at: commentIndices, endOfComment: endOfComment)
+            guard let useDocComment = formatter.shouldBeDocComment(at: commentIndices, endOfComment: endOfComment) else {
+                return
+            }
 
             // Determine whether or not this is the start of a list of sequential declarations, like:
             //
@@ -148,15 +150,16 @@ extension Formatter {
     func shouldBeDocComment(
         at indices: [Int],
         endOfComment: Int
-    ) -> Bool {
+    ) -> Bool? {
         guard let startIndex = indices.min(),
               let nextDeclarationIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfComment)
         else { return false }
 
-        // Check if this is a special type of comment that isn't documentation
+        // Check if this is a directive like MARK or swiftformat:disable etc.
+        // In that case just preserve the comment as-is.
         for index in indices {
             if case let .commentBody(body)? = next(.nonSpace, after: index), body.isCommentDirective {
-                return false
+                return nil
             }
         }
 

--- a/Tests/Rules/DocCommentsTests.swift
+++ b/Tests/Rules/DocCommentsTests.swift
@@ -642,4 +642,43 @@ final class DocCommentsTests: XCTestCase {
 
         testFormatting(for: input, rule: .docComments)
     }
+
+    func testPreserveDocCommentContinuousWithMarkComment() {
+        let input = """
+        // MARK: - PlaceholderFlowOrigin
+        /// Placeholder text describing a sample flow origin.
+        public enum PlaceholderFlowOrigin {
+            case standard(ScreenAuthenticationType)
+            case premium(sampleType: ScreenAuthenticationType?)
+        }
+        """
+
+        testFormatting(for: input, rule: .docComments, exclude: [.blankLinesAroundMark])
+    }
+
+    func testPreserveDocCommentAfterSwiftFormatDirective() {
+        let input = """
+        // swiftformat:enable docComments
+        /// Placeholder text describing a sample flow origin.
+        public enum PlaceholderFlowOrigin {
+            case standard(ScreenAuthenticationType)
+            case premium(sampleType: ScreenAuthenticationType?)
+        }
+        """
+
+        testFormatting(for: input, rule: .docComments)
+    }
+
+    func testPreserveDocCommentBeforeSwiftFormatDirective() {
+        let input = """
+        /// Placeholder text describing a sample flow origin.
+        // swiftformat:enable:next docComments
+        public enum PlaceholderFlowOrigin {
+            case standard(ScreenAuthenticationType)
+            case premium(sampleType: ScreenAuthenticationType?)
+        }
+        """
+
+        testFormatting(for: input, rule: .docComments)
+    }
 }


### PR DESCRIPTION
This PR updates the `docComments` rule to preserve the formatting of comments with directives.

Previously any comment containing a directive was fully converted to a regular comment, even if the non-directive lines of the comment block was otherwise using doc comments.

Fixes #2308.