### PR TITLE
Update redundantSelf rule to support functions with no body

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -3156,7 +3156,7 @@ extension Formatter {
         /// The range of the `where` clause if present
         let whereClauseRange: ClosedRange<Int>?
         /// The range of the function body (`{ ... }`) if present.
-        /// A protocol method requirement doesn't have a body.
+        /// A protocol method requirement, or a function with a `@_silgen` attribute, doesn't have a body.
         let bodyRange: ClosedRange<Int>?
 
         /// The full range of this declaration

--- a/Tests/ParsingHelpersTests.swift
+++ b/Tests/ParsingHelpersTests.swift
@@ -1180,6 +1180,9 @@ final class ParsingHelpersTests: XCTestCase {
             private(set)
             var instanceVar = "test" // trailing comment
 
+            @_silgen_name("__MARKER_functionWithNoBody")
+            func functionWithNoBody(_ x: String) -> Int?
+
             @objc
             private var computed: String {
                 get {
@@ -1304,6 +1307,9 @@ final class ParsingHelpersTests: XCTestCase {
                 private(set)
                 var instanceVar = "test" // trailing comment
 
+                @_silgen_name("__MARKER_functionWithNoBody")
+                func functionWithNoBody(_ x: String) -> Int?
+
                 @objc
                 private var computed: String {
                     get {
@@ -1363,6 +1369,16 @@ final class ParsingHelpersTests: XCTestCase {
 
         XCTAssertEqual(
             declarations[7].body?[2].tokens.string,
+            """
+                @_silgen_name(\"__MARKER_functionWithNoBody\")
+                func functionWithNoBody(_ x: String) -> Int?
+
+
+            """
+        )
+
+        XCTAssertEqual(
+            declarations[7].body?[3].tokens.string,
             """
                 @objc
                 private var computed: String {

--- a/Tests/Rules/RedundantSelfTests.swift
+++ b/Tests/Rules/RedundantSelfTests.swift
@@ -2973,6 +2973,35 @@ final class RedundantSelfTests: XCTestCase {
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
+    func testFunctionWithNoBodyFollowedByStaticFunction() {
+        let input = """
+        struct Foo {
+            let foo: String
+
+            @_silgen_name("__MARKER_doIt")
+            func doIt(_ x: String) -> Int?
+
+            static func bar() {
+                print(self.foo)
+            }
+        }
+        """
+
+        let output = """
+        struct Foo {
+            let foo: String
+
+            @_silgen_name("__MARKER_doIt")
+            func doIt(_ x: String) -> Int?
+
+            static func bar() {
+                print(foo)
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantSelf)
+    }
+
     func testNoInsertSelfBeforeSet() {
         let input = """
         class Foo {


### PR DESCRIPTION
I found that it's possible for a function in a normal type body to not have a function body:

```swift
@_silgen_name("__MARKER_functionWithNoBody")
func functionWithNoBody(_ x: String) -> Int?
```

This would previously confuse the `redundantSelf` rule, which could trigger fatal errors like `"The static modifier is not valid outside a type body"`.