### PR TITLE
Update `organizeDeclarations` to handle that optional properties have an implicit default value

### DIFF
--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -316,7 +316,20 @@ extension Formatter {
                 return true
             }
 
-            return declaration.parsePropertyDeclaration()?.value != nil
+            guard let property = declaration.parsePropertyDeclaration() else {
+                return false
+            }
+
+            if property.value != nil {
+                return true
+            }
+
+            // Optional properties default to `nil`
+            if property.type?.isOptionalType == true {
+                return true
+            }
+
+            return false
         }()
 
         // `let` properties with default values are not part of the memberwise init.

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -4429,11 +4429,12 @@ final class OrganizeDeclarationsTests: XCTestCase {
     }
 
     func testPrivateLetWithDefaultValueAllowsReordering() {
-        // private let with default value is NOT part of memberwise init,
-        // so it can be freely reordered (baz moves after bar)
+        // `private let` with default value, or `@State private var` with default value,
+        // is NOT part of memberwise init so it can be freely reordered (baz moves after bar)
         let input = """
         struct Foo {
             private let baz = Baz()
+            @State private var foo: Foo?
             let bar: Bar
         }
         """
@@ -4446,6 +4447,8 @@ final class OrganizeDeclarationsTests: XCTestCase {
             let bar: Bar
 
             // MARK: Private
+
+            @State private var foo: Foo?
 
             private let baz = Baz()
         }


### PR DESCRIPTION
This PR updates the `organizeDeclarations` rule to handle that optional properties have an implicit default value (nil).