### PR TITLE
Update `organizeDeclarations` to sort members that don't affect a struct's synthesized memberwise init

### DIFF
--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -209,22 +209,27 @@ extension Formatter {
             sortAlphabeticallyWithinSubcategories: sortAlphabeticallyWithinSubcategories
         )
 
-        // The compiler will synthesize a memberwise init for `struct`
-        // declarations that don't have an `init` declaration.
-        // We have to take care to not reorder any properties (but reordering functions etc is ok!)
-        if !sortAlphabeticallyWithinSubcategories, typeDeclaration.keyword == "struct",
-           !typeDeclaration.body.contains(where: { $0.keyword == "init" }),
-           !preservesSynthesizedMemberwiseInitializer(categorizedDeclarations, sortedDeclarations)
+        // The compiler will synthesize a memberwise init for `struct` declarations that don't have an `init` declaration.
+        // We have to ensure we preserve the relative order of declarations that appear in the synthesized init.
+        if typeDeclaration.keyword == "struct",
+           !sortAlphabeticallyWithinSubcategories,
+           !typeDeclaration.body.contains(where: { $0.keyword == "init" })
         {
-            // If sorting by category and by type could cause compilation failures
-            // by not correctly preserving the synthesized memberwise initializer,
-            // try to sort _only_ by category (so we can try to preserve the correct category separators)
-            sortedDeclarations = sortDeclarations(categorizedDeclarations, sortAlphabeticallyWithinSubcategories: false)
+            let requiredSubordering = categorizedDeclarations.filter { affectsSynthesizedMemberwiseInitializerParameterOrdering($0.declaration) }
 
-            // If sorting _only_ by category still changes the synthesized memberwise initializer,
-            // then there's nothing we can do to organize this struct.
-            if !preservesSynthesizedMemberwiseInitializer(categorizedDeclarations, sortedDeclarations) {
-                return nil
+            if !requiredSubordering.isEmpty {
+                for index in requiredSubordering.indices.dropFirst() {
+                    let declarationToReorder = requiredSubordering[index]
+                    let currentIndex = sortedDeclarations.firstIndex(where: { $0.declaration === declarationToReorder.declaration })!
+                    let requiredPreviousDeclaration = requiredSubordering[index - 1]
+                    let currentIndexOfPreviousDeclaration = sortedDeclarations.firstIndex(where: { $0.declaration === requiredPreviousDeclaration.declaration })!
+
+                    // If this declaration is ordered before the next required declaration, move it to be after it. This preserves the required ordering.
+                    if currentIndex < currentIndexOfPreviousDeclaration {
+                        sortedDeclarations.insert(declarationToReorder, at: currentIndexOfPreviousDeclaration + 1)
+                        sortedDeclarations.remove(at: currentIndex)
+                    }
+                }
             }
         }
 

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -1904,18 +1904,44 @@ final class OrganizeDeclarationsTests: XCTestCase {
     func testDoesntBreakStructSynthesizedMemberwiseInitializer() {
         let input = """
         public struct Foo {
-            var bar: Int {
-                didSet {}
-            }
+            
+            let foo: Foo
+            @State var bar: Bar?
+            @ObservedObject var baaz: Baaz
+            public let quux: Quux
 
-            var baz: Int
-            public let quux: Int
+            public var content: some View {
+                foo
+            }
         }
 
-        Foo(bar: 1, baz: 2, quux: 3)
+        Foo(foo: 1, bar: 2, baaz: 3, quux: 4)
         """
 
-        testFormatting(for: input, rule: .organizeDeclarations)
+        let output = """
+        public struct Foo {
+
+            // MARK: Public
+
+            public var content: some View {
+                foo
+            }
+
+            // MARK: Internal
+
+            let foo: Foo
+
+            @State var bar: Bar?
+            @ObservedObject var baaz: Baaz
+
+            public let quux: Quux
+
+        }
+
+        Foo(foo: 1, bar: 2, baaz: 3, quux: 4)
+        """
+
+        testFormatting(for: input, [output], rules: [.organizeDeclarations, .consecutiveBlankLines], exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope, .privateStateVariables])
     }
 
     func testOrganizesStructPropertiesThatDontBreakMemberwiseInitializer() {


### PR DESCRIPTION
Previously, `organizeDeclarations` would bail out completely if sorting a `struct` would affect the ordering of members of the memberwise int.

Instead, we should sort all of the declarations that _don't_ affect the memberwise init, and simply preserve the relative ordering of the properties that do affect the memberwise init.