### PR TITLE
Use doc comments on local functions

### DIFF
--- a/RegressionTests/RegressionTests.swift
+++ b/RegressionTests/RegressionTests.swift
@@ -31,7 +31,7 @@ final class RegressionTests: XCTestCase {
             Swift.print(message)
         }
         // NOTE: to update regression suite, run again without `--lint` argument
-        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots Sources --unexclude Snapshots --symlinks follow --cache ignore --lint"), .ok)
+        XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --cache ignore --lint"), .ok)
     }
 
     func testCache() {
@@ -39,7 +39,7 @@ final class RegressionTests: XCTestCase {
             Swift.print(message)
         }
         // NOTE: to update regression suite, run again without `--lint` argument
-        let result = CLI.run(in: projectDirectory.path, with: "Sources --cache clear --lint")
+        let result = CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --cache clear --lint")
         XCTAssertEqual(result, .ok)
 
         // Test cache
@@ -49,7 +49,7 @@ final class RegressionTests: XCTestCase {
                 Swift.print(message)
                 messages.append(message)
             }
-            XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Sources --symlinks follow --lint --verbose"), .ok)
+            XCTAssertEqual(CLI.run(in: projectDirectory.path, with: "Snapshots --unexclude Snapshots --symlinks follow --lint --verbose"), .ok)
             XCTAssert(messages.contains("-- no changes (cached)"))
         }
     }

--- a/Sources/CommandLine.swift
+++ b/Sources/CommandLine.swift
@@ -597,7 +597,7 @@ func processArguments(_ args: [String], environment: [String: String] = [:], in 
             inputURLs += try parseScriptInput(from: environment)
         }
 
-        /// Treat values for arguments that do not take a value as input paths
+        // Treat values for arguments that do not take a value as input paths
         func addInputPaths(for argName: String) throws {
             guard let arg = args[argName], !arg.isEmpty else {
                 return

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -884,10 +884,10 @@ extension Formatter {
             }
         }
 
-        /// Wraps / re-wraps a multi-line statement where each delimiter index
-        /// should be the first token on its line, if the statement
-        /// is longer than the max width or there is already a linebreak
-        /// adjacent to one of the delimiters
+        // Wraps / re-wraps a multi-line statement where each delimiter index
+        // should be the first token on its line, if the statement
+        // is longer than the max width or there is already a linebreak
+        // adjacent to one of the delimiters
         @discardableResult
         func wrapMultilineStatement(
             startIndex: Int,
@@ -2650,14 +2650,14 @@ extension Formatter {
                         closureLocalNames.insert("self")
                     }
 
-                    /// Whether or not the closure at the current index permits implicit self.
-                    ///
-                    /// SE-0269 (in Swift 5.3) allows implicit self when:
-                    ///  - the closure captures self explicitly using [self] or [unowned self]
-                    ///  - self is not a reference type
-                    ///
-                    /// SE-0365 (in Swift 5.8) additionally allows implicit self using
-                    /// [weak self] captures after self has been unwrapped.
+                    // Whether or not the closure at the current index permits implicit self.
+                    //
+                    // SE-0269 (in Swift 5.3) allows implicit self when:
+                    //  - the closure captures self explicitly using [self] or [unowned self]
+                    //  - self is not a reference type
+                    //
+                    // SE-0365 (in Swift 5.8) additionally allows implicit self using
+                    // [weak self] captures after self has been unwrapped.
                     func closureAllowsImplicitSelf() -> Bool {
                         guard options.swiftVersion >= "5.3" else {
                             return false

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1513,7 +1513,7 @@ extension Formatter {
     ) -> TypeName? {
         let startToken = tokens[startOfTypeIndex]
 
-        /// Helpers that calls `parseType` with all of the optional params passed in by default
+        // Helpers that calls `parseType` with all of the optional params passed in by default
         func parseType(at index: Int) -> TypeName? {
             self.parseType(
                 at: index,

--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -58,7 +58,7 @@ public extension FormatRule {
                 scopeStack.removeLast()
             }
 
-            /// Returns the change in index after applying indent if needed for noIndent ifdef
+            // Returns the change in index after applying indent if needed for noIndent ifdef
             func applyNoIndentIfdefFix(ifdefIndent: String, at startIndex: Int) -> Int {
                 let currentIndent = formatter.currentIndentForLine(at: startIndex)
                 let isNested = noIndentIfdefDepth > 1

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -666,8 +666,8 @@ extension Formatter {
         var declarationGroups: [[Declaration]] = []
         var currentGroup: [Declaration] = []
 
-        /// Ends the current group, ensuring that groups are only recorded
-        /// when they contain two or more declarations.
+        // Ends the current group, ensuring that groups are only recorded
+        // when they contain two or more declarations.
         func endCurrentGroup(addingToExistingGroup declarationToAdd: Declaration? = nil) {
             if let declarationToAdd {
                 currentGroup.append(declarationToAdd)

--- a/Sources/Rules/RedundantType.swift
+++ b/Sources/Rules/RedundantType.swift
@@ -60,7 +60,7 @@ public extension FormatRule {
                 return
             }
 
-            /// Removes a type already processed by `compare(typeStartingAfter:withTypeStartingAfter:)`
+            // Removes a type already processed by `compare(typeStartingAfter:withTypeStartingAfter:)`
             func removeType(after indexBeforeStartOfType: Int, i: Int, j: Int, wasValue: Bool) {
                 if isInferred {
                     formatter.removeTokens(in: colonIndex ... typeEndIndex)

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -576,7 +576,7 @@ public func applyRules(
         }
     }
 
-    /// Split tokens into lines
+    // Split tokens into lines
     func getLines(in tokens: [Token], includingLinebreaks: Bool) -> [Int: ArraySlice<Token>] {
         var lines: [Int: ArraySlice<Token>] = [:]
         var startIndex = 0, nextLine = 1


### PR DESCRIPTION
This PR updates the `docComments` rule to use doc comments on local functions.