### PR TITLE
fix: Back-deploy range containment check

### DIFF
--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -401,10 +401,13 @@ extension Collection<Declaration> {
         forEachRecursiveDeclaration { declaration in
             guard declaration.range.contains(index) else { return }
 
-            if let containingDeclaration,
-               !containingDeclaration.range.contains(declaration.range)
-            {
-                return
+            // Back-deployable range containment check (avoids macOS 13+ API)
+            if let outer = containingDeclaration?.range {
+                let containsInner = outer.lowerBound <= declaration.range.lowerBound
+                    && outer.upperBound >= declaration.range.upperBound
+                if !containsInner {
+                    return
+                }
             }
 
             containingDeclaration = declaration


### PR DESCRIPTION
seeing some build failure on sonoma:

```
  /private/tmp/swiftformat-20260126-4529-2pqdby/SwiftFormat-0.59.0/Sources/Declaration.swift:405:45: error: 'contains' is only available in macOS 13.0 or newer
  386 | // MARK: - Helpers
  387 | 
  388 | extension Collection<Declaration> {
      | `- note: add @available attribute to enclosing extension
  389 |     /// Performs the given operation for each declaration in this tree of declarations.
  390 |     func forEachRecursiveDeclaration(_ operation: (Declaration) -> Void) {
      :
  396 | 
  397 |     /// Searches for and returns the inner-most declaration that contains the given index
  398 |     func declaration(containing index: Int) -> Declaration? {
      |          `- note: add @available attribute to enclosing instance method
  399 |         var containingDeclaration: Declaration?
  400 | 
      :
  403 | 
  404 |             if let containingDeclaration,
  405 |                !containingDeclaration.range.contains(declaration.range)
      |                                             |- error: 'contains' is only available in macOS 13.0 or newer
      |                                             `- note: add 'if #available' version check
  406 |             {
  407 |                 return
```

- https://github.com/Homebrew/homebrew-core/actions/runs/21336516063/job/61431237836?pr=264410#step:3:57
- https://github.com/Homebrew/homebrew-core/pull/264410

closes #2327