### PR TITLE
Fix double-indent for if/switch assignments inside --ifdef no-indent

### DIFF
--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -631,6 +631,12 @@ public extension FormatRule {
                 } else if linewrapped {
                     // Don't indent line starting with dot if previous line was just a closing brace
                     var lastToken = formatter.tokens[lastNonSpaceOrLinebreakIndex]
+                    let isConditionalAssignmentLinebreak =
+                        formatter.options.ifdefIndent == .noIndent &&
+                        noIndentIfdefDepth > 0 &&
+                        scopeStack.last == .operator("=", .infix) &&
+                        lastNonSpaceOrLinebreakIndex > -1 &&
+                        formatter.tokens[lastNonSpaceOrLinebreakIndex] == .operator("=", .infix)
                     if formatter.options.allmanBraces, nextToken == .startOfScope("{"),
                        formatter.isStartOfClosure(at: nextNonSpaceIndex)
                     {
@@ -675,10 +681,14 @@ public extension FormatRule {
                                 indent += formatter.options.indent
                             }
                         } else if !formatter.options.xcodeIndentation || !formatter.isWrappedDeclaration(at: i) {
-                            indent += formatter.linewrapIndent(at: i)
+                            if !isConditionalAssignmentLinebreak {
+                                indent += formatter.linewrapIndent(at: i)
+                            }
                         }
                     } else if !formatter.options.xcodeIndentation || !formatter.isWrappedDeclaration(at: i) {
-                        indent += formatter.linewrapIndent(at: i)
+                        if !isConditionalAssignmentLinebreak {
+                            indent += formatter.linewrapIndent(at: i)
+                        }
                     }
 
                     linewrapStack[linewrapStack.count - 1] = true

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -6479,6 +6479,27 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, output, rule: .indent, exclude: [.wrapMultilineStatementBraces])
     }
 
+    func testIndentIfExpressionAssignmentInsideNoIndentIfdef() {
+        let input = """
+        #if os(iOS)
+        func makeRecipients(subtitle: String) {
+          let recipients: [INPerson] =
+            if subtitle.isEmpty {
+              []
+            } else {
+              [
+                subtitle,
+              ]
+            }
+          _ = recipients
+        }
+        #endif
+        """
+
+        let options = FormatOptions(indent: "  ", ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
     func testIndentIfExpressionAssignmentOnSameLine() {
         let input = """
         let foo = if let bar {


### PR DESCRIPTION
### Summary:
SwiftFormat 0.59.0 added special indent handling for multiline `if`/`switch` expressions assigned with `=` by pushing an `=` operator scope onto the indent stack. Inside `#if` blocks with `--ifdef no-indent`, the linewrap logic was already applying the `#if`-aware indent on the first linebreak after `=`. The new `=` scope caused that first linebreak to receive both the `=` scope indent and the linewrap indent, producing a double indent like:

```swift
let value =
    if condition
  {
```

This change adds a narrow guard for the first linebreak immediately following an infix `=` inside a `#if` region when `ifdefIndent == .noIndent`, skipping the extra linewrap indent in that specific case. The `=` scope still applies, and other multiline assignments continue to indent correctly.

### Validation:
Added regression coverage in `IndentTests` via
`testIndentIfExpressionAssignmentInsideNoIndentIfdef`.

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->