### PR TITLE
Align #else/#elseif/#endif to matching #if in --ifdef no-indent

### DIFF
--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -70,7 +70,7 @@ public extension FormatRule {
                 return 0
             }
 
-            func matchingIfdefIndent(forDirectiveAt directiveIndex: Int) -> String? {
+            func matchingIfdefIndent(forDirectiveAt directiveIndex: Int, fallbackIndent: String) -> String {
                 var nestedEndifCount = 0
                 var index = directiveIndex - 1
                 while index >= 0 {
@@ -88,7 +88,7 @@ public extension FormatRule {
                     }
                     index -= 1
                 }
-                return nil
+                return fallbackIndent
             }
 
             var i = i
@@ -285,9 +285,8 @@ public extension FormatRule {
                     i += applyIndent(indent, at: start)
                 case .noIndent:
                     // #else/#elseif should be at same level as corresponding #if
-                    let targetIndent = matchingIfdefIndent(forDirectiveAt: i)
-                        ?? indentStack.last
-                        ?? ""
+                    let fallbackIndent = indentStack.last ?? ""
+                    let targetIndent = matchingIfdefIndent(forDirectiveAt: i, fallbackIndent: fallbackIndent)
                     if formatter.currentIndentForLine(at: start) != targetIndent {
                         i += applyIndent(targetIndent, at: start)
                     }
@@ -416,10 +415,8 @@ public extension FormatRule {
                     } else if token == .endOfScope("#endif"), formatter.options.ifdefIndent == .noIndent {
                         // #endif should be at same level as corresponding #if
                         // Align to the indent of the matching #if when available.
-                        let targetIndent = matchingIfdefIndent(forDirectiveAt: i)
-                            ?? ifdefIndentBeforePop
-                            ?? indentStack.last
-                            ?? ""
+                        let fallbackIndent = ifdefIndentBeforePop ?? indentStack.last ?? ""
+                        let targetIndent = matchingIfdefIndent(forDirectiveAt: i, fallbackIndent: fallbackIndent)
                         if formatter.currentIndentForLine(at: start) != targetIndent {
                             i += applyIndent(targetIndent, at: start)
                         }

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -4726,6 +4726,23 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
+    func testNoIndentIfdefFragmentWithUnmatchedDirectivesInsideScope() {
+        let input = """
+        {
+            #endif
+                #else
+        }
+        """
+        let output = """
+        {
+            #endif
+            #else
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent, fragment: true)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
     func testNoIndentIfElse() {
         let input = """
         func foo() {


### PR DESCRIPTION
### Summary
- Directive alignment used the current indent stack plus a conservative fix that allowed over-indented directives at single depth, making bad indent sticky (e.g. an over-indented `#else` would remain over-indented).
- To fix this, we scan backward to find the indent of the matching `#if` while accounting for nested `#if/#endif` pairs. For `#else/#elseif/#endif` under `--ifdef no-indent`, align directly to that matching `#if` indent when available.

### Tests
- `swift test` passes locally.

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->