### PR TITLE
Update `docComments` rule to handle conditional compilation blocks in function bodies

### DIFF
--- a/Sources/Rules/DocComments.swift
+++ b/Sources/Rules/DocComments.swift
@@ -175,21 +175,8 @@ extension Formatter {
         }
 
         // For local declarations other than nested functions, use standard comments.
-        if declarationToken != .keyword("func"),
-           let startOfEnclosingScope = index(of: .startOfScope, before: startIndex)
-        {
-            switch tokens[startOfEnclosingScope] {
-            case .startOfScope("#if"):
-                break
-            case .startOfScope("{"):
-                guard let scope = lastSignificantKeyword(at: startOfEnclosingScope, excluding: ["where"]),
-                      ["class", "actor", "struct", "enum", "protocol", "extension"].contains(scope)
-                else {
-                    return false
-                }
-            default:
-                return false
-            }
+        if declarationToken != .keyword("func"), declarationScope(at: startIndex) == .local {
+            return false
         }
 
         // If there are blank lines between comment and declaration, comment is not treated as doc comment

--- a/Tests/Rules/DocCommentsTests.swift
+++ b/Tests/Rules/DocCommentsTests.swift
@@ -115,6 +115,11 @@ final class DocCommentsTests: XCTestCase {
                 /// an entire following block of code (not just the property)
                 let bar: Bar? = Bar()
                 print(bar)
+
+                #if DEBUG
+                    /// This comment is in a conditional compilation block
+                    let baaz = Baaz()
+                #endif
             }
 
             var baaz: Baaz {
@@ -150,6 +155,11 @@ final class DocCommentsTests: XCTestCase {
                 // an entire following block of code (not just the property)
                 let bar: Bar? = Bar()
                 print(bar)
+
+                #if DEBUG
+                    // This comment is in a conditional compilation block
+                    let baaz = Baaz()
+                #endif
             }
 
             var baaz: Baaz {


### PR DESCRIPTION
This PR updates the `docComments` rule to handle conditional compilation blocks in function bodies. Fixes #2335.