### PR TITLE
Update `redundantMemberwiseInit` to preserve inits with attributes

### DIFF
--- a/Sources/Declaration.swift
+++ b/Sources/Declaration.swift
@@ -133,6 +133,11 @@ extension Declaration {
         return allModifiers
     }
 
+    /// The attributes before this declaration's keyword.
+    var attributes: [String] {
+        modifiers.filter(\.isAttribute)
+    }
+
     /// Whether or not this declaration has the given modifier
     func hasModifier(_ modifier: String) -> Bool {
         formatter.modifiersForDeclaration(at: keywordIndex, contains: modifier)

--- a/Sources/Rules/RedundantEquatable.swift
+++ b/Sources/Rules/RedundantEquatable.swift
@@ -42,6 +42,12 @@ public extension FormatRule {
                 continue
             }
 
+            // Don't remove functions that have attributes (e.g. @usableFromInline, @inlinable)
+            // since these attributes can't be applied to synthesized Equatable conformances
+            guard equatableType.equatableFunction.attributes.isEmpty else {
+                continue
+            }
+
             // The compiler automatically synthesizes Equatable implementations for structs
             // as long as all of the properties are themselves Equatable. This is usually true
             //

--- a/Sources/Rules/RedundantMemberwiseInit.swift
+++ b/Sources/Rules/RedundantMemberwiseInit.swift
@@ -123,6 +123,12 @@ public extension FormatRule {
                     continue
                 }
 
+                // Don't remove inits that have attributes (e.g. @usableFromInline, @inlinable)
+                // since these attributes can't be applied to synthesized memberwise inits
+                if !initDeclaration.attributes.isEmpty {
+                    continue
+                }
+
                 // Parse the init function using the parseFunctionDeclaration helper
                 guard let functionDecl = formatter.parseFunctionDeclaration(keywordIndex: initDeclaration.keywordIndex),
                       let bodyRange = functionDecl.bodyRange

--- a/Tests/Rules/RedundantEquatableTests.swift
+++ b/Tests/Rules/RedundantEquatableTests.swift
@@ -619,4 +619,34 @@ final class RedundantEquatableTests: XCTestCase {
 
         testFormatting(for: input, rule: .redundantEquatable)
     }
+
+    func testPreserveEquatableImplementationWithUsableFromInlineAttribute() {
+        let input = """
+        public struct Foo: Equatable {
+            let bar: String
+
+            @usableFromInline
+            static func == (lhs: Foo, rhs: Foo) -> Bool {
+                lhs.bar == rhs.bar
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .redundantEquatable)
+    }
+
+    func testPreserveEquatableImplementationWithInlinableAttribute() {
+        let input = """
+        public struct Foo: Equatable {
+            let bar: String
+
+            @inlinable
+            static func == (lhs: Foo, rhs: Foo) -> Bool {
+                lhs.bar == rhs.bar
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .redundantEquatable)
+    }
 }

--- a/Tests/Rules/RedundantMemberwiseInitTests.swift
+++ b/Tests/Rules/RedundantMemberwiseInitTests.swift
@@ -677,7 +677,9 @@ final class RedundantMemberwiseInitTests: XCTestCase {
         testFormatting(for: input, rule: .redundantMemberwiseInit, exclude: [.redundantSelf, .trailingSpace, .indent])
     }
 
-    func testRemoveInitWithAttributes() {
+    func testPreserveInitWithAttributes() {
+        // Inits with attributes like @inlinable can't be removed because
+        // synthesized memberwise inits don't support these attributes
         let input = """
         struct Person {
             var name: String
@@ -690,59 +692,7 @@ final class RedundantMemberwiseInitTests: XCTestCase {
             }
         }
         """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveInitWithMultipleAttributes() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            @inlinable
-            @available(iOS 13.0, *)
-            init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit)
-    }
-
-    func testRemoveInitWithAttributesAndComments() {
-        let input = """
-        struct Person {
-            var name: String
-            var age: Int
-
-            // Initializes a person with name and age
-            @inlinable
-            internal init(name: String, age: Int) {
-                self.name = name
-                self.age = age
-            }
-        }
-        """
-        let output = """
-        struct Person {
-            var name: String
-            var age: Int
-        }
-        """
-        testFormatting(for: input, output, rule: .redundantMemberwiseInit, exclude: [.docComments])
+        testFormatting(for: input, rule: .redundantMemberwiseInit)
     }
 
     func testDontRemoveInitWithPrivateStoredProperty() {


### PR DESCRIPTION
Resolves https://github.com/nicklockwood/SwiftFormat/issues/2324