### PR TITLE
Add `--test-case-name-format raw-identifiers` option to `swiftTestingTestCaseNames` rule (enabled by default)

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3632,7 +3632,11 @@ set to 4.2 or above.
 
 ## swiftTestingTestCaseNames
 
-In Swift Testing, don't prefix @Test methods with 'test'.
+In Swift Testing, don't prefix @Test methods with 'test', and use raw identifier test function names.
+
+Option | Description
+--- | ---
+`--test-case-name-format` | Swift Testing test case name format: "preserve" or "raw-identifiers" (default)
 
 <details>
 <summary>Examples</summary>
@@ -3642,7 +3646,7 @@ In Swift Testing, don't prefix @Test methods with 'test'.
 
   struct MyFeatureTests {
 -     @Test func testMyFeatureHasNoBugs() {
-+     @Test func myFeatureHasNoBugs() {
++     @Test func `my feature has no bugs`() {
           let myFeature = MyFeature()
           myFeature.runAction()
           #expect(!myFeature.hasBugs, "My feature has no bugs")

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -1888,10 +1888,13 @@ extension Formatter {
 
         // Ensure that the new identifier is valid (e.g. starts with a letter, not a number),
         // and is unique / doesn't already exist somewhere in the file.
+        let unescapedName = newMethodName.hasPrefix("`") && newMethodName.hasSuffix("`")
+            ? String(newMethodName.dropFirst().dropLast()) : newMethodName
         guard !newMethodName.isEmpty,
               newMethodName.first?.isLetter == true || newMethodName.first == "`",
               !tokens.contains(.identifier(newMethodName)),
-              !swiftKeywords.union(["Any", "Self", "self", "super", "nil", "true", "false"]).contains(newMethodName)
+              !tokens.contains(.identifier(unescapedName)),
+              !swiftKeywords.union(["Any", "Self", "self", "super", "nil", "true", "false"]).contains(unescapedName)
         else { return }
 
         replaceToken(at: methodNameIndex, with: .identifier(newMethodName))

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1459,6 +1459,13 @@ struct _Descriptors {
         toArgument: { $0.rawValue }
     )
 
+    let testCaseNameFormat = OptionDescriptor(
+        argumentName: "test-case-name-format",
+        displayName: "Test Case Name Format",
+        help: "Swift Testing test case name format:",
+        keyPath: \.testCaseNameFormat
+    )
+
     // MARK: - Internal
 
     let fragment = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -187,6 +187,12 @@ public enum ClosureVoidReturn: String, CaseIterable {
     case preserve
 }
 
+/// Format for Swift Testing test case names
+public enum TestCaseNameFormat: String, CaseIterable {
+    case preserve
+    case rawIdentifiers = "raw-identifiers"
+}
+
 public enum TrailingCommas: String, CaseIterable {
     case never
     case always
@@ -878,6 +884,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var redundantAsync: RedundantEffectMode
     public var allowPartialWrapping: Bool
     public var preferSynthesizedInitForInternalStructs: PreferSynthesizedInitMode
+    public var testCaseNameFormat: TestCaseNameFormat
 
     /// Deprecated
     public var indentComments: Bool
@@ -1023,6 +1030,7 @@ public struct FormatOptions: CustomStringConvertible {
                 redundantAsync: RedundantEffectMode = .testsOnly,
                 allowPartialWrapping: Bool = true,
                 preferSynthesizedInitForInternalStructs: PreferSynthesizedInitMode = .never,
+                testCaseNameFormat: TestCaseNameFormat = .rawIdentifiers,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -1157,6 +1165,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.redundantAsync = redundantAsync
         self.allowPartialWrapping = allowPartialWrapping
         self.preferSynthesizedInitForInternalStructs = preferSynthesizedInitForInternalStructs
+        self.testCaseNameFormat = testCaseNameFormat
         self.indentComments = indentComments
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules/SwiftTestingTestCaseNames.swift
+++ b/Sources/Rules/SwiftTestingTestCaseNames.swift
@@ -1,15 +1,27 @@
 // Created by Cal Stephens on 2/19/25.
 // Copyright © 2025 Airbnb Inc. All rights reserved.
 
+import Foundation
+
 public extension FormatRule {
     static let swiftTestingTestCaseNames = FormatRule(
-        help: "In Swift Testing, don't prefix @Test methods with 'test'."
+        help: "In Swift Testing, don't prefix @Test methods with 'test', and use raw identifier test function names.",
+        options: ["test-case-name-format"]
     ) { formatter in
         guard formatter.hasImport("Testing") else { return }
 
         formatter.forEach(.keyword("func")) { funcKeywordIndex, _ in
-            if formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") {
-                formatter.removeTestPrefix(fromFunctionAt: funcKeywordIndex)
+            guard formatter.modifiersForDeclaration(at: funcKeywordIndex, contains: "@Test") else { return }
+
+            formatter.removeTestPrefix(fromFunctionAt: funcKeywordIndex)
+
+            switch formatter.options.testCaseNameFormat {
+            case .rawIdentifiers:
+                guard formatter.options.swiftVersion >= "6.2" else { return }
+                formatter.convertToRawIdentifier(forTestFunctionAt: funcKeywordIndex)
+
+            case .preserve:
+                break
             }
         }
     } examples: {
@@ -19,7 +31,7 @@ public extension FormatRule {
 
           struct MyFeatureTests {
         -     @Test func testMyFeatureHasNoBugs() {
-        +     @Test func myFeatureHasNoBugs() {
+        +     @Test func `my feature has no bugs`() {
                   let myFeature = MyFeature()
                   myFeature.runAction()
                   #expect(!myFeature.hasBugs, "My feature has no bugs")
@@ -36,5 +48,147 @@ public extension FormatRule {
           }
         ```
         """
+    }
+}
+
+extension Formatter {
+    /// Converts a `@Test` function name to use a raw identifier (backtick-quoted name with spaces).
+    /// If the `@Test` attribute has a display name, uses that as the function name and removes it from the attribute.
+    /// Otherwise, converts the camelCase/underscore function name to a space-separated raw identifier.
+    func convertToRawIdentifier(forTestFunctionAt funcKeywordIndex: Int) {
+        guard let methodNameIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: funcKeywordIndex),
+              tokens[methodNameIndex].isIdentifier
+        else { return }
+
+        let methodName = tokens[methodNameIndex].string
+
+        // Check if the @Test attribute has a display name argument
+        if var displayName = testDisplayName(forDeclarationAt: funcKeywordIndex) {
+            // Remove any existing backticks from the test name, since raw identifiers cant contain backticks
+            displayName = displayName.replacingOccurrences(of: "`", with: "")
+
+            let newMethodName = "`\(displayName)`"
+            updateFunctionName(forFunctionAt: funcKeywordIndex, to: newMethodName)
+            removeTestDisplayNameString(forDeclarationAt: funcKeywordIndex)
+        } else {
+            // Convert the method name to a raw identifier
+            let baseName = methodName.camelCaseToWords()
+            guard !baseName.isEmpty, baseName != methodName else { return }
+
+            let newMethodName = "`\(baseName)`"
+            guard tokens[methodNameIndex] != .identifier(newMethodName) else { return }
+
+            updateFunctionName(forFunctionAt: funcKeywordIndex, to: newMethodName)
+        }
+    }
+
+    /// Extracts the display name string from a `@Test("display name")` attribute, if present.
+    func testDisplayName(forDeclarationAt funcKeywordIndex: Int) -> String? {
+        // Walk backwards from `func` to find `@Test`
+        var testAttrIndex: Int?
+        _ = modifiersForDeclaration(at: funcKeywordIndex, contains: { index, modifier in
+            if modifier.hasPrefix("@Test(") || modifier.hasPrefix("@Test (") {
+                testAttrIndex = index
+                return true
+            }
+            return false
+        })
+
+        guard let attrIndex = testAttrIndex,
+              let parenStart = index(of: .startOfScope("("), after: attrIndex),
+              let firstToken = index(of: .nonSpaceOrCommentOrLinebreak, after: parenStart),
+              tokens[firstToken] == .startOfScope("\"")
+        else { return nil }
+
+        // Collect string content between the opening and closing quotes
+        guard let stringEnd = endOfScope(at: firstToken) else { return nil }
+
+        // Extract the string literal content (between the quotes)
+        var displayName = ""
+        for i in (firstToken + 1) ..< stringEnd {
+            displayName += tokens[i].string
+        }
+
+        return displayName.isEmpty ? nil : displayName
+    }
+
+    /// Removes the display name from a `@Test("display name")` or `@Test("display name", ...)` attribute.
+    func removeTestDisplayNameString(forDeclarationAt funcKeywordIndex: Int) {
+        var testAttrIndex: Int?
+        _ = modifiersForDeclaration(at: funcKeywordIndex, contains: { index, modifier in
+            if modifier.hasPrefix("@Test(") || modifier.hasPrefix("@Test (") {
+                testAttrIndex = index
+                return true
+            }
+            return false
+        })
+
+        guard let attrIndex = testAttrIndex,
+              let parenStart = index(of: .startOfScope("("), after: attrIndex),
+              let firstToken = index(of: .nonSpaceOrCommentOrLinebreak, after: parenStart),
+              tokens[firstToken] == .startOfScope("\""),
+              let stringEnd = endOfScope(at: firstToken)
+        else { return }
+
+        let parenEnd = endOfScope(at: parenStart)!
+
+        // Check if there are additional arguments after the display name
+        if let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: stringEnd),
+           tokens[nextToken] == .delimiter(",")
+        {
+            // Remove from the string start through the comma and any trailing space
+            let removeEnd = index(of: .nonSpaceOrComment, after: nextToken) ?? (nextToken + 1)
+            removeTokens(in: firstToken ..< removeEnd)
+        } else {
+            // This is the only argument — remove the entire parentheses
+            // Also remove any space between @Test and (
+            let removeStart = (index(of: .nonSpaceOrComment, after: attrIndex) == parenStart)
+                ? (attrIndex + 1) : parenStart
+            removeTokens(in: removeStart ... parenEnd)
+        }
+    }
+}
+
+extension String {
+    /// Converts a method name (camelCase, underscore-separated, or already-backticked) to space-separated words.
+    /// Returns an empty string if conversion isn't possible.
+    func camelCaseToWords() -> String {
+        let baseName = self
+
+        // Handle existing raw identifiers: `some name` -> some name
+        if baseName.hasPrefix("`"), baseName.hasSuffix("`") {
+            return String(baseName.dropFirst().dropLast())
+        }
+
+        guard !baseName.isEmpty, baseName.first?.isLetter == true else { return "" }
+
+        // Split on underscores and camelCase boundaries, then join with spaces
+        var words: [String] = []
+        for segment in baseName.split(separator: "_") {
+            words.append(contentsOf: String(segment).splitCamelCase())
+        }
+
+        return words.joined(separator: " ").lowercased()
+    }
+
+    /// Splits a camelCase string into individual words.
+    func splitCamelCase() -> [String] {
+        var words: [String] = []
+        var currentWord = ""
+
+        for char in self {
+            if char.isUppercase, !currentWord.isEmpty {
+                words.append(currentWord)
+                currentWord = String(char)
+            } else {
+                currentWord.append(char)
+            }
+        }
+
+        if !currentWord.isEmpty {
+            words.append(currentWord)
+        }
+
+        return words
     }
 }

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -39,14 +39,14 @@ final class PreferSwiftTestingTests: XCTestCase {
         import Testing
 
         final class MyFeatureTests {
-            @Test func myFeatureWorks() {
+            @Test func `my feature works`() {
                 let myFeature = MyFeature()
                 myFeature.runAction()
                 #expect(myFeature.worksProperly)
                 #expect(myFeature.screens.count == 8)
             }
 
-            @Test func myFeatureHasNoBugs() {
+            @Test func `my feature has no bugs`() {
                 let myFeature = MyFeature()
                 myFeature.runAction()
                 #expect(!myFeature.hasBugs, "My feature has no bugs")
@@ -56,8 +56,8 @@ final class PreferSwiftTestingTests: XCTestCase {
         }
         """
 
-        let options = FormatOptions(swiftVersion: "6.0")
-        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports, .isEmpty], options: options)
+        let options = FormatOptions(swiftVersion: "6.2")
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports, .isEmpty, .swiftTestingTestCaseNames], options: options)
     }
 
     func testConvertsTestSuiteWithSetUpTearDown() {


### PR DESCRIPTION
This PR adds a new enabled-by-default `--test-case-name-format raw-identifiers` option to the `swiftTestingTestCaseNames` rule.