### PR TITLE
Add CI lint job

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -14,3 +14,12 @@ jobs:
         run: |
           echo "❌ Pull request must target the 'develop' branch. Current base: '${{ github.event.pull_request.base.ref }}'"
           exit 1
+
+  lint:
+    name: "Lint"
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Lint
+        run: CommandLineTool/swiftformat . --cache ignore --lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ swift test --enable-test-discovery
 
 # Test a specific rule (works on both macOS and Linux)
 ./Scripts/test_rule.sh <ruleName>
+
+# Format the codebase (run after making changes)
+# ./Scripts/test_rule.sh runs this automatically
+./format.sh
 ```
 
 ## Adding New Rules


### PR DESCRIPTION
This PR adds a CI job to lint the code, using the same configuration as the local `format.sh`.

If only running tests via `swift test`, `format.sh` isn't currently run. We could potentially add a test that does this as a side-effect, but either way a CI job is reasonable.