### PR TITLE
Fix indentCase handling (fixes #2442)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,23 +21,23 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64, linux/arm64

--- a/.github/workflows/label_fixed_issues.yml
+++ b/.github/workflows/label_fixed_issues.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Extract issue numbers from PR
         id: extract_issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -38,7 +38,7 @@ jobs:
             return issueNumbers;
 
       - name: Add label to issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issueNumbers = ${{ steps.extract_issues.outputs.result }};

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Set Version Number
         run: echo "Using version number $GITHUB_REF_NAME" && sed -i "s/let swiftFormatVersion = \"[^\"]*\"/let swiftFormatVersion = \"$GITHUB_REF_NAME\"/" Sources/SwiftFormat.swift
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Install cross-binutils for aarch64
         run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
       - name: Build and export binaries
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Rules.md
+++ b/Rules.md
@@ -3722,7 +3722,7 @@ Format Swift Testing @Test and @Suite names.
 Option | Description
 --- | ---
 `--test-case-name-format` | Swift Testing test case name format: "preserve", "raw-identifiers" (default) or "standard-identifiers"
-`--suite-name-format` | Swift Testing suite name format: "preserve", "raw-identifiers" or "standard-identifiers" (default)
+`--suite-name-format` | Swift Testing suite name format: "preserve" (default), "raw-identifiers" or "standard-identifiers"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2644,13 +2644,22 @@ extension Formatter {
                     continue
                 case .keyword("while") where lastKeyword == "repeat":
                     lastKeyword = ""
+                case .startOfScope("#if"), .keyword("#elseif"):
+                    // Skip the condition to avoid treating compiler directive
+                    // arguments (e.g., `os(iOS)`) as property references
+                    if case .startOfScope = token {
+                        scopeStack.append((token, []))
+                    }
+                    if let linebreakIndex = self.index(of: .linebreak, after: index) {
+                        index = linebreakIndex
+                    }
                 case let .keyword(name) where !name.isMacro:
                     lastKeyword = name
                     lastKeywordIndex = index
                 case .startOfScope("/*"), .startOfScope("//"):
                     index = endOfScope(at: index) ?? (tokens.count - 1)
                     updateEnablement(at: index)
-                case .startOfScope where token.isStringDelimiter, .startOfScope("#if"),
+                case .startOfScope where token.isStringDelimiter,
                      .startOfScope("["), .startOfScope("("):
                     scopeStack.append((token, []))
                 case .startOfScope(":"):

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -1055,7 +1055,7 @@ public struct FormatOptions: CustomStringConvertible {
                 allowPartialWrapping: Bool = true,
                 preferSynthesizedInitForInternalStructs: PreferSynthesizedInitMode = .never,
                 testCaseNameFormat: SwiftTestingNameFormat = .rawIdentifiers,
-                suiteNameFormat: SwiftTestingNameFormat = .standardIdentifiers,
+                suiteNameFormat: SwiftTestingNameFormat = .preserve,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,

--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -29,6 +29,11 @@ public extension FormatRule {
         var lineIndex = 0
         var preserveIfdefDepth = 0
 
+        var isInSwitchCondition = false
+        var isInSwitchBody = false
+        var switchPairLevel = -1
+        var pairStack: [Token] = []
+
         @discardableResult
         func applyIndent(_ indent: String, at index: Int) -> Int {
             if formatter.options.ifdefIndent == .preserve, preserveIfdefDepth > 0 {
@@ -55,6 +60,18 @@ public extension FormatRule {
                 linewrapStack.removeLast()
                 scopeStartLineIndexes.removeLast()
                 scopeStack.removeLast()
+            }
+
+            switch token {
+            case .startOfScope("("), .startOfScope("{"), .startOfScope("["):
+                pairStack.append(token)
+            case .endOfScope(")"), .endOfScope("}"), .endOfScope("]"):
+                pairStack.removeLast()
+            case .keyword("switch"):
+                isInSwitchCondition = true
+                switchPairLevel = pairStack.count
+            default:
+                break
             }
 
             var i = i
@@ -94,11 +111,17 @@ public extension FormatRule {
                     }
                 case ":":
                     indent += formatter.options.indent
-                    if formatter.options.indentCase,
-                       scopeStack.count < 2 || scopeStack[scopeStack.count - 2] != .startOfScope("#if")
-                    {
+                case "{" where isInSwitchCondition && pairStack.count == switchPairLevel + 1:
+                    if formatter.options.indentCase {
                         indent += formatter.options.indent
+                        indentStack.append(indent)
+                        stringBodyIndentStack.append("")
+                        indentCounts.append(indentCount)
+                        scopeStartLineIndexes.append(lineIndex)
+                        linewrapStack.append(false)
                     }
+                    isInSwitchBody = true
+                    isInSwitchCondition = false
                 case "#if":
                     if let lineIndex = formatter.index(of: .linebreak, after: i),
                        let nextKeyword = formatter.next(.nonSpaceOrCommentOrLinebreak, after: lineIndex), [
@@ -106,9 +129,6 @@ public extension FormatRule {
                        ].contains(nextKeyword)
                     {
                         indent = indentStack[indentStack.count - indentCount - 1]
-                        if formatter.options.indentCase {
-                            indent += formatter.options.indent
-                        }
                     }
                     switch formatter.options.ifdefIndent {
                     case .indent:
@@ -220,9 +240,6 @@ public extension FormatRule {
                 var indent = indentStack[indentStack.count - 2]
                 if scopeStack.last == .startOfScope(":") {
                     indent = indentStack[indentStack.count - 4]
-                    if formatter.options.indentCase {
-                        indent += formatter.options.indent
-                    }
                 }
                 let start = formatter.startOfLine(at: i)
                 switch formatter.options.ifdefIndent {
@@ -235,9 +252,6 @@ public extension FormatRule {
                 }
             case .keyword("@unknown") where scopeStack.last != .startOfScope("#if"):
                 var indent = indentStack[indentStack.count - 2]
-                if formatter.options.indentCase {
-                    indent += formatter.options.indent
-                }
                 let start = formatter.startOfLine(at: i)
                 let stringIndent = stringBodyIndentStack.last!
                 i += applyIndent(stringIndent + indent, at: start)
@@ -336,6 +350,21 @@ public extension FormatRule {
                         popScope()
                     }
 
+                    // If we're in a switch with the indentCase option enabled, pop an extra scope
+                    if token == .endOfScope("}"),
+                       isInSwitchBody,
+                       pairStack.count == switchPairLevel,
+                       formatter.options.indentCase
+                    {
+                        indentStack.removeLast()
+                        stringBodyIndentStack.removeLast()
+                        indentCounts.removeLast()
+                        linewrapStack.removeLast()
+                        scopeStartLineIndexes.removeLast()
+                        isInSwitchBody = false
+                        switchPairLevel = -1
+                    }
+
                     // Don't reduce indent if line doesn't start with end of scope
                     let start = formatter.startOfLine(at: i)
                     guard let firstIndex = formatter.index(of: .nonSpaceOrComment, after: start - 1) else {
@@ -349,11 +378,6 @@ public extension FormatRule {
                         i += applyIndent("", at: start)
                     } else {
                         var indent = indentStack.last ?? ""
-                        if token.isSwitchCaseOrDefault,
-                           formatter.options.indentCase, !formatter.isInIfdef(at: i, scopeStack: scopeStack)
-                        {
-                            indent += formatter.options.indent
-                        }
                         let stringIndent = stringBodyIndentStack.last!
                         i += applyIndent(stringIndent + indent, at: start)
                     }
@@ -361,9 +385,6 @@ public extension FormatRule {
                     var indent = indentStack[indentStack.count - 2]
                     if scopeStack.last == .startOfScope(":"), indentStack.count > 1 {
                         indent = indentStack[indentStack.count - 4]
-                        if formatter.options.indentCase {
-                            indent += formatter.options.indent
-                        }
                         popScope()
                     }
                     switch formatter.options.ifdefIndent {
@@ -389,9 +410,6 @@ public extension FormatRule {
                 if formatter.next(.nonSpaceOrComment, after: i)?.isLinebreak == true {
                     indent += formatter.options.indent
                 } else {
-                    if formatter.options.indentCase {
-                        indent += formatter.options.indent
-                    }
                     // Align indent with previous case value
                     indent += formatter.spaceEquivalentToWidth(5)
                 }

--- a/Sources/Rules/SwiftTestingTestCaseNames.swift
+++ b/Sources/Rules/SwiftTestingTestCaseNames.swift
@@ -228,7 +228,8 @@ extension String {
     }
 
     /// Splits a camelCase string into individual words, treating consecutive uppercase letters as acronyms.
-    /// For example: "UUIDIsValid" → ["UUID", "Is", "Valid"], "alphabetStartsWithABC" → ["alphabet", "Starts", "With", "ABC"].
+    /// For example: "UUIDIsValid" → ["UUID", "Is", "Valid"], "alphabetStartsWithABC" → ["alphabet", "Starts", "With", "ABC"],
+    /// "greaterThan100" → ["greater", "Than", "100"].
     func splitCamelCase() -> [String] {
         var words: [String] = []
         var currentWord = ""
@@ -241,8 +242,8 @@ extension String {
             if char.isUppercase {
                 if currentWord.isEmpty {
                     currentWord.append(char)
-                } else if currentWord.last!.isLowercase {
-                    // Lower→Upper transition: start a new word
+                } else if currentWord.last!.isLowercase || currentWord.last!.isNumber {
+                    // Lower→Upper or Number→Upper transition: start a new word
                     words.append(currentWord)
                     currentWord = String(char)
                 } else if let next = nextChar, next.isLowercase {
@@ -254,8 +255,22 @@ extension String {
                     // Continue accumulating the uppercase sequence (acronym)
                     currentWord.append(char)
                 }
+            } else if char.isNumber {
+                if !currentWord.isEmpty, !currentWord.last!.isNumber {
+                    // Letter→Number transition: start a new word
+                    words.append(currentWord)
+                    currentWord = String(char)
+                } else {
+                    currentWord.append(char)
+                }
             } else {
-                currentWord.append(char)
+                if !currentWord.isEmpty, currentWord.last!.isNumber {
+                    // Number→Letter transition: start a new word
+                    words.append(currentWord)
+                    currentWord = String(char)
+                } else {
+                    currentWord.append(char)
+                }
             }
         }
 

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -6073,13 +6073,13 @@ final class IndentTests: XCTestCase {
         let input = """
         switch testKey {
             case "organization"
-            where testValues.map(String.init).compactMap { try? Entity.ID($0, format: .number) }
-            .contains(Self.sessionInteractor.stage.value?.membership?.organization.id ?? .zero): // 2
+                where testValues.map(String.init).compactMap { try? Entity.ID($0, format: .number) }
+                .contains(Self.sessionInteractor.stage.value?.membership?.organization.id ?? .zero): // 2
                 continue
 
             case "user"
-            where testValues.map(String.init).compactMap { try? Entity.ID($0, format: .number) }
-            .contains(Self.sessionInteractor.stage.value?.session?.user.id ?? .zero): // 3
+                where testValues.map(String.init).compactMap { try? Entity.ID($0, format: .number) }
+                .contains(Self.sessionInteractor.stage.value?.session?.user.id ?? .zero): // 3
                 continue
         }
         """

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -1376,6 +1376,37 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
+    func testMultilineSwitchCasePatternWithIndentCaseTrue() {
+        let input = """
+        switch x {
+        case let .foo(
+        longVariableName,
+        otherLongVariableName
+        ):
+        break
+        case bar:
+        break
+        default:
+        break
+        }
+        """
+        let output = """
+        switch x {
+            case let .foo(
+                longVariableName,
+                otherLongVariableName
+            ):
+                break
+            case bar:
+                break
+            default:
+                break
+        }
+        """
+        let options = FormatOptions(indentCase: true)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
     func testNoMangleLabelWhenIndentCaseTrue() {
         let input = """
         foo: while true {

--- a/Tests/Rules/RedundantSelfTests.swift
+++ b/Tests/Rules/RedundantSelfTests.swift
@@ -3034,6 +3034,57 @@ final class RedundantSelfTests: XCTestCase {
         testFormatting(for: input, rule: .redundantSelf, options: options)
     }
 
+    func testNoInsertSelfInCompilerDirectiveOsCondition() {
+        let input = """
+        class Foo {
+            var iOS = true
+
+            func bar() {
+                #if os(iOS)
+                    print("ios")
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(explicitSelf: .insert)
+        testFormatting(for: input, rule: .redundantSelf, options: options)
+    }
+
+    func testNoInsertSelfInCompilerDirectiveElseIfCondition() {
+        let input = """
+        class Foo {
+            var iOS = true
+            var macOS = false
+
+            func bar() {
+                #if os(iOS)
+                    print("ios")
+                #elseif os(macOS)
+                    print("macos")
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(explicitSelf: .insert)
+        testFormatting(for: input, rule: .redundantSelf, options: options)
+    }
+
+    func testNoInsertSelfForFlagInCompilerDirectiveCondition() {
+        let input = """
+        class Foo {
+            var DEBUG = true
+
+            func bar() {
+                #if DEBUG
+                    print("debug")
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(explicitSelf: .insert)
+        testFormatting(for: input, rule: .redundantSelf, options: options)
+    }
+
     func testNoInsertSelfBeforeBinding() {
         let input = """
         struct MyView: View {

--- a/Tests/Rules/RedundantSwiftTestingSuiteTests.swift
+++ b/Tests/Rules/RedundantSwiftTestingSuiteTests.swift
@@ -241,7 +241,26 @@ final class RedundantSwiftTestingSuiteTests: XCTestCase {
             }
         }
         """
-        testFormatting(for: input, [output], rules: [.swiftTestingTestCaseNames, .redundantSwiftTestingSuite])
+        testFormatting(for: input, [output], rules: [.swiftTestingTestCaseNames, .redundantSwiftTestingSuite],
+                       options: FormatOptions(suiteNameFormat: .standardIdentifiers))
+    }
+
+    func testKeepSuiteWithDisplayNameWhenSuiteNameFormatIsPreserve() {
+        let input = """
+        import Testing
+
+        @Suite("Display Name")
+        struct MyTests {
+            @Test func feature() {
+                #expect(true)
+            }
+        }
+        """
+        testFormatting(
+            for: input,
+            rules: [.swiftTestingTestCaseNames, .redundantSwiftTestingSuite],
+            options: FormatOptions(suiteNameFormat: .preserve)
+        )
     }
 
     func testKeepSuiteWithArgumentsAndComments() {

--- a/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
+++ b/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
@@ -221,6 +221,87 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
                        options: FormatOptions(swiftVersion: "6.2"))
     }
 
+    func testConvertsTestNameWithTrailingNumberToRawIdentifier() {
+        let input = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func testValueIsGreaterThan100() {
+                #expect(true)
+            }
+        }
+        """
+
+        let output = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func `value is greater than 100`() {
+                #expect(true)
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
+                       options: FormatOptions(swiftVersion: "6.2"))
+    }
+
+    func testConvertsTestNameWithMiddleNumberToRawIdentifier() {
+        let input = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func testPhase2IsComplete() {
+                #expect(true)
+            }
+        }
+        """
+
+        let output = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func `phase 2 is complete`() {
+                #expect(true)
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
+                       options: FormatOptions(swiftVersion: "6.2"))
+    }
+
+    func testConvertsTestNameWithLeadingNumberToRawIdentifier() {
+        let input = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func test100IsGreaterThan99() {
+                #expect(true)
+            }
+        }
+        """
+
+        let output = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func `100 is greater than 99`() {
+                #expect(true)
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
+                       options: FormatOptions(swiftVersion: "6.2"))
+    }
+
     func testUsesDisplayNameForRawIdentifier() {
         let input = """
         import Testing

--- a/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
+++ b/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
@@ -791,7 +791,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -815,7 +815,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -839,7 +839,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -854,7 +854,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -878,7 +878,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"))
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"))
     }
 
     // MARK: - @Suite with raw-identifiers
@@ -970,6 +970,25 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
                                               swiftVersion: "6.2"))
     }
 
+    func testSuitePreserveKeepsDisplayNameWithBothRules() {
+        let input = """
+        import Testing
+
+        @Suite("My Feature Tests")
+        struct MyFeatureTests {
+            @Test func myTest() {}
+        }
+        """
+
+        testFormatting(
+            for: input,
+            rules: [.swiftTestingTestCaseNames, .redundantSwiftTestingSuite],
+            options: FormatOptions(testCaseNameFormat: .preserve,
+                                   suiteNameFormat: .preserve,
+                                   swiftVersion: "6.2")
+        )
+    }
+
     // MARK: - @Suite on class/actor/enum
 
     func testSuiteWorksWithClass() {
@@ -992,7 +1011,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -1016,7 +1035,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -1040,7 +1059,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 
@@ -1072,7 +1091,7 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames,
-                       options: FormatOptions(testCaseNameFormat: .preserve, swiftVersion: "6.2"),
+                       options: FormatOptions(testCaseNameFormat: .preserve, suiteNameFormat: .standardIdentifiers, swiftVersion: "6.2"),
                        exclude: [.redundantSwiftTestingSuite])
     }
 


### PR DESCRIPTION
As described in #2442, the `indentCase` formatting option has some unexpected behaviour. I've updated handling of `indentCase` in `Result/Indent.swift` to match my mental model of what `indentCase` does.

My mental model for `indentCase` is that it should lead to identical behaviour to the default switch statement formatting behaviour except with the entire body of the switch statement indented an additional level.

This mental model lines up with SwiftFormat's behaviour in most cases. The only exceptions that I know of are #2442, and the `testIndentSwitchCaseWhere` test case which I had to update after my changes. My justification for updating the `testIndentSwitchCaseWhere` test case rather than changing my implementation to preserve the behaviour that it originally tested for is that if you run that same test case without `indentCase` you get the same `where` clause wrapping behaviour as my implementation; and it doesn't make sense to me that `where` clause wrapping should be affected by the `indentCase` option.

## Implementation

In order to implement this new behaviour, I ripped out all existing `indentCase` handling (which was originally spread all through the `applyIndent` implementation), and replaced it with a more direct approach. Most of the new code is used to detect whether a given `{` token is the start of a `switch` statement body, and similarly whether a given `}` token is the end of a `switch` statement body. If `indentCase` is enabled, then I add one more level of indentation (and push it onto the indentation scope so that `case`'s scope-ending behaviour doesn't mess things up) when a `switch` body begins, and remove it when a `switch` body ends.