### PR TITLE
Fix trailing comma for @convention closures

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -334,8 +334,8 @@ extension Formatter {
             } else if next(.nonSpaceOrComment, after: endIndex) == .startOfScope("(") {
                 isType = true
             } else if var prevIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: index) {
-                if tokens[prevIndex].isAttribute {
-                    prevIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: prevIndex) ?? prevIndex
+                if let attributeIndex = startOfAttribute(at: prevIndex) {
+                    prevIndex = self.index(of: .nonSpaceOrCommentOrLinebreak, before: attributeIndex) ?? prevIndex
                 }
                 let prevToken = tokens[prevIndex]
                 switch prevToken {

--- a/Tests/Rules/TrailingCommasTests.swift
+++ b/Tests/Rules/TrailingCommasTests.swift
@@ -904,6 +904,14 @@ final class TrailingCommasTests: XCTestCase {
             quux: String // trailing comma not supported
         )
 
+        let closure: @convention(block) (
+            String,
+            String // trailing comma not supported
+        ) -> (
+            bar: String,
+            quux: String // trailing comma not supported
+        )
+
         let closure: (
             String,
             String // trailing comma not supported
@@ -974,6 +982,10 @@ final class TrailingCommasTests: XCTestCase {
         public typealias StringToInt = (
             String
         ) -> Int
+
+        public typealias BlockClosure = @convention(block) (
+            String
+        ) -> Void
 
         public enum Toster {
             public typealias StringToInt = ((
@@ -2709,6 +2721,14 @@ final class TrailingCommasTests: XCTestCase {
             quux: String
         )
 
+        let closure: @convention(block) (
+            String,
+            String
+        ) -> (
+            bar: String,
+            quux: String
+        )
+
         let closure: (
             String,
             String
@@ -2740,6 +2760,14 @@ final class TrailingCommasTests: XCTestCase {
         )
 
         let closure: @Sendable (
+            String,
+            String,
+        ) -> (
+            bar: String,
+            quux: String,
+        )
+
+        let closure: @convention(block) (
             String,
             String,
         ) -> (
@@ -2842,6 +2870,10 @@ final class TrailingCommasTests: XCTestCase {
             String
         ) -> Int
 
+        public typealias BlockClosure = @convention(block) (
+            String
+        ) -> Void
+
         public enum Toster {
             public typealias StringToInt = ((
                 String
@@ -2863,6 +2895,10 @@ final class TrailingCommasTests: XCTestCase {
         public typealias StringToInt = (
             String,
         ) -> Int
+
+        public typealias BlockClosure = @convention(block) (
+            String,
+        ) -> Void
 
         public enum Toster {
             public typealias StringToInt = ((


### PR DESCRIPTION
Updates the parsing helper to check if the previous token is "part of an attribute" (e.g. the `)` in `@convention(block)`) instead of just itself an attribute.

Fixes https://github.com/nicklockwood/SwiftFormat/issues/2451