### PR TITLE
 Add redundantEmptyView rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -50,6 +50,7 @@
 * [redundantBackticks](#redundantBackticks)
 * [redundantBreak](#redundantBreak)
 * [redundantClosure](#redundantClosure)
+* [redundantEmptyView](#redundantEmptyView)
 * [redundantEquatable](#redundantEquatable)
 * [redundantExtensionACL](#redundantExtensionACL)
 * [redundantFileprivate](#redundantFileprivate)
@@ -2394,6 +2395,26 @@ which are called immediately.
 - }()
 + lazy var bar = Bar(baaz: baaz,
 +                    quux: quux)
+```
+
+</details>
+<br/>
+
+## redundantEmptyView
+
+Remove redundant `else { EmptyView() }` branches in SwiftUI result builders.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  var body: some View {
+      if condition {
+          Text("Hello")
+-     } else {
+-         EmptyView()
+      }
+  }
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -73,6 +73,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantBackticks": .redundantBackticks,
     "redundantBreak": .redundantBreak,
     "redundantClosure": .redundantClosure,
+    "redundantEmptyView": .redundantEmptyView,
     "redundantEquatable": .redundantEquatable,
     "redundantExtensionACL": .redundantExtensionACL,
     "redundantFileprivate": .redundantFileprivate,

--- a/Sources/Rules/RedundantEmptyView.swift
+++ b/Sources/Rules/RedundantEmptyView.swift
@@ -35,16 +35,22 @@ public extension FormatRule {
 }
 
 extension Formatter {
+    /// Returns the range to remove if the `else` at `elseKeywordIndex` is a redundant
+    /// `else { EmptyView() }` in a result builder, or `nil` if it should be preserved.
     func redundantEmptyViewElseRange(at elseKeywordIndex: Int) -> ClosedRange<Int>? {
         guard isInResultBuilder(at: elseKeywordIndex),
+              // Skip `else if` chains — only plain `else` can be redundant
               next(.nonSpaceOrCommentOrLinebreak, after: elseKeywordIndex) != .keyword("if"),
+              // Verify the preceding if-body closes with `}`
               let previousTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: elseKeywordIndex),
               tokens[previousTokenIndex] == .endOfScope("}"),
+              // Preserve comments between `}` and `else`
               tokens[(previousTokenIndex + 1) ..< elseKeywordIndex].allSatisfy(\.isSpaceOrLinebreak),
               let startOfElseBody = index(of: .nonSpaceOrCommentOrLinebreak, after: elseKeywordIndex),
               tokens[startOfElseBody] == .startOfScope("{"),
               tokens[(elseKeywordIndex + 1) ..< startOfElseBody].allSatisfy(\.isSpaceOrLinebreak),
               let endOfElseBody = endOfScope(at: startOfElseBody),
+              // Verify the else body contains exactly one expression, with no comments
               let firstTokenInElseBody = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfElseBody),
               let elseExpressionRange = parseExpressionRange(startingAt: firstTokenInElseBody),
               index(of: .nonSpaceOrCommentOrLinebreak, after: elseExpressionRange.upperBound) == endOfElseBody,
@@ -55,12 +61,16 @@ extension Formatter {
             return nil
         }
 
+        // Remove from after the if-body `}` through the else-body `}`
         return (previousTokenIndex + 1) ... endOfElseBody
     }
 
+    /// Whether the expression in the given range is `EmptyView()` or `SwiftUI.EmptyView()`
+    /// with no arguments and no modifiers.
     func expressionIsEmptyView(in expressionRange: ClosedRange<Int>) -> Bool {
         var emptyViewIdentifierIndex = expressionRange.lowerBound
 
+        // Handle fully-qualified `SwiftUI.EmptyView()`
         if tokens[emptyViewIdentifierIndex] == .identifier("SwiftUI") {
             guard let dotIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: emptyViewIdentifierIndex),
                   tokens[dotIndex] == .operator(".", .infix),
@@ -72,6 +82,7 @@ extension Formatter {
             emptyViewIdentifierIndex = nextIdentifierIndex
         }
 
+        // Verify it's `EmptyView()` with no arguments and no trailing modifiers
         guard tokens[emptyViewIdentifierIndex] == .identifier("EmptyView"),
               let startOfArguments = index(of: .nonSpaceOrCommentOrLinebreak, after: emptyViewIdentifierIndex),
               tokens[startOfArguments] == .startOfScope("("),

--- a/Sources/Rules/RedundantEmptyView.swift
+++ b/Sources/Rules/RedundantEmptyView.swift
@@ -1,0 +1,88 @@
+//
+//  RedundantEmptyView.swift
+//  SwiftFormat
+//
+//  Created by Manuel Lopez on 2026-03-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Remove redundant `else { EmptyView() }` in result builders
+    static let redundantEmptyView = FormatRule(
+        help: "Remove redundant `else { EmptyView() }` branches in SwiftUI result builders."
+    ) { formatter in
+        formatter.forEach(.keyword("else")) { elseIndex, _ in
+            guard let redundantElseRange = formatter.redundantEmptyViewElseRange(at: elseIndex) else {
+                return
+            }
+            formatter.removeTokens(in: redundantElseRange)
+        }
+    } examples: {
+        """
+        ```diff
+          var body: some View {
+              if condition {
+                  Text("Hello")
+        -     } else {
+        -         EmptyView()
+              }
+          }
+        ```
+        """
+    }
+}
+
+extension Formatter {
+    func redundantEmptyViewElseRange(at elseKeywordIndex: Int) -> ClosedRange<Int>? {
+        guard isInResultBuilder(at: elseKeywordIndex),
+              next(.nonSpaceOrCommentOrLinebreak, after: elseKeywordIndex) != .keyword("if"),
+              let previousTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, before: elseKeywordIndex),
+              tokens[previousTokenIndex] == .endOfScope("}"),
+              tokens[(previousTokenIndex + 1) ..< elseKeywordIndex].allSatisfy(\.isSpaceOrLinebreak),
+              let startOfElseBody = index(of: .nonSpaceOrCommentOrLinebreak, after: elseKeywordIndex),
+              tokens[startOfElseBody] == .startOfScope("{"),
+              tokens[(elseKeywordIndex + 1) ..< startOfElseBody].allSatisfy(\.isSpaceOrLinebreak),
+              let endOfElseBody = endOfScope(at: startOfElseBody),
+              let firstTokenInElseBody = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfElseBody),
+              let elseExpressionRange = parseExpressionRange(startingAt: firstTokenInElseBody),
+              index(of: .nonSpaceOrCommentOrLinebreak, after: elseExpressionRange.upperBound) == endOfElseBody,
+              tokens[(startOfElseBody + 1) ..< firstTokenInElseBody].allSatisfy(\.isSpaceOrLinebreak),
+              tokens[(elseExpressionRange.upperBound + 1) ..< endOfElseBody].allSatisfy(\.isSpaceOrLinebreak),
+              expressionIsEmptyView(in: elseExpressionRange)
+        else {
+            return nil
+        }
+
+        return (previousTokenIndex + 1) ... endOfElseBody
+    }
+
+    func expressionIsEmptyView(in expressionRange: ClosedRange<Int>) -> Bool {
+        var emptyViewIdentifierIndex = expressionRange.lowerBound
+
+        if tokens[emptyViewIdentifierIndex] == .identifier("SwiftUI") {
+            guard let dotIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: emptyViewIdentifierIndex),
+                  tokens[dotIndex] == .operator(".", .infix),
+                  let nextIdentifierIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                  tokens[nextIdentifierIndex] == .identifier("EmptyView")
+            else {
+                return false
+            }
+            emptyViewIdentifierIndex = nextIdentifierIndex
+        }
+
+        guard tokens[emptyViewIdentifierIndex] == .identifier("EmptyView"),
+              let startOfArguments = index(of: .nonSpaceOrCommentOrLinebreak, after: emptyViewIdentifierIndex),
+              tokens[startOfArguments] == .startOfScope("("),
+              let endOfArguments = endOfScope(at: startOfArguments),
+              endOfArguments == expressionRange.upperBound,
+              tokens[(emptyViewIdentifierIndex + 1) ..< startOfArguments].allSatisfy(\.isSpaceOrLinebreak),
+              tokens[(startOfArguments + 1) ..< endOfArguments].allSatisfy(\.isSpaceOrLinebreak)
+        else {
+            return false
+        }
+
+        return true
+    }
+}

--- a/Tests/Rules/RedundantEmptyViewTests.swift
+++ b/Tests/Rules/RedundantEmptyViewTests.swift
@@ -187,6 +187,30 @@ final class RedundantEmptyViewTests: XCTestCase {
         testFormatting(for: input, output, rule: .redundantEmptyView)
     }
 
+    func testRemoveFullyQualifiedSwiftUIEmptyView() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                } else {
+                    SwiftUI.EmptyView()
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
     func testDoNotRemoveElseWithModifiedEmptyView() {
         let input = """
         struct ContentView: View {

--- a/Tests/Rules/RedundantEmptyViewTests.swift
+++ b/Tests/Rules/RedundantEmptyViewTests.swift
@@ -121,6 +121,72 @@ final class RedundantEmptyViewTests: XCTestCase {
         testFormatting(for: input, rule: .redundantEmptyView)
     }
 
+    func testRemoveRedundantEmptyViewElseInIfElseIfElseChain() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                ForEach(items, id: \\.self) { item in
+                    if item.type == .primary {
+                        PrimaryView(item: item)
+                    } else if item.type == .secondary {
+                        SecondaryView(item: item)
+                    } else {
+                        EmptyView()
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            var body: some View {
+                ForEach(items, id: \\.self) { item in
+                    if item.type == .primary {
+                        PrimaryView(item: item)
+                    } else if item.type == .secondary {
+                        SecondaryView(item: item)
+                    }
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
+    func testRemoveOnlyInnerRedundantEmptyViewElseInNestedIf() {
+        let input = """
+        struct ContentView: View {
+            @ViewBuilder
+            func visibleSection(fieldID: String?, makeSection: () -> some View) -> some View {
+                if let fieldID {
+                    if isVisible(fieldID) {
+                        makeSection()
+                    } else {
+                        EmptyView()
+                    }
+                } else {
+                    makeSection()
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            @ViewBuilder
+            func visibleSection(fieldID: String?, makeSection: () -> some View) -> some View {
+                if let fieldID {
+                    if isVisible(fieldID) {
+                        makeSection()
+                    }
+                } else {
+                    makeSection()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
     func testDoNotRemoveElseWithModifiedEmptyView() {
         let input = """
         struct ContentView: View {

--- a/Tests/Rules/RedundantEmptyViewTests.swift
+++ b/Tests/Rules/RedundantEmptyViewTests.swift
@@ -1,0 +1,139 @@
+//
+//  RedundantEmptyViewTests.swift
+//  SwiftFormatTests
+//
+//  Created by Manuel Lopez on 2026-03-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class RedundantEmptyViewTests: XCTestCase {
+    func testRemoveRedundantEmptyViewElseInViewBody() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                } else {
+                    EmptyView()
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
+    func testRemoveInlineRedundantEmptyViewElseInViewBuilderProperty() {
+        let input = """
+        struct ContentView: View {
+            @ViewBuilder
+            var description: some View {
+                if condition {
+                    Text("Hello")
+                } else { 
+                    EmptyView() 
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            @ViewBuilder
+            var description: some View {
+                if condition {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
+    func testRemoveRedundantEmptyViewElseInNestedResultBuilder() {
+        let input = """
+        struct ContentView: View {
+            let items: [Bool]
+
+            var body: some View {
+                ForEach(items.indices, id: \\.self) { index in
+                    if items[index] {
+                        Text("\\(index)")
+                    } else {
+                        EmptyView()
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            let items: [Bool]
+
+            var body: some View {
+                ForEach(items.indices, id: \\.self) { index in
+                    if items[index] {
+                        Text("\\(index)")
+                    }
+                }
+            }
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantEmptyView)
+    }
+
+    func testDoNotRemoveRedundantEmptyViewElseOutsideResultBuilder() {
+        let input = """
+        func render(condition: Bool) {
+            if condition {
+                print("Hello")
+            } else {
+                EmptyView()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantEmptyView)
+    }
+
+    func testDoNotRemoveElseContainingComment() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                } else {
+                    // Keep this branch for documentation
+                    EmptyView()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantEmptyView)
+    }
+
+    func testDoNotRemoveElseWithModifiedEmptyView() {
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                if condition {
+                    Text("Hello")
+                } else {
+                    EmptyView()
+                        .hidden()
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantEmptyView)
+    }
+}

--- a/Tests/Rules/RedundantNilInitTests.swift
+++ b/Tests/Rules/RedundantNilInitTests.swift
@@ -213,8 +213,18 @@ final class RedundantNilInitTests: XCTestCase {
             }
         }
         """
+        let output = """
+        struct TestView: View {
+            var body: some View {
+                if true {
+                    var foo: String? = nil
+                    Text(foo ?? "")
+                }
+            }
+        }
+        """
         let options = FormatOptions(nilInit: .remove)
-        testFormatting(for: input, rule: .redundantNilInit,
+        testFormatting(for: input, [input, output], rules: [.redundantNilInit],
                        options: options)
     }
 
@@ -514,8 +524,18 @@ final class RedundantNilInitTests: XCTestCase {
             }
         }
         """
+        let output = """
+        struct TestView: View {
+            var body: some View {
+                if true {
+                    var foo: String?
+                    Text(foo ?? "")
+                }
+            }
+        }
+        """
         let options = FormatOptions(nilInit: .insert)
-        testFormatting(for: input, rule: .redundantNilInit,
+        testFormatting(for: input, [input, output], rules: [.redundantNilInit],
                        options: options)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->

Adds a new redundantEmptyView formatting rule that removes redundant `else { EmptyView() }` branches in SwiftUI view builders.

In SwiftUI view builders, an if statement without an else branch implicitly produces no content when the condition is false, making an explicit `else { EmptyView() }` unnecessary.

```diff
var body: some View {
    if condition {
        Text("Hello")
-     } else {
-         EmptyView()
    }
}
```