### PR TITLE
Replace objc string methods with swift equivalents #2292

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -46,6 +46,7 @@
 * [preferCountWhere](#preferCountWhere)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
+* [preferSwiftStringAPI](#preferSwiftStringAPI)
 * [redundantAsync](#redundantAsync)
 * [redundantBackticks](#redundantBackticks)
 * [redundantBreak](#redundantBreak)
@@ -2116,6 +2117,21 @@ Convert trivial `map { $0.foo }` closures to keyPath-based syntax.
 
 - let barArray = fooArray.compactMap { $0.optionalBar }
 + let barArray = fooArray.compactMap(\.optionalBar)
+```
+
+</details>
+<br/>
+
+## preferSwiftStringAPI
+
+Replace Objective-C bridged String methods with Swift equivalents.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- str.replacingOccurrences(of: "foo", with: "bar")
++ str.replacing("foo", with: "bar")
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -66,6 +66,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferFinalClasses": .preferFinalClasses,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
+    "preferSwiftStringAPI": .preferSwiftStringAPI,
     "preferSwiftTesting": .preferSwiftTesting,
     "privateStateVariables": .privateStateVariables,
     "propertyTypes": .propertyTypes,

--- a/Sources/Rules/PreferSwiftStringAPI.swift
+++ b/Sources/Rules/PreferSwiftStringAPI.swift
@@ -1,0 +1,54 @@
+//
+//  PreferSwiftStringAPI.swift
+//  SwiftFormat
+//
+//  Created by Sutheesh Sukumaran on 05/04/2026.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Replace Objective-C bridged String methods with their Swift equivalents
+    static let preferSwiftStringAPI = FormatRule(
+        help: "Replace Objective-C bridged String methods with Swift equivalents."
+    ) { formatter in
+        // replacing(_:with:) was introduced in Swift 5.7
+        guard formatter.options.swiftVersion >= "5.7" else { return }
+
+        formatter.forEach(.identifier("replacingOccurrences")) { i, _ in
+            // Must be a method call (preceded by a dot)
+            guard let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i),
+                  formatter.tokens[prevIndex] == .operator(".", .infix)
+            else { return }
+
+            // Must be followed immediately by a `(` argument list
+            guard let openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i),
+                  formatter.tokens[openParenIndex] == .startOfScope("(")
+            else { return }
+
+            // Only transform the two-argument form: `replacingOccurrences(of:with:)`
+            let args = formatter.parseFunctionCallArguments(startOfScope: openParenIndex)
+            guard args.count == 2,
+                  args[0].label == "of",
+                  args[1].label == "with",
+                  let ofLabelIndex = args[0].labelIndex
+            else { return }
+
+            // Remove the `of:` label and any whitespace up to the value.
+            // Since ofLabelIndex > i, this does not invalidate index i.
+            let valueStart = args[0].valueRange.lowerBound
+            formatter.removeTokens(in: ofLabelIndex ..< valueStart)
+
+            // Rename `replacingOccurrences` → `replacing`
+            formatter.replaceToken(at: i, with: .identifier("replacing"))
+        }
+    } examples: {
+        """
+        ```diff
+        - str.replacingOccurrences(of: "foo", with: "bar")
+        + str.replacing("foo", with: "bar")
+        ```
+        """
+    }
+}

--- a/Tests/Rules/PreferSwiftStringAPITests.swift
+++ b/Tests/Rules/PreferSwiftStringAPITests.swift
@@ -1,0 +1,102 @@
+//
+//  PreferSwiftStringAPITests.swift
+//  SwiftFormatTests
+//
+//  Created by Sutheesh Sukumaran on 05/04/2026.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferSwiftStringAPITests: XCTestCase {
+    func testReplacingOccurrences() {
+        let input = """
+        str.replacingOccurrences(of: "foo", with: "bar")
+        """
+
+        let output = """
+        str.replacing("foo", with: "bar")
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesOnOptionalChain() {
+        let input = """
+        str?.replacingOccurrences(of: "foo", with: "bar")
+        """
+
+        let output = """
+        str?.replacing("foo", with: "bar")
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesMultiline() {
+        let input = """
+        str.replacingOccurrences(
+            of: "foo",
+            with: "bar"
+        )
+        """
+
+        let output = """
+        str.replacing(
+            "foo",
+            with: "bar"
+        )
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesNotTransformedBeforeSwift5_7() {
+        let input = """
+        str.replacingOccurrences(of: "foo", with: "bar")
+        """
+
+        let options = FormatOptions(swiftVersion: "5.6")
+        testFormatting(for: input, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesWithOptionsNotTransformed() {
+        let input = """
+        str.replacingOccurrences(of: "foo", with: "bar", options: [.caseInsensitive])
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesWithRangeNotTransformed() {
+        let input = """
+        str.replacingOccurrences(of: "foo", with: "bar", options: [], range: str.startIndex...)
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .preferSwiftStringAPI, options: options)
+    }
+
+    func testReplacingOccurrencesNotTransformedWhenNoVersionSet() {
+        let input = """
+        str.replacingOccurrences(of: "foo", with: "bar")
+        """
+
+        testFormatting(for: input, rule: .preferSwiftStringAPI)
+    }
+
+    func testFreestandingReplacingOccurrencesNotTransformed() {
+        let input = """
+        replacingOccurrences(of: "foo", with: "bar")
+        """
+
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .preferSwiftStringAPI, options: options)
+    }
+}


### PR DESCRIPTION
Add preferSwiftStringAPI rule (#2292)

Replaces the Objective-C bridged `replacingOccurrences(of:with:)` with Swift-native `replacing(_:with:)`. The ObjC method has known Unicode bugs (e.g. corrupting emoji flag sequences); the Swift equivalent is safer, shorter, and available from Swift 5.7+.

Only the two-argument form is transformed — calls with `options:` or `range:` are left unchanged as they have no direct Swift equivalent.

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [ ] The base branch of the pull request is `develop`
- [ ] Any code changes include corresponding test cases
-->