### PR TITLE
Fix conditional import parsing with access modifiers

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2496,8 +2496,10 @@ extension Formatter {
                 }
                 let nextToken = tokens[nextTokenIndex]
                 let isImportKeyword = nextToken == .keyword("import")
-                // Access modifier (e.g. "public") can precede "import" on the same line (Swift 6)
-                let isAccessModifierBeforeImport = nextToken.isKeyword && _FormatRules.aclModifiers.contains(nextToken.string)
+                // Access modifiers only continue the import block when they are immediately followed by import.
+                let isAccessModifierBeforeImport = nextToken.isKeyword &&
+                    _FormatRules.aclModifiers.contains(nextToken.string) &&
+                    next(.nonSpaceOrComment, after: nextTokenIndex) == .keyword("import")
                 if !isImportKeyword, !isAccessModifierBeforeImport {
                     // End of imports
                     pushStack()

--- a/Tests/Rules/SortImportsTests.swift
+++ b/Tests/Rules/SortImportsTests.swift
@@ -409,6 +409,20 @@ final class SortImportsTests: XCTestCase {
         testFormatting(for: input, output, rule: .sortImports)
     }
 
+    func testNoMangleConditionalImportsFollowedByPrivateDeclaration() {
+        let input = """
+        #if canImport(UIKit)
+        import UIKit
+        private struct Foo {}
+        #elseif canImport(AppKit)
+        import AppKit
+        private struct Foo {}
+        #endif
+        """
+        let options = FormatOptions(swiftVersion: "6.1")
+        testFormatting(for: input, rule: .sortImports, options: options, exclude: [.blankLineAfterImports, .indent])
+    }
+
     func testNoMoveSwiftToolsVersionLine() {
         let input = """
         // swift-tools-version: 6.2


### PR DESCRIPTION
Prevent `sortImports` from treating access-controlled declarations after an import as Swift 6 access-controlled imports. This keeps `#if` / `#elseif` import blocks intact when a branch-local declaration follows the import.

Could result in a change like this:
```diff
#if canImport(UIKit)
-import UIKit
-private struct Foo {}
-#elseif canImport(AppKit)
import AppKit
+import UIKit
private struct Foo {}
#endif
```

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->