### PR TITLE
fix: preserve == for types with Any.Type stored properties

### DIFF
--- a/Sources/Rules/RedundantEquatable.swift
+++ b/Sources/Rules/RedundantEquatable.swift
@@ -314,7 +314,7 @@ extension Formatter {
 extension TypeName {
     /// Whether or not this type name is known to be non-Equatable
     var isKnownNonEquatableType: Bool {
-        let knownNonEquatableTypes = ["AnyClass"]
+        let knownNonEquatableTypes = ["AnyClass", "Any.Type"]
         return knownNonEquatableTypes.contains(string) || isTuple
     }
 }

--- a/Tests/Rules/RedundantEquatableTests.swift
+++ b/Tests/Rules/RedundantEquatableTests.swift
@@ -575,6 +575,21 @@ final class RedundantEquatableTests: XCTestCase {
         testFormatting(for: input, [output], rules: [.redundantEquatable, .emptyBraces, .wrapAttributes, .emptyExtensions, .consecutiveBlankLines], options: options)
     }
 
+    func testPreserveCustomEquatableImplementationComparingAnyType() {
+        // `Any.Type` defines an `==` operator but is not Equatable.
+        let input = """
+        struct Foo: Equatable {
+            let ty: Any.Type
+
+            static func == (lhs: Foo, rhs: Foo) -> Bool {
+                lhs.ty == rhs.ty
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .redundantEquatable)
+    }
+
     func testPreserveCustomEquatableImplementationComparingAnyClass() {
         // `AnyClass` defines an `==` operator but is not Equatable.
         let input = """


### PR DESCRIPTION
Fixes #2502

This PR was created autonomously by the RedOS coding factory (ENG agent). Part of our daily OSS contribution program targeting Java AI projects.

## Summary

The `redundantEquatable` rule was incorrectly removing manually implemented `==` operators from structs containing `Any.Type` stored properties. Since `Any.Type` is not `Equatable`, the compiler cannot synthesize an `==` for such types — the manual implementation must be preserved.

## Changes

- Added `"Any.Type"` to the `knownNonEquatableTypes` list in `TypeName.isKnownNonEquatableType`, mirroring the existing handling of `AnyClass`
- Added a test case `testPreserveCustomEquatableImplementationComparingAnyType` that reproduces the exact scenario from issue #2502