### PR TITLE
Fix unsafe keyword dot-spacing edge case (#2472)

### DIFF
--- a/Sources/Rules/SpaceAroundOperators.swift
+++ b/Sources/Rules/SpaceAroundOperators.swift
@@ -63,7 +63,7 @@ public extension FormatRule {
                 switch formatter.tokens[prevIndex] {
                 case .operator(_, .infix), .startOfScope:
                     return
-                case let token where [.keyword("unsafe"), .identifier("unsafe")].contains(token):
+                case let token where [.identifier("unsafe")].contains(token):
                     return // `unsafe` is contextual, so leave existing spacing unchanged.
                 case let token where token.isUnwrapOperator:
                     if let prevToken = formatter.last(.nonSpace, before: prevIndex),

--- a/Sources/Rules/SpaceAroundOperators.swift
+++ b/Sources/Rules/SpaceAroundOperators.swift
@@ -63,6 +63,8 @@ public extension FormatRule {
                 switch formatter.tokens[prevIndex] {
                 case .operator(_, .infix), .startOfScope:
                     return
+                case let token where [.keyword("unsafe"), .identifier("unsafe")].contains(token):
+                    return // `unsafe` is contextual, so leave existing spacing unchanged.
                 case let token where token.isUnwrapOperator:
                     if let prevToken = formatter.last(.nonSpace, before: prevIndex),
                        [.keyword("as"), .keyword("try")].contains(prevToken)

--- a/Tests/Rules/SpaceAroundOperatorsTests.swift
+++ b/Tests/Rules/SpaceAroundOperatorsTests.swift
@@ -54,6 +54,20 @@ final class SpaceAroundOperatorsTests: XCTestCase {
         testFormatting(for: input, rule: .spaceAroundOperators)
     }
 
+    func testSpacePreservedBetweenUnsafeAndDot() {
+        let input = """
+        unsafe .foo
+        """
+        testFormatting(for: input, rule: .spaceAroundOperators)
+    }
+
+    func testNoSpaceAddedBetweenUnsafeAndDot() {
+        let input = """
+        unsafe.foo
+        """
+        testFormatting(for: input, rule: .spaceAroundOperators)
+    }
+
     func testSpaceBetweenOptionalAndDefaultValueInFunction() {
         let input = """
         func foo(bar _: String?=nil) {}


### PR DESCRIPTION
Fix spacing changes around `unsafe` before dot (#2472)

## Summary
- Fixes a `spaceAroundOperators` edge case where `unsafe .member` could be rewritten to `unsafe.member`.
- Treats `unsafe` as contextual in this position and leaves existing spacing unchanged to avoid changing code meaning.
- Adds regression tests for both forms (`unsafe .foo` and `unsafe.foo`).

## Why this approach
`unsafe` is contextual in modern Swift memory-safety features, but can still appear as an identifier in other contexts.
A formatter that always inserts/removes spacing around `unsafe.` risks changing semantics.
The safest minimal fix for this rule is to preserve user-written spacing when `.` follows `unsafe`, rather than normalize it.