### PR TITLE
Update dependabot PRs to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    target-branch: "develop"


### PR DESCRIPTION
This PR updates @dependabot PRs to target the `develop` branch instead of `main`.