### PR TITLE
Fix race condition when parsing config files

### DIFF
--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -346,10 +346,22 @@ func gatherOptions(_ options: inout Options, for inputURL: URL, with logger: Log
 private var configCache = [URL: [[String: String]]]()
 private let configQueue = DispatchQueue(label: "swiftformat.config", qos: .userInteractive)
 private func processDirectory(_ inputURL: URL, with options: inout Options, logger: Logger?) throws {
-    if let args = configQueue.sync(execute: { configCache[inputURL] }) {
-        try options.addArguments(args, in: inputURL.path)
-        return
+    let inputURL = inputURL.standardizedFileURL
+    let args = try configQueue.sync { () throws -> [[String: String]] in
+        if let args = configCache[inputURL] {
+            return args
+        }
+
+        let args = try parseConfigArguments(in: inputURL, options: options, logger: logger)
+        configCache[inputURL] = args
+        return args
     }
+
+    assert(options.formatOptions != nil)
+    try options.addArguments(args, in: inputURL.path)
+}
+
+private func parseConfigArguments(in inputURL: URL, options: Options, logger: Logger?) throws -> [[String: String]] {
     var args = [[String: String]]()
     let manager = FileManager.default
     let configFile = inputURL.appendingPathComponent(swiftFormatConfigurationFile)
@@ -394,11 +406,7 @@ private func processDirectory(_ inputURL: URL, with options: inout Options, logg
             }
         }
     }
-    configQueue.async {
-        configCache[inputURL] = args
-    }
-    assert(options.formatOptions != nil)
-    try options.addArguments(args, in: inputURL.standardizedFileURL.path)
+    return args
 }
 
 /// Line and column offset in source

--- a/Tests/CommandLineTests.swift
+++ b/Tests/CommandLineTests.swift
@@ -646,6 +646,39 @@ final class CommandLineTests: XCTestCase {
         }
     }
 
+    func testConfigFileIsReadOnceWhenGatheringOptionsConcurrently() throws {
+        try withTmpFiles([
+            ".swiftformat": """
+            --rules indent
+            """,
+            "File.swift": """
+            let value = 0
+            """,
+        ]) { url in
+            guard url.pathExtension == "swift" else { return }
+
+            let configFile = url.deletingLastPathComponent().appendingPathComponent(".swiftformat")
+            var logMessages = [String]()
+            var errors = [Error]()
+            let logQueue = DispatchQueue(label: "swiftformat.test.config-log")
+
+            DispatchQueue.concurrentPerform(iterations: 50) { _ in
+                var options = Options.default
+                do {
+                    try gatherOptions(&options, for: url, with: { message in
+                        logQueue.sync { logMessages.append(message) }
+                    })
+                } catch {
+                    logQueue.sync { errors.append(error) }
+                }
+            }
+
+            let messages = logMessages.filter { $0 == "Reading config file at \(configFile.path)" }
+            XCTAssertEqual(messages.count, 1, "\(messages)")
+            XCTAssertTrue(errors.isEmpty, "\(errors)")
+        }
+    }
+
     func testLintCommandOutputsOrganizeDeclarationOrderingViolations() {
         var output: [String] = []
         CLI.print = { message, _ in


### PR DESCRIPTION
https://github.com/nicklockwood/SwiftFormat/commit/afe7956293afa49a3fa15d6b9f80bf5431b163e4 introduced additional concurrency that lead to configuration files being parsed potentially multiple times.

This is especially visible when manually passing a list of files to `swiftformat`. It then logs `Reading config file at <path>` several times.

This pull request fixes that by moving parsing to the config queue.

The added unit test doesn't pass before this change and passes after.