### PR TITLE
Add `redundantStateInit` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -70,6 +70,7 @@
 * [redundantReturn](#redundantReturn)
 * [redundantSelf](#redundantSelf)
 * [redundantSendable](#redundantSendable)
+* [redundantStateInit](#redundantStateInit)
 * [redundantStaticSelf](#redundantStaticSelf)
 * [redundantSwiftTestingSuite](#redundantSwiftTestingSuite)
 * [redundantThrows](#redundantThrows)
@@ -3026,6 +3027,30 @@ Remove redundant explicit Sendable conformance from non-public structs and enums
 + fileprivate enum ParsingState {
       case idle
       case running
+  }
+```
+
+</details>
+<br/>
+
+## redundantStateInit
+
+Remove explicit initialization of SwiftUI property wrapper storage that can be assigned directly.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  struct ContentView: View {
+      @State private var foo: String
+      @ObservedObject private var bar: MyObservableObject
+
+      init() {
+-         _foo = State(wrappedValue: "foo")
++         foo = "foo"
+-         _bar = .init(wrappedValue: MyObservableObject())
++         bar = MyObservableObject()
+      }
   }
 ```
 

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -95,6 +95,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantReturn": .redundantReturn,
     "redundantSelf": .redundantSelf,
     "redundantSendable": .redundantSendable,
+    "redundantStateInit": .redundantStateInit,
     "redundantStaticSelf": .redundantStaticSelf,
     "redundantSwiftTestingSuite": .redundantSwiftTestingSuite,
     "redundantThrows": .redundantThrows,

--- a/Sources/Rules/RedundantSelf.swift
+++ b/Sources/Rules/RedundantSelf.swift
@@ -12,6 +12,7 @@ public extension FormatRule {
     /// Insert or remove redundant self keyword
     static let redundantSelf = FormatRule(
         help: "Insert/remove explicit `self` where applicable.",
+        orderAfter: [.redundantStateInit],
         options: ["self", "self-required"]
     ) { formatter in
         _ = formatter.options.selfRequired

--- a/Sources/Rules/RedundantStateInit.swift
+++ b/Sources/Rules/RedundantStateInit.swift
@@ -1,0 +1,140 @@
+//
+//  RedundantStateInit.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 2026-06-04.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Removes redundant explicit initialization of SwiftUI property wrapper storage,
+    /// e.g. `_foo = State(wrappedValue: x)` in favor of `foo = x`.
+    static let redundantStateInit = FormatRule(
+        help: "Remove explicit initialization of SwiftUI property wrapper storage that can be assigned directly."
+    ) { formatter in
+        formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
+            guard let typeDeclaration = declaration.asTypeDeclaration else { return }
+
+            // The property wrappers whose backing storage can instead be assigned directly.
+            // `@StateObject` is intentionally excluded: its wrapped value can't be assigned
+            // directly, so `_bar = StateObject(wrappedValue:)` is required.
+            let directlyAssignableProperties = formatter.directlyAssignablePropertyWrapperNames(in: typeDeclaration.body)
+            guard !directlyAssignableProperties.isEmpty else { return }
+
+            for initDeclaration in typeDeclaration.body where initDeclaration.keyword == "init" {
+                guard let bodyRange = formatter.parseFunctionDeclaration(keywordIndex: initDeclaration.keywordIndex)?.bodyRange
+                else { continue }
+
+                // Process the top-level assignments in the init body from back to front so that
+                // the indices of earlier statements remain valid as we rewrite later ones.
+                var searchEnd = bodyRange.upperBound
+                while let assignmentIndex = formatter.lastIndex(in: (bodyRange.lowerBound + 1) ..< searchEnd, where: {
+                    $0.isOperator("=", .infix)
+                }) {
+                    // The left-hand side must be a bare `_property` identifier at the start of a statement.
+                    guard let lhsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: assignmentIndex),
+                          case let .identifier(lhsName) = formatter.tokens[lhsIndex],
+                          lhsName.hasPrefix("_"), lhsName.count > 1,
+                          let beforeLhsIndex = formatter.index(of: .nonSpaceOrComment, before: lhsIndex),
+                          formatter.tokens[beforeLhsIndex].isLinebreak
+                          || formatter.tokens[beforeLhsIndex] == .startOfScope("{")
+                          || formatter.tokens[beforeLhsIndex] == .delimiter(";"),
+                          directlyAssignableProperties.contains(String(lhsName.dropFirst())),
+                          let rhsStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: assignmentIndex)
+                    else {
+                        searchEnd = assignmentIndex
+                        continue
+                    }
+
+                    // The right-hand side must be either an implicit `.init(...)` or an explicit
+                    // `State(...)` / `ObservedObject(...)` (optionally module-qualified or generic) call.
+                    var openParenIndex: Int?
+                    if formatter.tokens[rhsStartIndex].isOperator(".") {
+                        if let initIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: rhsStartIndex, if: { $0 == .identifier("init") }) {
+                            openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: initIndex, if: { $0 == .startOfScope("(") })
+                        }
+                    } else if let type = formatter.parseType(at: rhsStartIndex),
+                              let baseName = type.string.components(separatedBy: ".").last?.components(separatedBy: "<").first,
+                              baseName == "State" || baseName == "ObservedObject"
+                    {
+                        openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: type.range.upperBound, if: { $0 == .startOfScope("(") })
+                    }
+
+                    guard let openParenIndex,
+                          let closeParenIndex = formatter.endOfScope(at: openParenIndex)
+                    else {
+                        searchEnd = assignmentIndex
+                        continue
+                    }
+
+                    // The call must have exactly one argument labeled `initialValue:` or `wrappedValue:`.
+                    let arguments = formatter.parseFunctionCallArguments(startOfScope: openParenIndex)
+                    guard let argument = arguments.first, arguments.count == 1,
+                          argument.label == "initialValue" || argument.label == "wrappedValue"
+                    else {
+                        searchEnd = assignmentIndex
+                        continue
+                    }
+
+                    // Replace the wrapper initialization with the wrapped value, and insert an explicit
+                    // `self.` so the assignment refers to the property rather than an argument or local
+                    // that shadows its name (e.g. `init(foo:) { _foo = ... }`). The `redundantSelf` rule
+                    // runs afterwards and removes the `self.` where unnecessary.
+                    formatter.replaceTokens(in: rhsStartIndex ... closeParenIndex, with: Array(formatter.tokens[argument.valueRange]))
+                    formatter.replaceToken(at: lhsIndex, with: [
+                        .identifier("self"), .operator(".", .infix), .identifier(String(lhsName.dropFirst())),
+                    ])
+
+                    searchEnd = lhsIndex
+                }
+            }
+        }
+    } examples: {
+        """
+        ```diff
+          struct ContentView: View {
+              @State private var foo: String
+              @ObservedObject private var bar: MyObservableObject
+
+              init() {
+        -         _foo = State(wrappedValue: "foo")
+        +         foo = "foo"
+        -         _bar = .init(wrappedValue: MyObservableObject())
+        +         bar = MyObservableObject()
+              }
+          }
+        ```
+        """
+    }
+}
+
+extension Formatter {
+    /// The names of properties in the given declarations using a property wrapper whose
+    /// backing storage can be assigned directly (`@State` or `@ObservedObject`).
+    /// Recurses into conditional compilation blocks but not into nested types.
+    func directlyAssignablePropertyWrapperNames(in declarations: [Declaration]) -> Set<String> {
+        var names = Set<String>()
+        for member in declarations {
+            // Don't look at properties of nested types
+            if member.asTypeDeclaration != nil {
+                continue
+            }
+
+            // Recurse into conditional compilation blocks (`#if ... #endif`)
+            if let body = member.body {
+                names.formUnion(directlyAssignablePropertyWrapperNames(in: body))
+                continue
+            }
+
+            guard member.keyword == "var" || member.keyword == "let",
+                  let property = member.parsePropertyDeclaration(),
+                  member.attributes.contains("@State") || member.attributes.contains("@ObservedObject")
+            else { continue }
+
+            names.insert(property.identifier)
+        }
+        return names
+    }
+}

--- a/Tests/Rules/RedundantStateInitTests.swift
+++ b/Tests/Rules/RedundantStateInitTests.swift
@@ -1,0 +1,264 @@
+//
+//  RedundantStateInitTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 2026-06-04.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class RedundantStateInitTests: XCTestCase {
+    func testRemovesRedundantStateInit() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = .init(initialValue: "foo")
+                _foo = .init(wrappedValue: "foo")
+                _baaz = .init(initialValue: MyObservableObject())
+                _baaz = .init(wrappedValue: MyObservableObject())
+
+                _foo = State(initialValue: "foo")
+                _foo = State(wrappedValue: "foo")
+                _baaz = ObservedObject(initialValue: MyObservableObject())
+                _baaz = ObservedObject(wrappedValue: MyObservableObject())
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+            @ObservedObject private var baaz: MyObservableObject
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init() {
+                foo = "foo"
+                foo = "foo"
+                baaz = MyObservableObject()
+                baaz = MyObservableObject()
+
+                foo = "foo"
+                foo = "foo"
+                baaz = MyObservableObject()
+                baaz = MyObservableObject()
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+            @ObservedObject private var baaz: MyObservableObject
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testInsertsSelfWhenAssignmentWouldBeShadowed() {
+        let input = """
+        struct MyView: View {
+            init(foo: String) {
+                _foo = State(wrappedValue: foo)
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init(foo: String) {
+                self.foo = foo
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testPreservesStateObjectInit() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _bar = .init(wrappedValue: MyObservableObject())
+                _bar = StateObject(wrappedValue: MyObservableObject())
+            }
+
+            var body: some View {}
+
+            @StateObject private var bar: MyObservableObject
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+
+    func testPreservesDirectAssignments() {
+        let input = """
+        struct MyView: View {
+            init() {
+                foo = "foo"
+                baaz = MyObservableObject()
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+            @ObservedObject private var baaz: MyObservableObject
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+
+    func testPreservesModuleQualifiedState() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = SwiftUI.State(wrappedValue: "foo")
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init() {
+                foo = "foo"
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testRemovesGenericStateInit() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = State<String>(initialValue: "foo")
+                _foo = State<String>(wrappedValue: "foo")
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init() {
+                foo = "foo"
+                foo = "foo"
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testPreservesUnrelatedWrapperInit() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = Binding(get: { "foo" }, set: { _ in })
+            }
+
+            var body: some View {}
+
+            @Binding private var foo: String
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+
+    func testPreservesWhenPropertyHasNoMatchingWrapper() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = State(wrappedValue: "foo")
+            }
+
+            var body: some View {}
+
+            private var foo: String = ""
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+
+    func testRewritesComplexWrappedValue() {
+        let input = """
+        struct MyView: View {
+            init(model: Model) {
+                _foo = State(wrappedValue: model.makeValue(with: 1, 2, 3))
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init(model: Model) {
+                foo = model.makeValue(with: 1, 2, 3)
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testRemovesCommentOutsideValueWhenRewriting() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = State( /* discarded */ wrappedValue: "foo")
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        let output = """
+        struct MyView: View {
+            init() {
+                foo = "foo"
+            }
+
+            var body: some View {}
+
+            @State private var foo: String
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
+    }
+
+    func testDoesntRewriteRegularBackingPropertyAssignment() {
+        let input = """
+        struct Foo {
+            init() {
+                _foo = State(wrappedValue: "foo")
+            }
+
+            var _foo: String
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+}

--- a/Tests/Rules/UnusedPrivateDeclarationsTests.swift
+++ b/Tests/Rules/UnusedPrivateDeclarationsTests.swift
@@ -253,7 +253,7 @@ final class UnusedPrivateDeclarationsTests: XCTestCase {
             @State private var showButton: Bool
         }
         """
-        testFormatting(for: input, rule: .unusedPrivateDeclarations, exclude: [.privateStateVariables])
+        testFormatting(for: input, rule: .unusedPrivateDeclarations, exclude: [.privateStateVariables, .redundantStateInit])
     }
 
     func testDoesNotRemoveUnderscoredDeclarationIfUsed() {


### PR DESCRIPTION
This PR adds a new `redundantStateInit` rule: 

```diff
  struct ContentView: View {
      @State private var foo: String
      @ObservedObject private var bar: MyObservableObject

      init() {
-         _foo = State(wrappedValue: "foo")
+         foo = "foo"
-         _bar = .init(wrappedValue: MyObservableObject())
+         bar = MyObservableObject()
      }
  }
```