### PR TITLE
Add `redundantSwiftUIGroup` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -73,6 +73,7 @@
 * [redundantStateInit](#redundantStateInit)
 * [redundantStaticSelf](#redundantStaticSelf)
 * [redundantSwiftTestingSuite](#redundantSwiftTestingSuite)
+* [redundantSwiftUIGroup](#redundantSwiftUIGroup)
 * [redundantThrows](#redundantThrows)
 * [redundantType](#redundantType)
 * [redundantTypedThrows](#redundantTypedThrows)
@@ -3108,6 +3109,39 @@ Remove redundant @Suite attribute with no arguments.
       @Test func feature() {
           #expect(true)
       }
+  }
+```
+
+</details>
+<br/>
+
+## redundantSwiftUIGroup
+
+Remove redundant SwiftUI Group wrapper views in favor of @ViewBuilder.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+  struct MyView: View {
+    var body: some View {
+-     Group {
+        Text("foo")
+        Text("bar")
+-     }
+    }
+  }
+```
+
+```diff
+  struct MyView: View {
++   @ViewBuilder
+    var content: some View {
+-     Group {
+        Text("foo")
+        Text("bar")
+-     }
+    }
   }
 ```
 

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2280,6 +2280,47 @@ extension Formatter {
         return index(of: .nonSpaceOrCommentOrLinebreak, after: expressionRange.upperBound) == endOfScopeIndex
     }
 
+    /// Whether the body is a single expression that is not a conditional (if/switch).
+    /// Conditional expressions need @ViewBuilder when branches return different types.
+    func scopeBodyIsSingleNonConditionalExpression(at startOfScopeIndex: Int) -> Bool {
+        guard let firstTokenInBody = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfScopeIndex),
+              tokens[firstTokenInBody] != .keyword("if"),
+              tokens[firstTokenInBody] != .keyword("switch")
+        else { return false }
+        return scopeBodyIsSingleExpression(at: startOfScopeIndex)
+    }
+
+    /// Whether the given type conforms to View
+    func isViewType(_ type: TypeDeclaration?) -> Bool {
+        guard let type else { return false }
+        return type.conformances.contains { conformance in
+            conformance.conformance.string == "View"
+        }
+    }
+
+    /// Whether the given type conforms to ViewModifier
+    func isViewModifierType(_ type: TypeDeclaration?) -> Bool {
+        guard let type else { return false }
+        return type.conformances.contains { conformance in
+            conformance.conformance.string == "ViewModifier"
+        }
+    }
+
+    /// Finds the index of a @ViewBuilder attribute for the given declaration, if present
+    func indexOfViewBuilderAttribute(for declaration: Declaration) -> Int? {
+        let startOfModifiers = declaration.startOfModifiersIndex(includingAttributes: true)
+        let keywordIndex = declaration.keywordIndex
+
+        var index = startOfModifiers
+        while index < keywordIndex {
+            if tokens[index].string == "@ViewBuilder" {
+                return index
+            }
+            index += 1
+        }
+        return nil
+    }
+
     /// Whether or not the comment starting at the given index is a doc comment
     func isDocComment(startOfComment: Int) -> Bool {
         let commentToken = tokens[startOfComment]

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -98,6 +98,7 @@ let ruleRegistry: [String: FormatRule] = [
     "redundantStateInit": .redundantStateInit,
     "redundantStaticSelf": .redundantStaticSelf,
     "redundantSwiftTestingSuite": .redundantSwiftTestingSuite,
+    "redundantSwiftUIGroup": .redundantSwiftUIGroup,
     "redundantThrows": .redundantThrows,
     "redundantType": .redundantType,
     "redundantTypedThrows": .redundantTypedThrows,

--- a/Sources/Rules/RedundantSwiftUIGroup.swift
+++ b/Sources/Rules/RedundantSwiftUIGroup.swift
@@ -1,0 +1,231 @@
+//
+//  RedundantSwiftUIGroup.swift
+//  SwiftFormat
+//
+//  Created by Cal Stephens on 2025-12-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Remove redundant SwiftUI Group wrapper views in favor of @ViewBuilder
+    static let redundantSwiftUIGroup = FormatRule(
+        help: "Remove redundant SwiftUI Group wrapper views in favor of @ViewBuilder.",
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
+            let bodyScope: ClosedRange<Int>?
+            let isBodyMember: Bool
+            let isInsideViewType: Bool
+
+            // Parse the declaration to get body scope and check if it's a body member
+            if declaration.keyword == "var" || declaration.keyword == "let",
+               let property = declaration.parsePropertyDeclaration()
+            {
+                bodyScope = property.body?.scopeRange
+                // A var named "body" is only the protocol body if it's on a View
+                // (ViewModifier.body must be a function, not a property)
+                let isViewType = formatter.isViewType(declaration.parentType)
+                let isViewModifierType = formatter.isViewModifierType(declaration.parentType)
+                isBodyMember = property.identifier == "body" && isViewType
+                isInsideViewType = isViewType || isViewModifierType
+            } else if declaration.keyword == "func",
+                      let function = formatter.parseFunctionDeclaration(keywordIndex: declaration.keywordIndex)
+            {
+                bodyScope = function.bodyRange
+                // A func named "body" is only the protocol body if it's on a ViewModifier
+                // (View.body must be a property, not a function)
+                let isViewType = formatter.isViewType(declaration.parentType)
+                let isViewModifierType = formatter.isViewModifierType(declaration.parentType)
+                isBodyMember = function.name == "body" && isViewModifierType
+                isInsideViewType = isViewType || isViewModifierType
+            } else {
+                return
+            }
+
+            guard let bodyScope else { return }
+
+            // Only process declarations inside View/ViewModifier types
+            // (we need @ViewBuilder to be valid for the replacement)
+            guard isInsideViewType else { return }
+
+            // Check if the body contains a single Group { } expression with no modifiers
+            guard let groupInfo = formatter.topLevelGroupWithoutModifiers(in: bodyScope) else { return }
+
+            // Determine if we need @ViewBuilder after removing the Group
+            // - If it's the body protocol requirement, @ViewBuilder is implied
+            // - If the Group body is a single non-conditional expression, @ViewBuilder is not needed
+            let hasExistingViewBuilder = formatter.indexOfViewBuilderAttribute(for: declaration) != nil
+            let needsViewBuilder = !isBodyMember
+                && !formatter.scopeBodyIsSingleNonConditionalExpression(at: groupInfo.closureStartIndex)
+
+            // Determine where to add @ViewBuilder if needed, before performing any mutations.
+            // This is before the modifiers (a lower index than the Group in the body), so it
+            // stays valid after the Group is removed below.
+            let addViewBuilderAt = needsViewBuilder && !hasExistingViewBuilder
+                ? formatter.startOfModifiers(at: declaration.keywordIndex, includingAttributes: true)
+                : nil
+
+            // Remove the Group first so the @ViewBuilder insertion index above remains valid.
+            formatter.removeRedundantGroup(
+                groupStartIndex: groupInfo.groupStartIndex,
+                groupEndIndex: groupInfo.groupEndIndex,
+                closureBodyRange: groupInfo.closureBodyRange
+            )
+
+            if let addViewBuilderAt {
+                formatter.insertViewBuilderAttribute(at: addViewBuilderAt)
+            }
+        }
+    } examples: {
+        """
+        ```diff
+          struct MyView: View {
+            var body: some View {
+        -     Group {
+                Text("foo")
+                Text("bar")
+        -     }
+            }
+          }
+        ```
+
+        ```diff
+          struct MyView: View {
+        +   @ViewBuilder
+            var content: some View {
+        -     Group {
+                Text("foo")
+                Text("bar")
+        -     }
+            }
+          }
+        ```
+        """
+    }
+}
+
+extension Formatter {
+    /// Information about a top-level Group without modifiers
+    struct GroupInfo {
+        let groupStartIndex: Int
+        let groupEndIndex: Int
+        let closureStartIndex: Int
+        let closureBodyRange: ClosedRange<Int>
+    }
+
+    /// Finds a top-level Group { } call without modifiers in the given scope
+    func topLevelGroupWithoutModifiers(in bodyScope: ClosedRange<Int>) -> GroupInfo? {
+        // Find the first non-space/comment/linebreak token in the body
+        guard let firstTokenIndex = index(of: .nonSpaceOrCommentOrLinebreak, after: bodyScope.lowerBound),
+              firstTokenIndex < bodyScope.upperBound
+        else { return nil }
+
+        // Check if it's "Group"
+        guard tokens[firstTokenIndex] == .identifier("Group") else { return nil }
+
+        // Find the Group call structure and closure
+        guard let groupCallInfo = parseGroupCall(startingAt: firstTokenIndex) else { return nil }
+
+        // Check that the Group is the only thing in the body (no modifiers after)
+        guard let tokenAfterGroup = index(of: .nonSpaceOrCommentOrLinebreak, after: groupCallInfo.groupEndIndex),
+              tokenAfterGroup == bodyScope.upperBound
+        else { return nil }
+
+        // Get the body range inside the closure
+        guard let closureBodyRange = closureBodyRange(closureStartIndex: groupCallInfo.closureStartIndex) else { return nil }
+
+        return GroupInfo(
+            groupStartIndex: firstTokenIndex,
+            groupEndIndex: groupCallInfo.groupEndIndex,
+            closureStartIndex: groupCallInfo.closureStartIndex,
+            closureBodyRange: closureBodyRange
+        )
+    }
+
+    /// Parses a Group call and returns information about its structure
+    func parseGroupCall(startingAt groupIndex: Int) -> (groupEndIndex: Int, closureStartIndex: Int)? {
+        guard let nextToken = index(of: .nonSpaceOrCommentOrLinebreak, after: groupIndex) else { return nil }
+
+        // Case 1: Group { } - trailing closure directly after identifier
+        if tokens[nextToken] == .startOfScope("{"),
+           let endOfClosure = endOfScope(at: nextToken)
+        {
+            return (groupEndIndex: endOfClosure, closureStartIndex: nextToken)
+        }
+
+        // Case 2: Group() { } or Group(content: { }) - parentheses first
+        if tokens[nextToken] == .startOfScope("("),
+           let endOfParens = endOfScope(at: nextToken)
+        {
+            // Check for trailing closure after parentheses: Group() { }
+            if let afterParens = index(of: .nonSpaceOrCommentOrLinebreak, after: endOfParens),
+               tokens[afterParens] == .startOfScope("{"),
+               let endOfClosure = endOfScope(at: afterParens)
+            {
+                return (groupEndIndex: endOfClosure, closureStartIndex: afterParens)
+            }
+
+            // Check for content closure inside parentheses: Group(content: { })
+            if let contentLabel = index(of: .nonSpaceOrCommentOrLinebreak, after: nextToken),
+               tokens[contentLabel] == .identifier("content"),
+               let colon = index(of: .nonSpaceOrCommentOrLinebreak, after: contentLabel),
+               tokens[colon] == .delimiter(":"),
+               let closureStart = index(of: .nonSpaceOrCommentOrLinebreak, after: colon),
+               tokens[closureStart] == .startOfScope("{")
+            {
+                // The end of the group expression is the closing paren
+                return (groupEndIndex: endOfParens, closureStartIndex: closureStart)
+            }
+        }
+
+        return nil
+    }
+
+    /// Gets the range of the body inside a closure (excluding braces)
+    func closureBodyRange(closureStartIndex: Int) -> ClosedRange<Int>? {
+        guard let closureEndIndex = endOfScope(at: closureStartIndex),
+              closureStartIndex + 1 < closureEndIndex
+        else { return nil }
+
+        guard let firstToken = index(of: .nonSpaceOrCommentOrLinebreak, after: closureStartIndex),
+              let lastToken = index(of: .nonSpaceOrCommentOrLinebreak, before: closureEndIndex),
+              firstToken <= lastToken
+        else { return nil }
+
+        return firstToken ... lastToken
+    }
+
+    /// Removes a redundant Group, replacing it with its closure body contents
+    func removeRedundantGroup(
+        groupStartIndex: Int,
+        groupEndIndex: Int,
+        closureBodyRange: ClosedRange<Int>
+    ) {
+        // Extract the closure body tokens
+        let bodyTokens = Array(tokens[closureBodyRange])
+
+        // Remove the entire Group expression
+        removeTokens(in: groupStartIndex ... groupEndIndex)
+
+        // Insert the body tokens (indent rule will fix indentation)
+        insert(bodyTokens, at: groupStartIndex)
+    }
+
+    /// Inserts an `@ViewBuilder` attribute on its own line before the declaration at the given index
+    func insertViewBuilderAttribute(at index: Int) {
+        // Any existing indentation before the insertion point now indents `@ViewBuilder`,
+        // so the declaration that follows needs its own copy of the indentation.
+        let currentIndent = currentIndentForLine(at: index)
+
+        // Attributes are represented as `.keyword` tokens (e.g. `@objc`, `@main`). Inserting an
+        // `.identifier` instead causes other rules like `organizeDeclarations` to misparse the
+        // declaration and insert a spurious blank line after the attribute.
+        var tokensToInsert: [Token] = [.keyword("@ViewBuilder"), linebreakToken(for: index)]
+        if !currentIndent.isEmpty {
+            tokensToInsert.append(.space(currentIndent))
+        }
+        insert(tokensToInsert, at: index)
+    }
+}

--- a/Sources/Rules/RedundantViewBuilder.swift
+++ b/Sources/Rules/RedundantViewBuilder.swift
@@ -96,37 +96,6 @@ public extension FormatRule {
 }
 
 extension Formatter {
-    /// Whether the given type conforms to View
-    func isViewType(_ type: TypeDeclaration?) -> Bool {
-        guard let type else { return false }
-        return type.conformances.contains { conformance in
-            conformance.conformance.string == "View"
-        }
-    }
-
-    /// Whether the given type conforms to ViewModifier
-    func isViewModifierType(_ type: TypeDeclaration?) -> Bool {
-        guard let type else { return false }
-        return type.conformances.contains { conformance in
-            conformance.conformance.string == "ViewModifier"
-        }
-    }
-
-    /// Finds the index of a @ViewBuilder attribute for the given declaration, if present
-    func indexOfViewBuilderAttribute(for declaration: Declaration) -> Int? {
-        let startOfModifiers = declaration.startOfModifiersIndex(includingAttributes: true)
-        let keywordIndex = declaration.keywordIndex
-
-        var index = startOfModifiers
-        while index < keywordIndex {
-            if tokens[index].string == "@ViewBuilder" {
-                return index
-            }
-            index += 1
-        }
-        return nil
-    }
-
     /// Removes a @ViewBuilder attribute at the given index, including the trailing linebreak if on its own line
     func removeViewBuilderAttribute(at attributeIndex: Int) {
         var startIndex = attributeIndex
@@ -157,15 +126,5 @@ extension Formatter {
         }
 
         removeTokens(in: startIndex ... endIndex)
-    }
-
-    /// Whether the body is a single expression that is not a conditional (if/switch).
-    /// Conditional expressions need @ViewBuilder when branches return different types.
-    func scopeBodyIsSingleNonConditionalExpression(at startOfScopeIndex: Int) -> Bool {
-        guard let firstTokenInBody = index(of: .nonSpaceOrCommentOrLinebreak, after: startOfScopeIndex),
-              tokens[firstTokenInBody] != .keyword("if"),
-              tokens[firstTokenInBody] != .keyword("switch")
-        else { return false }
-        return scopeBodyIsSingleExpression(at: startOfScopeIndex)
     }
 }

--- a/Tests/Rules/RedundantSwiftUIGroupTests.swift
+++ b/Tests/Rules/RedundantSwiftUIGroupTests.swift
@@ -1,0 +1,447 @@
+//
+//  RedundantSwiftUIGroupTests.swift
+//  SwiftFormatTests
+//
+//  Created by Cal Stephens on 2025-12-19.
+//  Copyright © 2024 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class RedundantSwiftUIGroupTests: XCTestCase {
+    func testRemoveRedundantGroupInViewBody() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveRedundantGroupInViewModifierBody() {
+        let input = """
+        struct MyModifier: ViewModifier {
+            func body(content: Content) -> some View {
+                Group {
+                    content
+                    Text("overlay")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyModifier: ViewModifier {
+            func body(content: Content) -> some View {
+                content
+                Text("overlay")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testKeepGroupWithModifiers() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+                .foregroundColor(.red)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testKeepGroupWithPaddingModifier() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+                .padding()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testRemoveGroupWithSingleExpression() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupInHelperPropertyWithViewBuilder() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderWhenRemovingGroupFromHelper() {
+        // Without @ViewBuilder, we need to add it when removing Group with multiple views
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderAfterComment() {
+        // @ViewBuilder should be added after comments, not before
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            // MARK: Private
+
+            private var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            // MARK: Private
+
+            @ViewBuilder
+            private var content: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderDoesntInsertBlankLineWithOrganizeDeclarations() {
+        // Inserting @ViewBuilder must not leave the declaration line unindented, which
+        // previously combined with organizeDeclarations to produce a spurious blank line
+        // between the attribute and the declaration.
+        let input = """
+        struct MyView: View {
+          @FocusState private var streetFieldFocused: Bool
+          @AccessibilityFocusState private var isExpandedContentFocused: Bool
+
+          private var formGroup: some View {
+            Group {
+              Text("foo")
+              Text("bar")
+            }
+          }
+        }
+        """
+        let output = """
+        struct MyView: View {
+          @FocusState private var streetFieldFocused: Bool
+          @AccessibilityFocusState private var isExpandedContentFocused: Bool
+
+          @ViewBuilder
+          private var formGroup: some View {
+            Text("foo")
+            Text("bar")
+          }
+        }
+        """
+        var options = FormatOptions.default
+        options.indent = "  "
+        testFormatting(
+            for: input, [output],
+            rules: [.redundantSwiftUIGroup, .organizeDeclarations, .indent],
+            options: options,
+            exclude: [.blankLinesAtStartOfScope, .blankLinesAtEndOfScope]
+        )
+    }
+
+    func testRemoveGroupInHelperPropertyWithSingleExpression() {
+        // Single expression doesn't need @ViewBuilder, so Group can be removed
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    Text("Hello")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Text("Hello")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithParentheses() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group() {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithContentLabel() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group(content: {
+                    Text("foo")
+                    Text("bar")
+                })
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                Text("foo")
+                Text("bar")
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testKeepGroupWhenNotTopLevel() {
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                VStack {
+                    Group {
+                        Text("foo")
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testKeepGroupInNonViewType() {
+        let input = """
+        struct MyHelper {
+            var content: some View {
+                Group {
+                    Text("foo")
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, rule: .redundantSwiftUIGroup)
+    }
+
+    func testRemoveGroupInNestedView() {
+        let input = """
+        struct OuterView: View {
+            var body: some View {
+                InnerView()
+            }
+
+            struct InnerView: View {
+                var body: some View {
+                    Group {
+                        Text("Inner")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct OuterView: View {
+            var body: some View {
+                InnerView()
+            }
+
+            struct InnerView: View {
+                var body: some View {
+                    Text("Inner")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testAddViewBuilderWhenRemovingGroupWithConditional() {
+        // Conditional expressions need @ViewBuilder, so add it when removing Group
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            var content: some View {
+                Group {
+                    if condition {
+                        Text("foo")
+                    } else {
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                content
+            }
+
+            @ViewBuilder
+            var content: some View {
+                if condition {
+                    Text("foo")
+                } else {
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+
+    func testRemoveGroupWithConditionalInViewBody() {
+        // View.body has implied @ViewBuilder, so Group can be removed
+        let input = """
+        struct MyView: View {
+            var body: some View {
+                Group {
+                    if condition {
+                        Text("foo")
+                    } else {
+                        Text("bar")
+                    }
+                }
+            }
+        }
+        """
+        let output = """
+        struct MyView: View {
+            var body: some View {
+                if condition {
+                    Text("foo")
+                } else {
+                    Text("bar")
+                }
+            }
+        }
+        """
+        testFormatting(for: input, [output], rules: [.redundantSwiftUIGroup, .indent])
+    }
+}


### PR DESCRIPTION
This PR adds a new `redundantSwiftUIGroup` rule. The body of a `@ViewBuilder` is already implicitly a `Group`.

```diff
  struct MyView: View {
    var body: some View {
-     Group {
        Text("foo")
        Text("bar")
-     }
    }
  }
```

```diff
+   @ViewBuilder
    var content: some View {
-     Group {
        Text("foo")
        Text("bar")
-     }
    }
```