### PR TITLE
Add --conditional-bodies option to exclude guard bodies from wrapping

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -4375,6 +4375,10 @@ Wrap the bodies of inline switch cases onto a new line.
 
 Wrap the bodies of inline conditional statements onto a new line.
 
+Option | Description
+--- | ---
+`--conditional-bodies` | Wrap conditional bodies: "all" (default) or "if-only"
+
 <details>
 <summary>Examples</summary>
 
@@ -4390,6 +4394,18 @@ Wrap the bodies of inline conditional statements onto a new line.
 + if foo {
 +    return bar
 + }
+```
+
+With `--conditional-bodies if-only`, `guard` bodies are not wrapped:
+
+```diff
+- if foo { return bar }
++ if foo {
++    return bar
++ }
+
+  // guard is not affected (both statement and expression)
+  guard let foo = bar else { return baz }
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -4377,7 +4377,8 @@ Wrap the bodies of inline conditional statements onto a new line.
 
 Option | Description
 --- | ---
-`--conditional-bodies` | Wrap conditional bodies: "all" (default) or "if-only"
+`--wrap-if-body` | Wrap if/else bodies onto a new line: "true" (default) or "false"
+`--wrap-guard-body` | Wrap guard bodies onto a new line: "true" (default) or "false"
 
 <details>
 <summary>Examples</summary>
@@ -4396,7 +4397,7 @@ Option | Description
 + }
 ```
 
-With `--conditional-bodies if-only`, `guard` bodies are not wrapped:
+With `--wrap-guard-body false`, `guard` bodies are not wrapped:
 
 ```diff
 - if foo { return bar }
@@ -4404,7 +4405,7 @@ With `--conditional-bodies if-only`, `guard` bodies are not wrapped:
 +    return bar
 + }
 
-  // guard is not affected (both statement and expression)
+  // guard is not affected
   guard let foo = bar else { return baz }
 ```
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -829,11 +829,17 @@ struct _Descriptors {
         help: "Placement of else in guard statements:",
         keyPath: \.guardElsePosition
     )
-    let wrapConditionalBodiesScope = OptionDescriptor(
-        argumentName: "conditional-bodies",
-        displayName: "Conditional Bodies Scope",
-        help: "Wrap conditional bodies: \"all\" (default) or \"if-only\"",
-        keyPath: \.wrapConditionalBodiesScope
+    let wrapIfBody = OptionDescriptor(
+        argumentName: "wrap-if-body",
+        displayName: "Wrap If Body",
+        help: "Wrap if/else bodies onto a new line: \"true\" (default) or \"false\"",
+        keyPath: \.wrapIfBody
+    )
+    let wrapGuardBody = OptionDescriptor(
+        argumentName: "wrap-guard-body",
+        displayName: "Wrap Guard Body",
+        help: "Wrap guard bodies onto a new line: \"true\" (default) or \"false\"",
+        keyPath: \.wrapGuardBody
     )
     let explicitSelf = OptionDescriptor(
         argumentName: "self",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -829,6 +829,12 @@ struct _Descriptors {
         help: "Placement of else in guard statements:",
         keyPath: \.guardElsePosition
     )
+    let wrapConditionalBodiesScope = OptionDescriptor(
+        argumentName: "conditional-bodies",
+        displayName: "Conditional Bodies Scope",
+        help: "Wrap conditional bodies: \"all\" (default) or \"if-only\"",
+        keyPath: \.wrapConditionalBodiesScope
+    )
     let explicitSelf = OptionDescriptor(
         argumentName: "self",
         displayName: "Self",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -113,6 +113,12 @@ public enum GuardElsePosition: String, CaseIterable {
     case auto
 }
 
+/// Which conditional statements to wrap bodies for
+public enum ConditionalBodiesScope: String, CaseIterable {
+    case all
+    case ifOnly = "if-only"
+}
+
 /// Where to place the access control keyword of an extension
 public enum ExtensionACLPlacement: String, CaseIterable {
     case onExtension = "on-extension"
@@ -820,6 +826,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var stripUnusedArguments: ArgumentStrippingMode
     public var elsePosition: ElsePosition
     public var guardElsePosition: GuardElsePosition
+    public var wrapConditionalBodiesScope: ConditionalBodiesScope
     public var explicitSelf: SelfMode
     public var selfRequired: Set<String>
     public var throwCapturing: Set<String>
@@ -968,6 +975,7 @@ public struct FormatOptions: CustomStringConvertible {
                 stripUnusedArguments: ArgumentStrippingMode = .all,
                 elsePosition: ElsePosition = .sameLine,
                 guardElsePosition: GuardElsePosition = .auto,
+                wrapConditionalBodiesScope: ConditionalBodiesScope = .all,
                 explicitSelf: SelfMode = .remove,
                 selfRequired: Set<String> = [],
                 throwCapturing: Set<String> = [],
@@ -1105,6 +1113,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.stripUnusedArguments = stripUnusedArguments
         self.elsePosition = elsePosition
         self.guardElsePosition = guardElsePosition
+        self.wrapConditionalBodiesScope = wrapConditionalBodiesScope
         self.explicitSelf = explicitSelf
         self.selfRequired = selfRequired
         self.throwCapturing = throwCapturing

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -113,7 +113,6 @@ public enum GuardElsePosition: String, CaseIterable {
     case auto
 }
 
-
 /// Where to place the access control keyword of an extension
 public enum ExtensionACLPlacement: String, CaseIterable {
     case onExtension = "on-extension"

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -113,11 +113,6 @@ public enum GuardElsePosition: String, CaseIterable {
     case auto
 }
 
-/// Which conditional statements to wrap bodies for
-public enum ConditionalBodiesScope: String, CaseIterable {
-    case all
-    case ifOnly = "if-only"
-}
 
 /// Where to place the access control keyword of an extension
 public enum ExtensionACLPlacement: String, CaseIterable {
@@ -826,7 +821,8 @@ public struct FormatOptions: CustomStringConvertible {
     public var stripUnusedArguments: ArgumentStrippingMode
     public var elsePosition: ElsePosition
     public var guardElsePosition: GuardElsePosition
-    public var wrapConditionalBodiesScope: ConditionalBodiesScope
+    public var wrapIfBody: Bool
+    public var wrapGuardBody: Bool
     public var explicitSelf: SelfMode
     public var selfRequired: Set<String>
     public var throwCapturing: Set<String>
@@ -975,7 +971,8 @@ public struct FormatOptions: CustomStringConvertible {
                 stripUnusedArguments: ArgumentStrippingMode = .all,
                 elsePosition: ElsePosition = .sameLine,
                 guardElsePosition: GuardElsePosition = .auto,
-                wrapConditionalBodiesScope: ConditionalBodiesScope = .all,
+                wrapIfBody: Bool = true,
+                wrapGuardBody: Bool = true,
                 explicitSelf: SelfMode = .remove,
                 selfRequired: Set<String> = [],
                 throwCapturing: Set<String> = [],
@@ -1113,7 +1110,8 @@ public struct FormatOptions: CustomStringConvertible {
         self.stripUnusedArguments = stripUnusedArguments
         self.elsePosition = elsePosition
         self.guardElsePosition = guardElsePosition
-        self.wrapConditionalBodiesScope = wrapConditionalBodiesScope
+        self.wrapIfBody = wrapIfBody
+        self.wrapGuardBody = wrapGuardBody
         self.explicitSelf = explicitSelf
         self.selfRequired = selfRequired
         self.throwCapturing = throwCapturing

--- a/Sources/Rules/WrapConditionalBodies.swift
+++ b/Sources/Rules/WrapConditionalBodies.swift
@@ -12,15 +12,15 @@ public extension FormatRule {
     static let wrapConditionalBodies = FormatRule(
         help: "Wrap the bodies of inline conditional statements onto a new line.",
         disabledByDefault: true,
-        options: ["conditional-bodies"],
+        options: ["wrap-if-body", "wrap-guard-body"],
         sharedOptions: ["linebreaks", "indent"]
     ) { formatter in
         formatter.forEachToken(where: { [.keyword("if"), .keyword("else")].contains($0) }) { i, token in
-            if token == .keyword("else"),
-               formatter.options.wrapConditionalBodiesScope == .ifOnly,
-               formatter.isGuardElse(at: i)
-            {
-                return
+            let isGuardElse = token == .keyword("else") && formatter.isGuardElse(at: i)
+            if isGuardElse {
+                guard formatter.options.wrapGuardBody else { return }
+            } else {
+                guard formatter.options.wrapIfBody else { return }
             }
             guard let startIndex = formatter.index(of: .startOfScope("{"), after: i) else {
                 return formatter.fatalError("Expected {", at: i)
@@ -43,7 +43,7 @@ public extension FormatRule {
         + }
         ```
 
-        With `--conditional-bodies if-only`, `guard` bodies are not wrapped:
+        With `--wrap-guard-body false`, `guard` bodies are not wrapped:
 
         ```diff
         - if foo { return bar }
@@ -51,7 +51,7 @@ public extension FormatRule {
         +    return bar
         + }
 
-          // guard is not affected (both statement and expression)
+          // guard is not affected
           guard let foo = bar else { return baz }
         ```
         """

--- a/Sources/Rules/WrapConditionalBodies.swift
+++ b/Sources/Rules/WrapConditionalBodies.swift
@@ -12,9 +12,16 @@ public extension FormatRule {
     static let wrapConditionalBodies = FormatRule(
         help: "Wrap the bodies of inline conditional statements onto a new line.",
         disabledByDefault: true,
+        options: ["conditional-bodies"],
         sharedOptions: ["linebreaks", "indent"]
     ) { formatter in
-        formatter.forEachToken(where: { [.keyword("if"), .keyword("else")].contains($0) }) { i, _ in
+        formatter.forEachToken(where: { [.keyword("if"), .keyword("else")].contains($0) }) { i, token in
+            if token == .keyword("else"),
+               formatter.options.wrapConditionalBodiesScope == .ifOnly,
+               formatter.isGuardElse(at: i)
+            {
+                return
+            }
             guard let startIndex = formatter.index(of: .startOfScope("{"), after: i) else {
                 return formatter.fatalError("Expected {", at: i)
             }
@@ -34,6 +41,18 @@ public extension FormatRule {
         + if foo {
         +    return bar
         + }
+        ```
+
+        With `--conditional-bodies if-only`, `guard` bodies are not wrapped:
+
+        ```diff
+        - if foo { return bar }
+        + if foo {
+        +    return bar
+        + }
+
+          // guard is not affected (both statement and expression)
+          guard let foo = bar else { return baz }
         ```
         """
     }

--- a/Tests/Rules/WrapConditionalBodiesTests.swift
+++ b/Tests/Rules/WrapConditionalBodiesTests.swift
@@ -298,6 +298,76 @@ final class WrapConditionalBodiesTests: XCTestCase {
         testFormatting(for: input, rule: .wrapConditionalBodies)
     }
 
+    // MARK: - if-only scope
+
+    func testIfOnlyScopeWrapsIf() {
+        let input = """
+        if foo { return bar }
+        """
+        let output = """
+        if foo {
+            return bar
+        }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options)
+    }
+
+    func testIfOnlyScopeDoesNotWrapGuard() {
+        let input = """
+        guard let foo = bar else { return }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
+    }
+
+    func testIfOnlyScopeDoesNotWrapGuardWithValue() {
+        let input = """
+        guard let foo = bar else { return baz }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
+    }
+
+    func testIfOnlyScopeWrapsIfElse() {
+        let input = """
+        if foo { return bar } else { return baz }
+        """
+        let output = """
+        if foo {
+            return bar
+        } else {
+            return baz
+        }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options)
+    }
+
+    func testIfOnlyScopeWrapsIfExpression() {
+        let input = """
+        let isX = if condition { true } else { false }
+        """
+        let output = """
+        let isX = if condition {
+            true
+        } else {
+            false
+        }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options,
+                       exclude: [.wrapMultilineConditionalAssignment, .braces, .indent, .wrapMultilineStatementBraces])
+    }
+
+    func testIfOnlyScopeDoesNotWrapGuardWithMultipleConditions() {
+        let input = """
+        guard a, b, c else { return }
+        """
+        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
+    }
+
     func testInsideMultilineStringLiteral() {
         let input = """
         let foo = \"""

--- a/Tests/Rules/WrapConditionalBodiesTests.swift
+++ b/Tests/Rules/WrapConditionalBodiesTests.swift
@@ -298,9 +298,9 @@ final class WrapConditionalBodiesTests: XCTestCase {
         testFormatting(for: input, rule: .wrapConditionalBodies)
     }
 
-    // MARK: - if-only scope
+    // MARK: - wrap-guard-body false
 
-    func testIfOnlyScopeWrapsIf() {
+    func testWrapGuardBodyFalseWrapsIf() {
         let input = """
         if foo { return bar }
         """
@@ -309,27 +309,27 @@ final class WrapConditionalBodiesTests: XCTestCase {
             return bar
         }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options)
     }
 
-    func testIfOnlyScopeDoesNotWrapGuard() {
+    func testWrapGuardBodyFalseDoesNotWrapGuard() {
         let input = """
         guard let foo = bar else { return }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
     }
 
-    func testIfOnlyScopeDoesNotWrapGuardWithValue() {
+    func testWrapGuardBodyFalseDoesNotWrapGuardWithValue() {
         let input = """
         guard let foo = bar else { return baz }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
     }
 
-    func testIfOnlyScopeWrapsIfElse() {
+    func testWrapGuardBodyFalseWrapsIfElse() {
         let input = """
         if foo { return bar } else { return baz }
         """
@@ -340,11 +340,11 @@ final class WrapConditionalBodiesTests: XCTestCase {
             return baz
         }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options)
     }
 
-    func testIfOnlyScopeWrapsIfExpression() {
+    func testWrapGuardBodyFalseWrapsIfExpression() {
         let input = """
         let isX = if condition { true } else { false }
         """
@@ -355,17 +355,40 @@ final class WrapConditionalBodiesTests: XCTestCase {
             false
         }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options,
                        exclude: [.wrapMultilineConditionalAssignment, .braces, .indent, .wrapMultilineStatementBraces])
     }
 
-    func testIfOnlyScopeDoesNotWrapGuardWithMultipleConditions() {
+    func testWrapGuardBodyFalseDoesNotWrapGuardWithMultipleConditions() {
         let input = """
         guard a, b, c else { return }
         """
-        let options = FormatOptions(wrapConditionalBodiesScope: .ifOnly)
+        let options = FormatOptions(wrapGuardBody: false)
         testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
+    }
+
+    // MARK: - wrap-if-body false
+
+    func testWrapIfBodyFalseDoesNotWrapIf() {
+        let input = """
+        if foo { return bar }
+        """
+        let options = FormatOptions(wrapIfBody: false)
+        testFormatting(for: input, rule: .wrapConditionalBodies, options: options)
+    }
+
+    func testWrapIfBodyFalseWrapsGuard() {
+        let input = """
+        guard let foo = bar else { return }
+        """
+        let output = """
+        guard let foo = bar else {
+            return
+        }
+        """
+        let options = FormatOptions(wrapIfBody: false)
+        testFormatting(for: input, output, rule: .wrapConditionalBodies, options: options)
     }
 
     func testInsideMultilineStringLiteral() {


### PR DESCRIPTION
## Summary

Adds two boolean options to `wrapConditionalBodies` for independent control over `if` and `guard` body wrapping.

Many projects use single-line `guard` patterns as a convention:
```swift
guard let self else { return }
guard a, b else { return }
```
Enabling `wrapConditionalBodies` currently forces these onto multiple lines, which is undesirable when the intent is to keep early-exit guards concise.

## New Options

- `--wrap-if-body true|false` (default: `true`) — wrap `if`/`else` bodies onto a new line
- `--wrap-guard-body true|false` (default: `true`) — wrap `guard` bodies onto a new line

Both default to `true`, preserving existing behavior.

```swift
// --wrap-guard-body false

// wrapped ✅
if foo { return bar }
// →
if foo {
    return bar
}

// unchanged ✅
guard let self else { return }
guard a, b else { return }
```

## Implementation

Uses the existing `isGuardElse(at:)` helper to distinguish `guard...else` bodies from `if`/`else` bodies.

## Related

See also #2545 for a discussion on optionally skipping if expression bodies.