### PR TITLE
Update `redundantStateInit` to not apply if the `@State` property declaration has a default value

### DIFF
--- a/Sources/Rules/RedundantStateInit.swift
+++ b/Sources/Rules/RedundantStateInit.swift
@@ -130,7 +130,10 @@ extension Formatter {
 
             guard member.keyword == "var" || member.keyword == "let",
                   let property = member.parsePropertyDeclaration(),
-                  member.attributes.contains("@State") || member.attributes.contains("@ObservedObject")
+                  member.attributes.contains("@State") || member.attributes.contains("@ObservedObject"),
+                  // A direct assignment (`self.foo = x`) has no effect when the property has a default value,
+                  // whereas the backing-storage form (`_foo = .init(initialValue: x)`) does override it.
+                  property.value == nil
             else { continue }
 
             names.insert(property.identifier)

--- a/Tests/Rules/RedundantStateInitTests.swift
+++ b/Tests/Rules/RedundantStateInitTests.swift
@@ -249,6 +249,22 @@ final class RedundantStateInitTests: XCTestCase {
         testFormatting(for: input, [output], rules: [.redundantStateInit, .redundantSelf])
     }
 
+    func testPreservesWhenPropertyHasDefaultValue() {
+        let input = """
+        struct MyView: View {
+            init() {
+                _foo = .init(initialValue: "foo from init")
+                _foo = State(wrappedValue: "foo from init")
+            }
+
+            var body: some View {}
+
+            @State private var foo = "foo from declaration"
+        }
+        """
+        testFormatting(for: input, rule: .redundantStateInit)
+    }
+
     func testDoesntRewriteRegularBackingPropertyAssignment() {
         let input = """
         struct Foo {


### PR DESCRIPTION
I found an edge case where `State.init(initialValue:)` has a different behavior than setting the underlying value directly:

```swift
struct MyView {
  init() {
    _value = .init(initialValue: "value from init") // this initial value replaces the initial value from the @State declaration
    self.value = "value from init" // would have no effect
  }

  @State private var value = "initial value from declaration" // default value here
}
```

This PR preserves the init call in that case.