### PR TITLE
Update `redundantOptionalBinding` to convert `if let x = property` to `if let property`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -2699,6 +2699,13 @@ Remove redundant identifiers in optional binding conditions.
 + guard let self else {
       return
   }
+
+- if let foo = bar {
+-     baaz(foo)
+- }
++ if let bar {
++     baaz(bar)
++ }
 ```
 
 </details>

--- a/Rules.md
+++ b/Rules.md
@@ -2686,6 +2686,10 @@ Remove redundant `@objc` annotations.
 
 Remove redundant identifiers in optional binding conditions.
 
+Option | Description
+--- | ---
+`--redundant-optional-binding` | Bindings to simplify: "always" (default) or "same-name-only"
+
 <details>
 <summary>Examples</summary>
 
@@ -2699,13 +2703,15 @@ Remove redundant identifiers in optional binding conditions.
 + guard let self else {
       return
   }
+```
 
-- if let foo = bar {
--     baaz(foo)
-- }
-+ if let bar {
-+     baaz(bar)
-+ }
+```diff
+  // With --redundant-optional-binding always (default)
+- if let f = foo {
+-     print(f)
++ if let foo {
++     print(foo)
+  }
 ```
 
 </details>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1507,6 +1507,13 @@ struct _Descriptors {
         falseValues: ["preserve"]
     )
 
+    let redundantOptionalBinding = OptionDescriptor(
+        argumentName: "redundant-optional-binding",
+        displayName: "Redundant Optional Binding",
+        help: "Bindings to simplify: \"always\" (default) or \"same-name-only\"",
+        keyPath: \.redundantOptionalBinding
+    )
+
     // MARK: - Internal
 
     let fragment = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -194,6 +194,14 @@ public enum SwiftTestingNameFormat: String, CaseIterable {
     case standardIdentifiers = "standard-identifiers"
 }
 
+/// Which optional binding conditions the `redundantOptionalBinding` rule should simplify
+public enum RedundantOptionalBindingMode: String, CaseIterable {
+    /// Only remove the redundant identifier when both names match, e.g. `if let foo = foo`
+    case sameNameOnly = "same-name-only"
+    /// Also rename the binding when the names differ, e.g. `if let foo = bar` → `if let bar`
+    case always
+}
+
 public enum TrailingCommas: String, CaseIterable {
     case never
     case always
@@ -926,6 +934,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var suiteNameFormat: SwiftTestingNameFormat
     public var testCaseAccessControl: Visibility
     public var guardLikeIfStatements: Bool
+    public var redundantOptionalBinding: RedundantOptionalBindingMode
 
     /// Deprecated
     public var indentComments: Bool
@@ -1077,6 +1086,7 @@ public struct FormatOptions: CustomStringConvertible {
                 suiteNameFormat: SwiftTestingNameFormat = .preserve,
                 testCaseAccessControl: Visibility = .internal,
                 guardLikeIfStatements: Bool = false,
+                redundantOptionalBinding: RedundantOptionalBindingMode = .always,
                 // Doesn't really belong here, but hard to put elsewhere
                 fragment: Bool = false,
                 ignoreConflictMarkers: Bool = false,
@@ -1217,6 +1227,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.suiteNameFormat = suiteNameFormat
         self.testCaseAccessControl = testCaseAccessControl
         self.guardLikeIfStatements = guardLikeIfStatements
+        self.redundantOptionalBinding = redundantOptionalBinding
         self.indentComments = indentComments
         self.fragment = fragment
         self.ignoreConflictMarkers = ignoreConflictMarkers

--- a/Sources/Rules/RedundantOptionalBinding.swift
+++ b/Sources/Rules/RedundantOptionalBinding.swift
@@ -13,7 +13,8 @@ public extension FormatRule {
         help: "Remove redundant identifiers in optional binding conditions.",
         // We can convert `if let foo = self.foo` to just `if let foo`,
         // but only if `redundantSelf` can first remove the `self.`.
-        orderAfter: [.redundantSelf]
+        orderAfter: [.redundantSelf],
+        options: ["redundant-optional-binding"]
     ) { formatter in
         formatter.forEachToken { i, token in
             // `if let foo` conditions were added in Swift 5.7 (SE-0345)
@@ -38,7 +39,7 @@ public extension FormatRule {
             if bindingName == rhsName {
                 // `if let foo = foo` → `if let foo`
                 formatter.removeTokens(in: identifierIndex + 1 ... rhsIndex)
-            } else if !rhsName.hasPrefix("$") {
+            } else if formatter.options.redundantOptionalBinding == .always, !rhsName.hasPrefix("$") {
                 // `if let foo = bar` → `if let bar` when the names don't conflict
                 // (skip when rhs is a closure shorthand parameter like `$0`,
                 // since `if let $0` is invalid Swift)
@@ -63,13 +64,15 @@ public extension FormatRule {
         + guard let self else {
               return
           }
+        ```
 
-        - if let foo = bar {
-        -     baaz(foo)
-        - }
-        + if let bar {
-        +     baaz(bar)
-        + }
+        ```diff
+          // With --redundant-optional-binding always (default)
+        - if let f = foo {
+        -     print(f)
+        + if let foo {
+        +     print(foo)
+          }
         ```
         """
     }
@@ -175,9 +178,13 @@ extension Formatter {
         // Exclude member accesses: `foo.name` (infix dot) and `.name` implicit member (prefix dot).
         if let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: idx),
            case let .operator(".", _) = tokens[prev]
-        { return false }
+        {
+            return false
+        }
         // Exclude function call argument labels (e.g. `foo(name: value)`)
-        if isArgumentPosition(at: idx) { return false }
+        if isArgumentPosition(at: idx) {
+            return false
+        }
         return true
     }
 }

--- a/Sources/Rules/RedundantOptionalBinding.swift
+++ b/Sources/Rules/RedundantOptionalBinding.swift
@@ -17,26 +17,38 @@ public extension FormatRule {
     ) { formatter in
         formatter.forEachToken { i, token in
             // `if let foo` conditions were added in Swift 5.7 (SE-0345)
-            if formatter.options.swiftVersion >= "5.7",
+            guard formatter.options.swiftVersion >= "5.7",
+                  [.keyword("let"), .keyword("var")].contains(token),
+                  formatter.isConditionalStatement(at: i),
 
-               [.keyword("let"), .keyword("var")].contains(token),
-               formatter.isConditionalStatement(at: i),
+                  let identifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i),
+                  case let .identifier(bindingName) = formatter.tokens[identifierIndex],
 
-               let identiferIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i),
-               let identifier = formatter.token(at: identiferIndex),
+                  let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: identifierIndex, if: {
+                      $0 == .operator("=", .infix)
+                  }),
 
-               let equalsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: identiferIndex, if: {
-                   $0 == .operator("=", .infix)
-               }),
+                  let rhsIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex),
+                  case let .identifier(rhsName) = formatter.tokens[rhsIndex],
 
-               let nextIdentifierIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: equalsIndex, if: {
-                   $0 == identifier
-               }),
+                  let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: rhsIndex),
+                  [.startOfScope("{"), .delimiter(","), .keyword("else")].contains(nextToken)
+            else { return }
 
-               let nextToken = formatter.next(.nonSpaceOrCommentOrLinebreak, after: nextIdentifierIndex),
-               [.startOfScope("{"), .delimiter(","), .keyword("else")].contains(nextToken)
-            {
-                formatter.removeTokens(in: identiferIndex + 1 ... nextIdentifierIndex)
+            if bindingName == rhsName {
+                // `if let foo = foo` → `if let foo`
+                formatter.removeTokens(in: identifierIndex + 1 ... rhsIndex)
+            } else if !rhsName.hasPrefix("$") {
+                // `if let foo = bar` → `if let bar` when the names don't conflict
+                // (skip when rhs is a closure shorthand parameter like `$0`,
+                // since `if let $0` is invalid Swift)
+                formatter.tryConvertDifferentNameBinding(
+                    bindingName: bindingName,
+                    rhsName: rhsName,
+                    identifierIndex: identifierIndex,
+                    rhsIndex: rhsIndex,
+                    ifLetKeywordIndex: i
+                )
             }
         }
     } examples: {
@@ -51,7 +63,121 @@ public extension FormatRule {
         + guard let self else {
               return
           }
+
+        - if let foo = bar {
+        -     baaz(foo)
+        - }
+        + if let bar {
+        +     baaz(bar)
+        + }
         ```
         """
+    }
+}
+
+extension Formatter {
+    /// Attempts to convert `if let foo = bar` to `if let bar`, renaming `foo` → `bar`
+    /// in subsequent conditions and the body. For `guard`, also renames in the continuation
+    /// after the `}`, but only when the guard is a direct child of a function or var body —
+    /// otherwise the binding's scope is hard to determine correctly (e.g. inside switch cases,
+    /// the continuation can extend past sibling declarations).
+    /// Skips the transformation if `rhsName` already appears in the rename range, since
+    /// the new binding would shadow it.
+    func tryConvertDifferentNameBinding(
+        bindingName: String,
+        rhsName: String,
+        identifierIndex: Int,
+        rhsIndex: Int,
+        ifLetKeywordIndex: Int
+    ) {
+        guard let startOfConditional = startOfConditionalStatement(at: ifLetKeywordIndex),
+              let startBrace = index(of: .startOfScope("{"), after: ifLetKeywordIndex),
+              let endBrace = endOfScope(at: startBrace)
+        else { return }
+
+        var renameRanges: [Range<Int>] = []
+
+        if tokens[startOfConditional] == .keyword("guard") {
+            guard let enclosingScopeStart = index(of: .startOfScope("{"), before: startOfConditional),
+                  isFunctionOrComputedPropertyBody(at: enclosingScopeStart),
+                  let enclosingScopeEnd = endOfScope(at: enclosingScopeStart)
+            else { return }
+
+            // Subsequent conditions: from after the rhs to the `else` keyword
+            if let elseIndex = index(of: .keyword("else"), after: rhsIndex), elseIndex < startBrace {
+                renameRanges.append((rhsIndex + 1) ..< elseIndex)
+            }
+
+            // Else body: must not contain `bindingName` (we can't rename uses we don't own there)
+            let elseBodyRange = (startBrace + 1) ..< endBrace
+            guard !containsIdentifier(bindingName, in: elseBodyRange) else { return }
+
+            // Continuation: from after the guard's `}` to the end of the enclosing function/var body
+            renameRanges.append((endBrace + 1) ..< enclosingScopeEnd)
+        } else {
+            // For if/while: subsequent conditions + body
+            renameRanges.append((rhsIndex + 1) ..< endBrace)
+        }
+
+        // Skip if `rhsName` is referenced in any rename range. After renaming, the new binding
+        // shadows the outer `rhsName`, so any reference to the outer variable would silently
+        // become a reference to the binding instead — a semantic change.
+        for range in renameRanges {
+            if containsIdentifier(rhsName, in: range) {
+                return
+            }
+        }
+
+        for range in renameRanges {
+            renameIdentifier(bindingName, to: rhsName, in: range)
+        }
+
+        // Replace `bindingName = rhsName` with just `rhsName`
+        replaceToken(at: identifierIndex, with: .identifier(rhsName))
+        removeTokens(in: identifierIndex + 1 ... rhsIndex)
+    }
+
+    /// Returns true if the `{` at `idx` is the body of a function (`func`, `init`, `subscript`,
+    /// `deinit`) or a computed property (`var name: Type { ... }`).
+    func isFunctionOrComputedPropertyBody(at idx: Int) -> Bool {
+        guard tokens[idx] == .startOfScope("{"), !isStartOfClosure(at: idx) else { return false }
+        guard let keywordIndex = indexOfLastSignificantKeyword(at: idx, excluding: ["where"]) else {
+            return false
+        }
+        switch tokens[keywordIndex].string {
+        case "func", "init", "subscript", "deinit", "var":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns true if `name` appears as a value reference (not a member access or argument label)
+    /// anywhere in the given range.
+    func containsIdentifier(_ name: String, in range: Range<Int>) -> Bool {
+        range.contains(where: { isValueReference(name, at: $0) })
+    }
+
+    /// Renames all value references to `name` (excluding member accesses and argument labels)
+    /// to `newName` within the given range.
+    func renameIdentifier(_ name: String, to newName: String, in range: Range<Int>) {
+        for idx in stride(from: range.upperBound - 1, through: range.lowerBound, by: -1) {
+            if isValueReference(name, at: idx) {
+                replaceToken(at: idx, with: .identifier(newName))
+            }
+        }
+    }
+
+    /// Returns true if the token at `idx` is identifier `name` used as a value reference,
+    /// i.e., not a member access (`.name`) and not a function call argument label (`name:`).
+    func isValueReference(_ name: String, at idx: Int) -> Bool {
+        guard tokens[idx] == .identifier(name) else { return false }
+        // Exclude member accesses: `foo.name` (infix dot) and `.name` implicit member (prefix dot).
+        if let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: idx),
+           case let .operator(".", _) = tokens[prev]
+        { return false }
+        // Exclude function call argument labels (e.g. `foo(name: value)`)
+        if isArgumentPosition(at: idx) { return false }
+        return true
     }
 }

--- a/Tests/Rules/RedundantOptionalBindingTests.swift
+++ b/Tests/Rules/RedundantOptionalBindingTests.swift
@@ -128,15 +128,19 @@ final class RedundantOptionalBindingTests: XCTestCase {
         testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
     }
 
-    func testKeepsNonRedundantOptional() {
+    func testRenamesWhenOnlyNewNameUsedInIfBody() {
         let input = """
         if let foo = bar {
             print(foo)
         }
         """
-
+        let output = """
+        if let bar {
+            print(bar)
+        }
+        """
         let options = FormatOptions(swiftVersion: "5.7")
-        testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
     }
 
     func testKeepsOptionalNotEligibleForShorthand() {
@@ -179,5 +183,191 @@ final class RedundantOptionalBindingTests: XCTestCase {
 
         let options = FormatOptions(swiftVersion: "5.7")
         testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameWhenNewNameAlreadyReferencedInBody() {
+        // We can't safely rename `foo` → `bar` because `bar` is already referenced in the body
+        // and the new binding would shadow the outer `bar`, silently changing what `bar` refers to.
+        let input = """
+        if let foo = bar {
+            baaz(bar)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testRenamesBindingWhenOldNameNotUsedInIfBodyAndRhsIsUsed() {
+        let input = """
+        if let foo = bar {
+            return foo
+        }
+        """
+        let output = """
+        if let bar {
+            return bar
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameBindingWhenOldNameUsedInIfBody() {
+        let input = """
+        if let foo = bar {
+            baaz(foo, bar)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testRenamesGuardBindingDirectlyInFunctionBody() {
+        let input = """
+        func foo() -> Int? {
+            guard let foo = bar else {
+                return nil
+            }
+            return foo
+        }
+        """
+        let output = """
+        func foo() -> Int? {
+            guard let bar else {
+                return nil
+            }
+            return bar
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options, exclude: [.blankLinesAfterGuardStatements])
+    }
+
+    func testRenamesGuardBindingInComputedPropertyBody() {
+        let input = """
+        var foo: Int? {
+            guard let foo = bar else {
+                return nil
+            }
+            return foo
+        }
+        """
+        let output = """
+        var foo: Int? {
+            guard let bar else {
+                return nil
+            }
+            return bar
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options, exclude: [.blankLinesAfterGuardStatements])
+    }
+
+    func testDoesNotRenameGuardBindingInsideSwitchCase() {
+        // The guard's continuation extends to the end of the enclosing function, not the case.
+        // Renaming `media` could affect references in sibling functions inside the same enum/class.
+        let input = """
+        enum Handler {
+            static func handle(_ action: Action) {
+                switch action {
+                case .reorder(let mediaItem):
+                    guard let media = mediaItem else { return }
+                    moveMedia(media)
+                }
+            }
+            static func moveMedia(_ media: MediaItem) {
+                use(media.id)
+            }
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options,
+                       exclude: [.blankLinesAfterGuardStatements, .blankLinesBetweenScopes,
+                                 .hoistPatternLet, .wrapConditionalBodies])
+    }
+
+    func testRenamesBindingWhenOldNameUsedInSubsequentCondition() {
+        let input = """
+        if let foo = bar, foo.isValid {
+            use(foo)
+        }
+        """
+        let output = """
+        if let bar, bar.isValid {
+            use(bar)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameArgumentLabelsMatchingBindingName() {
+        let input = """
+        func foo() -> MigrationPlan? {
+            if let from = fromValue, let to = toValue {
+                return MigrationPlan(from: from, to: to)
+            }
+            return nil
+        }
+        """
+        let output = """
+        func foo() -> MigrationPlan? {
+            if let fromValue, let toValue {
+                return MigrationPlan(from: fromValue, to: toValue)
+            }
+            return nil
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameDictionaryKeyMatchingBindingName() {
+        let input = """
+        if let foo = bar {
+            let dict = [foo: "value"]
+            use(dict)
+        }
+        """
+        let output = """
+        if let bar {
+            let dict = [bar: "value"]
+            use(dict)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameToClosureShorthandParameter() {
+        // `if let $0` is invalid Swift — closure shorthand parameters can't be used as binding names.
+        let input = """
+        let result = items.compactMap {
+            if let value = $0 {
+                return value
+            }
+            return nil
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testDoesNotRenameImplicitMemberExpressionMatchingBindingName() {
+        // `.url(...)` is an implicit member expression (enum case), not a value reference.
+        // Renaming the binding `url` → `value` should not affect `.url`.
+        let input = """
+        if let url = value {
+            return .url(url)
+        }
+        """
+        let output = """
+        if let value {
+            return .url(value)
+        }
+        """
+        let options = FormatOptions(swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
     }
 }

--- a/Tests/Rules/RedundantOptionalBindingTests.swift
+++ b/Tests/Rules/RedundantOptionalBindingTests.swift
@@ -143,6 +143,31 @@ final class RedundantOptionalBindingTests: XCTestCase {
         testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
     }
 
+    func testSameNameOnlyModePreservesDifferentNameBinding() {
+        let input = """
+        if let foo = bar {
+            print(foo)
+        }
+        """
+        let options = FormatOptions(redundantOptionalBinding: .sameNameOnly, swiftVersion: "5.7")
+        testFormatting(for: input, rule: .redundantOptionalBinding, options: options)
+    }
+
+    func testSameNameOnlyModeStillRemovesRedundantSameNameBinding() {
+        let input = """
+        if let foo = foo {
+            print(foo)
+        }
+        """
+        let output = """
+        if let foo {
+            print(foo)
+        }
+        """
+        let options = FormatOptions(redundantOptionalBinding: .sameNameOnly, swiftVersion: "5.7")
+        testFormatting(for: input, output, rule: .redundantOptionalBinding, options: options)
+    }
+
     func testKeepsOptionalNotEligibleForShorthand() {
         let input = """
         if let foo = self.foo, let bar = bar(), let baaz = baaz[0] {

--- a/Tests/Rules/RedundantSelfTests.swift
+++ b/Tests/Rules/RedundantSelfTests.swift
@@ -4861,7 +4861,7 @@ final class RedundantSelfTests: XCTestCase {
         """
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantSelf, options: options,
-                       exclude: [.braces, .indent, .wrapMultilineConditionalAssignment])
+                       exclude: [.braces, .indent, .redundantOptionalBinding, .wrapMultilineConditionalAssignment])
     }
 
     func testRedundantSelfWithSwitchExpressionInGuardLetBindingChain() {
@@ -4882,6 +4882,7 @@ final class RedundantSelfTests: XCTestCase {
         let options = FormatOptions(swiftVersion: "5.9")
         testFormatting(for: input, rule: .redundantSelf, options: options,
                        exclude: [.blankLinesAfterGuardStatements,
+                                 .redundantOptionalBinding,
                                  .wrapConditionalBodies,
                                  .wrapMultilineConditionalAssignment])
     }


### PR DESCRIPTION
This PR extends the `redundantOptionalBinding` rule to also convert `if let x = property` to `if let property`:

```diff
- if let f = foo {
-     print(f)
+ if let foo {
+     print(foo)
  }
```

This is the new default behavior, but can be disabled with `--redundant-optional-binding same-name-only`.