### PR TITLE
Add rule to prefer `flatMap { ... }` over `map { ... }.reduce([], +)`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -44,6 +44,7 @@
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferCountWhere](#preferCountWhere)
+* [preferFlatMap](#preferFlatMap)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
 * [redundantAsync](#redundantAsync)
@@ -2096,6 +2097,24 @@ Prefer defining `final` classes. To suppress this rule, add "Base" to the class 
 
   /// Base class to be subclassed by other features
   class MyCustomizationPoint {}
+```
+
+</details>
+<br/>
+
+## preferFlatMap
+
+Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let allItems = sections.map { $0.items }.reduce([], +)
++ let allItems = sections.flatMap { $0.items }
+
+- let allItems = sections.map({ $0.items }).reduce([], +)
++ let allItems = sections.flatMap({ $0.items })
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -64,6 +64,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferCountWhere": .preferCountWhere,
     "preferExplicitFalse": .preferExplicitFalse,
     "preferFinalClasses": .preferFinalClasses,
+    "preferFlatMap": .preferFlatMap,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
     "preferSwiftStringAPI": .preferSwiftStringAPI,

--- a/Sources/Rules/PreferFlatMap.swift
+++ b/Sources/Rules/PreferFlatMap.swift
@@ -1,0 +1,89 @@
+//
+//  PreferFlatMap.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 6/24/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferFlatMap = FormatRule(
+        help: "Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`."
+    ) { formatter in
+        formatter.forEach(.identifier("map")) { mapIndex, _ in
+            guard let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: mapIndex) else { return }
+
+            // Parse the `map` call, which takes exactly one closure
+            // and is either `map { ... }` or `map({ ... })`
+            let endOfMapCall: Int
+
+            if formatter.tokens[nextIndex] == .startOfScope("("),
+               let startOfClosureIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextIndex),
+               formatter.tokens[startOfClosureIndex] == .startOfScope("{"),
+               let endOfClosureIndex = formatter.endOfScope(at: startOfClosureIndex),
+               let tokenAfterClosure = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfClosureIndex),
+               formatter.tokens[tokenAfterClosure] == .endOfScope(")")
+            {
+                endOfMapCall = tokenAfterClosure
+            }
+
+            else if formatter.tokens[nextIndex] == .startOfScope("{"),
+                    let endOfClosureIndex = formatter.endOfScope(at: nextIndex)
+            {
+                endOfMapCall = endOfClosureIndex
+            }
+
+            else {
+                return
+            }
+
+            // Require a `.reduce` call immediately after the `map` call.
+            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfMapCall),
+                  formatter.tokens[dotIndex] == .operator(".", .infix),
+                  let reduceIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                  formatter.tokens[reduceIndex] == .identifier("reduce"),
+                  let openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: reduceIndex),
+                  formatter.tokens[openParenIndex] == .startOfScope("("),
+                  let closeParenIndex = formatter.endOfScope(at: openParenIndex)
+            else { return }
+
+            // Require the reduce arguments to be exactly `[], +`, i.e. an empty
+            // array literal seed combined with the `+` operator. This is the
+            // flatten-by-concatenation shape that `flatMap` expresses directly.
+            guard let openBracketIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: openParenIndex),
+                  formatter.tokens[openBracketIndex] == .startOfScope("["),
+                  let closeBracketIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: openBracketIndex),
+                  formatter.tokens[closeBracketIndex] == .endOfScope("]"),
+                  let commaIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeBracketIndex),
+                  formatter.tokens[commaIndex] == .delimiter(","),
+                  let plusIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: commaIndex),
+                  formatter.tokens[plusIndex].isOperator("+"),
+                  let afterPlusIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: plusIndex),
+                  afterPlusIndex == closeParenIndex
+            else { return }
+
+            // Bail if the span we'd remove contains a comment, so we never
+            // silently delete a comment between the `map` and `reduce` calls.
+            let removalRange = (endOfMapCall + 1) ... closeParenIndex
+            guard !formatter.tokens[removalRange].contains(where: \.isComment) else { return }
+
+            // Remove the `.reduce([], +)` suffix (including any whitespace or
+            // line breaks between the map call and the reduce call), then
+            // rename `map` to `flatMap`.
+            formatter.removeTokens(in: removalRange)
+            formatter.replaceToken(at: mapIndex, with: .identifier("flatMap"))
+        }
+    } examples: {
+        """
+        ```diff
+        - let allItems = sections.map { $0.items }.reduce([], +)
+        + let allItems = sections.flatMap { $0.items }
+
+        - let allItems = sections.map({ $0.items }).reduce([], +)
+        + let allItems = sections.flatMap({ $0.items })
+        ```
+        """
+    }
+}

--- a/Tests/Rules/PreferFlatMapTests.swift
+++ b/Tests/Rules/PreferFlatMapTests.swift
@@ -1,0 +1,162 @@
+//
+//  PreferFlatMapTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 6/24/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferFlatMapTests: XCTestCase {
+    func testConvertMapReduceTrailingClosureToFlatMap() {
+        let input = """
+        sections.map { $0.items }.reduce([], +)
+        """
+
+        let output = """
+        sections.flatMap { $0.items }
+        """
+
+        testFormatting(for: input, output, rule: .preferFlatMap)
+    }
+
+    func testConvertMapReduceParenClosureToFlatMap() {
+        let input = """
+        sections.map({ $0.items }).reduce([], +)
+        """
+
+        let output = """
+        sections.flatMap({ $0.items })
+        """
+
+        // Exclude `trailingClosures`, which would otherwise rewrite the
+        // preserved paren-closure form into a trailing closure.
+        testFormatting(for: input, output, rule: .preferFlatMap, exclude: [.trailingClosures])
+    }
+
+    func testConvertMultilineMapReduce() {
+        let input = """
+        actionGroups
+            .map { group in
+                group.actionRows
+            }
+            .reduce([], +)
+        """
+
+        let output = """
+        actionGroups
+            .flatMap { group in
+                group.actionRows
+            }
+        """
+
+        testFormatting(for: input, output, rule: .preferFlatMap)
+    }
+
+    func testConvertNestedMapReduce() {
+        let input = """
+        groups.map { group in
+            group.rows.map { $0.cells }.reduce([], +)
+        }.reduce([], +)
+        """
+
+        let output = """
+        groups.flatMap { group in
+            group.rows.flatMap { $0.cells }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferFlatMap)
+    }
+
+    func testConvertPreservesChainedCallAfterReduce() {
+        let input = """
+        sections.map { $0.items }.reduce([], +).count
+        """
+
+        let output = """
+        sections.flatMap { $0.items }.count
+        """
+
+        testFormatting(for: input, output, rule: .preferFlatMap)
+    }
+
+    func testPreservesCompactMapReduce() {
+        let input = """
+        sections.compactMap { $0.items }.reduce([], +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesCommentBetweenMapAndReduce() {
+        let input = """
+        sections.map { $0.items } // flatten
+            .reduce([], +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesCommentInsideReduce() {
+        let input = """
+        sections.map { $0.items }.reduce(/* seed */ [], +)
+        """
+
+        // Exclude `spaceAroundComments`, which would otherwise insert a space
+        // after the open paren; the point here is that `preferFlatMap` itself
+        // leaves the commented `reduce` call untouched.
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.spaceAroundComments])
+    }
+
+    func testPreservesReduceWithNonEmptySeed() {
+        let input = """
+        values.map { $0.count }.reduce(0, +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesReduceWithNonEmptyArraySeed() {
+        let input = """
+        sections.map { $0.items }.reduce([defaultItem], +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesReduceWithDifferentOperator() {
+        let input = """
+        sets.map { $0.elements }.reduce([], -)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesReduceWithClosureCombinator() {
+        let input = """
+        sections.map { $0.items }.reduce([]) { $0 + $1 }
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesStandaloneMap() {
+        let input = """
+        sections.map { $0.items }
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesMapFollowedByOtherCall() {
+        let input = """
+        sections.map { $0.items }.filter { !$0.isEmpty }
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+}


### PR DESCRIPTION
### What

Adds a new rule, `preferFlatMap`, that converts `map { ... }.reduce([], +)` to `flatMap { ... }`.

```diff
- let allItems = sections.map { $0.items }.reduce([], +)
+ let allItems = sections.flatMap { $0.items }
```

### Why

`map { ... }.reduce([], +)` builds an intermediate `[[Element]]` and then flattens it by repeated concatenation (re-allocating and copying on each `+`). `flatMap { ... }` produces the same result directly, avoids the intermediate allocations, and reads more clearly.

SwiftLint has a (lint-only, non-autocorrectable) [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) rule for this same transform — this brings it to SwiftFormat as an autocorrecting rule, in the spirit of the README's note that "SwiftFormat even fixes some style violations that SwiftLint warns about but can't currently autocorrect."

### Scope / safety

The rule is intentionally conservative — it only rewrites cases that are provably behavior-preserving:

- **Only `map`** is matched. `compactMap { ... }.reduce([], +)` is *not* equivalent to `flatMap { ... }` when the closure returns an optional, so it's left untouched.
- **Only the exact `reduce([], +)` shape** — an empty array-literal seed combined with the `+` operator. Non-empty seeds (`reduce([x], +)`), type-annotated seeds (`reduce([Int](), +)`), other operators (`reduce([], -)`), and closure combinators (`reduce([]) { $0 + $1 }`) are all preserved.
- Both trailing-closure and parenthesized-closure forms are handled.
- Bails (rather than silently deleting) if a comment sits between the `map` and `reduce` calls.