### PR TITLE
Add rule to prefer `contains` over `range(of:)` compared against nil

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -129,6 +129,7 @@
 * [noExplicitOwnership](#noExplicitOwnership)
 * [noGuardInTests](#noGuardInTests)
 * [organizeDeclarations](#organizeDeclarations)
+* [preferContainsOverRange](#preferContainsOverRange)
 * [preferExplicitFalse](#preferExplicitFalse)
 * [preferFinalClasses](#preferFinalClasses)
 * [preferSwiftStringAPI](#preferSwiftStringAPI)
@@ -2019,6 +2020,30 @@ Without this declaration, only functions will be reordered, while properties wil
 +
   }
 ```
+
+</details>
+<br/>
+
+## preferContainsOverRange
+
+Prefer `contains` over `range(of:)` compared against nil.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- if text.range(of: "needle") != nil {
++ if text.contains("needle") {
+
+- if text.range(of: "needle") == nil {
++ if !text.contains("needle") {
+```
+
+***NOTE:*** In rare cases this rewrite can change behavior — e.g. an
+`NSString` receiver whose `range(of:)` returns a non-optional `NSRange`
+(where `!= nil` is always true), or a type without a matching `contains`
+overload. For this reason the rule is disabled by default, and must be
+enabled via the `--enable preferContainsOverRange` option.
 
 </details>
 <br/>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -61,6 +61,7 @@ let ruleRegistry: [String: FormatRule] = [
     "numberFormatting": .numberFormatting,
     "opaqueGenericParameters": .opaqueGenericParameters,
     "organizeDeclarations": .organizeDeclarations,
+    "preferContainsOverRange": .preferContainsOverRange,
     "preferCountWhere": .preferCountWhere,
     "preferExplicitFalse": .preferExplicitFalse,
     "preferFinalClasses": .preferFinalClasses,

--- a/Sources/Rules/PreferContainsOverRange.swift
+++ b/Sources/Rules/PreferContainsOverRange.swift
@@ -1,0 +1,165 @@
+//
+//  PreferContainsOverRange.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 6/25/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferContainsOverRange = FormatRule(
+        help: "Prefer `contains` over `range(of:)` compared against nil.",
+        disabledByDefault: true
+    ) { formatter in
+        formatter.forEach(.identifier("range")) { rangeIndex, _ in
+            // Require a member call: something `.range(...)`.
+            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: rangeIndex),
+                  formatter.tokens[dotIndex] == .operator(".", .infix),
+                  let openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: rangeIndex),
+                  formatter.tokens[openParenIndex] == .startOfScope("("),
+                  let closeParenIndex = formatter.endOfScope(at: openParenIndex)
+            else { return }
+
+            // Require a single `of:` labeled argument. The `range(of:options:range:)`
+            // overloads take additional arguments and aren't equivalent to `contains`, so a
+            // top-level comma in the call disqualifies it. Commas nested inside the argument
+            // expression (e.g. `range(of: foo(a, b))`) don't count, so skip nested scopes.
+            guard let labelIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: openParenIndex),
+                  formatter.tokens[labelIndex] == .identifier("of"),
+                  let colonIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: labelIndex),
+                  formatter.tokens[colonIndex] == .delimiter(":")
+            else { return }
+
+            var scanIndex = colonIndex
+            while scanIndex < closeParenIndex {
+                if formatter.tokens[scanIndex].isStartOfScope {
+                    guard let scopeEnd = formatter.endOfScope(at: scanIndex) else { return }
+                    scanIndex = scopeEnd
+                } else if formatter.tokens[scanIndex] == .delimiter(",") {
+                    return // top-level comma: a multi-argument `range(of:options:…)` call
+                }
+                scanIndex += 1
+            }
+
+            // The argument must be non-empty (e.g. `range(of:)` as a method reference is not a call we handle).
+            guard let argStartIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: colonIndex),
+                  argStartIndex < closeParenIndex
+            else { return }
+
+            // Require a trailing `!= nil` or `== nil` comparison.
+            guard let operatorIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeParenIndex),
+                  let nilIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: operatorIndex),
+                  formatter.tokens[nilIndex] == .identifier("nil")
+            else { return }
+
+            let negate: Bool
+            switch formatter.tokens[operatorIndex] {
+            case .operator("!=", .infix): negate = false // range(of:) != nil  ->  contains(_:)
+            case .operator("==", .infix): negate = true // range(of:) == nil  -> !contains(_:)
+            default: return
+            }
+
+            // Bail rather than silently delete any comment in the spans we rewrite.
+            guard !formatter.tokens[(rangeIndex + 1) ... argStartIndex].contains(where: \.isComment),
+                  !formatter.tokens[closeParenIndex ... nilIndex].contains(where: \.isComment)
+            else { return }
+
+            // Find the start of the receiver expression (the value `.range` is called on),
+            // so a negated rewrite can insert `!` before the whole expression. Returns nil if
+            // the receiver uses optional chaining (`foo?.range(of:)` yields `Range?`, so the
+            // comparison can't be rewritten to a plain `Bool` `contains`).
+            guard let receiverStart = formatter.startOfRangeReceiver(endingAt: dotIndex) else { return }
+
+            // Rewrite right-to-left so earlier indices stay valid.
+
+            // 1. Drop the trailing comparison: ` != nil` / ` == nil`.
+            formatter.removeTokens(in: (closeParenIndex + 1) ... nilIndex)
+
+            // 2. Drop the `of:` label (and the space after the colon) so
+            //    `range(of: x)` becomes `contains(x)`.
+            formatter.removeTokens(in: labelIndex ..< argStartIndex)
+
+            // 3. Rename `range` to `contains`.
+            formatter.replaceToken(at: rangeIndex, with: .identifier("contains"))
+
+            // 4. Negate the receiver expression for the `== nil` case.
+            if negate {
+                formatter.insert(.operator("!", .prefix), at: receiverStart)
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - if text.range(of: "needle") != nil {
+        + if text.contains("needle") {
+
+        - if text.range(of: "needle") == nil {
+        + if !text.contains("needle") {
+        ```
+
+        ***NOTE:*** In rare cases this rewrite can change behavior — e.g. an
+        `NSString` receiver whose `range(of:)` returns a non-optional `NSRange`
+        (where `!= nil` is always true), or a type without a matching `contains`
+        overload. For this reason the rule is disabled by default, and must be
+        enabled via the `--enable preferContainsOverRange` option.
+        """
+    }
+}
+
+extension Formatter {
+    /// Given the index of the `.` immediately before a `range(of:)` call, returns the index of
+    /// the first token of the receiver expression that `range(of:)` is called on — the position
+    /// where a `!` should be inserted to negate the whole `contains` call.
+    ///
+    /// Walks backwards across member-access dots and balanced trailing scopes (subscripts, call
+    /// parentheses, and generic argument clauses), and stops at the first token that bounds the
+    /// expression (an infix operator, delimiter, keyword, or start of an enclosing scope).
+    ///
+    /// Returns `nil` when the negating `!` couldn't be placed safely:
+    /// - optional chaining / force-unwrap in the receiver (`foo?.range(of:)` yields `Range?`, so
+    ///   the nil comparison can't become a plain `Bool`-returning `contains`),
+    /// - a leading-dot (implicit member) receiver (`.foo.range(of:)`), where a prefix `!` would be
+    ///   malformed,
+    /// - a prefix operator immediately before the receiver (`-foo.range(of:)`), where inserting `!`
+    ///   would juxtapose unary operators.
+    func startOfRangeReceiver(endingAt dotIndex: Int) -> Int? {
+        var start = dotIndex
+        while let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: start) {
+            switch tokens[prev] {
+            case .operator(".", _), .delimiter("."):
+                // Only an identifier or a closing scope can precede an ordinary member-access dot.
+                // Anything else (or nothing) means a leading-dot implicit member (`.foo`), which
+                // has no value token to prefix with `!`, so bail.
+                guard let beforeDot = index(of: .nonSpaceOrCommentOrLinebreak, before: prev),
+                      tokens[beforeDot].isIdentifier || tokens[beforeDot].isEndOfScope
+                else { return nil }
+                start = prev
+
+            case .identifier:
+                start = prev
+
+            case .operator("?", _), .operator("!", _):
+                // Optional chaining (or force-unwrap) in the receiver changes the result type
+                // of the call, so we can't safely rewrite the nil comparison.
+                return nil
+
+            case .operator(_, .prefix):
+                // A prefix operator right before the receiver (e.g. `-foo`) would be juxtaposed
+                // with the `!` we'd insert. Bail rather than emit invalid syntax.
+                return nil
+
+            case .endOfScope(")"), .endOfScope("]"), .endOfScope(">"):
+                guard let scopeStart = startOfScope(at: prev) else { return nil }
+                start = scopeStart
+
+            default:
+                // Any other token (infix operator, delimiter, keyword, start of scope) bounds
+                // the receiver expression.
+                return start
+            }
+        }
+        return start
+    }
+}

--- a/Tests/Rules/PreferContainsOverRangeTests.swift
+++ b/Tests/Rules/PreferContainsOverRangeTests.swift
@@ -1,0 +1,214 @@
+//
+//  PreferContainsOverRangeTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 6/25/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferContainsOverRangeTests: XCTestCase {
+    func testConvertRangeNotEqualNilToContains() {
+        let input = """
+        text.range(of: "needle") != nil
+        """
+
+        let output = """
+        text.contains("needle")
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testConvertRangeEqualNilToNotContains() {
+        let input = """
+        text.range(of: "needle") == nil
+        """
+
+        let output = """
+        !text.contains("needle")
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testConvertWithReceiverChainNegated() {
+        let input = """
+        if model.title.range(of: query) == nil {}
+        """
+
+        let output = """
+        if !model.title.contains(query) {}
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testConvertInsideCondition() {
+        let input = """
+        if text.range(of: "needle") != nil {
+            handle()
+        }
+        """
+
+        let output = """
+        if text.contains("needle") {
+            handle()
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testConvertWithDataReceiver() {
+        let input = """
+        body.range(of: Data(phone.utf8)) != nil
+        """
+
+        let output = """
+        body.contains(Data(phone.utf8))
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesRangeWithAdditionalArguments() {
+        let input = """
+        text.range(of: "needle", options: .caseInsensitive) != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testConvertArgumentContainingNestedCommas() {
+        let input = """
+        text.range(of: makeNeedle(a, b)) != nil
+        """
+
+        let output = """
+        text.contains(makeNeedle(a, b))
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesRangeNotComparedToNil() {
+        let input = """
+        let r = text.range(of: "needle")
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesRangeComparedToOtherValue() {
+        let input = """
+        text.range(of: "needle") != other
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesRangeWithoutOfLabel() {
+        let input = """
+        array.range(in: bounds) != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testNegationInCompoundBooleanOnlyNegatesReceiver() {
+        let input = """
+        if foo && text.range(of: x) == nil {}
+        """
+
+        let output = """
+        if foo && !text.contains(x) {}
+        """
+
+        // Exclude `andOperator`, which would rewrite `&&` to a comma in the `if` condition;
+        // the point here is that the `!` negates only the `text` receiver, not `foo`.
+        testFormatting(for: input, output, rule: .preferContainsOverRange, exclude: [.andOperator])
+    }
+
+    func testConvertNotEqualNilInCompoundBoolean() {
+        let input = """
+        if foo && text.range(of: x) != nil {}
+        """
+
+        let output = """
+        if foo && text.contains(x) {}
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange, exclude: [.andOperator])
+    }
+
+    func testPreservesOptionalChainedReceiver() {
+        let input = """
+        text?.range(of: x) != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesOptionalChainedReceiverInChain() {
+        let input = """
+        items.first?.name.range(of: "z") == nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testConvertGenericReceiverNegated() {
+        let input = """
+        Box<Item>().range(of: x) == nil
+        """
+
+        let output = """
+        !Box<Item>().contains(x)
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testConvertSubscriptReceiverNegated() {
+        let input = """
+        items[index].range(of: x) == nil
+        """
+
+        let output = """
+        !items[index].contains(x)
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesLeadingDotReceiver() {
+        let input = """
+        let b: Bool = .text.range(of: x) == nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesPrefixOperatorBeforeReceiver() {
+        let input = """
+        let n = -value.range(of: x) == nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverRange)
+    }
+
+    func testPreservesCommentInsideRangeCall() {
+        let input = """
+        text.range(of: /* needle */ "needle") != nil
+        """
+
+        // Exclude `spaceAroundComments`, which would otherwise reformat the comment
+        // spacing; the point here is that `preferContainsOverRange` leaves the
+        // commented call untouched.
+        testFormatting(for: input, rule: .preferContainsOverRange, exclude: [.spaceAroundComments])
+    }
+}


### PR DESCRIPTION
### What

Adds a new rule, `preferContainsOverRange`, that converts a `range(of:)` call compared against `nil` into a `contains` membership check.

```diff
- if text.range(of: "needle") != nil {
+ if text.contains("needle") {

- if text.range(of: "needle") == nil {
+ if !text.contains("needle") {
```

### Why

`x.range(of: y) != nil` searches for a range only to discard it and test emptiness; `x.contains(y)` expresses the membership test directly and reads more clearly.

SwiftLint has a lint-only (non-autocorrectable) [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) rule for this; this brings it to SwiftFormat as an autocorrecting rule.

### Scope / safety

The rule is intentionally conservative:

- **Single `of:` argument only.** The `range(of:options:range:)` overloads aren't equivalent to `contains`, so a top-level comma in the call disqualifies it. Commas nested inside the argument expression (e.g. `range(of: makeNeedle(a, b))`) don't count.
- **Safe negation only.** For the `== nil` case, the `!` is inserted at the start of the receiver expression. The rule handles generic, subscript, and call receivers (via balanced scopes), and **bails** when `!` can't be placed safely: optional-chained / force-unwrapped receivers (`foo?.range(of:)` yields `Range?`, not a `Bool`-comparable value), leading-dot implicit members, and prefix operators immediately before the receiver.
- **Comment-preserving.** Bails rather than silently deleting a comment in the rewritten spans.

### Disabled by default

Like `isEmpty`, this is `disabledByDefault: true`. In rare cases the rewrite can change behavior — e.g. an `NSString` receiver whose `range(of:)` returns a non-optional `NSRange` (so `!= nil` is always `true`), or a type without a matching `contains` overload. Opt in via `--enable preferContainsOverRange`.