### PR TITLE
Add rule to prefer `first(where:)` over `filter(_:).first`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -44,6 +44,7 @@
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
 * [preferCountWhere](#preferCountWhere)
+* [preferFirstWhere](#preferFirstWhere)
 * [preferFlatMap](#preferFlatMap)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
@@ -2122,6 +2123,24 @@ Prefer defining `final` classes. To suppress this rule, add "Base" to the class 
 
   /// Base class to be subclassed by other features
   class MyCustomizationPoint {}
+```
+
+</details>
+<br/>
+
+## preferFirstWhere
+
+Prefer `first(where:)` over `filter(_:).first`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- planets.filter { $0.hasMoons }.first
++ planets.first(where: { $0.hasMoons })
+
+- planets.filter({ $0.hasMoons }).first
++ planets.first(where: { $0.hasMoons })
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -65,6 +65,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferCountWhere": .preferCountWhere,
     "preferExplicitFalse": .preferExplicitFalse,
     "preferFinalClasses": .preferFinalClasses,
+    "preferFirstWhere": .preferFirstWhere,
     "preferFlatMap": .preferFlatMap,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,

--- a/Sources/Rules/PreferFirstWhere.swift
+++ b/Sources/Rules/PreferFirstWhere.swift
@@ -1,0 +1,114 @@
+//
+//  PreferFirstWhere.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 6/25/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferFirstWhere = FormatRule(
+        help: "Prefer `first(where:)` over `filter(_:).first`."
+    ) { formatter in
+        formatter.forEach(.identifier("filter")) { filterIndex, _ in
+            guard let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: filterIndex) else { return }
+
+            // Parse the `filter` call, which takes exactly one closure
+            // and is either `filter { ... }` or `filter({ ... })`
+            let openParen: Int?
+            let startOfClosure: Int
+            let endOfClosure: Int
+            let closeParen: Int?
+
+            if formatter.tokens[nextIndex] == .startOfScope("("),
+               let startOfClosureIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: nextIndex),
+               formatter.tokens[startOfClosureIndex] == .startOfScope("{"),
+               let endOfClosureIndex = formatter.endOfScope(at: startOfClosureIndex),
+               let tokenAfterClosure = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfClosureIndex),
+               formatter.tokens[tokenAfterClosure] == .endOfScope(")")
+            {
+                openParen = nextIndex
+                startOfClosure = startOfClosureIndex
+                endOfClosure = endOfClosureIndex
+                closeParen = tokenAfterClosure
+            }
+
+            else if formatter.tokens[nextIndex] == .startOfScope("{"),
+                    let endOfClosureIndex = formatter.endOfScope(at: nextIndex)
+            {
+                openParen = nil
+                startOfClosure = nextIndex
+                endOfClosure = endOfClosureIndex
+                closeParen = nil
+            }
+
+            else {
+                return
+            }
+
+            // Check if there's a `.first` property access after the filter call
+            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeParen ?? endOfClosure),
+                  formatter.tokens[dotIndex] == .operator(".", .infix),
+                  let firstIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                  formatter.tokens[firstIndex] == .identifier("first")
+            else { return }
+
+            // Ensure the `.first` is a property access, not a method call like `first(where:)`
+            // or `first(3)`. Only the no-argument `.first` property is equivalent to `first(where:)`.
+            if let tokenAfterFirst = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstIndex),
+               formatter.tokens[tokenAfterFirst].isStartOfScope
+            {
+                return
+            }
+
+            // Remove the `.first` property access, including any whitespace or line breaks between
+            // the filter call and `.first` (so a multiline `.first` on its own line doesn't leave a
+            // dangling blank line). Bail rather than silently delete a comment in that span.
+            let endOfFilterCall = closeParen ?? endOfClosure
+            guard !formatter.tokens[(endOfFilterCall + 1) ... firstIndex].contains(where: \.isComment) else { return }
+            formatter.removeTokens(in: (endOfFilterCall + 1) ... firstIndex)
+
+            // Replace the `filter(_:)` call with `first(where:)`.
+            // Since the `where` label provides semantic value,
+            // convert to the non-trailing-closure form.
+
+            // Replace `filter({ ... })` with `first(where: { ... })`.
+            if let openParen, let closeParen {
+                formatter.replaceToken(at: filterIndex, with: .identifier("first"))
+
+                formatter.insert(
+                    [.identifier("where"), .delimiter(":"), .space(" ")],
+                    at: openParen + 1
+                )
+            }
+
+            // Replace `filter { ... }` with `first(where: { ... })`.
+            else {
+                formatter.insert(.endOfScope(")"), at: endOfClosure + 1)
+
+                formatter.insert(
+                    [.startOfScope("("), .identifier("where"), .delimiter(":"), .space(" ")],
+                    at: startOfClosure
+                )
+
+                if formatter.tokens[filterIndex + 1].isSpace {
+                    formatter.removeToken(at: filterIndex + 1)
+                }
+
+                formatter.replaceToken(at: filterIndex, with: .identifier("first"))
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - planets.filter { $0.hasMoons }.first
+        + planets.first(where: { $0.hasMoons })
+
+        - planets.filter({ $0.hasMoons }).first
+        + planets.first(where: { $0.hasMoons })
+        ```
+        """
+    }
+}

--- a/Tests/Rules/PreferFirstWhereTests.swift
+++ b/Tests/Rules/PreferFirstWhereTests.swift
@@ -1,0 +1,173 @@
+//
+//  PreferFirstWhereTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 6/25/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferFirstWhereTests: XCTestCase {
+    func testConvertFilterParenClosureToFirstWhere() {
+        let input = """
+        planets.filter({ $0.hasMoons }).first
+        """
+
+        let output = """
+        planets.first(where: { $0.hasMoons })
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertFilterTrailingClosureToFirstWhere() {
+        let input = """
+        planets.filter { $0.hasMoons }.first
+        """
+
+        let output = """
+        planets.first(where: { $0.hasMoons })
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertMultilineFilter() {
+        let input = """
+        planets
+            .filter { planet in
+                planet.hasMoons
+            }
+            .first
+        """
+
+        // The rule converts the `filter` call in place and drops the trailing `.first`, leaving the
+        // `first(where:)` where `filter` was (the now-empty `.first` line is removed).
+        let output = """
+        planets
+            .first(where: { planet in
+                planet.hasMoons
+            })
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertNestedFilterFirst() {
+        let input = """
+        systems.filter { system in
+            system.planets.filter { $0.hasMoons }.first != nil
+        }.first
+        """
+
+        let output = """
+        systems.first(where: { system in
+            system.planets.first(where: { $0.hasMoons }) != nil
+        })
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertPreservesOptionalChainAfterFirst() {
+        let input = """
+        planets.filter { $0.hasMoons }.first?.name
+        """
+
+        let output = """
+        planets.first(where: { $0.hasMoons })?.name
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertPreservesNilCoalescingAfterFirst() {
+        let input = """
+        planets.filter { $0.hasMoons }.first ?? defaultPlanet
+        """
+
+        let output = """
+        planets.first(where: { $0.hasMoons }) ?? defaultPlanet
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertPreservesForceUnwrapAfterFirst() {
+        let input = """
+        planets.filter { $0.hasMoons }.first!
+        """
+
+        let output = """
+        planets.first(where: { $0.hasMoons })!
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testPreservesCommentBetweenFilterAndFirst() {
+        let input = """
+        planets
+            .filter { $0.hasMoons }
+            // pick the first
+            .first
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+
+    func testConvertPreservesCommentInsideClosure() {
+        let input = """
+        planets.filter { /* gas giants */ $0.hasMoons }.first
+        """
+
+        let output = """
+        planets.first(where: { /* gas giants */ $0.hasMoons })
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testPreservesFirstMethodWithWhere() {
+        let input = """
+        planets.filter { $0.hasMoons }.first(where: { $0.isHabitable })
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+
+    func testPreservesFirstMethodWithCount() {
+        let input = """
+        planets.filter { $0.hasMoons }.first(3)
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+
+    func testPreservesStandaloneFilter() {
+        let input = """
+        planets.filter { $0.hasMoons }
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+
+    func testPreservesFilterFollowedByOtherProperty() {
+        let input = """
+        planets.filter { $0.hasMoons }.count
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+
+    func testPreservesFilterFollowedByLast() {
+        let input = """
+        planets.filter { $0.hasMoons }.last
+        """
+
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
+}


### PR DESCRIPTION
`x.filter { p }.first` builds a filtered collection only to take its first element; `x.first(where: { p })` finds that element directly and stops early.

Modeled on the existing `preferCountWhere` rule. Differences:
- No Swift-version guard — `first(where:)` predates Swift's `count(where:)`.
- Only the no-argument `.first` *property* is matched; `.first(where:)`, `.first(3)`, etc. are method calls and left alone (the token after `first` being a start-of-scope disqualifies it).
- Removes the whole span between the filter call and `.first` (including any intervening linebreak/indentation), so a `.first` on its own line doesn't leave a dangling blank line. Bails rather than silently deleting a comment in that span.

Prior art: SwiftLint's lint-only `first_where` rule.

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [ ] The base branch of the pull request is `develop`
- [ ] Any code changes include corresponding test cases
-->