### PR TITLE
Fix preferSwiftTesting spuriously adding UIKit import for UInt types

### DIFF
--- a/Sources/Rules/PreferSwiftTesting.swift
+++ b/Sources/Rules/PreferSwiftTesting.swift
@@ -280,10 +280,13 @@ extension Formatter {
         return false
     }
 
-    /// Whether or not this file includes a symbol starting with the UI prefix, which indicates that it probably comes from the UIKit library.
+    /// Whether or not this file references a UIKit symbol (an identifier with a `UI` prefix followed by an uppercase letter, e.g. `UIView`).
     func referencesUIKitSymbols() -> Bool {
+        // The trailing-uppercase check excludes stdlib `UInt`/`UInt8`/... (which are
+        // `UI`+lowercase); without it they'd get a spurious `import UIKit` that fails
+        // to compile on non-UIKit platforms.
         let allIdentifiersInFile = Set(tokens.lazy.filter(\.isIdentifier).map(\.string))
-        return allIdentifiersInFile.contains(where: { $0.hasPrefix("UI") })
+        return allIdentifiersInFile.contains(where: { $0.hasPrefix("UI") && $0.dropFirst(2).first?.isUppercase == true })
     }
 
     /// Converts the XCTest helper function (e.g. `XCTAssert(...)`) at the given index

--- a/Tests/Rules/PreferSwiftTestingTests.swift
+++ b/Tests/Rules/PreferSwiftTestingTests.swift
@@ -913,4 +913,32 @@ final class PreferSwiftTestingTests: XCTestCase {
         let options = FormatOptions(swiftVersion: "6.0")
         testFormatting(for: input, rule: .preferSwiftTesting, options: options)
     }
+
+    func testDoesNotImportUIKitForUIntStdlibTypes() {
+        let input = """
+        import XCTest
+
+        final class CryptoTests: XCTestCase {
+            func testDigestLength() {
+                let digest = [UInt8](repeating: 0, count: 32)
+                XCTAssertEqual(digest.count, 32)
+            }
+        }
+        """
+
+        let output = """
+        import Foundation
+        import Testing
+
+        final class CryptoTests {
+            @Test func digestLength() {
+                let digest = [UInt8](repeating: 0, count: 32)
+                #expect(digest.count == 32)
+            }
+        }
+        """
+
+        let options = FormatOptions(swiftVersion: "6.0")
+        testFormatting(for: input, [output], rules: [.preferSwiftTesting, .sortImports], options: options)
+    }
 }


### PR DESCRIPTION
## Problem
`referencesUIKitSymbols()` treats any identifier starting with "UI" as a UIKit
symbol. The stdlib types `UInt`/`UInt8`/`UInt16`/`UInt32`/`UInt64` all start with
"UI", so any XCTest file using them gains a spurious `import UIKit` when converted
to Swift Testing — which fails to compile on non-UIKit platforms (macOS CLI /
SwiftPM targets). Repro: an XCTest file containing `let v: UInt8 = 0`.

## Fix
Require the character after the `UI` prefix to be uppercase. UIKit symbols are
`UI` + uppercase (`UIView`, `UIButton`), whereas the stdlib `UInt*` types are
`UI` + lowercase — this excludes them without a hardcoded list and keeps matching
all current/future UIKit types. (Thanks @calda for the suggestion.)

## Test
Added `testDoesNotImportUIKitForUIntStdlibTypes`; all existing PreferSwiftTesting
tests still pass (24/24 locally).
