### PR TITLE
Add rule to prefer `min()` over `sorted().first`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -48,6 +48,7 @@
 * [preferFlatMap](#preferFlatMap)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
+* [preferMinOverSorted](#preferMinOverSorted)
 * [redundantAsync](#redundantAsync)
 * [redundantBackticks](#redundantBackticks)
 * [redundantBreak](#redundantBreak)
@@ -2237,6 +2238,24 @@ Convert trivial `map { $0.foo }` closures to keyPath-based syntax.
 
 - let barArray = fooArray.compactMap { $0.optionalBar }
 + let barArray = fooArray.compactMap(\.optionalBar)
+```
+
+</details>
+<br/>
+
+## preferMinOverSorted
+
+Prefer `min()` over `sorted().first`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let smallest = values.sorted().first
++ let smallest = values.min()
+
+- let earliest = events.sorted(by: { $0.date < $1.date }).first
++ let earliest = events.min(by: { $0.date < $1.date })
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -69,6 +69,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferFlatMap": .preferFlatMap,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
+    "preferMinOverSorted": .preferMinOverSorted,
     "preferSwiftStringAPI": .preferSwiftStringAPI,
     "preferSwiftTesting": .preferSwiftTesting,
     "privateStateVariables": .privateStateVariables,

--- a/Sources/Rules/PreferMinOverSorted.swift
+++ b/Sources/Rules/PreferMinOverSorted.swift
@@ -1,0 +1,78 @@
+//
+//  PreferMinOverSorted.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 6/26/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferMinOverSorted = FormatRule(
+        help: "Prefer `min()` over `sorted().first`."
+    ) { formatter in
+        formatter.forEach(.identifier("sorted")) { sortedIndex, _ in
+            // Require a member call: something `.sorted(...)`.
+            guard let dotBeforeSorted = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: sortedIndex),
+                  formatter.tokens[dotBeforeSorted] == .operator(".", .infix),
+                  let openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: sortedIndex),
+                  formatter.tokens[openParenIndex] == .startOfScope("("),
+                  let closeParenIndex = formatter.endOfScope(at: openParenIndex)
+            else { return }
+
+            // `sorted()` and `sorted(by:)` are the only forms equivalent to `min`.
+            // `sorted()` → no arguments; `sorted(by:)` → a single `by:` argument that passes
+            // through unchanged to `min(by:)`.
+            let args = formatter.parseFunctionCallArguments(startOfScope: openParenIndex)
+            switch args.count {
+            case 0:
+                break
+            case 1 where args[0].label == "by":
+                break
+            default:
+                return
+            }
+
+            // Require a trailing `.first` *property* access. Only `.first` is rewritten, not
+            // `.last`: `sorted().first` always equals `min()` (both pick the first minimal element),
+            // but `sorted().last` does NOT equal `max()` when elements tie under the comparator —
+            // `sorted().last` is the last tied element while `max()` returns the first maximal one.
+            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeParenIndex),
+                  formatter.tokens[dotIndex] == .operator(".", .infix),
+                  let accessorIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                  formatter.tokens[accessorIndex] == .identifier("first")
+            else { return }
+
+            // Ensure `.first` is a property access, not a method call (`.first(where:)`)
+            // or a subscript (`.first[0]`).
+            if let tokenAfterAccessor = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: accessorIndex),
+               formatter.tokens[tokenAfterAccessor].isStartOfScope
+            {
+                return
+            }
+
+            // Bail rather than silently delete a comment in the `.first` suffix span
+            // (between the `sorted(...)` close paren and the accessor).
+            guard !formatter.tokens[(closeParenIndex + 1) ... accessorIndex].contains(where: \.isComment) else { return }
+
+            // Remove the trailing `.first` (and any whitespace/linebreaks before it, so a chained
+            // `.first` on its own line doesn't leave a dangling blank line).
+            formatter.removeTokens(in: (closeParenIndex + 1) ... accessorIndex)
+
+            // Rename `sorted` → `min`. The `(...)` argument list (empty or `by:`) is reused as-is:
+            // `sorted(by: p).first` → `min(by: p)`, `sorted().first` → `min()`.
+            formatter.replaceToken(at: sortedIndex, with: .identifier("min"))
+        }
+    } examples: {
+        """
+        ```diff
+        - let smallest = values.sorted().first
+        + let smallest = values.min()
+
+        - let earliest = events.sorted(by: { $0.date < $1.date }).first
+        + let earliest = events.min(by: { $0.date < $1.date })
+        ```
+        """
+    }
+}

--- a/Tests/Rules/PreferMinOverSortedTests.swift
+++ b/Tests/Rules/PreferMinOverSortedTests.swift
@@ -1,0 +1,156 @@
+//
+//  PreferMinOverSortedTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 6/26/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferMinOverSortedTests: XCTestCase {
+    func testConvertSortedFirstToMin() {
+        let input = """
+        let smallest = values.sorted().first
+        """
+
+        let output = """
+        let smallest = values.min()
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedLast() {
+        // `sorted().last` is intentionally NOT rewritten to `max()`: on comparator ties,
+        // `sorted().last` returns the last tied element while `max()` returns the first maximal
+        // one, so the rewrite would not be behavior-preserving.
+        let input = """
+        let largest = values.sorted().last
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedByLast() {
+        let input = """
+        let latest = events.sorted(by: { $0.date < $1.date }).last
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedReversedFirst() {
+        // `sorted().reversed().first` is equivalent to `sorted().last`, not `min()`, so it must NOT
+        // be rewritten — same tie-breaking divergence from `max()` as `.last` (see testPreservesSortedLast).
+        let input = """
+        let largest = values.sorted().reversed().first
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testConvertSortedByFirstToMinBy() {
+        let input = """
+        let earliest = events.sorted(by: { $0.date < $1.date }).first
+        """
+
+        let output = """
+        let earliest = events.min(by: { $0.date < $1.date })
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testConvertSortedByOperatorReference() {
+        let input = """
+        let smallest = values.sorted(by: <).first
+        """
+
+        let output = """
+        let smallest = values.min(by: <)
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testConvertSortedByThrowingComparatorFirst() {
+        let input = """
+        let earliest = try events.sorted(by: throwingComparator).first
+        """
+
+        let output = """
+        let earliest = try events.min(by: throwingComparator)
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testConvertChainedReceiver() {
+        let input = """
+        let first = model.scores.values.sorted().first
+        """
+
+        let output = """
+        let first = model.scores.values.min()
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedWithoutAccessor() {
+        let input = """
+        let ordered = values.sorted()
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedFirstWhere() {
+        let input = """
+        let match = values.sorted().first(where: { $0 > 0 })
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testConvertSortedFirstWithOptionalChainSubscript() {
+        // `.first?[0]` is a property access followed by an optional-chained subscript; `min()?[0]`
+        // is equivalent (both yield the smallest element, then subscript into it).
+        let input = """
+        let top = values.sorted().first?[0]
+        """
+
+        let output = """
+        let top = values.min()?[0]
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedFollowedByOtherAccessor() {
+        let input = """
+        let n = values.sorted().count
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedWithExtraArguments() {
+        let input = """
+        let first = values.sorted(by: areInOrder, stable: true).first
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesPrefixedSortedAccessor() {
+        let input = """
+        let count = values.sorted().firstIndex(of: x)
+        """
+
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
+}


### PR DESCRIPTION
### What

Adds a new rule, `preferMinOverSorted`, that converts `x.sorted().first` to `x.min()` (and `x.sorted(by: areInIncreasingOrder).first` to `x.min(by: areInIncreasingOrder)`).

```diff
- let smallest = values.sorted().first
+ let smallest = values.min()

- let earliest = events.sorted(by: { $0.date < $1.date }).first
+ let earliest = events.min(by: { $0.date < $1.date })
```

### Why

`sorted().first` sorts the entire sequence — O(n log n) plus a full copy — only to take the smallest element. `min()` finds it in a single O(n) pass with no allocation.

### Why `.first`-only (and not `.last` → `max()`)

The rule deliberately rewrites **only** `.first`. `sorted().last` → `max()` is **not** behavior-preserving on comparator ties:

- Both `min(by:)` and `max(by:)` keep the **first** element of a tie group (they only swap the running best on a *strict* comparison, never on a tie).
- `sorted(by:)` places tied elements in a contiguous run, so `.first` reads the **front** of the smallest run (matching `min()`), but `.last` reads the **back** of the largest run — whereas `max()` returns the **front** of it.
- Concretely: `[(5, "a"), (5, "b")].sorted(by: { $0.0 < $1.0 }).last` is `(5, "b")`, but `.max(by:)` is `(5, "a")`. Any element with identity beyond the comparator key (tuples-by-key, objects, structs) would silently change.

So only the `.first → min` direction is safe. `.last` and the equivalent `sorted().reversed().first` are left untouched (with regression tests to keep it that way).

### Scope / safety

- Matches only `sorted()` / `sorted(by:)` (no extra arguments).
- Only the no-argument `.first` *property* — `.first(where:)` / `.first(n)` method calls and subscripts are left alone.
- Bails rather than silently deleting a comment in the rewritten span.
