### PR TITLE
Add rule to prefer `contains(where:)` over `first(where:) != nil`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -43,6 +43,7 @@
 * [noForceUnwrapInTests](#noForceUnwrapInTests)
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
+* [preferContainsOverFirst](#preferContainsOverFirst)
 * [preferCountWhere](#preferCountWhere)
 * [preferFirstWhere](#preferFirstWhere)
 * [preferFlatMap](#preferFlatMap)
@@ -2039,6 +2040,24 @@ Without this declaration, only functions will be reordered, while properties wil
 +     public func d() {}
 +
   }
+```
+
+</details>
+<br/>
+
+## preferContainsOverFirst
+
+Prefer `contains(where:)` over `first(where:)` / `firstIndex(where:)` compared against nil.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- if numbers.first(where: { $0 < 0 }) != nil {
++ if numbers.contains(where: { $0 < 0 }) {
+
+- if numbers.firstIndex(where: { $0 < 0 }) == nil {
++ if !numbers.contains(where: { $0 < 0 }) {
 ```
 
 </details>

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -573,6 +573,62 @@ extension Formatter {
         return index(of: .operator("->", .infix), in: startIndex + 1 ..< endIndex)
     }
 
+    /// Given the index of the `.` immediately before a member call (e.g. the `.` before
+    /// `foo` in `receiver.foo(...)`), returns the index of the first token of the receiver
+    /// expression the member is called on — the position where a prefix operator like `!`
+    /// could be inserted to negate the whole expression.
+    ///
+    /// Walks backwards across member-access dots and balanced trailing scopes (subscripts, call
+    /// parentheses, and generic argument clauses), stopping at the first token that bounds the
+    /// expression (an infix operator, delimiter, keyword, or start of an enclosing scope).
+    ///
+    /// Returns `nil` when a prefix operator couldn't be placed safely:
+    /// - optional chaining / force-unwrap in the receiver (`foo?.bar()`), since the result type
+    ///   then differs (e.g. an `Optional`),
+    /// - a leading-dot (implicit member) receiver (`.foo.bar()`), where a prefix operator would be
+    ///   malformed,
+    /// - a prefix operator immediately before the receiver (`-foo.bar()`), where inserting another
+    ///   prefix operator would juxtapose unary operators.
+    func startOfMemberCallReceiver(endingAt dotIndex: Int) -> Int? {
+        var start = dotIndex
+        while let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: start) {
+            switch tokens[prev] {
+            case .operator(".", _), .delimiter("."):
+                // Only an identifier or a closing scope can precede an ordinary member-access dot.
+                // Anything else (or nothing) means a leading-dot implicit member (`.foo`), which
+                // has no value token to prefix, so bail.
+                guard let beforeDot = index(of: .nonSpaceOrCommentOrLinebreak, before: prev),
+                      tokens[beforeDot].isIdentifier || tokens[beforeDot].isEndOfScope
+                else { return nil }
+                start = prev
+
+            case .identifier:
+                start = prev
+
+            case .operator("?", _), .operator("!", _):
+                // Optional chaining (or force-unwrap) in the receiver changes the result type.
+                return nil
+
+            case .operator(_, .prefix):
+                // A prefix operator right before the receiver (e.g. `-foo`) would be juxtaposed
+                // with the operator we'd insert. Bail rather than emit invalid syntax.
+                return nil
+
+            case .endOfScope(")"), .endOfScope("]"), .endOfScope(">"), .endOfScope("}"):
+                // Skip balanced trailing scopes: call parens `()`, subscripts `[]`, generic
+                // argument clauses `<>`, and trailing closures `{}` (e.g. `foo.filter { ... }.bar`).
+                guard let scopeStart = startOfScope(at: prev) else { return nil }
+                start = scopeStart
+
+            default:
+                // Any other token (infix operator, delimiter, keyword, start of scope) bounds
+                // the receiver expression.
+                return start
+            }
+        }
+        return start
+    }
+
     /// Recursively searches to the start of scopes until we either no longer find a scope or we know we are in a closure.
     func isInClosure(at index: Int) -> Bool {
         guard let startOfScopeIndex = startOfScope(at: index) else {

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -61,6 +61,7 @@ let ruleRegistry: [String: FormatRule] = [
     "numberFormatting": .numberFormatting,
     "opaqueGenericParameters": .opaqueGenericParameters,
     "organizeDeclarations": .organizeDeclarations,
+    "preferContainsOverFirst": .preferContainsOverFirst,
     "preferContainsOverRange": .preferContainsOverRange,
     "preferCountWhere": .preferCountWhere,
     "preferExplicitFalse": .preferExplicitFalse,

--- a/Sources/Rules/PreferContainsOverFirst.swift
+++ b/Sources/Rules/PreferContainsOverFirst.swift
@@ -1,0 +1,125 @@
+//
+//  PreferContainsOverFirst.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 6/29/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferContainsOverFirst = FormatRule(
+        help: "Prefer `contains(where:)` over `first(where:)` / `firstIndex(where:)` compared against nil."
+    ) { formatter in
+        for accessor in ["first", "firstIndex"] {
+            formatter.forEach(.identifier(accessor)) { accessorIndex, _ in
+                // Require a member call: something `.first(...)` / `.firstIndex(...)`.
+                guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: accessorIndex),
+                      formatter.tokens[dotIndex] == .operator(".", .infix),
+                      let scopeIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: accessorIndex)
+                else { return }
+
+                // Parse the call arguments with the shared helper, which handles both the
+                // `first(where: { ... })` paren form and the trailing-closure `first { ... }` form.
+                // Each must be a single argument equivalent to `contains(where:)`: a `where:`-labeled
+                // paren argument, or the unlabeled trailing closure. A non-`where:` paren label (e.g.
+                // `firstIndex(of:)`), extra arguments, or the bare `.first` property don't apply.
+                guard let args = formatter.parseFunctionCallArguments(after: accessorIndex),
+                      args.count == 1
+                else { return }
+
+                let isTrailingClosure = formatter.tokens[scopeIndex] == .startOfScope("{")
+                if isTrailingClosure {
+                    guard args[0].label == nil else { return }
+                } else {
+                    guard args[0].label == "where" else { return }
+                }
+
+                // End of the call expression: the closure's `}` for the trailing-closure form,
+                // otherwise the closing paren.
+                let endOfCall: Int
+                if isTrailingClosure {
+                    endOfCall = args[0].valueRange.upperBound
+                } else {
+                    guard let closeParenIndex = formatter.endOfScope(at: scopeIndex) else { return }
+                    endOfCall = closeParenIndex
+                }
+
+                // Require a trailing `!= nil` or `== nil` comparison.
+                guard let operatorIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfCall),
+                      let nilIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: operatorIndex),
+                      formatter.tokens[nilIndex] == .identifier("nil")
+                else { return }
+
+                let negate: Bool
+                switch formatter.tokens[operatorIndex] {
+                case .operator("!=", .infix): negate = false // first(where:) != nil  ->  contains(where:)
+                case .operator("==", .infix): negate = true // first(where:) == nil  -> !contains(where:)
+                default: return
+                }
+
+                // Bail rather than silently delete a comment in the trailing comparison span.
+                guard !formatter.tokens[endOfCall ... nilIndex].contains(where: \.isComment) else { return }
+
+                // For the `== nil` case, find the start of the receiver expression so the negating
+                // `!` can be inserted before the whole expression (bails on optional chaining etc.).
+                let receiverStart: Int?
+                if negate {
+                    guard let start = formatter.startOfMemberCallReceiver(endingAt: dotIndex) else { return }
+                    receiverStart = start
+                } else {
+                    receiverStart = nil
+                }
+
+                // For the trailing-closure form we move the closure into `(where: ...)`, which means
+                // collapsing any whitespace between the accessor and its `{`. Bail rather than
+                // silently discard a comment living in that gap (the closure body is untouched).
+                if isTrailingClosure,
+                   formatter.tokens[(accessorIndex + 1) ..< scopeIndex].contains(where: \.isComment)
+                {
+                    return
+                }
+
+                // Rewrite right-to-left so earlier indices stay valid.
+
+                // 1. Drop the trailing comparison: ` != nil` / ` == nil`.
+                formatter.removeTokens(in: (endOfCall + 1) ... nilIndex)
+
+                // 2. For the trailing-closure form, wrap the closure in `(where: { ... })` so it
+                //    matches `contains(where:)` (which has no trailing-closure-friendly position).
+                if isTrailingClosure {
+                    formatter.insert(.endOfScope(")"), at: endOfCall + 1)
+                    formatter.insert(
+                        [.startOfScope("("), .identifier("where"), .delimiter(":"), .space(" ")],
+                        at: scopeIndex
+                    )
+                    // Collapse any whitespace or linebreak between the accessor and the (now
+                    // wrapped) closure so `first { ... }` becomes `contains(where: { ... })`
+                    // instead of leaving a stray space or newline before the inserted `(`.
+                    if accessorIndex + 1 < scopeIndex {
+                        formatter.removeTokens(in: (accessorIndex + 1) ..< scopeIndex)
+                    }
+                }
+
+                // 3. Rename `first` / `firstIndex` → `contains`. The `(where: ...)` argument is reused.
+                formatter.replaceToken(at: accessorIndex, with: .identifier("contains"))
+
+                // 4. Negate the receiver expression for the `== nil` case.
+                if let receiverStart {
+                    formatter.insert(.operator("!", .prefix), at: receiverStart)
+                }
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - if numbers.first(where: { $0 < 0 }) != nil {
+        + if numbers.contains(where: { $0 < 0 }) {
+
+        - if numbers.firstIndex(where: { $0 < 0 }) == nil {
+        + if !numbers.contains(where: { $0 < 0 }) {
+        ```
+        """
+    }
+}

--- a/Sources/Rules/PreferContainsOverRange.swift
+++ b/Sources/Rules/PreferContainsOverRange.swift
@@ -54,7 +54,7 @@ public extension FormatRule {
             // so a negated rewrite can insert `!` before the whole expression. Returns nil if
             // the receiver uses optional chaining (`foo?.range(of:)` yields `Range?`, so the
             // comparison can't be rewritten to a plain `Bool` `contains`).
-            guard let receiverStart = formatter.startOfRangeReceiver(endingAt: dotIndex) else { return }
+            guard let receiverStart = formatter.startOfMemberCallReceiver(endingAt: dotIndex) else { return }
 
             // Rewrite right-to-left so earlier indices stay valid.
 
@@ -89,61 +89,5 @@ public extension FormatRule {
         overload. For this reason the rule is disabled by default, and must be
         enabled via the `--enable preferContainsOverRange` option.
         """
-    }
-}
-
-extension Formatter {
-    /// Given the index of the `.` immediately before a `range(of:)` call, returns the index of
-    /// the first token of the receiver expression that `range(of:)` is called on — the position
-    /// where a `!` should be inserted to negate the whole `contains` call.
-    ///
-    /// Walks backwards across member-access dots and balanced trailing scopes (subscripts, call
-    /// parentheses, and generic argument clauses), and stops at the first token that bounds the
-    /// expression (an infix operator, delimiter, keyword, or start of an enclosing scope).
-    ///
-    /// Returns `nil` when the negating `!` couldn't be placed safely:
-    /// - optional chaining / force-unwrap in the receiver (`foo?.range(of:)` yields `Range?`, so
-    ///   the nil comparison can't become a plain `Bool`-returning `contains`),
-    /// - a leading-dot (implicit member) receiver (`.foo.range(of:)`), where a prefix `!` would be
-    ///   malformed,
-    /// - a prefix operator immediately before the receiver (`-foo.range(of:)`), where inserting `!`
-    ///   would juxtapose unary operators.
-    func startOfRangeReceiver(endingAt dotIndex: Int) -> Int? {
-        var start = dotIndex
-        while let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: start) {
-            switch tokens[prev] {
-            case .operator(".", _), .delimiter("."):
-                // Only an identifier or a closing scope can precede an ordinary member-access dot.
-                // Anything else (or nothing) means a leading-dot implicit member (`.foo`), which
-                // has no value token to prefix with `!`, so bail.
-                guard let beforeDot = index(of: .nonSpaceOrCommentOrLinebreak, before: prev),
-                      tokens[beforeDot].isIdentifier || tokens[beforeDot].isEndOfScope
-                else { return nil }
-                start = prev
-
-            case .identifier:
-                start = prev
-
-            case .operator("?", _), .operator("!", _):
-                // Optional chaining (or force-unwrap) in the receiver changes the result type
-                // of the call, so we can't safely rewrite the nil comparison.
-                return nil
-
-            case .operator(_, .prefix):
-                // A prefix operator right before the receiver (e.g. `-foo`) would be juxtaposed
-                // with the `!` we'd insert. Bail rather than emit invalid syntax.
-                return nil
-
-            case .endOfScope(")"), .endOfScope("]"), .endOfScope(">"):
-                guard let scopeStart = startOfScope(at: prev) else { return nil }
-                start = scopeStart
-
-            default:
-                // Any other token (infix operator, delimiter, keyword, start of scope) bounds
-                // the receiver expression.
-                return start
-            }
-        }
-        return start
     }
 }

--- a/Tests/Rules/PreferContainsOverFirstTests.swift
+++ b/Tests/Rules/PreferContainsOverFirstTests.swift
@@ -1,0 +1,188 @@
+//
+//  PreferContainsOverFirstTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 6/29/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferContainsOverFirstTests: XCTestCase {
+    func testConvertFirstWhereNotEqualNil() {
+        let input = """
+        let hasNegative = numbers.first(where: { $0 < 0 }) != nil
+        """
+
+        let output = """
+        let hasNegative = numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertFirstWhereEqualNilNegated() {
+        let input = """
+        let noNegative = numbers.first(where: { $0 < 0 }) == nil
+        """
+
+        let output = """
+        let noNegative = !numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertFirstIndexWhereNotEqualNil() {
+        let input = """
+        let exists = numbers.firstIndex(where: { $0 < 0 }) != nil
+        """
+
+        let output = """
+        let exists = numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertFirstIndexWhereEqualNilNegated() {
+        let input = """
+        let missing = numbers.firstIndex(where: { $0 < 0 }) == nil
+        """
+
+        let output = """
+        let missing = !numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertTrailingClosureFirstNotEqualNil() {
+        let input = """
+        let hasNegative = numbers.first { $0 < 0 } != nil
+        """
+
+        let output = """
+        let hasNegative = numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertTrailingClosureFirstEqualNilNegated() {
+        let input = """
+        let noNegative = numbers.first { $0 < 0 } == nil
+        """
+
+        let output = """
+        let noNegative = !numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertTrailingClosureReceiverEqualNilNegated() {
+        let input = """
+        let noMatch = numbers.filter { $0 > 0 }.first(where: { $0 > 5 }) == nil
+        """
+
+        // The negating `!` must precede the whole receiver chain (including the leading
+        // `.filter { ... }` trailing closure), not land between the closure's `}` and `.contains`.
+        let output = """
+        let noMatch = !numbers.filter { $0 > 0 }.contains(where: { $0 > 5 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertTrailingClosureWithLinebreakBeforeBrace() {
+        let input = """
+        let hasNegative = numbers.first
+            { $0 < 0 } != nil
+        """
+
+        // A linebreak between `first` and its trailing `{` is collapsed when the closure is
+        // wrapped into `(where: ...)`, rather than leaving a stray newline before the `(`.
+        let output = """
+        let hasNegative = numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testPreservesCommentBetweenAccessorAndTrailingClosure() {
+        let input = """
+        let hasNegative = numbers.first /* pick */ { $0 < 0 } != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+
+    func testConvertWithChainedReceiver() {
+        let input = """
+        let exists = model.items.values.first(where: { $0.isActive }) != nil
+        """
+
+        let output = """
+        let exists = model.items.values.contains(where: { $0.isActive })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testNegationInCompoundBooleanOnlyNegatesReceiver() {
+        let input = """
+        if foo && numbers.first(where: { $0 < 0 }) == nil {}
+        """
+
+        let output = """
+        if foo && !numbers.contains(where: { $0 < 0 }) {}
+        """
+
+        // Exclude `andOperator`, which rewrites `&&` to a comma in `if` conditions; the point here
+        // is that the `!` negates only the `numbers` receiver, not `foo`.
+        testFormatting(for: input, output, rule: .preferContainsOverFirst, exclude: [.andOperator])
+    }
+
+    func testPreservesFirstWhereNotComparedToNil() {
+        let input = """
+        let firstNegative = numbers.first(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+
+    func testPreservesFirstWhereComparedToOtherValue() {
+        let input = """
+        let match = numbers.first(where: { $0 < 0 }) != other
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+
+    func testPreservesFirstIndexOf() {
+        let input = """
+        let exists = numbers.firstIndex(of: 5) != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+
+    func testPreservesFirstProperty() {
+        let input = """
+        let exists = numbers.first != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+
+    func testPreservesOptionalChainedReceiver() {
+        let input = """
+        let exists = model?.numbers.first(where: { $0 < 0 }) == nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
+}

--- a/Tests/Rules/PreferContainsOverRangeTests.swift
+++ b/Tests/Rules/PreferContainsOverRangeTests.swift
@@ -211,4 +211,19 @@ final class PreferContainsOverRangeTests: XCTestCase {
         // commented call untouched.
         testFormatting(for: input, rule: .preferContainsOverRange, exclude: [.spaceAroundComments])
     }
+
+    func testConvertTrailingClosureReceiverEqualNilNegated() {
+        let input = """
+        let missing = items.map { $0.name }.joined().range(of: "x") == nil
+        """
+
+        // The negating `!` must precede the whole receiver chain, including the leading
+        // `.map { ... }` trailing closure, rather than landing between the closure's `}`
+        // and the chained call.
+        let output = """
+        let missing = !items.map { $0.name }.joined().contains("x")
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
 }

--- a/Tests/Rules/PreferFirstWhereTests.swift
+++ b/Tests/Rules/PreferFirstWhereTests.swift
@@ -69,7 +69,9 @@ final class PreferFirstWhereTests: XCTestCase {
         })
         """
 
-        testFormatting(for: input, output, rule: .preferFirstWhere)
+        // Exclude `preferContainsOverFirst`, which would further rewrite the inner
+        // `first(where:) != nil` into `contains(where:)`; this test isolates `preferFirstWhere`.
+        testFormatting(for: input, output, rule: .preferFirstWhere, exclude: [.preferContainsOverFirst])
     }
 
     func testConvertPreservesOptionalChainAfterFirst() {


### PR DESCRIPTION
### What

Adds a new rule, `preferContainsOverFirst`, that converts `first(where:)` / `firstIndex(where:)` calls compared against `nil` into a `contains(where:)` membership check.

```diff
- if numbers.first(where: { $0 < 0 }) != nil {
+ if numbers.contains(where: { $0 < 0 }) {

- if numbers.firstIndex(where: { $0 < 0 }) == nil {
+ if !numbers.contains(where: { $0 < 0 }) {
```

The trailing-closure form is handled too, rewrapped as `contains(where:)`:

```diff
- if numbers.first(where: { $0 < 0 }) != nil {
+ if numbers.contains(where: { $0 < 0 }) {
```

### Why

`x.first(where: p) != nil` and `x.firstIndex(where: p) != nil` find and return the matched element (or its index) only to discard it and test for existence. `x.contains(where: p)` expresses that existence test directly and returns a plain `Bool`. The `== nil` forms map to the negated `!contains(where:)`.

`firstIndex(where:) != nil` is equivalent because an index exists exactly when a matching element exists.

This pairs with the existing `preferContainsOverRange` rule (same `!= nil` / `== nil` → `contains` / `!contains` shape).

### Scope / safety

The rule is intentionally conservative:

- **`where:`-closure calls only.** Both the `first(where:)` paren form and the trailing-closure `first { ... }` form are matched. A non-closure argument like `firstIndex(of:)`, the bare `.first` *property*, and `first(n)` are all left alone.
- **`nil` comparison only.** Only `!= nil` / `== nil` trigger the rewrite; a comparison against any other value is left untouched.
- **Safe negation only.** For the `== nil` case the `!` is inserted at the start of the *whole* receiver expression. This is shared with `preferContainsOverRange` via a new `Formatter.startOfMemberCallReceiver(endingAt:)` helper (extracted from that rule's previously-private `startOfRangeReceiver`). The helper walks back across member-access dots and balanced trailing scopes — call parens, subscripts, generic argument clauses, **and trailing closures** — and **bails** when `!` can't be placed safely: optional-chained / force-unwrapped receivers (`foo?.first(where:)` yields an `Optional`, not a `Bool`-comparable value), leading-dot implicit members, and prefix operators immediately before the receiver.
- **Comment-preserving.** Bails rather than silently deleting a comment in any rewritten span (including between the accessor and a trailing closure).

### Note

Extracting the shared receiver-walk helper also surfaced and fixed a latent bug in `preferContainsOverRange`: its private walker didn't skip a trailing-closure `{}` scope, so a receiver like `a.filter { ... }.range(of: x) == nil` placed the `!` between the closure's `}` and the chained call, producing invalid syntax. The generalized helper handles `{}` and is covered by a regression test in both rules' test suites.