### PR TITLE
Fix `preferContainsOverFirst` rewriting optional-chained receivers

### DIFF
--- a/Sources/Rules/PreferContainsOverFirst.swift
+++ b/Sources/Rules/PreferContainsOverFirst.swift
@@ -62,15 +62,14 @@ public extension FormatRule {
                 // Bail rather than silently delete a comment in the trailing comparison span.
                 guard !formatter.tokens[endOfCall ... nilIndex].contains(where: \.isComment) else { return }
 
-                // For the `== nil` case, find the start of the receiver expression so the negating
-                // `!` can be inserted before the whole expression (bails on optional chaining etc.).
-                let receiverStart: Int?
-                if negate {
-                    guard let start = formatter.startOfMemberCallReceiver(endingAt: dotIndex) else { return }
-                    receiverStart = start
-                } else {
-                    receiverStart = nil
-                }
+                // Find the start of the receiver expression. This serves two purposes:
+                //  - it locates where a negating `!` is inserted for the `== nil` case, and
+                //  - it detects optional chaining / force-unwrap in the receiver, which must bail in
+                //    *both* comparison directions: `foo?.first(where:)` yields an `Optional`, so
+                //    `foo?.contains(where:)` is `Bool?` rather than the `Bool` the nil comparison
+                //    produces (and `foo?.first(where:) != nil` is `false`, not `nil`, when `foo` is
+                //    nil). It also bails on leading-dot implicit members and prefix operators.
+                guard let receiverStart = formatter.startOfMemberCallReceiver(endingAt: dotIndex) else { return }
 
                 // For the trailing-closure form we move the closure into `(where: ...)`, which means
                 // collapsing any whitespace between the accessor and its `{`. Bail rather than
@@ -106,7 +105,7 @@ public extension FormatRule {
                 formatter.replaceToken(at: accessorIndex, with: .identifier("contains"))
 
                 // 4. Negate the receiver expression for the `== nil` case.
-                if let receiverStart {
+                if negate {
                     formatter.insert(.operator("!", .prefix), at: receiverStart)
                 }
             }

--- a/Tests/Rules/PreferContainsOverFirstTests.swift
+++ b/Tests/Rules/PreferContainsOverFirstTests.swift
@@ -185,4 +185,15 @@ final class PreferContainsOverFirstTests: XCTestCase {
 
         testFormatting(for: input, rule: .preferContainsOverFirst)
     }
+
+    func testPreservesOptionalChainedReceiverNotEqualNil() {
+        // `model?.numbers.first(where:) != nil` is `Bool` (false when `model` is nil), but
+        // `model?.numbers.contains(where:)` is `Bool?` (nil when `model` is nil) — a different
+        // type and value — so the `!= nil` direction must also bail on optional chaining.
+        let input = """
+        let exists = model?.numbers.first(where: { $0 < 0 }) != nil
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFirst)
+    }
 }


### PR DESCRIPTION
### What

Fixes a correctness bug in `preferContainsOverFirst` (added in #2574). The rule only bailed on an optional-chained (or force-unwrapped) receiver in the `== nil` direction. In the `!= nil` direction it rewrote an optional-chained receiver unsafely:

```diff
- if foo?.first(where: { $0.isMatch }) != nil { ... }
+ if foo?.contains(where: { $0.isMatch }) { ... }   // ❌ doesn't compile
```

### Why it's wrong

`foo?.first(where: p) != nil` and `foo?.contains(where: p)` are not equivalent when `foo` is optional:

- `foo?.first(where: p) != nil` is `Bool` — `false` when `foo` is `nil`.
- `foo?.contains(where: p)` is `Bool?` — `nil` when `foo` is `nil`.

Besides the value difference, the `Bool?` result fails to compile anywhere a `Bool` is required (`if`, `&&`, ternary, etc.):

```
error: optional type 'Bool?' cannot be used as a boolean; test for '!= nil' instead
```

### Fix

Compute `startOfMemberCallReceiver(endingAt:)` unconditionally and bail when it returns `nil` — it already detects `?` / `!` in the receiver (as well as leading-dot implicit members and prefix operators) — in *both* comparison directions. The negating `!` is still only inserted when rewriting `== nil`.

Adds a regression test for the `!= nil` optional-chain case (the `== nil` case was already covered).

### How found

Caught applying the rule across a large codebase: `definition.properties?.first(where: { ... }) != nil`, used in a ternary, stopped compiling after the rewrite. Full test suite passes (5706 tests).