### PR TITLE
Fix `preferMinOverSorted` / `preferFirstWhere` skipping `if let` bindings

### DIFF
--- a/Sources/Rules/PreferFirstWhere.swift
+++ b/Sources/Rules/PreferFirstWhere.swift
@@ -47,8 +47,12 @@ public extension FormatRule {
 
             // Ensure the `.first` is a property access, not a method call like `first(where:)`
             // or `first(3)`. Only the no-argument `.first` property is equivalent to `first(where:)`.
+            // A following `{` that begins a control-flow body rather than a closure (e.g.
+            // `if let x = xs.filter { ... }.first {`) does *not* disqualify it — there `.first` is
+            // still a property access, so only bail on a `{` that actually starts a closure.
             if let tokenAfterFirst = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: firstIndex),
-               formatter.tokens[tokenAfterFirst].isStartOfScope
+               formatter.tokens[tokenAfterFirst].isStartOfScope,
+               formatter.tokens[tokenAfterFirst] != .startOfScope("{") || formatter.isStartOfClosure(at: tokenAfterFirst)
             {
                 return
             }

--- a/Sources/Rules/PreferMinOverSorted.swift
+++ b/Sources/Rules/PreferMinOverSorted.swift
@@ -44,10 +44,14 @@ public extension FormatRule {
                   formatter.tokens[accessorIndex] == .identifier("first")
             else { return }
 
-            // Ensure `.first` is a property access, not a method call (`.first(where:)`)
-            // or a subscript (`.first[0]`).
+            // Ensure `.first` is a property access, not a method call (`.first(where:)`),
+            // a subscript (`.first[0]`), or a trailing-closure call (`.first { ... }`).
+            // A following `{` that begins a control-flow body rather than a closure (e.g.
+            // `if let x = xs.sorted().first {`) does *not* disqualify it — there `.first` is
+            // still a property access, so only bail on a `{` that actually starts a closure.
             if let tokenAfterAccessor = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: accessorIndex),
-               formatter.tokens[tokenAfterAccessor].isStartOfScope
+               formatter.tokens[tokenAfterAccessor].isStartOfScope,
+               formatter.tokens[tokenAfterAccessor] != .startOfScope("{") || formatter.isStartOfClosure(at: tokenAfterAccessor)
             {
                 return
             }

--- a/Tests/Rules/PreferFirstWhereTests.swift
+++ b/Tests/Rules/PreferFirstWhereTests.swift
@@ -172,4 +172,48 @@ final class PreferFirstWhereTests: XCTestCase {
 
         testFormatting(for: input, rule: .preferFirstWhere)
     }
+
+    func testConvertFilterFirstInIfLetBinding() {
+        let input = """
+        if let firstMoon = planets.filter({ $0.hasMoons }).first {
+            visit(firstMoon)
+        }
+        """
+
+        // The trailing `{` here begins the `if` body, not a closure, so `.first` is still a
+        // property access and should be rewritten.
+        let output = """
+        if let firstMoon = planets.first(where: { $0.hasMoons }) {
+            visit(firstMoon)
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testConvertFilterFirstTrailingClosureInIfLetBinding() {
+        let input = """
+        if let firstMoon = planets.filter { $0.hasMoons }.first {
+            visit(firstMoon)
+        }
+        """
+
+        let output = """
+        if let firstMoon = planets.first(where: { $0.hasMoons }) {
+            visit(firstMoon)
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferFirstWhere)
+    }
+
+    func testPreservesFilterFirstWithTrailingClosureOnFirst() {
+        let input = """
+        let match = planets.filter { $0.hasMoons }.first { $0.isHabitable }
+        """
+
+        // The final `{` is a trailing closure on `first` (i.e. `first(where:)`), not the `.first`
+        // property, so this must be left untouched.
+        testFormatting(for: input, rule: .preferFirstWhere)
+    }
 }

--- a/Tests/Rules/PreferMinOverSortedTests.swift
+++ b/Tests/Rules/PreferMinOverSortedTests.swift
@@ -153,4 +153,48 @@ final class PreferMinOverSortedTests: XCTestCase {
 
         testFormatting(for: input, rule: .preferMinOverSorted)
     }
+
+    func testConvertSortedFirstInIfLetBinding() {
+        let input = """
+        if let smallest = values.sorted().first {
+            use(smallest)
+        }
+        """
+
+        // The trailing `{` here begins the `if` body, not a closure, so `.first` is still a
+        // property access and should be rewritten.
+        let output = """
+        if let smallest = values.min() {
+            use(smallest)
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testConvertSortedFirstInWhileLetBinding() {
+        let input = """
+        while let smallest = values.sorted().first {
+            values.removeFirst()
+        }
+        """
+
+        let output = """
+        while let smallest = values.min() {
+            values.removeFirst()
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferMinOverSorted)
+    }
+
+    func testPreservesSortedFirstTrailingClosure() {
+        let input = """
+        let match = values.sorted().first { $0 > 0 }
+        """
+
+        // Here the `{` is a trailing closure on `first`, so it's `first(where:)`, not the
+        // `.first` property, and must be left untouched.
+        testFormatting(for: input, rule: .preferMinOverSorted)
+    }
 }


### PR DESCRIPTION
### What

`preferMinOverSorted` and `preferFirstWhere` both failed to rewrite `.first` when it was the last token of an `if let` / `while let` binding condition:

```diff
- if let smallest = values.sorted().first { ... }
+ if let smallest = values.min() { ... }

- if let firstMoon = planets.filter { $0.hasMoons }.first { ... }
+ if let firstMoon = planets.first(where: { $0.hasMoons }) { ... }
```

`guard let ... else` and plain `let` bindings already worked.

### Why

Both rules require the trailing `.first` to be a *property* access, and bail when the next token starts a scope — to exclude method calls (`.first(where:)`), subscripts (`.first[0]`), and trailing-closure calls (`.first { ... }`):

```swift
if let tokenAfterAccessor = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: accessorIndex),
   formatter.tokens[tokenAfterAccessor].isStartOfScope
{
    return
}
```

But when `.first` is the last token of an `if`/`while` binding condition, the very next token is the `{` that opens the control-flow body — also a start-of-scope — so the rule bailed even though `.first` there is a plain property access. (`guard let` avoids this because `else` follows `.first`, not `{`; plain `let` avoids it because a newline/expression follows.)

### Fix

Only bail on a `{` that actually starts a closure (`isStartOfClosure(at:)`); a control-flow body `{` should not disqualify the property access:

```swift
formatter.tokens[tokenAfterAccessor].isStartOfScope,
formatter.tokens[tokenAfterAccessor] != .startOfScope("{") || formatter.isStartOfClosure(at: tokenAfterAccessor)
```

`(` / `[` / `<` still bail (method call / subscript / generic), and a genuine trailing-closure `{` still bails via `isStartOfClosure`.

### Tests

Adds `if let` and `while let` conversion tests to both rules, plus trailing-closure negative tests confirming `.first { ... }` (i.e. `first(where:)`) is still left untouched. Full suite passes (5729 tests).