### PR TITLE
Fix `startOfMemberCallReceiver` walking past statement boundaries

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -603,6 +603,13 @@ extension Formatter {
                 start = prev
 
             case .identifier:
+                // An identifier directly followed by another identifier (`start`) is a juxtaposition
+                // that can't occur mid-expression — it means `prev` is the last token of a *previous*
+                // statement on the line above (Swift's newline statement terminator isn't a token, so
+                // it can't otherwise bound the walk). The current `start` is the receiver root.
+                if tokens[start].isIdentifier {
+                    return start
+                }
                 start = prev
 
             case .operator("?", _), .operator("!", _):
@@ -615,8 +622,14 @@ extension Formatter {
                 return nil
 
             case .endOfScope(")"), .endOfScope("]"), .endOfScope(">"), .endOfScope("}"):
-                // Skip balanced trailing scopes: call parens `()`, subscripts `[]`, generic
-                // argument clauses `<>`, and trailing closures `{}` (e.g. `foo.filter { ... }.bar`).
+                // A closing scope directly followed by an identifier (`start`) is a juxtaposition
+                // that can't occur mid-expression (a member access would need a `.` between them), so
+                // `prev` closes a *previous* statement on the line above and `start` is the receiver
+                // root. Otherwise skip the balanced trailing scope: call parens `()`, subscripts `[]`,
+                // generic argument clauses `<>`, and trailing closures `{}` (`foo.filter { ... }.bar`).
+                if tokens[start].isIdentifier {
+                    return start
+                }
                 guard let scopeStart = startOfScope(at: prev) else { return nil }
                 start = scopeStart
 

--- a/Tests/Rules/PreferContainsOverFirstTests.swift
+++ b/Tests/Rules/PreferContainsOverFirstTests.swift
@@ -196,4 +196,38 @@ final class PreferContainsOverFirstTests: XCTestCase {
 
         testFormatting(for: input, rule: .preferContainsOverFirst)
     }
+
+    func testNegationInsertedAtOwnStatementNotPriorStatementEndingInScope() {
+        // The `== nil` expression is a bare statement following another statement that ends in a
+        // closing `}`. The negating `!` must be inserted before `numbers` on its own line, not
+        // carried up into the previous statement's expression.
+        let input = """
+        perform { work() }
+        numbers.first(where: { $0 < 0 }) == nil
+        """
+
+        let output = """
+        perform { work() }
+        !numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
+
+    func testNegationInsertedAtOwnStatementNotPriorStatementEndingInIdentifier() {
+        // Same boundary issue where the previous statement ends in a bare identifier: the walk must
+        // stop at the `identifier` <newline> `numbers` juxtaposition, not treat `state` as part of
+        // the receiver chain.
+        let input = """
+        refresh.state
+        numbers.first(where: { $0 < 0 }) == nil
+        """
+
+        let output = """
+        refresh.state
+        !numbers.contains(where: { $0 < 0 })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFirst)
+    }
 }

--- a/Tests/Rules/PreferContainsOverRangeTests.swift
+++ b/Tests/Rules/PreferContainsOverRangeTests.swift
@@ -226,4 +226,38 @@ final class PreferContainsOverRangeTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .preferContainsOverRange)
     }
+
+    func testNegationInsertedAtOwnStatementNotPriorStatementEndingInScope() {
+        // The `== nil` expression is a bare statement following another statement that ends in a
+        // closing `}`. The negating `!` must be inserted before `text` on its own line, not carried
+        // up into the previous statement's expression.
+        let input = """
+        perform { work() }
+        text.range(of: "x") == nil
+        """
+
+        let output = """
+        perform { work() }
+        !text.contains("x")
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
+
+    func testNegationInsertedAtOwnStatementNotPriorStatementEndingInIdentifier() {
+        // Same boundary issue where the previous statement ends in a bare identifier: the walk must
+        // stop at the `identifier` <newline> `text` juxtaposition, not treat `state` as part of the
+        // receiver chain.
+        let input = """
+        refresh.state
+        text.range(of: "x") == nil
+        """
+
+        let output = """
+        refresh.state
+        !text.contains("x")
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverRange)
+    }
 }


### PR DESCRIPTION
### What

`startOfMemberCallReceiver(endingAt:)` walks left from a member-access dot to find the start of the receiver expression (used by `preferContainsOverRange` and `preferContainsOverFirst` to place a negating `!`). It skips balanced trailing scopes and member-access dots, but nothing stopped the walk at a **statement boundary**. Swift's newline statement terminator isn't a token, so when the match was a bare `expr == nil` statement whose previous line ended in a closing `}` / `)` / `]` or an identifier, the walk ran on into the previous statement and the `!` landed there:

```diff
  perform { work() }
- numbers.first(where: { $0 < 0 }) == nil
+ !perform { work() }              // ❌ `!` inserted on the previous statement
+ numbers.contains(where: { $0 < 0 })   // ❌ and this line lost its negation
```

Expected:

```diff
  perform { work() }
- numbers.first(where: { $0 < 0 }) == nil
+ !numbers.contains(where: { $0 < 0 })
```

### Why

A member-access chain only ever continues to the left through a `.`. So an identifier or a closing scope sitting **directly** before the current receiver token, with no `.` between them, is a juxtaposition that can't occur mid-expression — it's the end of a *previous* statement on the line above. The walk should stop and treat the current token as the receiver root in that case.

### Fix

In the `.identifier` and `.endOfScope(…)` cases, if the token we're currently positioned at (`start`) is an identifier, then `prev` (an identifier or closing scope) cannot be part of the same expression — return `start` as the root instead of continuing. This bounds the walk correctly while still handling all `.`-joined chains: `foo().bar`, `xs[0].y`, `x.foo()[0].bar`, and multiline `.map { }.filter { }` chains.

Only the negating (`== nil`) path was affected in practice — the `!= nil` path calls the helper solely to detect optional chaining and never inserts `!`. An assignment / `return` / `if` before the expression already bounded the walk, so triggering the bug needed a bare, discarded `expr == nil` statement — uncommon, but a real miscompile.

### Tests

Adds a regression test to both `PreferContainsOverFirstTests` and `PreferContainsOverRangeTests` (a `== nil` statement following a `{ }`-terminated statement). Full suite passes (5731 tests).