### PR TITLE
Add rule to prefer `contains(where:)` over `filter(_:).isEmpty`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -43,6 +43,7 @@
 * [noForceUnwrapInTests](#noForceUnwrapInTests)
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
+* [preferContainsOverFilterIsEmpty](#preferContainsOverFilterIsEmpty)
 * [preferContainsOverFirst](#preferContainsOverFirst)
 * [preferCountWhere](#preferCountWhere)
 * [preferFirstWhere](#preferFirstWhere)
@@ -2041,6 +2042,24 @@ Without this declaration, only functions will be reordered, while properties wil
 +     public func d() {}
 +
   }
+```
+
+</details>
+<br/>
+
+## preferContainsOverFilterIsEmpty
+
+Prefer `contains(where:)` over `filter(_:).isEmpty`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- if messages.filter({ $0.isUnread }).isEmpty {
++ if !messages.contains(where: { $0.isUnread }) {
+
+- let hasUnread = !messages.filter { $0.isUnread }.isEmpty
++ let hasUnread = messages.contains(where: { $0.isUnread })
 ```
 
 </details>

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -589,7 +589,13 @@ extension Formatter {
     ///   malformed,
     /// - a prefix operator immediately before the receiver (`-foo.bar()`), where inserting another
     ///   prefix operator would juxtapose unary operators.
-    func startOfMemberCallReceiver(endingAt dotIndex: Int) -> Int? {
+    ///
+    /// Pass `stoppingAtLeadingNegation: true` when the caller wants to *cancel* an existing prefix
+    /// `!` rather than insert one (e.g. `!xs.filter { … }.isEmpty` → `xs.contains(where: …)`). A
+    /// leading prefix `!` then bounds the receiver on the left (the returned index is the receiver
+    /// root just after the `!`) instead of causing a `nil` bail; the caller can find the `!` itself
+    /// with `index(of:.nonSpaceOrCommentOrLinebreak, before:)`.
+    func startOfMemberCallReceiver(endingAt dotIndex: Int, stoppingAtLeadingNegation: Bool = false) -> Int? {
         var start = dotIndex
         while let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: start) {
             switch tokens[prev] {
@@ -611,6 +617,11 @@ extension Formatter {
                     return start
                 }
                 start = prev
+
+            case .operator("!", .prefix) where stoppingAtLeadingNegation:
+                // Leading boolean negation the caller intends to cancel — it bounds the receiver on
+                // the left. Return the receiver root (the current `start`, just after the `!`).
+                return start
 
             case .operator("?", _), .operator("!", _):
                 // Optional chaining (or force-unwrap) in the receiver changes the result type.

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -61,6 +61,7 @@ let ruleRegistry: [String: FormatRule] = [
     "numberFormatting": .numberFormatting,
     "opaqueGenericParameters": .opaqueGenericParameters,
     "organizeDeclarations": .organizeDeclarations,
+    "preferContainsOverFilterIsEmpty": .preferContainsOverFilterIsEmpty,
     "preferContainsOverFirst": .preferContainsOverFirst,
     "preferContainsOverRange": .preferContainsOverRange,
     "preferCountWhere": .preferCountWhere,

--- a/Sources/Rules/PreferContainsOverFilterIsEmpty.swift
+++ b/Sources/Rules/PreferContainsOverFilterIsEmpty.swift
@@ -1,0 +1,149 @@
+//
+//  PreferContainsOverFilterIsEmpty.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 7/2/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferContainsOverFilterIsEmpty = FormatRule(
+        help: "Prefer `contains(where:)` over `filter(_:).isEmpty`."
+    ) { formatter in
+        formatter.forEach(.identifier("filter")) { filterIndex, _ in
+            // Require a member call: something `.filter(...)`.
+            guard let dotBeforeFilter = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: filterIndex),
+                  formatter.tokens[dotBeforeFilter] == .operator(".", .infix),
+                  let scopeIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: filterIndex)
+            else { return }
+
+            // `filter` must be called with a single closure argument, either the trailing-closure
+            // `filter { ... }` form or the parenthesized `filter({ ... })` form. A stored-predicate
+            // argument (`filter(predicate)`) isn't matched — we only reuse a literal closure.
+            guard let args = formatter.parseFunctionCallArguments(after: filterIndex),
+                  args.count == 1,
+                  args[0].label == nil,
+                  formatter.tokens[args[0].valueRange.lowerBound] == .startOfScope("{")
+            else { return }
+
+            let isTrailingClosure = formatter.tokens[scopeIndex] == .startOfScope("{")
+
+            // End of the `filter(...)` call: the closure's `}` for the trailing-closure form,
+            // otherwise the closing paren.
+            let endOfCall: Int
+            if isTrailingClosure {
+                endOfCall = args[0].valueRange.upperBound
+            } else {
+                guard let closeParenIndex = formatter.endOfScope(at: scopeIndex) else { return }
+                endOfCall = closeParenIndex
+            }
+
+            // Require a trailing `.isEmpty` *property* access.
+            guard let dotIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: endOfCall),
+                  formatter.tokens[dotIndex] == .operator(".", .infix),
+                  let isEmptyIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotIndex),
+                  formatter.tokens[isEmptyIndex] == .identifier("isEmpty")
+            else { return }
+
+            // `.isEmpty` must be the *end* of the expression. The rewrite inserts (or cancels) a
+            // prefix `!`, which binds looser than any postfix operator, so any postfix continuation
+            // after `.isEmpty` would be captured by the `!` and change meaning:
+            //   `xs.filter { }.isEmpty.description`  -> `!xs.contains(...).description`  (== `!String`)
+            //   `xs.filter { }.isEmpty!`             -> `!xs.contains(...)!`             (wrong precedence)
+            // So bail on a trailing member-access `.`, a call/subscript/generic/closure start-of-scope,
+            // or a postfix `!` / `?`. A `{` that opens a *control-flow* body (e.g.
+            // `if xs.filter { }.isEmpty {`) is not a postfix continuation and does not disqualify it.
+            if let tokenAfterIsEmpty = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: isEmptyIndex) {
+                switch formatter.tokens[tokenAfterIsEmpty] {
+                case .operator(".", .infix), .delimiter("."),
+                     .operator("!", .postfix), .operator("?", .postfix):
+                    return
+                case .startOfScope("{") where !formatter.isStartOfClosure(at: tokenAfterIsEmpty):
+                    break // control-flow body, e.g. `if xs.filter { }.isEmpty { ... }`
+                case let token where token.isStartOfScope:
+                    return // call `(`, subscript `[`, generic `<`, or trailing closure `{`
+                default:
+                    break
+                }
+            }
+
+            // Find the start of the receiver expression. `stoppingAtLeadingNegation` makes a leading
+            // `!` (the `!xs.filter { … }.isEmpty` cancellation case) bound the receiver instead of
+            // bailing. Still bails on optional chaining / force-unwrap (result-type change), leading-dot
+            // implicit members, and other prefix operators.
+            guard let receiverStart = formatter.startOfMemberCallReceiver(
+                endingAt: dotBeforeFilter,
+                stoppingAtLeadingNegation: true
+            ) else { return }
+
+            // A prefix `!` immediately before the receiver is an existing negation to cancel.
+            let leadingNegation: Int?
+            if let prev = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: receiverStart),
+               formatter.tokens[prev] == .operator("!", .prefix)
+            {
+                leadingNegation = prev
+            } else {
+                leadingNegation = nil
+            }
+
+            // Bail rather than silently delete a comment in any span we rewrite.
+            guard !formatter.tokens[endOfCall ... isEmptyIndex].contains(where: \.isComment) else { return }
+            if isTrailingClosure,
+               formatter.tokens[(filterIndex + 1) ..< scopeIndex].contains(where: \.isComment)
+            {
+                return
+            }
+
+            // Rewrite right-to-left so earlier indices stay valid.
+
+            // 1. Drop the trailing `.isEmpty`.
+            formatter.removeTokens(in: (endOfCall + 1) ... isEmptyIndex)
+
+            // 2. Reshape `filter`'s argument into `(where: { ... })`.
+            if isTrailingClosure {
+                // `filter { ... }` -> `contains(where: { ... })`
+                formatter.insert(.endOfScope(")"), at: endOfCall + 1)
+                formatter.insert(
+                    [.startOfScope("("), .identifier("where"), .delimiter(":"), .space(" ")],
+                    at: scopeIndex
+                )
+                // Collapse any whitespace/linebreak between `filter` and its `{`.
+                if filterIndex + 1 < scopeIndex {
+                    formatter.removeTokens(in: (filterIndex + 1) ..< scopeIndex)
+                }
+            } else {
+                // `filter({ ... })` -> `contains(where: { ... })`
+                formatter.insert(
+                    [.identifier("where"), .delimiter(":"), .space(" ")],
+                    at: scopeIndex + 1
+                )
+            }
+
+            // 3. Rename `filter` -> `contains`.
+            formatter.replaceToken(at: filterIndex, with: .identifier("contains"))
+
+            // 4. Reconcile negation. `filter { ... }.isEmpty` means "nothing matches", i.e.
+            //    `!contains(where:)`. If the expression was already negated (`!xs.filter { ... }.isEmpty`),
+            //    the two negations cancel: just drop the existing `!`. Otherwise insert one.
+            if let leadingNegation {
+                // Drop the existing `!` (a prefix operator binds directly to its operand, so there's
+                // no whitespace between it and the receiver to clean up).
+                formatter.removeToken(at: leadingNegation)
+            } else {
+                formatter.insert(.operator("!", .prefix), at: receiverStart)
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - if messages.filter({ $0.isUnread }).isEmpty {
+        + if !messages.contains(where: { $0.isUnread }) {
+
+        - let hasUnread = !messages.filter { $0.isUnread }.isEmpty
+        + let hasUnread = messages.contains(where: { $0.isUnread })
+        ```
+        """
+    }
+}

--- a/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
+++ b/Tests/Rules/BlankLinesAfterGuardStatementsTests.swift
@@ -726,7 +726,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
         else { return }
         """
 
-        testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies])
+        testFormatting(for: input, rule: .blankLinesAfterGuardStatements, exclude: [.wrapConditionalBodies, .preferContainsOverFilterIsEmpty])
     }
 
     func testNotInsertLineBreakInChainWhenBlankLineInsertedBetweenConsecutiveGuards() {
@@ -745,7 +745,7 @@ final class BlankLinesAfterGuardStatementsTests: XCTestCase {
             for: input,
             rule: .blankLinesAfterGuardStatements,
             options: FormatOptions(lineBetweenConsecutiveGuards: true),
-            exclude: [.wrapConditionalBodies]
+            exclude: [.wrapConditionalBodies, .preferContainsOverFilterIsEmpty]
         )
     }
 }

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -2966,7 +2966,7 @@ final class IndentTests: XCTestCase {
         else { return }
         """
         testFormatting(for: input, rule: .indent,
-                       exclude: [.wrapConditionalBodies])
+                       exclude: [.wrapConditionalBodies, .preferContainsOverFilterIsEmpty])
     }
 
     func testChainedFunctionInGuardWithXcodeIndentation2() {
@@ -2993,7 +2993,7 @@ final class IndentTests: XCTestCase {
         """
         let options = FormatOptions(xcodeIndentation: true)
         testFormatting(for: input, output, rule: .indent,
-                       options: options, exclude: [.wrapConditionalBodies, .blankLinesAfterGuardStatements])
+                       options: options, exclude: [.wrapConditionalBodies, .blankLinesAfterGuardStatements, .preferContainsOverFilterIsEmpty])
     }
 
     func testWrappedChainedFunctionsWithNestedScopeIndent() {

--- a/Tests/Rules/PreferContainsOverFilterIsEmptyTests.swift
+++ b/Tests/Rules/PreferContainsOverFilterIsEmptyTests.swift
@@ -1,0 +1,246 @@
+//
+//  PreferContainsOverFilterIsEmptyTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 7/2/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferContainsOverFilterIsEmptyTests: XCTestCase {
+    func testConvertFilterIsEmptyToNegatedContains() {
+        let input = """
+        let allRead = messages.filter { $0.isUnread }.isEmpty
+        """
+
+        let output = """
+        let allRead = !messages.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertParenFilterIsEmptyToNegatedContains() {
+        let input = """
+        let allRead = messages.filter({ $0.isUnread }).isEmpty
+        """
+
+        let output = """
+        let allRead = !messages.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertNegatedFilterIsEmptyCancelsNegation() {
+        let input = """
+        let hasUnread = !messages.filter { $0.isUnread }.isEmpty
+        """
+
+        // The existing `!` and the `filter { }.isEmpty` -> `!contains` negation cancel out.
+        let output = """
+        let hasUnread = messages.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertNegatedParenFilterIsEmptyCancelsNegation() {
+        let input = """
+        let hasUnread = !messages.filter({ $0.isUnread }).isEmpty
+        """
+
+        let output = """
+        let hasUnread = messages.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertInIfConditionInsertsNegation() {
+        let input = """
+        if messages.filter({ $0.isUnread }).isEmpty {
+            markAllRead()
+        }
+        """
+
+        // The trailing `{` opens the `if` body, not a closure, so `.isEmpty` is still a property.
+        let output = """
+        if !messages.contains(where: { $0.isUnread }) {
+            markAllRead()
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertNegatedInIfConditionCancelsNegation() {
+        let input = """
+        if !messages.filter { $0.isUnread }.isEmpty {
+            showBadge()
+        }
+        """
+
+        let output = """
+        if messages.contains(where: { $0.isUnread }) {
+            showBadge()
+        }
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertChainedReceiver() {
+        let input = """
+        let empty = model.items.values.filter { $0.isActive }.isEmpty
+        """
+
+        let output = """
+        let empty = !model.items.values.contains(where: { $0.isActive })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertPreservesCommentInsideClosure() {
+        let input = """
+        let allRead = messages.filter { /* unread only */ $0.isUnread }.isEmpty
+        """
+
+        let output = """
+        let allRead = !messages.contains(where: { /* unread only */ $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testConvertWhenIsEmptyFollowedByInfixOperator() {
+        // A trailing *infix* operator (unlike a postfix/member) is safe: the inserted prefix `!`
+        // binds tighter, so `!contains(...) == expected` matches the original `isEmpty == expected`.
+        let input = """
+        let match = messages.filter { $0.isUnread }.isEmpty == expected
+        """
+
+        let output = """
+        let match = !messages.contains(where: { $0.isUnread }) == expected
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesCommentBetweenFilterAndTrailingClosure() {
+        // A comment between `filter` and its trailing `{` would be dropped when the closure is moved
+        // into `(where: ...)`, so bail.
+        let input = """
+        let allRead = messages.filter /* pred */ { $0.isUnread }.isEmpty
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesOptionalChainedReceiver() {
+        // `messages?.filter { ... }.isEmpty` is `Bool?`; `messages?.contains(where:)` is also `Bool?`
+        // but the negation semantics of the whole expression differ, so bail to be safe.
+        let input = """
+        let allRead = messages?.filter { $0.isUnread }.isEmpty
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesForceUnwrappedReceiver() {
+        let input = """
+        let allRead = messages!.filter { $0.isUnread }.isEmpty
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesFilterWithStoredPredicate() {
+        // Not a literal closure argument, so there's no closure to move into `contains(where:)`.
+        let input = """
+        let allRead = messages.filter(isUnread).isEmpty
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesFilterFollowedByOtherProperty() {
+        let input = """
+        let n = messages.filter { $0.isUnread }.count
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesBareIsEmptyWithoutFilter() {
+        let input = """
+        let empty = messages.isEmpty
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesFilterIsEmptyMethodCall() {
+        // `.isEmpty()` as a method call (hypothetical custom type) isn't the Collection property.
+        let input = """
+        let empty = messages.filter { $0.isUnread }.isEmpty()
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesTrailingMemberAfterIsEmpty() {
+        // A trailing `.description` would be captured by the inserted prefix `!`
+        // (`!contains(...).description` == `!String`), so bail.
+        let input = """
+        let text = messages.filter { $0.isUnread }.isEmpty.description
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testPreservesTrailingForceUnwrapAfterIsEmpty() {
+        // A trailing postfix `!` binds tighter than the inserted prefix `!`, so bail.
+        let input = """
+        let b = obj.flags.filter { $0 }.isEmpty!
+        """
+
+        testFormatting(for: input, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testNegationInsertedAtOwnStatementNotPriorStatementEndingInScope() {
+        // The expression is a bare statement following one that ends in a closing `}`. The inserted
+        // `!` must land before `xs` on its own line, not be carried into the previous statement.
+        let input = """
+        perform { work() }
+        xs.filter { $0.isUnread }.isEmpty
+        """
+
+        let output = """
+        perform { work() }
+        !xs.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+
+    func testNegationCancellationNotStolenFromPriorStatement() {
+        // The previous statement's own prefix `!` must not be mistaken for this expression's leading
+        // negation and deleted. `xs.filter{}.isEmpty` (no leading `!`) gets a fresh `!`.
+        let input = """
+        let a = !flag
+        xs.filter { $0.isUnread }.isEmpty
+        """
+
+        let output = """
+        let a = !flag
+        !xs.contains(where: { $0.isUnread })
+        """
+
+        testFormatting(for: input, output, rule: .preferContainsOverFilterIsEmpty)
+    }
+}

--- a/Tests/Rules/RedundantParensTests.swift
+++ b/Tests/Rules/RedundantParensTests.swift
@@ -1288,7 +1288,7 @@ final class RedundantParensTests: XCTestCase {
         let input = """
         if (foo.filter { $0 > 1 }.isEmpty) {}
         """
-        testFormatting(for: input, rule: .redundantParens)
+        testFormatting(for: input, rule: .redundantParens, exclude: [.preferContainsOverFilterIsEmpty])
     }
 
     func testParensNotRemovedAroundClosure3() {

--- a/Tests/Rules/TrailingClosuresTests.swift
+++ b/Tests/Rules/TrailingClosuresTests.swift
@@ -154,14 +154,14 @@ final class TrailingClosuresTests: XCTestCase {
         guard case let .foo(bar) = baz.filter({ $0 == quux }).isEmpty else {}
         """
         testFormatting(for: input, rule: .trailingClosures,
-                       exclude: [.wrapConditionalBodies])
+                       exclude: [.wrapConditionalBodies, .preferContainsOverFilterIsEmpty])
     }
 
     func testParensAroundTrailingClosureInWhereClauseLetNotRemoved() {
         let input = """
         for _ in bar where baz.filter({ $0 == quux }).isEmpty {}
         """
-        testFormatting(for: input, rule: .trailingClosures)
+        testFormatting(for: input, rule: .trailingClosures, exclude: [.preferContainsOverFilterIsEmpty])
     }
 
     func testParensAroundTrailingClosureInSwitchNotRemoved() {

--- a/Tests/Rules/WrapArgumentsTests.swift
+++ b/Tests/Rules/WrapArgumentsTests.swift
@@ -2869,7 +2869,7 @@ final class WrapArgumentsTests: XCTestCase {
         testFormatting(
             for: input, rules: [.wrapArguments, .indent],
             options: FormatOptions(closingParenPosition: .sameLine, wrapConditions: .beforeFirst),
-            exclude: [.propertyTypes]
+            exclude: [.propertyTypes, .preferContainsOverFilterIsEmpty]
         )
     }
 


### PR DESCRIPTION
### What

Adds a new rule, `preferContainsOverFilterIsEmpty`, that converts a `filter(_:).isEmpty` membership test into `contains(where:)`.

```diff
- if messages.filter({ $0.isUnread }).isEmpty {
+ if !messages.contains(where: { $0.isUnread }) {

- let hasUnread = !messages.filter { $0.isUnread }.isEmpty
+ let hasUnread = messages.contains(where: { $0.isUnread })
```

### Why

`xs.filter { p }.isEmpty` builds an entire filtered array just to test whether anything matched; `!xs.contains(where: p)` answers the same question directly and short-circuits at the first match. It also reads more clearly.

The rule reconciles negation both ways:

- `xs.filter { p }.isEmpty` → `!xs.contains(where: p)` (insert a negation)
- `!xs.filter { p }.isEmpty` → `xs.contains(where: p)` (the two `!` cancel)

### Scope / safety

Intentionally conservative:

- **Single literal-closure argument only.** Matches the trailing-closure `filter { }` and parenthesized `filter({ })` forms; a stored-predicate argument (`filter(isUnread)`) is left alone since there's no closure to move into `contains(where:)`.
- **`.isEmpty` must end the expression.** The rewrite inserts (or cancels) a prefix `!`, which binds looser than any postfix operator, so a trailing member access, postfix `!`/`?`, call, or subscript after `.isEmpty` would be captured by the `!` and change meaning (`xs.filter { }.isEmpty.description` → `!xs.contains(...).description` == `!String`). The rule bails on those. A `{` that opens a control-flow body (e.g. `if xs.filter { }.isEmpty {`) is not a postfix continuation and is fine.
- **Bails on optional-chained / force-unwrapped receivers** (the result type would differ) and leading-dot implicit members.
- **Statement-boundary safe.** The receiver walk stops at statement boundaries, so the `!` is never inserted into — nor an existing `!` stolen from — an adjacent statement.

### Shared helper change

To locate where to insert (or which existing `!` to cancel) this reuses `startOfMemberCallReceiver`, extended with a `stoppingAtLeadingNegation: Bool = false` parameter: when `true`, a leading prefix `!` bounds the receiver on the left (so the caller can cancel it) instead of causing the helper to bail. The two existing callers (`preferContainsOverFirst`, `preferContainsOverRange`) keep the default and are unaffected.

### Tests

18 rule tests covering both `filter` forms, both negation directions, chained receivers, control-flow-body vs. trailing-closure disambiguation, statement boundaries (previous statement ending in `}` or a bare identifier, and a previous statement with its own `!`), comment preservation, and the negative cases (trailing member / postfix `!` / stored predicate / method-call `.isEmpty()` / optional-chained receiver). Full suite passes (5751 tests).