### PR TITLE
[codex] Add dark mode to documentation site

### DIFF
--- a/site/site_content.rb
+++ b/site/site_content.rb
@@ -61,13 +61,32 @@ class SiteContent
 
   # Write syntax.css used for code block highlighting.
   def generate_syntax_css
-    stdout, stderr, status = Open3.capture3('bundle', 'exec', 'rougify', 'style', 'github.light')
-    raise "rougify failed:\n#{stderr}" unless status.success?
+    light_css = syntax_css_for('github.light')
+    dark_css = syntax_css_for('github.dark')
 
-    File.write(syntax_css_path, stdout)
+    css = [
+      light_css.chomp,
+      '',
+      '@media (prefers-color-scheme: dark) {',
+      indent_css(dark_css).rstrip,
+      '}',
+    ].join("\n")
+
+    File.write(syntax_css_path, "#{css}\n")
   end
 
   private
+
+  def syntax_css_for(theme)
+    stdout, stderr, status = Open3.capture3('bundle', 'exec', 'rougify', 'style', theme)
+    raise "rougify failed for #{theme}:\n#{stderr}" unless status.success?
+
+    stdout
+  end
+
+  def indent_css(css)
+    css.lines.map { |line| line.strip.empty? ? line : "  #{line}" }.join
+  end
 
   # Prepends the table-of-contents marker to a page's body. `toc_levels`
   # overrides the site-wide `kramdown.toc_levels` config (see `_config.yml`)

--- a/site/src/assets/css/style.css
+++ b/site/src/assets/css/style.css
@@ -25,19 +25,21 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-background: #111113;
+    /* Matches GitHub's dark theme canvas color (rgb(22, 27, 34)) rather than
+       a near-black background. */
+    --color-background: #161b22;
     --color-text: #e6e6ea;
     --color-heading: #fff;
     --color-muted: #a0a0aa;
-    --color-link: #ff8a4c;
+    --color-link: #ffffff;
     --color-nav-link: #c7c7cf;
-    --color-nav-background: #17171a;
-    --color-sidebar-background: #17171a;
+    --color-nav-background: #161b22;
+    --color-sidebar-background: #161b22;
     --color-code-background: #232327;
-    --color-pre-background: #161b22;
-    --color-border: #303038;
-    --color-subtle-border: #393940;
-    --color-separator: #55555f;
+    --color-pre-background: #0d1117;
+    --color-border: #3e444c;
+    --color-subtle-border: #3e444c;
+    --color-separator: #3e444c;
     --color-heading-anchor: #6f6f78;
     color-scheme: dark;
   }
@@ -243,6 +245,14 @@ html {
   overflow-wrap: anywhere;
 }
 
+/* Bold text renders heavier on a dark background, so nested entries (e.g.
+   rule names under a category) use a lighter weight than in light mode. */
+@media (prefers-color-scheme: dark) {
+  .toc-sidebar #markdown-toc > li > ul a {
+    font-weight: 400;
+  }
+}
+
 .toc-sidebar #markdown-toc a:hover {
   color: var(--color-heading);
 }
@@ -373,6 +383,23 @@ pre {
   overflow-x: auto;
   background: var(--color-pre-background);
   border-radius: 6px;
+}
+
+/* Rouge's generated syntax.css sets its own `.highlight` background (to
+   match its theme's own canvas color), which otherwise wins over the rule
+   above since a class selector outranks a bare element selector. */
+pre.highlight {
+  background: var(--color-pre-background);
+}
+
+/* Rouge's generated github.dark theme sets a somewhat dim default token
+   color (#c9d1d9) for unhighlighted code text; lighten it to match the
+   rest of the page's body text. */
+@media (prefers-color-scheme: dark) {
+  pre.highlight,
+  pre.highlight .w {
+    color: var(--color-text);
+  }
 }
 
 /* Tables scroll horizontally within this wrapper (added by default.html)

--- a/site/src/assets/css/style.css
+++ b/site/src/assets/css/style.css
@@ -4,6 +4,45 @@
   box-sizing: border-box;
 }
 
+:root {
+  --nav-height: 63px; /* Fallback, updated dynamically by JS */
+  --color-background: #fff;
+  --color-text: #1d1d1f;
+  --color-heading: #000;
+  --color-muted: #86868b;
+  --color-link: #000;
+  --color-nav-link: #555;
+  --color-nav-background: #fff;
+  --color-sidebar-background: #fafafa;
+  --color-code-background: #f5f5f5;
+  --color-pre-background: #f6f8fa;
+  --color-border: #e5e5e5;
+  --color-subtle-border: #ddd;
+  --color-separator: #ccc;
+  --color-heading-anchor: #bbb;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #111113;
+    --color-text: #e6e6ea;
+    --color-heading: #fff;
+    --color-muted: #a0a0aa;
+    --color-link: #ff8a4c;
+    --color-nav-link: #c7c7cf;
+    --color-nav-background: #17171a;
+    --color-sidebar-background: #17171a;
+    --color-code-background: #232327;
+    --color-pre-background: #161b22;
+    --color-border: #303038;
+    --color-subtle-border: #393940;
+    --color-separator: #55555f;
+    --color-heading-anchor: #6f6f78;
+    color-scheme: dark;
+  }
+}
+
 body {
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   font-size: 16px;
@@ -11,24 +50,21 @@ body {
   line-height: 26px;
   margin: 0;
   padding: 0;
-  color: #1d1d1f;
+  color: var(--color-text);
+  background: var(--color-background);
   /* Break long tokens (URLs, flags, type names) instead of overflowing. */
   overflow-wrap: break-word;
 }
 
 /* Navigation */
-:root {
-  --nav-height: 63px; /* Fallback, updated dynamically by JS */
-}
-
 html {
   /* Extra offset so anchor targets aren't hidden under the sticky nav. */
   scroll-padding-top: calc(var(--nav-height) + 15px);
 }
 
 .top-nav {
-  background: white;
-  border-bottom: 1px solid #e5e5e5;
+  background: var(--color-nav-background);
+  border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -67,7 +103,7 @@ html {
 .nav-title {
   font-size: 18px;
   font-weight: 600;
-  color: black;
+  color: var(--color-heading);
   letter-spacing: -0.3px;
 }
 
@@ -80,22 +116,22 @@ html {
 .nav-link {
   font-size: 15px;
   font-weight: 500;
-  color: #555;
+  color: var(--color-nav-link);
   text-decoration: none;
   white-space: nowrap;
 }
 
 .nav-link:hover {
-  color: black;
+  color: var(--color-heading);
 }
 
 .nav-link.active {
-  color: black;
+  color: var(--color-heading);
   font-weight: 600;
 }
 
 .nav-separator {
-  color: #ccc;
+  color: var(--color-separator);
   font-weight: 400;
 }
 
@@ -105,9 +141,9 @@ html {
   font-family: inherit;
   font-size: 14px;
   font-weight: 600;
-  color: black;
+  color: var(--color-heading);
   background: none;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-subtle-border);
   border-radius: 6px;
   padding: 0.35rem 0.75rem;
   cursor: pointer;
@@ -168,8 +204,8 @@ html {
   max-height: calc(100vh - var(--nav-height));
   overflow-y: auto;
   overflow-x: hidden;
-  background: #fafafa;
-  border-right: 1px solid #e5e5e5;
+  background: var(--color-sidebar-background);
+  border-right: 1px solid var(--color-border);
   font-size: 14px;
   line-height: 1.5;
   /* Hide the scrollbar while keeping the sidebar scrollable. */
@@ -200,7 +236,7 @@ html {
 
 .toc-sidebar #markdown-toc a {
   display: block;
-  color: #555;
+  color: var(--color-nav-link);
   text-decoration: none;
   font-weight: 500;
   /* Wrap long rule names instead of scrolling the sidebar horizontally. */
@@ -208,12 +244,12 @@ html {
 }
 
 .toc-sidebar #markdown-toc a:hover {
-  color: black;
+  color: var(--color-heading);
 }
 
 /* The entry matching the current URL fragment is highlighted as selected. */
 .toc-sidebar #markdown-toc a.active {
-  color: black;
+  color: var(--color-heading);
   font-weight: 700;
 }
 
@@ -221,7 +257,7 @@ html {
    grouping nested sub-entries (e.g. rules.md's categories). On a flat TOC
    with no nesting (e.g. index.md) every entry stays the regular gray. */
 .toc-sidebar > #markdown-toc > li:has(> ul) > a {
-  color: black;
+  color: var(--color-heading);
   font-weight: 600;
 }
 
@@ -237,7 +273,7 @@ b {
 }
 
 a {
-  color: black;
+  color: var(--color-link);
   font-weight: 700;
   text-decoration-line: underline;
   text-decoration-thickness: auto;
@@ -245,7 +281,7 @@ a {
 }
 
 h1 {
-  color: black;
+  color: var(--color-heading);
   font-size: 40px;
   font-weight: 700;
   line-height: 44px;
@@ -257,12 +293,12 @@ h1 {
    metadata, not content. */
 .heading-note {
   margin-top: -0.75rem;
-  color: #86868b;
+  color: var(--color-muted);
   font-size: 15px;
 }
 
 h2 {
-  color: black;
+  color: var(--color-heading);
   font-size: 26px;
   font-weight: 600;
   line-height: 30px;
@@ -271,7 +307,7 @@ h2 {
 }
 
 h3 {
-  color: black;
+  color: var(--color-heading);
   font-size: 22px;
   font-weight: 600;
   line-height: 26px;
@@ -286,7 +322,7 @@ h3 {
 
 .content :is(h1, h2, h3, h4, h5, h6) .header-anchor::after {
   content: " #";
-  color: #bbb;
+  color: var(--color-heading-anchor);
   opacity: 0;
   font-weight: 400;
 }
@@ -304,7 +340,7 @@ code {
 }
 
 :not(pre) > code {
-  background: #f5f5f5;
+  background: var(--color-code-background);
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9em;
@@ -314,7 +350,7 @@ pre {
   margin: 1.5rem 0;
   padding: 1rem;
   overflow-x: auto;
-  background: #f6f8fa;
+  background: var(--color-pre-background);
   border-radius: 6px;
 }
 
@@ -342,13 +378,13 @@ table {
 
 th,
 td {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-subtle-border);
   padding: 0.5rem 0.75rem;
   text-align: left;
 }
 
 th {
-  background: #f5f5f5;
+  background: var(--color-code-background);
 }
 
 /* Responsive */
@@ -416,7 +452,7 @@ th {
     min-height: 0;
     max-height: none;
     overflow-y: auto;
-    background: white;
+    background: var(--color-background);
     border-right: none;
     /* Unlike the desktop sidebar, show the scroll indicator here since this
        overlay covers the whole screen with no other affordance that it


### PR DESCRIPTION
## Summary

- Adds system dark mode support to the documentation site via CSS custom properties and `prefers-color-scheme`.
- Updates generated Rouge syntax CSS to include both `github.light` and `github.dark` themes.

## Notes

- Consulted `CONTRIBUTING.md` for branch/PR conventions and `site/README.md` for the Jekyll site workflow.
- The workspace `AGENTS.md` says PRs should target `develop`, so this PR uses `develop` as the base branch.

## Validation

- `ruby -c site/site_content.rb`
- `git diff --check`
- `RBENV_VERSION=3.4.1 BUNDLE_PATH=/private/tmp/swiftformat-bundle rbenv exec bundle exec rake site:build`
- Captured screenshot evidence for both impacted site pages in light/dark mode at desktop and mobile widths.

## Screenshots

### Home

| Desktop light | Desktop dark |
| --- | --- |
| ![Home desktop light](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/c7124c816a6724f2bba6155604432b90ee1abc0a/home-desktop-light.svg) | ![Home desktop dark](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/c718a2fb626df356d5aa7c50d1a1d6a2cf6699f9/home-desktop-dark.svg) |

| Mobile light | Mobile dark |
| --- | --- |
| ![Home mobile light](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/070f9d8a068fb9c6787ebe6bfa5130ecf558d677/home-mobile-light.svg) | ![Home mobile dark](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/0b03a909061352982fc1b2829d8a4338b5dfa727/home-mobile-dark.svg) |

### Rules

| Desktop light | Desktop dark |
| --- | --- |
| ![Rules desktop light](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/3c3e09669e4ff5add186fab728e801be7a73d1ad/rules-desktop-light.svg) | ![Rules desktop dark](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/b523c584c10c97d2d40d3b1d7a13ed7d76ce55f3/rules-desktop-dark.svg) |

| Mobile light | Mobile dark |
| --- | --- |
| ![Rules mobile light](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/be99acc886d486ef8fbf9dbc5f93606ec2636608/rules-mobile-light.svg) | ![Rules mobile dark](https://gist.githubusercontent.com/Brett-Best/2c521d14ab5cb2ed0d6a23f65b25ab5e/raw/b527052a54dca619a2b574005cb47c59bc54c2ed/rules-mobile-dark.svg) |
