### PR TITLE
Change rules that may break build to disabled-by-default (`isEmpty`, `preferContains`, etc)

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -24,7 +24,6 @@
 * [duplicateImports](#duplicateImports)
 * [elseOnSameLine](#elseOnSameLine)
 * [emptyBraces](#emptyBraces)
-* [emptyExtensions](#emptyExtensions)
 * [enumNamespaces](#enumNamespaces)
 * [environmentEntry](#environmentEntry)
 * [extensionAccessControl](#extensionAccessControl)
@@ -37,7 +36,6 @@
 * [hoistTry](#hoistTry)
 * [indent](#indent)
 * [initCoderUnavailable](#initCoderUnavailable)
-* [isEmpty](#isEmpty)
 * [leadingDelimiters](#leadingDelimiters)
 * [linebreakAtEndOfFile](#linebreakAtEndOfFile)
 * [linebreaks](#linebreaks)
@@ -47,13 +45,8 @@
 * [noForceUnwrapInTests](#noForceUnwrapInTests)
 * [numberFormatting](#numberFormatting)
 * [opaqueGenericParameters](#opaqueGenericParameters)
-* [preferContains](#preferContains)
-* [preferCountWhere](#preferCountWhere)
-* [preferFirstWhere](#preferFirstWhere)
-* [preferFlatMap](#preferFlatMap)
 * [preferForLoop](#preferForLoop)
 * [preferKeyPath](#preferKeyPath)
-* [preferMinOverSorted](#preferMinOverSorted)
 * [redundantAsync](#redundantAsync)
 * [redundantBackticks](#redundantBackticks)
 * [redundantBreak](#redundantBreak)
@@ -130,12 +123,19 @@
 * [blankLineAfterSwitchCase](#blankLineAfterSwitchCase)
 * [blankLinesAfterGuardStatements](#blankLinesAfterGuardStatements)
 * [blockComments](#blockComments)
+* [emptyExtensions](#emptyExtensions)
+* [isEmpty](#isEmpty)
 * [markTypes](#markTypes)
 * [noExplicitOwnership](#noExplicitOwnership)
 * [noGuardInTests](#noGuardInTests)
 * [organizeDeclarations](#organizeDeclarations)
+* [preferContains](#preferContains)
+* [preferCountWhere](#preferCountWhere)
 * [preferExplicitFalse](#preferExplicitFalse)
 * [preferFinalClasses](#preferFinalClasses)
+* [preferFirstWhere](#preferFirstWhere)
+* [preferFlatMap](#preferFlatMap)
+* [preferMinOverSorted](#preferMinOverSorted)
 * [preferSwiftStringAPI](#preferSwiftStringAPI)
 * [preferSwiftTesting](#preferSwiftTesting)
 * [privateStateVariables](#privateStateVariables)
@@ -1033,7 +1033,7 @@ Use specified source file header template for all files.
 
 Option | Description
 --- | ---
-`--header` | Header comments: "strip", "ignore", or the text you wish use
+`--header` | Header comments: "strip", "ignore" (default), or the text you wish use
 `--date-format` | File header date format: "system" (default), "iso", "dmy", "mdy" or custom
 `--timezone` | File header date timezone: "system" (default) or a valid identifier/abbreviation
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -665,7 +665,7 @@ struct _Descriptors {
     let fileHeader = OptionDescriptor(
         argumentName: "header",
         displayName: "Header",
-        help: "Header comments: \"strip\", \"ignore\", or the text you wish use",
+        help: "Header comments: \"strip\", \"ignore\" (default), or the text you wish use",
         keyPath: \.fileHeader
     )
     let ifdefIndent = OptionDescriptor(

--- a/Sources/Rules/EmptyExtensions.swift
+++ b/Sources/Rules/EmptyExtensions.swift
@@ -12,6 +12,7 @@ public extension FormatRule {
     /// Remove empty, non-conforming, extensions.
     static let emptyExtensions = FormatRule(
         help: "Remove empty, non-protocol-conforming extensions.",
+        disabledByDefault: true,
         orderAfter: [.unusedPrivateDeclarations]
     ) { formatter in
         var emptyExtensions = [TypeDeclaration]()

--- a/Sources/Rules/IsEmpty.swift
+++ b/Sources/Rules/IsEmpty.swift
@@ -11,7 +11,8 @@ import Foundation
 public extension FormatRule {
     /// Replace count == 0 with isEmpty
     static let isEmpty = FormatRule(
-        help: "Prefer `isEmpty` over comparing `count` against zero."
+        help: "Prefer `isEmpty` over comparing `count` against zero.",
+        disabledByDefault: true
     ) { formatter in
         formatter.forEach(.identifier("count")) { i, _ in
             guard let dotIndex = formatter.index(of: .nonSpaceOrLinebreak, before: i, if: {

--- a/Sources/Rules/PreferContains.swift
+++ b/Sources/Rules/PreferContains.swift
@@ -11,7 +11,8 @@ import Foundation
 public extension FormatRule {
     /// Prefer `contains` over equivalent patterns using `filter`, `first`, or `range(of:)`.
     static let preferContains = FormatRule(
-        help: "Prefer `contains` over `filter(_:).isEmpty`, `first(where:) != nil`, and `range(of:) != nil`."
+        help: "Prefer `contains` over `filter(_:).isEmpty`, `first(where:) != nil`, and `range(of:) != nil`.",
+        disabledByDefault: true
     ) { formatter in
         // MARK: - filter(_:).isEmpty → !contains(where:)
 

--- a/Sources/Rules/PreferCountWhere.swift
+++ b/Sources/Rules/PreferCountWhere.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public extension FormatRule {
     static let preferCountWhere = FormatRule(
-        help: "Prefer `count(where:)` over `filter(_:).count`."
+        help: "Prefer `count(where:)` over `filter(_:).count`.",
+        disabledByDefault: true
     ) { formatter in
         // count(where:) was added in Swift 6.0
         guard formatter.options.swiftVersion >= "6.0" else { return }

--- a/Sources/Rules/PreferFirstWhere.swift
+++ b/Sources/Rules/PreferFirstWhere.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public extension FormatRule {
     static let preferFirstWhere = FormatRule(
-        help: "Prefer `first(where:)` over `filter(_:).first`."
+        help: "Prefer `first(where:)` over `filter(_:).first`.",
+        disabledByDefault: true
     ) { formatter in
         formatter.forEach(.identifier("filter")) { filterIndex, _ in
             // Parse the filter call arguments using the shared helper

--- a/Sources/Rules/PreferFlatMap.swift
+++ b/Sources/Rules/PreferFlatMap.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public extension FormatRule {
     static let preferFlatMap = FormatRule(
-        help: "Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`."
+        help: "Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.",
+        disabledByDefault: true
     ) { formatter in
         formatter.forEach(.identifier("map")) { mapIndex, _ in
             guard let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: mapIndex) else { return }

--- a/Sources/Rules/PreferMinOverSorted.swift
+++ b/Sources/Rules/PreferMinOverSorted.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public extension FormatRule {
     static let preferMinOverSorted = FormatRule(
-        help: "Prefer `min()` over `sorted().first`."
+        help: "Prefer `min()` over `sorted().first`.",
+        disabledByDefault: true
     ) { formatter in
         formatter.forEach(.identifier("sorted")) { sortedIndex, _ in
             // Require a member call: something `.sorted(...)`.


### PR DESCRIPTION
Rules that replace one standard library method call for another have the potential to break the build if a project defines subsets of these methods on their own types:

 - https://github.com/nicklockwood/SwiftFormat/issues/2595
 - https://github.com/nicklockwood/SwiftFormat/issues/2593

We will keep rules like this disabled by default.