### PR TITLE
Fix hoistAwait for async autoclosures

### DIFF
--- a/Sources/Rules/HoistAwait.swift
+++ b/Sources/Rules/HoistAwait.swift
@@ -16,11 +16,25 @@ public extension FormatRule {
     ) { formatter in
         guard formatter.options.swiftVersion >= "5.5" else { return }
 
+        var asyncCapturing = formatter.options.asyncCapturing
+        formatter.forEach(.keyword("func")) { i, _ in
+            guard let function = formatter.parseFunctionDeclaration(keywordIndex: i),
+                  let name = function.name,
+                  function.arguments.contains(where: { argument in
+                      let typeTokens = argument.type.tokens
+                      return typeTokens.contains(where: { $0.string == "@autoclosure" }) &&
+                          typeTokens.contains(where: { $0.string == "async" })
+                  })
+            else { return }
+
+            asyncCapturing.insert(name)
+        }
+
         formatter.forEachToken(where: {
             $0 == .startOfScope("(") || $0 == .startOfScope("[")
         }) { i, _ in
             formatter.hoistEffectKeyword("await", inScopeAt: i) { prevIndex in
-                formatter.isSymbol(at: prevIndex, in: formatter.options.asyncCapturing)
+                formatter.isSymbol(at: prevIndex, in: asyncCapturing)
             }
         }
     } examples: {

--- a/Sources/Rules/HoistTry.swift
+++ b/Sources/Rules/HoistTry.swift
@@ -13,7 +13,20 @@ public extension FormatRule {
         help: "Move inline `try` keyword(s) to start of expression.",
         options: ["throw-capturing"]
     ) { formatter in
-        let names = formatter.options.throwCapturing.union(["expect", "XCTUnwrap"])
+        var names = formatter.options.throwCapturing.union(["expect", "XCTUnwrap"])
+        formatter.forEach(.keyword("func")) { i, _ in
+            guard let function = formatter.parseFunctionDeclaration(keywordIndex: i),
+                  let name = function.name,
+                  function.arguments.contains(where: { argument in
+                      let typeTokens = argument.type.tokens
+                      return typeTokens.contains(where: { $0.string == "@autoclosure" }) &&
+                          typeTokens.contains(where: { $0.string == "throws" })
+                  })
+            else { return }
+
+            names.insert(name)
+        }
+
         formatter.forEachToken(where: {
             $0 == .startOfScope("(") || $0 == .startOfScope("[")
         }) { i, _ in

--- a/Tests/Rules/HoistAwaitTests.swift
+++ b/Tests/Rules/HoistAwaitTests.swift
@@ -274,6 +274,25 @@ final class HoistAwaitTests: XCTestCase {
                        options: FormatOptions(asyncCapturing: ["foo"], swiftVersion: "5.5"))
     }
 
+    func testNoHoistAwaitOutOfAsyncAutoclosureArgument() {
+        let input = """
+        func assertThrowsAsync(
+            _ expression: @autoclosure () async throws -> some Any,
+            _ errorHandler: (_ error: Error) -> Void
+        ) async {
+            do { _ = try await expression() } catch { errorHandler(error) }
+        }
+
+        func asyncThrowing() async throws -> String { throw MyError() }
+
+        func run() async {
+            await assertThrowsAsync(try await asyncThrowing()) { _ in }
+        }
+        """
+        testFormatting(for: input, rule: .hoistAwait,
+                       options: FormatOptions(swiftVersion: "5.5"))
+    }
+
     func testHoistAwaitAfterOrdinaryOperator() {
         let input = """
         let foo = bar + (await baz)

--- a/Tests/Rules/HoistAwaitTests.swift
+++ b/Tests/Rules/HoistAwaitTests.swift
@@ -283,7 +283,9 @@ final class HoistAwaitTests: XCTestCase {
             do { _ = try await expression() } catch { errorHandler(error) }
         }
 
-        func asyncThrowing() async throws -> String { throw MyError() }
+        func asyncThrowing() async throws -> String {
+            throw MyError()
+        }
 
         func run() async {
             await assertThrowsAsync(try await asyncThrowing()) { _ in }

--- a/Tests/Rules/HoistTryTests.swift
+++ b/Tests/Rules/HoistTryTests.swift
@@ -404,6 +404,26 @@ final class HoistTryTests: XCTestCase {
                        options: FormatOptions(throwCapturing: ["foo"]))
     }
 
+    func testNoHoistTryOutOfThrowingAutoclosureArgument() {
+        let input = """
+        func assertThrows(
+            _ expression: @autoclosure () throws -> some Any,
+            _ errorHandler: (_ error: Error) -> Void
+        ) {
+            do { _ = try expression() } catch { errorHandler(error) }
+        }
+
+        func throwing() throws -> String {
+            throw MyError()
+        }
+
+        func run() {
+            assertThrows(try throwing()) { _ in }
+        }
+        """
+        testFormatting(for: input, rule: .hoistTry)
+    }
+
     func testNoHoistFailToTerminate() {
         let input = """
         return ManyInitExample(


### PR DESCRIPTION
<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->

Fixes #2524.

## Summary

`hoistAwait` already avoids configured async-capturing functions, but it did not infer locally declared functions whose parameter type is an async autoclosure. When `--swiftversion` enabled the rule, that allowed the rule to hoist `await` out of an `@autoclosure () async throws` argument.

This scans local function declarations for async autoclosure parameters and treats those function names as async-capturing for the existing hoist check.

## Testing

- `swift build --product swiftformat`
- `.build/debug/swiftformat /tmp/swiftformat-2524-repro.swift --rules hoistAwait --swiftversion 5.10`
- `./Scripts/test_rule.sh hoistAwait` (fails locally before running tests because the active command-line tools cannot import `XCTest`: `error: no such module 'XCTest'`)

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
