### PR TITLE
Fix indent of trailing closure in method chain member inside #if

### DIFF
--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -589,6 +589,7 @@ public extension FormatRule {
                         ].contains(startToken) {
                             if let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: lineStart) {
                                 lastNonSpaceOrLinebreakIndex = index
+                                lastToken = formatter.tokens[lastNonSpaceOrLinebreakIndex]
                                 lineStart = formatter.startOfLine(at: lastNonSpaceOrLinebreakIndex, excludingIndent: true)
                             }
                         }

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -4490,6 +4490,25 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, rule: .indent)
     }
 
+    func testIndentIfDefPostfixMemberSyntax3() {
+        let input = """
+        struct MainView: View {
+            var body: some View {
+                ContainerView {
+                    SideView()
+                }
+                #if DEBUG
+                .sheet { _ in
+                    SheetView()
+                }
+                #endif
+                .modifier()
+            }
+        }
+        """
+        testFormatting(for: input, rule: .indent)
+    }
+
     func testNoIndentDotExpressionInsideIfdef() {
         let input = """
         let current: Platform = {
@@ -5339,6 +5358,48 @@ final class IndentTests: XCTestCase {
             .bar()
         #endif
             .baz()
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .outdent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testIfDefPostfixMemberSyntaxOutdenting4() {
+        let input = """
+        struct MainView: View {
+            var body: some View {
+                ContainerView {
+                    SideView()
+                }
+        #if DEBUG
+                .sheet { _ in
+                    SheetView()
+                }
+        #endif
+                .modifier()
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .outdent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testIfDefPostfixMemberSyntaxOutdenting5() {
+        let input = """
+        struct MainView: View {
+            var body: some View {
+                ContainerView {
+                    SideView()
+                } detail: {
+                    ContentView()
+                }
+        #if DEBUG
+                .sheet { _ in
+                    SheetView()
+                }
+        #endif
+                .modifier()
+            }
         }
         """
         let options = FormatOptions(ifdefIndent: .outdent)


### PR DESCRIPTION
**Problems**

When a method chain member follows a conditional compilation directive and has a multi-line trailing closure, the closure body and everything after `#endif` are indented one level too deep, and the result is not stable across repeated formatting runs:

    ContainerView {
        SideView()
    }
    #if DEBUG
    .sheet { _ in
            SheetView()    // over-indented
        }                  // over-indented
    #endif
        .modifier()        // over-indented

This affects all `--ifdef` modes except `preserve`.

The linewrap handling for lines starting with a `.` chain member skips back past directive lines by re-pointing `lastNonSpaceOrLinebreakIndex` at the code before the directive, but `lastToken` was never refreshed to match (it was changed from `let` to `var` when the skip was added in 27beabac, but no update was ever assigned). The stale token holds the directive's condition (e.g. `DEBUG`), which is not an `endOfScope`, so an extra indent level is wrongly pushed onto the linewrap stack. The chain member line itself is corrected later by the chained-function- after-closing-brace logic, but the corrupted stack entry determines the indentation of the member's trailing closure body and of chain members following `#endif`.

**Solution**

Refresh `lastToken` immediately after `lastNonSpaceOrLinebreakIndex` is re-pointed past the directive line, so the subsequent end-of-scope checks evaluate the token the index actually refers to.

**Testing**

Added three test cases verifying the correct formatting is stable: `testIndentIfDefPostfixMemberSyntax3` (default `--ifdef indent` mode) and `testIfDefPostfixMemberSyntaxOutdenting4/5` (`--ifdef outdent` mode, with single and multiple trailing closures on the preceding call.)

<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases
-->