### PR TITLE
Fix redundantInternal stripping required internal inside #if in non-internal extensions

### DIFF
--- a/Sources/Rules/RedundantInternal.swift
+++ b/Sources/Rules/RedundantInternal.swift
@@ -18,8 +18,15 @@ public extension FormatRule {
                 return
             }
 
+            // Find the enclosing scope, skipping over any conditional compilation blocks, which don't affect the access
+            // control of the declarations inside them.
+            var startOfScope = formatter.startOfScope(at: internalKeywordIndex)
+            while let scopeStart = startOfScope, formatter.tokens[scopeStart] == .startOfScope("#if") {
+                startOfScope = formatter.startOfScope(at: scopeStart)
+            }
+
             // If we're inside an extension, then `internal` is only redundant if the extension itself is `internal`.
-            if let startOfScope = formatter.startOfScope(at: internalKeywordIndex),
+            if let startOfScope,
                let typeKeywordIndex = formatter.indexOfLastSignificantKeyword(at: startOfScope, excluding: ["where"]),
                formatter.tokens[typeKeywordIndex] == .keyword("extension"),
                // In the language grammar, the ACL level always directly precedes the

--- a/Tests/Rules/RedundantInternalTests.swift
+++ b/Tests/Rules/RedundantInternalTests.swift
@@ -107,4 +107,62 @@ final class RedundantInternalTests: XCTestCase {
         """
         testFormatting(for: input, rule: .redundantInternal)
     }
+
+    func testPreservesInternalInPublicExtensionInsideConditionalCompilation() {
+        let input = """
+        public extension Color {
+            #if DEBUG
+                internal static var debugColor = false
+            #endif
+        }
+        """
+        testFormatting(for: input, rule: .redundantInternal)
+    }
+
+    func testPreservesInternalInPublicExtensionInsideNestedConditionalCompilation() {
+        let input = """
+        public extension Color {
+            #if os(macOS)
+                #if DEBUG
+                    internal static var debugColor = false
+                #endif
+            #else
+                internal static var releaseColor = false
+            #endif
+        }
+        """
+        testFormatting(for: input, rule: .redundantInternal)
+    }
+
+    func testRemovesInternalInInternalExtensionInsideConditionalCompilation() {
+        let input = """
+        extension Color {
+            #if DEBUG
+                internal static var debugColor = false
+            #endif
+        }
+        """
+        let output = """
+        extension Color {
+            #if DEBUG
+                static var debugColor = false
+            #endif
+        }
+        """
+        testFormatting(for: input, output, rule: .redundantInternal)
+    }
+
+    func testRemovesInternalInTopLevelConditionalCompilation() {
+        let input = """
+        #if DEBUG
+            internal struct Foo {}
+        #endif
+        """
+        let output = """
+        #if DEBUG
+            struct Foo {}
+        #endif
+        """
+        testFormatting(for: input, output, rule: .redundantInternal)
+    }
 }


### PR DESCRIPTION
## Problem

`redundantInternal` correctly preserves `internal` on members of a `public extension`, but incorrectly removed it when the member was wrapped in an `#if` / `#elseif` / `#else` block, silently changing the member's access level to that of the extension:

Fixes #2606

## Root cause

The rule finds the enclosing scope of the `internal` keyword via `startOfScope(at:)` and then looks for a preceding `extension` keyword. When the declaration is inside a conditional compilation block, the enclosing scope is the `#if` token rather than the extension's `{`, so the backwards keyword search stopped at the enclosing brace and the "inside a non-internal extension" check silently failed.

## Fix

When finding the enclosing scope, skip over `#if` scope starts, since conditional compilation blocks don't affect the access control of the declarations inside them. This matches how conditional compilation blocks are treated as transparent elsewhere (e.g. `Declaration.parentType`).

## Tests

- Preserves `internal` inside `#if` in a `public extension` (issue repro)
- Preserves `internal` in nested `#if` blocks and `#else` branches
- Still removes `internal` inside `#if` when the enclosing extension is internal
- Still removes `internal` inside a top-level `#if`


<!--
Thank you for contributing to SwiftFormat!

Pull request checklist:
- [x] The base branch of the pull request is `develop`
- [ ] Any code changes include corresponding test cases
-->