### PR TITLE
Fix --ifdef no-indent indentation for method chains and directives

### DIFF
--- a/Sources/Rules/Indent.swift
+++ b/Sources/Rules/Indent.swift
@@ -28,6 +28,9 @@ public extension FormatRule {
         var linewrapStack = [false]
         var lineIndex = 0
         var preserveIfdefDepth = 0
+        // In .noIndent mode, tracks the indent applied to each open #if so that
+        // the matching #else/#elseif/#endif can be aligned to the same level
+        var noIndentIfdefIndents: [String] = []
 
         @discardableResult
         func applyIndent(_ indent: String, at index: Int) -> Int {
@@ -35,6 +38,42 @@ public extension FormatRule {
                 return 0
             }
             return formatter.insertSpaceIfEnabled(indent, at: index)
+        }
+
+        func isIfdefDirective(_ token: Token) -> Bool {
+            [.startOfScope("#if"), .keyword("#else"), .keyword("#elseif"), .endOfScope("#endif")].contains(token)
+        }
+
+        func startsWithIfdefDirective(lineContaining index: Int) -> Bool {
+            isIfdefDirective(formatter.tokens[formatter.startOfLine(at: index, excludingIndent: true)])
+        }
+
+        /// In .noIndent mode, conditional compilation directives are transparent
+        /// to indent computation: code is indented as if the directives were absent.
+        /// Returns the last code token index at or before `index`, looking back past
+        /// any lines that consist of a conditional compilation directive.
+        func lastNonIfdefIndex(from index: Int) -> Int {
+            var index = index
+            while index > -1, startsWithIfdefDirective(lineContaining: index) {
+                guard let prev = formatter.index(
+                    of: .nonSpaceOrCommentOrLinebreak,
+                    before: formatter.startOfLine(at: index)
+                ) else {
+                    return -1
+                }
+                index = prev
+            }
+            return index
+        }
+
+        /// Returns the next code token index at or after `index`, skipping past
+        /// conditional compilation directive lines (used in .noIndent mode)
+        func nextNonIfdefIndex(from index: Int?) -> Int? {
+            var index = index
+            while let i = index, isIfdefDirective(formatter.tokens[i]) {
+                index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: formatter.endOfLine(at: i))
+            }
+            return index
         }
 
         if formatter.options.fragment,
@@ -197,6 +236,19 @@ public extension FormatRule {
                 indentCounts.append(indentCount)
                 scopeStartLineIndexes.append(lineIndex)
                 linewrapStack.append(false)
+                if string == "#if", formatter.options.ifdefIndent == .noIndent {
+                    // Remember the indent applied to this #if so the matching
+                    // #else/#elseif/#endif can be aligned to the same level
+                    noIndentIfdefIndents.append(indent)
+                    // Inherit the enclosing scope's linewrap state so that content
+                    // inside the ifdef is indented as if the directive were absent
+                    // (e.g. a method chain wrapped in #if stays at the chain level)
+                    if linewrapStack.count > 1, linewrapStack[linewrapStack.count - 2] {
+                        linewrapStack[linewrapStack.count - 1] = true
+                        indentStack.append(indent)
+                        stringBodyIndentStack.append("")
+                    }
+                }
             case .space:
                 if i == 0, !formatter.options.fragment,
                    formatter.token(at: i + 1)?.isLinebreak != true
@@ -226,8 +278,12 @@ public extension FormatRule {
                 }
                 let start = formatter.startOfLine(at: i)
                 switch formatter.options.ifdefIndent {
-                case .indent, .noIndent:
+                case .indent:
                     i += applyIndent(indent, at: start)
+                case .noIndent:
+                    // Align with the indent applied to the matching #if,
+                    // or the current scope level for unmatched directives
+                    i += applyIndent(noIndentIfdefIndents.last ?? indentStack.last ?? indent, at: start)
                 case .outdent:
                     i += applyIndent("", at: start)
                 case .preserve:
@@ -347,6 +403,11 @@ public extension FormatRule {
 
                     if token == .endOfScope("#endif"), formatter.options.ifdefIndent == .outdent {
                         i += applyIndent("", at: start)
+                    } else if token == .endOfScope("#endif"), formatter.options.ifdefIndent == .noIndent,
+                              let ifdefIndent = noIndentIfdefIndents.last
+                    {
+                        // Align with the indent applied to the matching #if
+                        i += applyIndent(ifdefIndent, at: start)
                     } else {
                         var indent = indentStack.last ?? ""
                         if token.isSwitchCaseOrDefault,
@@ -367,8 +428,11 @@ public extension FormatRule {
                         popScope()
                     }
                     switch formatter.options.ifdefIndent {
-                    case .indent, .noIndent:
+                    case .indent:
                         i += applyIndent(indent, at: formatter.startOfLine(at: i))
+                    case .noIndent:
+                        // Align with the indent applied to the matching #if
+                        i += applyIndent(noIndentIfdefIndents.last ?? indent, at: formatter.startOfLine(at: i))
                     case .outdent:
                         i += applyIndent("", at: formatter.startOfLine(at: i))
                     case .preserve:
@@ -378,8 +442,12 @@ public extension FormatRule {
                         popScope()
                     }
                 }
-                if token == .endOfScope("#endif"), formatter.options.ifdefIndent == .preserve {
-                    preserveIfdefDepth = max(preserveIfdefDepth - 1, 0)
+                if token == .endOfScope("#endif") {
+                    if formatter.options.ifdefIndent == .preserve {
+                        preserveIfdefDepth = max(preserveIfdefDepth - 1, 0)
+                    } else if formatter.options.ifdefIndent == .noIndent, !noIndentIfdefIndents.isEmpty {
+                        noIndentIfdefIndents.removeLast()
+                    }
                 }
             }
             switch token {
@@ -433,10 +501,20 @@ public extension FormatRule {
                 }
             case .linebreak:
                 // Detect linewrap
-                let nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i)
+                // In .noIndent mode, compute the linewrap state as if conditional
+                // compilation directives were absent, so that method chains and other
+                // continuations are unaffected by intervening #if/#endif lines
+                var effectiveLastIndex = lastNonSpaceOrLinebreakIndex
+                var nextTokenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: i)
+                if formatter.options.ifdefIndent == .noIndent {
+                    if effectiveLastIndex > -1 {
+                        effectiveLastIndex = lastNonIfdefIndex(from: effectiveLastIndex)
+                    }
+                    nextTokenIndex = nextNonIfdefIndex(from: nextTokenIndex)
+                }
                 let _nextToken = nextTokenIndex.map { formatter.tokens[$0] } ?? .space("")
-                let linewrapped = lastNonSpaceOrLinebreakIndex > -1 && (
-                    !formatter.isEndOfStatement(at: lastNonSpaceOrLinebreakIndex, in: scopeStack.last) ||
+                let linewrapped = effectiveLastIndex > -1 && (
+                    !formatter.isEndOfStatement(at: effectiveLastIndex, in: scopeStack.last) ||
                         (nextTokenIndex.map { formatter.isTrailingClosureLabel(at: $0) } == true) ||
                         !(nextTokenIndex == nil || [
                             .endOfScope("}"), .endOfScope("]"), .endOfScope(")"),
@@ -493,9 +571,17 @@ public extension FormatRule {
                                     && formatter.options.wrapConditions == .beforeFirst
                             )
                         }
+                        // In .noIndent mode, look back past directive lines so the
+                        // check below sees the last code line, as if the directives
+                        // were absent
+                        var prevCodeIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i)
+                        if formatter.options.ifdefIndent == .noIndent, let index = prevCodeIndex {
+                            let lastCodeIndex = lastNonIfdefIndex(from: index)
+                            prevCodeIndex = lastCodeIndex > -1 ? lastCodeIndex : nil
+                        }
                         if shouldIndentLeadingDotStatement,
                            formatter.next(.nonSpace, after: i) == .operator(".", .infix),
-                           let prevIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: i),
+                           let prevIndex = prevCodeIndex,
                            case let lineStart = formatter.index(of: .linebreak, before: prevIndex + 1) ??
                            formatter.startOfLine(at: prevIndex),
                            let startIndex = formatter.index(of: .nonSpace, after: lineStart),
@@ -574,7 +660,7 @@ public extension FormatRule {
                     }
                 } else if linewrapped {
                     // Don't indent line starting with dot if previous line was just a closing brace
-                    var lastToken = formatter.tokens[lastNonSpaceOrLinebreakIndex]
+                    var lastToken = formatter.tokens[effectiveLastIndex]
                     if formatter.options.allmanBraces, nextToken == .startOfScope("{"),
                        formatter.isStartOfClosure(at: nextNonSpaceIndex)
                     {
@@ -582,26 +668,25 @@ public extension FormatRule {
                     } else if formatter.token(at: nextTokenIndex ?? -1) == .operator(".", .infix) ||
                         formatter.isLabel(at: nextTokenIndex ?? -1)
                     {
-                        var lineStart = formatter.startOfLine(at: lastNonSpaceOrLinebreakIndex, excludingIndent: true)
+                        var lineStart = formatter.startOfLine(at: effectiveLastIndex, excludingIndent: true)
                         let startToken = formatter.token(at: lineStart)
-                        if let startToken, [
-                            .startOfScope("#if"), .keyword("#else"), .keyword("#elseif"), .endOfScope("#endif")
-                        ].contains(startToken) {
+                        if let startToken, isIfdefDirective(startToken) {
                             if let index = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: lineStart) {
                                 lastNonSpaceOrLinebreakIndex = index
-                                lastToken = formatter.tokens[lastNonSpaceOrLinebreakIndex]
-                                lineStart = formatter.startOfLine(at: lastNonSpaceOrLinebreakIndex, excludingIndent: true)
+                                effectiveLastIndex = index
+                                lastToken = formatter.tokens[effectiveLastIndex]
+                                lineStart = formatter.startOfLine(at: effectiveLastIndex, excludingIndent: true)
                             }
                         }
                         if formatter.token(at: lineStart) == .operator(".", .infix),
                            [.keyword("#else"), .keyword("#elseif"), .endOfScope("#endif")].contains(startToken)
                         {
                             indent = formatter.currentIndentForLine(at: lineStart)
-                        } else if formatter.tokens[lineStart ..< lastNonSpaceOrLinebreakIndex].allSatisfy({
+                        } else if formatter.tokens[lineStart ..< effectiveLastIndex].allSatisfy({
                             $0.isEndOfScope || $0.isSpaceOrComment
                         }) {
                             if lastToken.isEndOfScope {
-                                indent = formatter.currentIndentForLine(at: lastNonSpaceOrLinebreakIndex)
+                                indent = formatter.currentIndentForLine(at: effectiveLastIndex)
                             }
                             if formatter.options.ifdefIndent == .preserve, preserveIfdefDepth > 0 {
                                 // keep relative indentation unchanged
@@ -681,7 +766,7 @@ public extension FormatRule {
                     if formatter.options.ifdefIndent == .preserve, preserveIfdefDepth > 0 {
                         break
                     }
-                    var lastIndex = lastNonSpaceOrLinebreakIndex > -1 ? lastNonSpaceOrLinebreakIndex : i
+                    var lastIndex = effectiveLastIndex > -1 ? effectiveLastIndex : i
                     while formatter.token(at: lastIndex) == .endOfScope("#endif"),
                           let index = formatter.index(of: .startOfScope, before: lastIndex, if: {
                               $0 == .startOfScope("#if")

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -4050,13 +4050,13 @@ final class IndentTests: XCTestCase {
                 Text("Hello, world!")
                 // Comment above
                 #if os(macOS)
-                    .padding()
+                .padding()
                 #endif
 
                 Text("Hello, world!")
                 #if os(macOS)
-                    // Comment inside
-                    .padding()
+                // Comment inside
+                .padding()
                 #endif
 
                 // swiftformat:options --ifdef outdent
@@ -4764,8 +4764,22 @@ final class IndentTests: XCTestCase {
             }
         }
         """
+        let output = """
+        class Bar {
+            func foo() {
+                Text("Hello")
+                #if os(iOS)
+                .font(.largeTitle)
+                #elseif os(macOS)
+                .font(.headline)
+                #else
+                .font(.headline)
+                #endif
+            }
+        }
+        """
         let options = FormatOptions(ifdefIndent: .noIndent)
-        testFormatting(for: input, rule: .indent, options: options)
+        testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testIfDefPostfixMemberSyntaxNoIndenting2() {
@@ -4828,6 +4842,929 @@ final class IndentTests: XCTestCase {
             #else
             .init(style: .title2, size: 40)
             #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    // MARK: - noIndent spec scenarios
+
+    func testNoIndentBasicIfBlock() {
+        let input = """
+        func foo() {
+            #if DEBUG
+                print("debug")
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if DEBUG
+            print("debug")
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefFixesOverIndentedElse() {
+        let input = """
+        func example(flag: Bool) {
+          #if os(macOS)
+          if flag {
+            return
+          }
+              #else
+          return
+          #endif
+        }
+        """
+        let output = """
+        func example(flag: Bool) {
+          #if os(macOS)
+          if flag {
+            return
+          }
+          #else
+          return
+          #endif
+        }
+        """
+        let options = FormatOptions(indent: "  ", ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefFixesOverIndentedEndif() {
+        let input = """
+        func example() {
+          #if DEBUG
+          return
+              #endif
+        }
+        """
+        let output = """
+        func example() {
+          #if DEBUG
+          return
+          #endif
+        }
+        """
+        let options = FormatOptions(indent: "  ", ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefFragmentWithUnmatchedDirectivesInsideScope() {
+        let input = """
+        {
+            #endif
+                #else
+        }
+        """
+        let output = """
+        {
+            #endif
+            #else
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent, fragment: true)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfElse() {
+        let input = """
+        func foo() {
+            #if DEBUG
+                print("debug")
+            #else
+                print("release")
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if DEBUG
+            print("debug")
+            #else
+            print("release")
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfElseIf() {
+        let input = """
+        func foo() {
+            #if os(iOS)
+                print("iOS")
+            #elseif os(macOS)
+                print("macOS")
+            #else
+                print("other")
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if os(iOS)
+            print("iOS")
+            #elseif os(macOS)
+            print("macOS")
+            #else
+            print("other")
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainAfterClosingBrace() {
+        let input = """
+        var body: some View {
+            VStack {
+                Text("Hello")
+            }
+            #if os(iOS)
+                .padding()
+            #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            VStack {
+                Text("Hello")
+            }
+            #if os(iOS)
+            .padding()
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainInlineWithModifiers() {
+        let input = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                    .padding()
+                #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                .padding()
+                #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentAlreadyCorrectLevel() {
+        let input = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                .padding()
+                #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentUnderIndentedIfGetFixed() {
+        let input = """
+        func foo() {
+        #if DEBUG
+        print("debug")
+        #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if DEBUG
+            print("debug")
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentSwitchCases() {
+        let input = """
+        switch value {
+        case .a:
+            break
+        #if DEBUG
+            case .b:
+                break
+        #endif
+        }
+        """
+        let output = """
+        switch value {
+        case .a:
+            break
+        #if DEBUG
+        case .b:
+            break
+        #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentNestedIfBlocks() {
+        let input = """
+        func foo() {
+            #if os(iOS)
+                #if DEBUG
+                    print("iOS debug")
+                #endif
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if os(iOS)
+            #if DEBUG
+            print("iOS debug")
+            #endif
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMultipleStatements() {
+        let input = """
+        func foo() {
+            #if DEBUG
+                let x = 1
+                let y = 2
+                print(x + y)
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if DEBUG
+            let x = 1
+            let y = 2
+            print(x + y)
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainMultipleModifiers() {
+        let input = """
+        var body: some View {
+            Text("Hello")
+                #if os(iOS)
+                    .font(.title)
+                    .foregroundColor(.blue)
+                    .padding()
+                #elseif os(macOS)
+                    .font(.headline)
+                    .padding(.all, 20)
+                #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            Text("Hello")
+                #if os(iOS)
+                .font(.title)
+                .foregroundColor(.blue)
+                .padding()
+                #elseif os(macOS)
+                .font(.headline)
+                .padding(.all, 20)
+                #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainContinuesAfterEndif() {
+        let input = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                    .padding()
+                #endif
+                .background(Color.white)
+        }
+        """
+        let output = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                .padding()
+                #endif
+                .background(Color.white)
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentFileScope() {
+        let input = """
+        #if DEBUG
+            let debugMode = true
+        #else
+            let debugMode = false
+        #endif
+        """
+        let output = """
+        #if DEBUG
+        let debugMode = true
+        #else
+        let debugMode = false
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentTypeMembers() {
+        let input = """
+        struct Foo {
+            #if DEBUG
+                var debugValue: Int
+            #endif
+
+            var normalValue: String
+        }
+        """
+        let output = """
+        struct Foo {
+            #if DEBUG
+            var debugValue: Int
+            #endif
+
+            var normalValue: String
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentWithCommentsInside() {
+        let input = """
+        func foo() {
+            #if DEBUG
+                // This is a debug comment
+                print("debug")
+            #endif
+        }
+        """
+        let output = """
+        func foo() {
+            #if DEBUG
+            // This is a debug comment
+            print("debug")
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentPreservesCorrectLinewrapPosition() {
+        let input = """
+        var body: some View {
+            Text("Hello")
+                #if os(iOS)
+                .padding()
+                #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentComplexNestedView() {
+        let input = """
+        var body: some View {
+            HStack {
+                List {
+                    Text("Item")
+                }
+                .listStyle(.plain)
+                #if os(iOS)
+                    .introspect(.list, on: .iOS(.v15)) { _ in }
+                #elseif os(macOS)
+                    .introspect(.list, on: .macOS(.v12)) { _ in }
+                #endif
+            }
+        }
+        """
+        let output = """
+        var body: some View {
+            HStack {
+                List {
+                    Text("Item")
+                }
+                .listStyle(.plain)
+                #if os(iOS)
+                .introspect(.list, on: .iOS(.v15)) { _ in }
+                #elseif os(macOS)
+                .introspect(.list, on: .macOS(.v12)) { _ in }
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    // MARK: - noIndent advanced scenarios (swiftui-introspect patterns)
+
+    func testNoIndentFileLevelWrapperWithNestedCode() {
+        // Pattern: File wrapped in #if with deeply nested struct/function content
+        let input = """
+        #if !os(tvOS)
+        import SwiftUI
+
+        @MainActor
+        struct ListTests {
+            typealias PlatformList = UIScrollView
+
+            @Test func introspect() async throws {
+                let entity = try await introspection { spy in
+                    HStack {
+                        List {
+                            Text("Item 1")
+                        }
+                        .listStyle(.plain)
+                    }
+                }
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentFileLevelWrapperWithNestedIfdef() {
+        // Pattern: File-level #if with nested #if for platform-specific typealias
+        let input = """
+        #if !os(tvOS)
+        import SwiftUI
+
+        struct ListTests {
+            #if canImport(UIKit)
+            typealias PlatformList = UIScrollView
+            #elseif canImport(AppKit)
+            typealias PlatformList = NSTableView
+            #endif
+
+            func test() {
+                print("test")
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainWithCommentInsideIfdef() {
+        // Pattern: #if block with comment before the modifier
+        let input = """
+        var body: some View {
+            NavigationView {
+                Text("Hello")
+            }
+            .navigationViewStyle(.columns)
+            #if os(iOS)
+                // NB: this is necessary for introspection to work
+                .introspect(.navigationView, on: .iOS(.v15)) {
+                    $0.preferredDisplayMode = .oneOverSecondary
+                }
+            #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            NavigationView {
+                Text("Hello")
+            }
+            .navigationViewStyle(.columns)
+            #if os(iOS)
+            // NB: this is necessary for introspection to work
+            .introspect(.navigationView, on: .iOS(.v15)) {
+                $0.preferredDisplayMode = .oneOverSecondary
+            }
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentMethodChainWithTrailingClosureInsideIfdef() {
+        // Pattern: #if with modifier containing trailing closure
+        let input = """
+        var body: some View {
+            List {
+                Text("Item")
+            }
+            .listStyle(.plain)
+            #if os(iOS)
+                .introspect(.list, on: .iOS(.v15, .v16)) { tableView in
+                    tableView.backgroundColor = .clear
+                    tableView.separatorStyle = .none
+                }
+            #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            List {
+                Text("Item")
+            }
+            .listStyle(.plain)
+            #if os(iOS)
+            .introspect(.list, on: .iOS(.v15, .v16)) { tableView in
+                tableView.backgroundColor = .clear
+                tableView.separatorStyle = .none
+            }
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentNestedIfdefAtLinewrapLevel() {
+        // Pattern: #if at linewrap level inside file-level #if wrapper
+        let input = """
+        #if !os(tvOS)
+        struct Tests {
+            func test() {
+                let view = HStack {
+                    List {
+                        Text("Item")
+                            #if os(iOS)
+                            .introspect(.list, on: .iOS(.v15), scope: .ancestor) { _ in }
+                            #elseif os(macOS)
+                            .introspect(.list, on: .macOS(.v12), scope: .ancestor) { _ in }
+                            #endif
+                    }
+                    .listStyle(.inset)
+                }
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentMultipleConsecutiveIfdefBlocks() {
+        // Pattern: Multiple #if blocks in the same method chain
+        let input = """
+        var body: some View {
+            Text("Hello")
+                .font(.title)
+                #if os(iOS)
+                .padding()
+                #endif
+                #if DEBUG
+                .border(Color.red)
+                #endif
+                .background(Color.white)
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefWithMultiplePlatformBranches() {
+        // Pattern: Complex #if with multiple #elseif branches
+        let input = """
+        struct Tests {
+            func introspect() {
+                let view = NavigationView {
+                    Text("Content")
+                }
+                .navigationViewStyle(.columns)
+                #if os(iOS)
+                    .introspect(.navigationView, on: .iOS(.v13, .v14, .v15)) { spy in
+                        spy.preferredDisplayMode = .oneOverSecondary
+                    }
+                #elseif os(tvOS)
+                    .introspect(.navigationView, on: .tvOS(.v13, .v14, .v15)) { spy in
+                        // tvOS specific
+                    }
+                #elseif os(macOS)
+                    .introspect(.navigationView, on: .macOS(.v10_15, .v11, .v12)) { spy in
+                        // macOS specific
+                    }
+                #endif
+            }
+        }
+        """
+        let output = """
+        struct Tests {
+            func introspect() {
+                let view = NavigationView {
+                    Text("Content")
+                }
+                .navigationViewStyle(.columns)
+                #if os(iOS)
+                .introspect(.navigationView, on: .iOS(.v13, .v14, .v15)) { spy in
+                    spy.preferredDisplayMode = .oneOverSecondary
+                }
+                #elseif os(tvOS)
+                .introspect(.navigationView, on: .tvOS(.v13, .v14, .v15)) { spy in
+                    // tvOS specific
+                }
+                #elseif os(macOS)
+                .introspect(.navigationView, on: .macOS(.v10_15, .v11, .v12)) { spy in
+                    // macOS specific
+                }
+                #endif
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentIfdefInsideClosureArgument() {
+        // Pattern: #if inside a closure that's a function argument
+        let input = """
+        func test() {
+            let result = try await introspection(of: UIScrollView.self) { spy1, spy2 in
+                HStack {
+                    List {
+                        Text("Item 1")
+                    }
+                    .listStyle(.grouped)
+                    #if os(iOS)
+                        .introspect(.list(style: .grouped), on: .iOS(.v16, .v17)) { spy in
+                            spy1(spy)
+                        }
+                    #endif
+
+                    List {
+                        Text("Item 2")
+                    }
+                    .listStyle(.grouped)
+                }
+            }
+        }
+        """
+        let output = """
+        func test() {
+            let result = try await introspection(of: UIScrollView.self) { spy1, spy2 in
+                HStack {
+                    List {
+                        Text("Item 1")
+                    }
+                    .listStyle(.grouped)
+                    #if os(iOS)
+                    .introspect(.list(style: .grouped), on: .iOS(.v16, .v17)) { spy in
+                        spy1(spy)
+                    }
+                    #endif
+
+                    List {
+                        Text("Item 2")
+                    }
+                    .listStyle(.grouped)
+                }
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentIfdefAfterClosingBraceInChain() {
+        // Pattern: #if immediately after a closing brace in method chain
+        let input = """
+        var body: some View {
+            VStack {
+                Text("Hello")
+            }
+            #if os(iOS)
+                .padding()
+            #endif
+        }
+        """
+        let output = """
+        var body: some View {
+            VStack {
+                Text("Hello")
+            }
+            #if os(iOS)
+            .padding()
+            #endif
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options)
+    }
+
+    func testNoIndentDeepNestedIfdefInFileLevelWrapper() {
+        // Pattern: Deeply nested #if inside file-level #if wrapper
+        let input = """
+        #if !os(macOS)
+        import SwiftUI
+
+        @MainActor
+        struct SearchFieldTests {
+            typealias PlatformSearchField = UISearchBar
+
+            @Test func introspect() async throws {
+                try await introspection(of: PlatformSearchField.self) { spy in
+                    TabView {
+                        NavigationView {
+                            Text("Customized")
+                                .searchable(text: .constant(""))
+                                #if os(iOS)
+                                    .introspect(.searchField, on: .iOS(.v15, .v16)) { searchBar in
+                                        spy(searchBar)
+                                    }
+                                #elseif os(tvOS)
+                                    .introspect(.searchField, on: .tvOS(.v15, .v16)) { searchBar in
+                                        spy(searchBar)
+                                    }
+                                #endif
+                        }
+                        .navigationViewStyle(.stack)
+                    }
+                }
+            }
+        }
+        #endif
+        """
+        let output = """
+        #if !os(macOS)
+        import SwiftUI
+
+        @MainActor
+        struct SearchFieldTests {
+            typealias PlatformSearchField = UISearchBar
+
+            @Test func introspect() async throws {
+                try await introspection(of: PlatformSearchField.self) { spy in
+                    TabView {
+                        NavigationView {
+                            Text("Customized")
+                                .searchable(text: .constant(""))
+                                #if os(iOS)
+                                .introspect(.searchField, on: .iOS(.v15, .v16)) { searchBar in
+                                    spy(searchBar)
+                                }
+                                #elseif os(tvOS)
+                                .introspect(.searchField, on: .tvOS(.v15, .v16)) { searchBar in
+                                    spy(searchBar)
+                                }
+                                #endif
+                        }
+                        .navigationViewStyle(.stack)
+                    }
+                }
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentIfdefPreservesCorrectEndifLevel() {
+        // Pattern: Ensure #endif stays at same level as #if when at linewrap position
+        let input = """
+        #if !os(tvOS)
+        struct ListTests {
+            func test() {
+                let view = HStack {
+                    List {
+                        Text("Item 1")
+                            #if os(iOS) || os(visionOS)
+                            .introspect(.list, on: .iOS(.v14, .v15)) { _ in }
+                            .introspect(.list, on: .iOS(.v16, .v17)) { _ in }
+                            #elseif os(macOS)
+                            .introspect(.list, on: .macOS(.v11, .v12)) { _ in }
+                            #endif
+                    }
+                    .listStyle(.inset)
+                }
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentIfdefWithNestedTypealiasAndFunctions() {
+        // Pattern: Struct with #if for typealias followed by functions
+        let input = """
+        #if !os(tvOS)
+        struct ListWithInsetStyleTests {
+            #if canImport(UIKit)
+                typealias PlatformListWithInsetStyle = UIScrollView
+            #elseif canImport(AppKit)
+                typealias PlatformListWithInsetStyle = NSTableView
+            #endif
+
+            @Test func introspect() async throws {
+                let (entity1, entity2) = try await introspection(of: PlatformListWithInsetStyle.self) { spy1, spy2 in
+                    HStack {
+                        List {
+                            Text("Item 1")
+                        }
+                        .listStyle(.inset)
+                        #if os(iOS) || os(visionOS)
+                            .introspect(.list(style: .inset), on: .iOS(.v14, .v15), customize: spy1)
+                        #elseif os(macOS)
+                            .introspect(.list(style: .inset), on: .macOS(.v11, .v12), customize: spy1)
+                        #endif
+                    }
+                }
+            }
+        }
+        #endif
+        """
+        let output = """
+        #if !os(tvOS)
+        struct ListWithInsetStyleTests {
+            #if canImport(UIKit)
+            typealias PlatformListWithInsetStyle = UIScrollView
+            #elseif canImport(AppKit)
+            typealias PlatformListWithInsetStyle = NSTableView
+            #endif
+
+            @Test func introspect() async throws {
+                let (entity1, entity2) = try await introspection(of: PlatformListWithInsetStyle.self) { spy1, spy2 in
+                    HStack {
+                        List {
+                            Text("Item 1")
+                        }
+                        .listStyle(.inset)
+                        #if os(iOS) || os(visionOS)
+                        .introspect(.list(style: .inset), on: .iOS(.v14, .v15), customize: spy1)
+                        #elseif os(macOS)
+                        .introspect(.list(style: .inset), on: .macOS(.v11, .v12), customize: spy1)
+                        #endif
+                    }
+                }
+            }
+        }
+        #endif
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, output, rule: .indent, options: options, exclude: [.unusedArguments])
+    }
+
+    func testNoIndentIfdefInsideImmediatelyInvokedClosure() {
+        // Pattern: #if inside a closure that's immediately invoked for conditional values
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                Text("Hello")
+                    .toolbar {
+                        ToolbarItem(placement: {
+                            #if os(iOS)
+                            .cancellationAction
+                            #else
+                            .automatic
+                            #endif
+                        }()) {
+                            Button("Cancel") {}
+                        }
+                    }
+            }
         }
         """
         let options = FormatOptions(ifdefIndent: .noIndent)
@@ -6042,6 +6979,27 @@ final class IndentTests: XCTestCase {
         """
 
         testFormatting(for: input, output, rule: .indent, exclude: [.wrapMultilineStatementBraces])
+    }
+
+    func testIndentIfExpressionAssignmentInsideNoIndentIfdef() {
+        let input = """
+        #if os(iOS)
+        func makeRecipients(subtitle: String) {
+          let recipients: [INPerson] =
+            if subtitle.isEmpty {
+              []
+            } else {
+              [
+                subtitle,
+              ]
+            }
+          _ = recipients
+        }
+        #endif
+        """
+
+        let options = FormatOptions(indent: "  ", ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
     }
 
     func testIndentIfExpressionAssignmentOnSameLine() {

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -5190,6 +5190,62 @@ final class IndentTests: XCTestCase {
         testFormatting(for: input, output, rule: .indent, options: options)
     }
 
+    func testNoIndentIfdefInMethodChainAfterClosingBrace() {
+        // https://github.com/nicklockwood/SwiftFormat/issues/2535
+        let input = """
+        var body: some View {
+            VStack {
+                firstSection
+                #if DEBUG
+                debugSection
+                #endif
+                lastSection
+            }
+            .navigationTitle("Title")
+            #if DEBUG
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .detail:
+                    DetailView()
+                }
+            }
+            #endif
+            .alert("Error", isPresented: $showingErrorAlert) {
+                Button("OK", role: .cancel) {}
+            }
+            .task {
+                viewModel.load()
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefInMethodChainAfterMultilineCall() {
+        let input = """
+        var body: some View {
+            ContentView(
+                title: title
+            )
+            .alert(isPresented: $isAlertPresented) {
+                Text("alert")
+            }
+            #if os(iOS)
+            // iOS-only banner
+            .banner(isPresented: $isBannerPresented) {
+                BannerView(onDismiss: { dismiss() })
+            }
+            #endif
+            .fullScreenCover(item: $webViewURL) { url in
+                WebView(url: url)
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent)
+        testFormatting(for: input, rule: .indent, options: options)
+    }
+
     func testNoIndentFileScope() {
         let input = """
         #if DEBUG

--- a/Tests/Rules/IndentTests.swift
+++ b/Tests/Rules/IndentTests.swift
@@ -4048,16 +4048,16 @@ final class IndentTests: XCTestCase {
                 // swiftformat:options --ifdef no-indent
 
                 Text("Hello, world!")
-                // Comment above
-                #if os(macOS)
-                .padding()
-                #endif
+                    // Comment above
+                    #if os(macOS)
+                    .padding()
+                    #endif
 
                 Text("Hello, world!")
-                #if os(macOS)
-                // Comment inside
-                .padding()
-                #endif
+                    #if os(macOS)
+                    // Comment inside
+                    .padding()
+                    #endif
 
                 // swiftformat:options --ifdef outdent
 
@@ -4768,13 +4768,13 @@ final class IndentTests: XCTestCase {
         class Bar {
             func foo() {
                 Text("Hello")
-                #if os(iOS)
-                .font(.largeTitle)
-                #elseif os(macOS)
-                .font(.headline)
-                #else
-                .font(.headline)
-                #endif
+                    #if os(iOS)
+                    .font(.largeTitle)
+                    #elseif os(macOS)
+                    .font(.headline)
+                    #else
+                    .font(.headline)
+                    #endif
             }
         }
         """
@@ -5244,6 +5244,37 @@ final class IndentTests: XCTestCase {
         """
         let options = FormatOptions(ifdefIndent: .noIndent)
         testFormatting(for: input, rule: .indent, options: options)
+    }
+
+    func testNoIndentIfdefInMethodChainWithXcodeIndentation() {
+        // Directives in a method chain must not add an extra indent level
+        // to the enclosed or following lines when xcodeIndentation is enabled
+        let input = """
+        struct ContentView: View {
+            var body: some View {
+                Text("a")
+                    .padding()
+                    #if os(iOS)
+                        .background(Color.red)
+                    #endif
+                        .cornerRadius(8)
+            }
+        }
+        """
+        let output = """
+        struct ContentView: View {
+            var body: some View {
+                Text("a")
+                    .padding()
+                    #if os(iOS)
+                    .background(Color.red)
+                    #endif
+                    .cornerRadius(8)
+            }
+        }
+        """
+        let options = FormatOptions(ifdefIndent: .noIndent, xcodeIndentation: true)
+        testFormatting(for: input, output, rule: .indent, options: options)
     }
 
     func testNoIndentFileScope() {


### PR DESCRIPTION
## Summary

Fixes #2535, #1332

Related: #1632 — that report is about `--ifdef outdent`, which this PR
deliberately does not touch (all changes are gated on `no-indent`). Its
repro no longer reproduces on current `develop`.

With `--ifdef no-indent`, conditional compilation directives inside method
chains break indentation: the chain's linewrap state is destroyed at the
directive, content inside the block gets an extra indent level, and lines
after `#endif` stay over-indented (see #2535 for a full example).

## Approach

This takes a different approach from #2319 (reverted in #2345). Instead of
patching each symptom site with one-off checks, directives are made
**transparent to indent computation**: code is indented as if the
`#if`/`#else`/`#elseif`/`#endif` lines were absent, and the directive lines
themselves are placed at the level the enclosed code would naturally have.

This directly implements the behavior described in the revert PR #2345:

> The `#if` block should be indented the same way as whatever its code
> would be without the `#if` block [...] realistically the `#if` should
> be indented. One-off checks don't scale to handle this because it has
> to account for every existing indentation behavior.

All changes are gated on `ifdefIndent == .noIndent`, so `indent`,
`outdent` and `preserve` modes are completely unaffected.

Concretely:
- Linewrap detection at linebreaks skips past directive lines in both
  directions, so method chains continue across `#if`/`#endif`
- The `#if` scope inherits the enclosing scope's linewrap state, so
  content inside the block is indented as if the directive were absent
- The indent applied to each `#if` is remembered so the matching
  `#else`/`#elseif`/`#endif` align to the same level, falling back to
  the current scope level for unmatched directives in fragments
- The leading-dot checks used by `--xcode-indentation` also skip past
  directive lines, so the same guarantees hold with that option enabled

Example (no changes needed — the #1332 case is now stable):

```swift
Text("Example")
    .frame(maxWidth: 500, alignment: .leading)
    #if !os(tvOS)
    .font(.system(size: 14, design: .monospaced))
    #endif
    .padding(10)
```

## Relationship to #2604

#2604 recently fixed a closely related case (a trailing closure on a
member inside `#if`). This PR is rebased on top of it — the two changes
compose cleanly, and all of #2604's tests keep passing. There are still
some cases in this family that remain open, though: applying this PR's
test suite alone to current `develop` leaves 19 test cases failing,
including the main #2535 scenario. This PR aims to cover those remaining
cases in one place by normalizing the linewrap computation itself.

## Spec change

Two existing test expectations encoded the previous buggy behavior and
were updated to the canonical placement:

- `testIfDefIndentModes` — the `no-indent` section expected output
  identical to `indent` mode (content indented one extra level)
- `testIfDefPostfixMemberSyntaxNoIndenting` — accepted `#if` at statement
  level with content indented one extra level as already-formatted

Under this PR, directives and their content are deterministically placed
at the indentation the code would have without the directives, which also
makes formatting idempotent for these cases.

## Regression testing

Per the concern raised in #2345 about regression coverage:

- Restores the full regression test suite from #2319/#2331/#2333 that was
  removed by the revert (~1,000 lines), plus new test cases for #2535
  (method chain continuing at base level after a closing brace/paren) and
  for the `--xcode-indentation` + `no-indent` combination
- All 419 indent tests pass; the full test suite (5,818 tests) passes
- Verified against a real-world production codebase (~270 files) that
  uses `--ifdef noindent`: the only formatting changes are in a region
  with known-broken indentation, with zero changes elsewhere
- Verified on [swiftui-introspect](https://github.com/siteline/swiftui-introspect)
  (129 files, heavy `#if` use in SwiftUI modifier chains): with
  `--ifdef no-indent` the only changes are the canonical re-placement of
  directive lines and removal of the extra indent level inside blocks;
  the result is idempotent, and `--ifdef indent` / `--ifdef outdent`
  output is byte-identical to the unpatched build
- Verified that `--ifdef indent` / `--ifdef outdent` lint results are
  identical to the unpatched build on both corpora

## Tests

- [x] The base branch of the pull request is `develop`
- [x] Any code changes include corresponding test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
