### PR TITLE
Fix issue where swiftTestingTestCaseNames rule could accidentally not add backticks when required

### DIFF
--- a/Sources/FormattingHelpers.swift
+++ b/Sources/FormattingHelpers.swift
@@ -2154,6 +2154,12 @@ extension Formatter {
               !swiftKeywords.union(["Any", "Self", "self", "super", "nil", "true", "false"]).contains(unescapedName)
         else { return }
 
+        // Escape the new name in backticks if required, e.g. raw identifiers containing spaces
+        var newName = newName
+        if !newName.hasPrefix("`"), backticksRequired(forName: newName, at: nameIndex) {
+            newName = "`\(newName)`"
+        }
+
         replaceToken(at: nameIndex, with: .identifier(newName))
     }
 }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1539,8 +1539,11 @@ extension Formatter {
             return false
         }
 
-        let unescaped = token.unescaped()
+        return backticksRequired(forName: token.unescaped(), at: i, ignoreLeadingDot: ignoreLeadingDot)
+    }
 
+    /// Detect if the given unescaped identifier name would require backtick escaping at the given index
+    func backticksRequired(forName unescaped: String, at i: Int, ignoreLeadingDot: Bool = false) -> Bool {
         // This identifier may be a raw identifier like ``func `function name with spaces`()``.
         // Validate that the escaped identifier is a valid standard identifier.
         var scalarView = UnicodeScalarView(unescaped.unicodeScalars)
@@ -1594,7 +1597,7 @@ extension Formatter {
             if unescaped == "init" {
                 return true
             }
-            if options.swiftVersion >= "5" || self.token(at: prevIndex - 1)?.isOperator("\\") != true {
+            if options.swiftVersion >= "5" || token(at: prevIndex - 1)?.isOperator("\\") != true {
                 return ignoreLeadingDot
             }
             return true

--- a/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
+++ b/Tests/Rules/SwiftTestingTestCaseNamesTests.swift
@@ -105,6 +105,33 @@ final class SwiftTestingTestCaseNamesTests: XCTestCase {
         testFormatting(for: input, output, rule: .swiftTestingTestCaseNames)
     }
 
+    func testPreservesBackticksWhenRemovingTestPrefixFromRawIdentifier() {
+        let input = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func `testInit applies provided highlight state`() {
+                #expect(MyFeature.testInit().highlightState == .highlighted)
+            }
+        }
+        """
+
+        let output = """
+        import Testing
+
+        struct MyFeatureTests {
+            @Test
+            func `init applies provided highlight state`() {
+                #expect(MyFeature.testInit().highlightState == .highlighted)
+            }
+        }
+        """
+
+        testFormatting(for: input, [output], rules: [.swiftTestingTestCaseNames, .redundantBackticks],
+                       options: FormatOptions(swiftVersion: "6.2"))
+    }
+
     func testDoesntUpdateNameToIdentifierRequiringBackTicks() {
         let input = """
         import Testing


### PR DESCRIPTION
This PR fixes an issue where `swiftTestingTestCaseNames` rule could accidentally not add backticks when required