### PR TITLE
Prefer for-loop rule incorrectly applies to dollar-prefixed identifiers

### DIFF
--- a/Sources/Rules/PreferForLoop.swift
+++ b/Sources/Rules/PreferForLoop.swift
@@ -119,6 +119,10 @@ public extension FormatRule {
                 isAnonymousClosure = false
                 forEachValueNames = closureArguments.argumentIndices.map { formatter.tokens[$0].string }
                 inKeywordIndex = closureArguments.inKeywordIndex
+
+                // Dollar-prefixed parameters such as `$element` are invalid in
+                // for loop syntax, so we can't convert it to a for loop.
+                guard !forEachValueNames.contains(where: { $0.hasPrefix("$") }) else { return }
             } else {
                 isAnonymousClosure = true
                 inKeywordIndex = nil

--- a/Tests/Rules/PreferForLoopTests.swift
+++ b/Tests/Rules/PreferForLoopTests.swift
@@ -450,4 +450,43 @@ final class PreferForLoopTests: XCTestCase {
 
         testFormatting(for: input, output, rule: .preferForLoop, exclude: [.wrapConditionalBodies, .blankLinesAfterGuardStatements])
     }
+
+    func testDollarPrefixedElement() {
+        let input = """
+        @propertyWrapper
+        struct Wrapper<Value> {
+            let wrappedValue: Value
+
+            init(wrappedValue: Value) {
+                self.wrappedValue = wrappedValue
+            }
+
+            init(projectedValue: Wrapper<Value>) {
+                wrappedValue = projectedValue.wrappedValue
+            }
+
+            var projectedValue: Wrapper {
+                self
+            }
+        }
+
+        extension Wrapper: Sequence where Value: Sequence {
+            func makeIterator() -> LazyMapSequence<Value, Wrapper<Value.Element>>.Iterator {
+                wrappedValue.lazy
+                    .map { value in
+                        Wrapper<Value.Element>(wrappedValue: value)
+                    }
+                    .makeIterator()
+            }
+        }
+
+        func run() {
+            @Wrapper var sequence = [1, 2, 3]
+            $sequence.forEach { $element in
+                print($element)
+            }
+        }
+        """
+        testFormatting(for: input, rule: .preferForLoop)
+    }
 }


### PR DESCRIPTION
Fixes #2650.