### PR TITLE
Fix blank line before trailing infix operators

### DIFF
--- a/Sources/Rules/BlankLinesBetweenScopes.swift
+++ b/Sources/Rules/BlankLinesBetweenScopes.swift
@@ -70,7 +70,7 @@ public extension FormatRule {
                     }
                     switch formatter.tokens[nextNonCommentIndex] {
                     case .error, .endOfScope,
-                         .operator(".", _), .delimiter(","), .delimiter(":"),
+                         .operator(_, .infix), .delimiter(","), .delimiter(":"),
                          .keyword("else"), .keyword("catch"), .keyword("#else"), .keyword("#elseif"):
                         break outer
                     case .keyword("while"):

--- a/Tests/Rules/BlankLinesBetweenScopesTests.swift
+++ b/Tests/Rules/BlankLinesBetweenScopesTests.swift
@@ -253,6 +253,26 @@ final class BlankLinesBetweenScopesTests: XCTestCase {
         testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.emptyBraces])
     }
 
+    func testNoBlankLineBeforeInfixOperator() {
+        let inputs = [
+            """
+            let x = {
+                nil
+            }()
+                ?? 1
+            """,
+            """
+            let x = {
+                1
+            }()
+                + 1
+            """,
+        ]
+        for input in inputs {
+            testFormatting(for: input, rule: .blankLinesBetweenScopes, exclude: [.redundantClosure])
+        }
+    }
+
     func testNoBlankLineBeforeWhileInRepeatWhile() {
         let input = """
         repeat


### PR DESCRIPTION
Fixes #2648.

`blankLinesBetweenScopes` treated a line-leading infix operator after a multiline closure as the beginning of a separate declaration. This caused it to insert a blank line before operators such as `??`.

Treat infix operators as continuations, consistent with the existing handling for member chains, commas, and colons.

Added regression coverage for nil-coalescing and another infix operator.

Tests:

- `BlankLinesBetweenScopesTests`: 27 passed
- Full test suite: 5,933 passed
- SwiftFormat self-lint
