### PR TITLE
Add rule: prefer min()/max() over map { $0.foo }.min()/.max()

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -136,6 +136,7 @@
 * [preferFinalClasses](#preferFinalClasses)
 * [preferFirstWhere](#preferFirstWhere)
 * [preferFlatMap](#preferFlatMap)
+* [preferMinMaxOverMap](#preferMinMaxOverMap)
 * [preferMinOverSorted](#preferMinOverSorted)
 * [preferSwiftStringAPI](#preferSwiftStringAPI)
 * [preferSwiftTesting](#preferSwiftTesting)
@@ -2090,6 +2091,24 @@ Convert trivial `map { $0.foo }` closures to keyPath-based syntax.
 
 - let barArray = fooArray.compactMap { $0.optionalBar }
 + let barArray = fooArray.compactMap(\.optionalBar)
+```
+
+</details>
+<br/>
+
+## preferMinMaxOverMap
+
+Prefer `min()`/`max()` over `map { $0.foo }.min()`/`.max()`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let minY = vertices.map { $0.y }.min()!
++ let minY = vertices.min { $0.y < $1.y }!.y
+
+- let floorOffset = amenities.map { $0.box.minY }.min() ?? 0
++ let floorOffset = amenities.min { $0.box.minY < $1.box.minY }?.box.minY ?? 0
 ```
 
 </details>

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1643,6 +1643,13 @@ extension Formatter {
         return false
     }
 
+    /// Returns whether every token in the given range is whitespace, an identifier, or a `.`
+    /// operator — i.e. a plain dotted member-access chain (e.g. `$0.foo.bar`) with no calls,
+    /// subscripts, or other operators.
+    func isSimpleMemberAccessChain(in range: ClosedRange<Int>) -> Bool {
+        tokens[range].allSatisfy { $0.isSpace || $0.isIdentifier || $0.isOperator(".") }
+    }
+
     /// Returns true if the identifier at the specified index is a label
     func isLabel(at i: Int) -> Bool {
         guard case .identifier = token(at: i) else {

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -70,6 +70,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferFlatMap": .preferFlatMap,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
+    "preferMinMaxOverMap": .preferMinMaxOverMap,
     "preferMinOverSorted": .preferMinOverSorted,
     "preferSwiftStringAPI": .preferSwiftStringAPI,
     "preferSwiftTesting": .preferSwiftTesting,

--- a/Sources/Rules/PreferKeyPath.swift
+++ b/Sources/Rules/PreferKeyPath.swift
@@ -61,10 +61,10 @@ public extension FormatRule {
                 guard formatter.options.swiftVersion >= "6" else { return }
                 replacementTokens = tokenize("\\.self")
             } else {
-                let tokens = formatter.tokens[nextIndex + 1 ... lastIndex]
-                guard tokens.allSatisfy({ $0.isSpace || $0.isIdentifier || $0.isOperator(".") }) else {
+                guard formatter.isSimpleMemberAccessChain(in: nextIndex + 1 ... lastIndex) else {
                     return
                 }
+                let tokens = formatter.tokens[nextIndex + 1 ... lastIndex]
                 replacementTokens = [.operator("\\", .prefix)] + tokens
             }
             if let label {

--- a/Sources/Rules/PreferMinMaxOverMap.swift
+++ b/Sources/Rules/PreferMinMaxOverMap.swift
@@ -1,0 +1,102 @@
+//
+//  PreferMinMaxOverMap.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 8/19/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferMinMaxOverMap = FormatRule(
+        help: "Prefer `min()`/`max()` over `map { $0.foo }.min()`/`.max()`.",
+        disabledByDefault: true
+    ) { formatter in
+        formatter.forEach(.identifier("map")) { mapIndex, _ in
+            // Require a member call: something `.map { ... }` (trailing closure, no parens —
+            // `.map(someTransform)` isn't rewritten since there's no closure body to inspect).
+            guard let dotBeforeMap = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: mapIndex),
+                  formatter.tokens[dotBeforeMap] == .operator(".", .infix),
+                  let openBraceIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: mapIndex),
+                  formatter.tokens[openBraceIndex] == .startOfScope("{"),
+                  let closeBraceIndex = formatter.endOfScope(at: openBraceIndex)
+            else { return }
+
+            // The closure body must be exactly `$0` followed by a plain member-access chain
+            // (`$0.foo`, `$0.foo.bar`) — nothing else. This is what lets the same chain be safely
+            // reused three times below: twice to build the `min`/`max` comparator, and once more
+            // to re-extract the projected value from the element `min`/`max` returns. A computed
+            // expression (`$0.width * $0.height`), a function call, or a bare `$0` (identity map)
+            // can't be replayed this way, so all of those are left untouched.
+            guard let dollarZeroIndex = formatter.index(of: .nonSpaceOrLinebreak, after: openBraceIndex),
+                  formatter.tokens[dollarZeroIndex] == .identifier("$0"),
+                  let lastBodyIndex = formatter.index(of: .nonSpaceOrLinebreak, before: closeBraceIndex),
+                  lastBodyIndex > dollarZeroIndex
+            else { return }
+            guard formatter.isSimpleMemberAccessChain(in: (dollarZeroIndex + 1) ... lastBodyIndex) else {
+                return
+            }
+            let chainTokens = Array(formatter.tokens[(dollarZeroIndex + 1) ... lastBodyIndex])
+
+            // Require a trailing, argument-less `.min()` or `.max()` call. Unlike the `sorted().first`
+            // → `min()` rewrite, there's no tie-breaking hazard here for `.max()`: the map projects
+            // to a scalar, and every element tied on that scalar shares the same projected value, so
+            // it doesn't matter which tied element `min`/`max` picks — the re-extracted value is
+            // identical either way. Both directions are safe to rewrite symmetrically.
+            guard let dotBeforeAccessor = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeBraceIndex),
+                  formatter.tokens[dotBeforeAccessor] == .operator(".", .infix),
+                  let accessorIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotBeforeAccessor),
+                  case let .identifier(accessorName) = formatter.tokens[accessorIndex],
+                  accessorName == "min" || accessorName == "max",
+                  let openParenIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: accessorIndex),
+                  formatter.tokens[openParenIndex] == .startOfScope("("),
+                  let closeParenIndex = formatter.endOfScope(at: openParenIndex),
+                  formatter.parseFunctionCallArguments(startOfScope: openParenIndex).isEmpty
+            else { return }
+
+            // The result is only rewritten as far as an immediately-trailing `!`; anything else
+            // that follows (further chaining, a subscript) is out of scope, since inserting the
+            // re-extracted chain ahead of it would change what it's applied to. A trailing
+            // `?? default` is left completely alone — the rewrite only needs to land the
+            // re-extraction before it, which happens naturally since we stop at `closeParenIndex`.
+            var replacementEndIndex = closeParenIndex
+            var trailingMarker = Token.operator("?", .postfix)
+            if let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeParenIndex) {
+                switch formatter.tokens[nextIndex] {
+                case .operator("!", .postfix):
+                    trailingMarker = .operator("!", .postfix)
+                    replacementEndIndex = nextIndex
+
+                case .operator(".", .infix), .startOfScope("["):
+                    return
+
+                default:
+                    break
+                }
+            }
+
+            // Bail rather than silently dropping a comment anywhere in the span being rewritten.
+            guard !formatter.tokens[dotBeforeMap ... replacementEndIndex].contains(where: \.isComment) else { return }
+
+            let comparator: [Token] = [.identifier("$0")] + chainTokens
+                + [.space(" "), .operator("<", .infix), .space(" ")]
+                + [.identifier("$1")] + chainTokens
+            let replacement: [Token] = [.operator(".", .infix), .identifier(accessorName), .space(" "),
+                                        .startOfScope("{"), .space(" ")] + comparator
+                + [.space(" "), .endOfScope("}"), trailingMarker] + chainTokens
+
+            formatter.replaceTokens(in: dotBeforeMap ... replacementEndIndex, with: replacement)
+        }
+    } examples: {
+        """
+        ```diff
+        - let minY = vertices.map { $0.y }.min()!
+        + let minY = vertices.min { $0.y < $1.y }!.y
+
+        - let floorOffset = amenities.map { $0.box.minY }.min() ?? 0
+        + let floorOffset = amenities.min { $0.box.minY < $1.box.minY }?.box.minY ?? 0
+        ```
+        """
+    }
+}

--- a/Tests/Rules/PreferMinMaxOverMapTests.swift
+++ b/Tests/Rules/PreferMinMaxOverMapTests.swift
@@ -1,0 +1,181 @@
+//
+//  PreferMinMaxOverMapTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 8/19/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferMinMaxOverMapTests: XCTestCase {
+    func testConvertMapMinToMin() {
+        let input = """
+        let minY = vertices.map { $0.y }.min()
+        """
+
+        let output = """
+        let minY = vertices.min { $0.y < $1.y }?.y
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testConvertMapMaxToMax() {
+        let input = """
+        let maxX = boxes.map { $0.maxX }.max()
+        """
+
+        let output = """
+        let maxX = boxes.max { $0.maxX < $1.maxX }?.maxX
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testConvertMapMinWithForceUnwrap() {
+        let input = """
+        let minY = vertices.map { $0.y }.min()!
+        """
+
+        let output = """
+        let minY = vertices.min { $0.y < $1.y }!.y
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testConvertMapMinWithNilCoalescing() {
+        let input = """
+        let floorOffset = amenities.map { $0.box.minY }.min() ?? 0
+        """
+
+        let output = """
+        let floorOffset = amenities.min { $0.box.minY < $1.box.minY }?.box.minY ?? 0
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testConvertMapMaxWithMultiLevelChain() {
+        let input = """
+        let floorOffset = amenities.map { $0.box.minY }.max()
+        """
+
+        let output = """
+        let floorOffset = amenities.max { $0.box.minY < $1.box.minY }?.box.minY
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testConvertChainedReceiver() {
+        let input = """
+        let minY = model.scene.vertices.map { $0.y }.min()
+        """
+
+        let output = """
+        let minY = model.scene.vertices.min { $0.y < $1.y }?.y
+        """
+
+        testFormatting(for: input, output, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesComputedExpressionBody() {
+        let input = """
+        let area = boxes.map { $0.width * $0.height }.max()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesFunctionCallBody() {
+        let input = """
+        let value = boxes.map { transform($0) }.max()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesIdentityMap() {
+        let input = """
+        let smallest = values.map { $0 }.min()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesNamedClosureParameter() {
+        let input = """
+        let minY = vertices.map { item in item.y }.min()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesMinWithExplicitArgument() {
+        let input = """
+        let smallest = values.map { $0.y }.min(by: { $0 < $1 })
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesMaxWithExplicitArgument() {
+        let input = """
+        let largest = values.map { $0.y }.max(by: { $0 < $1 })
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesTrailingAccessorAfterMin() {
+        let input = """
+        let description = values.map { $0.y }.min().debugDescription
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesTrailingSubscriptAfterMin() {
+        let input = """
+        let first = values.map { $0.points }.min()[0]
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesNonTrailingClosureMapCall() {
+        let input = """
+        let minY = vertices.map(projection).min()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesFirstAfterMap() {
+        let input = """
+        let firstY = vertices.map { $0.y }.first
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesCommentInsideClosure() {
+        let input = """
+        let minY = vertices.map { /* projection */ $0.y }.min()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+
+    func testPreservesCommentBetweenMapAndAccessor() {
+        let input = """
+        let minY = vertices.map { $0.y } /* comment */ .min()
+        """
+
+        testFormatting(for: input, rule: .preferMinMaxOverMap)
+    }
+}


### PR DESCRIPTION
#### Summary

Adds a new `preferMinMaxOverMap` SwiftFormat rule (disabled by default, like its sibling `preferMinOverSorted`) and documents it in `Rules.md`.

#### Reasoning

`xs.map { $0.foo }.min()` allocates a full array of projected values just to reduce it to one — `xs.min { $0.foo < $1.foo }?.foo` finds the same value in a single O(n) pass with no allocation. Same motivation as `preferMinOverSorted`, but for `.map(...).min()/.max()` instead of `.sorted().first`.

Unlike `preferMinOverSorted`, both `min()` and `max()` are safe to rewrite here: that rule skips `.last` → `max()` because ties resolve differently (`min`/`max` keep the first tied element, `sorted().last` keeps the last). Here the map projects to a scalar and we only ever re-extract that same scalar from the winning element, so every tied element shares the same projected value — whichever one `min`/`max` picks, the result is identical.

Only rewrites when the map closure body is a plain `$0`-rooted member-access chain (`$0.foo`, `$0.box.minY`) — not a computed expression, function call, or identity map — since the same chain gets replayed three times: twice to build the comparator, once more to re-extract the value from the result. Repositions a trailing `!` past the re-extracted chain; a trailing `?? default` is left alone since it already lands after the insertion point. Bails on a comment anywhere in the rewritten span.

Also extracted the member-access-chain check (previously duplicated inline in `preferKeyPath`) into a shared `Formatter.isSimpleMemberAccessChain(in:)` helper in `ParsingHelpers.swift`, now used by both rules.

Manually verified against the real-world cases that motivated this (geometry/min-max reduction code from an iOS codebase audit) — the rule's output matched the hand-written fixes exactly in every case, including nested/parenthesized and `?? default` forms.