### PR TITLE
Add rule: prefer lazy.map before single-pass operations

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -136,6 +136,7 @@
 * [preferFinalClasses](#preferFinalClasses)
 * [preferFirstWhere](#preferFirstWhere)
 * [preferFlatMap](#preferFlatMap)
+* [preferLazyMap](#preferLazyMap)
 * [preferMinOverSorted](#preferMinOverSorted)
 * [preferSwiftStringAPI](#preferSwiftStringAPI)
 * [preferSwiftTesting](#preferSwiftTesting)
@@ -2090,6 +2091,27 @@ Convert trivial `map { $0.foo }` closures to keyPath-based syntax.
 
 - let barArray = fooArray.compactMap { $0.optionalBar }
 + let barArray = fooArray.compactMap(\.optionalBar)
+```
+
+</details>
+<br/>
+
+## preferLazyMap
+
+Prefer `lazy.map` over `map` before single-pass operations like `min()`.
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- let minY = vertices.map { $0.y }.min()
++ let minY = vertices.lazy.map { $0.y }.min()
+
+- let names = users.map { $0.name }.joined(separator: ", ")
++ let names = users.lazy.map { $0.name }.joined(separator: ", ")
+
+- let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
++ let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -70,6 +70,7 @@ let ruleRegistry: [String: FormatRule] = [
     "preferFlatMap": .preferFlatMap,
     "preferForLoop": .preferForLoop,
     "preferKeyPath": .preferKeyPath,
+    "preferLazyMap": .preferLazyMap,
     "preferMinOverSorted": .preferMinOverSorted,
     "preferSwiftStringAPI": .preferSwiftStringAPI,
     "preferSwiftTesting": .preferSwiftTesting,

--- a/Sources/Rules/PreferLazyMap.swift
+++ b/Sources/Rules/PreferLazyMap.swift
@@ -1,0 +1,90 @@
+//
+//  PreferLazyMap.swift
+//  SwiftFormat
+//
+//  Created by Jon Parise on 8/19/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    static let preferLazyMap = FormatRule(
+        help: "Prefer `lazy.map` over `map` before single-pass operations like `min()`.",
+        disabledByDefault: true
+    ) { formatter in
+        formatter.forEach(.identifier("map")) { mapIndex, _ in
+            // Require a member call with a trailing closure: something `.map { ... }`.
+            // `.map(transform)` is left alone — detecting where to insert `.lazy` safely across
+            // the other call forms isn't worth the added complexity.
+            guard let dotBeforeMap = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: mapIndex),
+                  formatter.tokens[dotBeforeMap] == .operator(".", .infix),
+                  let openBraceIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: mapIndex),
+                  formatter.tokens[openBraceIndex] == .startOfScope("{"),
+                  let closeBraceIndex = formatter.endOfScope(at: openBraceIndex)
+            else { return }
+
+            // Don't insert `.lazy` again if the receiver already has it.
+            if let receiverIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: dotBeforeMap),
+               formatter.tokens[receiverIndex] == .identifier("lazy")
+            {
+                return
+            }
+
+            // The mapped sequence must be consumed directly by one of the operations that walks it
+            // a single time, since those never need the intermediate array an eager `map` allocates.
+            guard let dotBeforeConsumer = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeBraceIndex),
+                  formatter.tokens[dotBeforeConsumer] == .operator(".", .infix),
+                  let consumerIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: dotBeforeConsumer),
+                  case let .identifier(consumer) = formatter.tokens[consumerIndex],
+                  Formatter.lazyMapConsumers.contains(consumer),
+                  let callIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: consumerIndex)
+            else { return }
+
+            // The consumer has to actually be *called*, either with an argument list (`min()`) or a
+            // trailing closure (`allSatisfy { ... }`). This is what limits `first` to `first(where:)`
+            // — see `lazyMapConsumers` — and skips an uncalled method reference. A `{` that opens a
+            // control-flow body rather than a closure doesn't count, since in that case the consumer
+            // is a property access rather than a call.
+            let callToken = formatter.tokens[callIndex]
+            guard callToken == .startOfScope("(")
+                || (callToken == .startOfScope("{") && formatter.isStartOfClosure(at: callIndex))
+            else { return }
+
+            formatter.insert([.identifier("lazy"), .operator(".", .infix)], at: mapIndex)
+        }
+    } examples: {
+        """
+        ```diff
+        - let minY = vertices.map { $0.y }.min()
+        + let minY = vertices.lazy.map { $0.y }.min()
+
+        - let names = users.map { $0.name }.joined(separator: ", ")
+        + let names = users.lazy.map { $0.name }.joined(separator: ", ")
+
+        - let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
+        + let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
+        ```
+        """
+    }
+}
+
+extension Formatter {
+    /// `Sequence` operations that consume their receiver in a single pass without materializing it,
+    /// so a preceding `map` can be made lazy to avoid allocating an intermediate array.
+    ///
+    /// Deliberately excludes operations that must materialize their receiver to do their work
+    /// (`sorted()`, `reversed()`), where laziness buys nothing.
+    ///
+    /// `first` refers only to `first(where:)`. The `first` *property* is declared on `Collection`
+    /// rather than `Sequence`, so its meaning depends on the receiver's type in a way that can't be
+    /// determined from the tokens alone — callers must require a call paren, which excludes it.
+    static let lazyMapConsumers: Set<String> = [
+        // Visit every element exactly once, so the closure is called the same number of times
+        // whether the `map` is eager or lazy — safe even for a closure with side effects.
+        "min", "max", "reduce", "joined",
+        // May exit early, so a lazy `map` can call the closure fewer times than an eager one.
+        // This is the same tradeoff the `preferFirstWhere` rule already makes.
+        "contains", "allSatisfy", "first",
+    ]
+}

--- a/Tests/Rules/PreferContainsTests.swift
+++ b/Tests/Rules/PreferContainsTests.swift
@@ -683,7 +683,7 @@ final class PreferContainsTests: XCTestCase {
         let missing = !items.map { $0.name }.joined().contains("x")
         """
 
-        testFormatting(for: input, output, rule: .preferContains)
+        testFormatting(for: input, output, rule: .preferContains, exclude: [.preferLazyMap])
     }
 
     func testRangeNegationInsertedAtOwnStatementNotPriorStatementEndingInScope() {

--- a/Tests/Rules/PreferFlatMapTests.swift
+++ b/Tests/Rules/PreferFlatMapTests.swift
@@ -98,7 +98,7 @@ final class PreferFlatMapTests: XCTestCase {
             .reduce([], +)
         """
 
-        testFormatting(for: input, rule: .preferFlatMap)
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.preferLazyMap])
     }
 
     func testPreservesCommentInsideReduce() {
@@ -109,7 +109,7 @@ final class PreferFlatMapTests: XCTestCase {
         // Exclude `spaceAroundComments`, which would otherwise insert a space
         // after the open paren; the point here is that `preferFlatMap` itself
         // leaves the commented `reduce` call untouched.
-        testFormatting(for: input, rule: .preferFlatMap, exclude: [.spaceAroundComments])
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.spaceAroundComments, .preferLazyMap])
     }
 
     func testPreservesReduceWithNonEmptySeed() {
@@ -117,7 +117,7 @@ final class PreferFlatMapTests: XCTestCase {
         values.map { $0.count }.reduce(0, +)
         """
 
-        testFormatting(for: input, rule: .preferFlatMap)
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.preferLazyMap])
     }
 
     func testPreservesReduceWithNonEmptyArraySeed() {
@@ -125,7 +125,7 @@ final class PreferFlatMapTests: XCTestCase {
         sections.map { $0.items }.reduce([defaultItem], +)
         """
 
-        testFormatting(for: input, rule: .preferFlatMap)
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.preferLazyMap])
     }
 
     func testPreservesReduceWithDifferentOperator() {
@@ -133,7 +133,7 @@ final class PreferFlatMapTests: XCTestCase {
         sets.map { $0.elements }.reduce([], -)
         """
 
-        testFormatting(for: input, rule: .preferFlatMap)
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.preferLazyMap])
     }
 
     func testPreservesReduceWithClosureCombinator() {
@@ -141,7 +141,7 @@ final class PreferFlatMapTests: XCTestCase {
         sections.map { $0.items }.reduce([]) { $0 + $1 }
         """
 
-        testFormatting(for: input, rule: .preferFlatMap)
+        testFormatting(for: input, rule: .preferFlatMap, exclude: [.preferLazyMap])
     }
 
     func testPreservesStandaloneMap() {

--- a/Tests/Rules/PreferLazyMapTests.swift
+++ b/Tests/Rules/PreferLazyMapTests.swift
@@ -1,0 +1,253 @@
+//
+//  PreferLazyMapTests.swift
+//  SwiftFormatTests
+//
+//  Created by Jon Parise on 8/19/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftFormat
+
+final class PreferLazyMapTests: XCTestCase {
+    func testInsertsLazyBeforeMin() {
+        let input = """
+        let minY = vertices.map { $0.y }.min()
+        """
+
+        let output = """
+        let minY = vertices.lazy.map { $0.y }.min()
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeMax() {
+        let input = """
+        let maxX = boxes.map { $0.maxX }.max()
+        """
+
+        let output = """
+        let maxX = boxes.lazy.map { $0.maxX }.max()
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeMinWithComparator() {
+        let input = """
+        let earliest = events.map { $0.date }.min(by: { $0 < $1 })
+        """
+
+        let output = """
+        let earliest = events.lazy.map { $0.date }.min(by: { $0 < $1 })
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeReduce() {
+        let input = """
+        let total = items.map { $0.price }.reduce(0, +)
+        """
+
+        let output = """
+        let total = items.lazy.map { $0.price }.reduce(0, +)
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeJoined() {
+        let input = """
+        let names = users.map { $0.name }.joined(separator: ", ")
+        """
+
+        let output = """
+        let names = users.lazy.map { $0.name }.joined(separator: ", ")
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeContains() {
+        let input = """
+        let hasZero = items.map { $0.count }.contains(0)
+        """
+
+        let output = """
+        let hasZero = items.lazy.map { $0.count }.contains(0)
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeContainsWhere() {
+        let input = """
+        let hasEmpty = rows.map { $0.title }.contains(where: { $0.isEmpty })
+        """
+
+        let output = """
+        let hasEmpty = rows.lazy.map { $0.title }.contains(where: { $0.isEmpty })
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeAllSatisfy() {
+        let input = """
+        let allPositive = items.map { $0.value }.allSatisfy { $0 > 0 }
+        """
+
+        let output = """
+        let allPositive = items.lazy.map { $0.value }.allSatisfy { $0 > 0 }
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeFirstWhere() {
+        let input = """
+        let firstEmpty = rows.map { $0.title }.first(where: { $0.isEmpty })
+        """
+
+        let output = """
+        let firstEmpty = rows.lazy.map { $0.title }.first(where: { $0.isEmpty })
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeMinWithTrailingClosure() {
+        let input = """
+        let earliest = events.map { $0.date }.min { $0 < $1 }
+        """
+
+        let output = """
+        let earliest = events.lazy.map { $0.date }.min { $0 < $1 }
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyBeforeFirstWithTrailingClosure() {
+        let input = """
+        let firstEmpty = rows.map { $0.title }.first { $0.isEmpty }
+        """
+
+        let output = """
+        let firstEmpty = rows.lazy.map { $0.title }.first { $0.isEmpty }
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyWithForceUnwrap() {
+        let input = """
+        let minY = vertices.map { $0.y }.min()!
+        """
+
+        let output = """
+        let minY = vertices.lazy.map { $0.y }.min()!
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyWithNilCoalescing() {
+        let input = """
+        let floorOffset = amenities.map { $0.box.minY }.min() ?? 0
+        """
+
+        let output = """
+        let floorOffset = amenities.lazy.map { $0.box.minY }.min() ?? 0
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyForComputedExpressionBody() {
+        let input = """
+        let area = boxes.map { $0.width * $0.height }.max()
+        """
+
+        let output = """
+        let area = boxes.lazy.map { $0.width * $0.height }.max()
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyForNamedClosureParameter() {
+        let input = """
+        let minY = vertices.map { item in item.y }.min()
+        """
+
+        let output = """
+        let minY = vertices.lazy.map { item in item.y }.min()
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyForChainedReceiver() {
+        let input = """
+        let minY = model.scene.vertices.map { $0.y }.min()
+        """
+
+        let output = """
+        let minY = model.scene.vertices.lazy.map { $0.y }.min()
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
+    func testPreservesFirstProperty() {
+        let input = """
+        let firstY = vertices.map { $0.y }.first
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesAlreadyLazyReceiver() {
+        let input = """
+        let minY = vertices.lazy.map { $0.y }.min()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesSorted() {
+        let input = """
+        let sortedYs = vertices.map { $0.y }.sorted()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesCount() {
+        let input = """
+        let count = vertices.map { $0.y }.count
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesUncalledMinReference() {
+        let input = """
+        let findMin = vertices.map { $0.y }.min
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesNonTrailingClosureMapCall() {
+        let input = """
+        let minY = vertices.map(projection).min()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+}

--- a/Tests/Rules/TrailingClosuresTests.swift
+++ b/Tests/Rules/TrailingClosuresTests.swift
@@ -178,7 +178,7 @@ final class TrailingClosuresTests: XCTestCase {
         let output = """
         foo.map { $0.path }.joined()
         """
-        testFormatting(for: input, output, rule: .trailingClosures)
+        testFormatting(for: input, output, rule: .trailingClosures, exclude: [.preferLazyMap])
     }
 
     func testSpaceNotInsertedAfterClosureBeforeUnwrap() {

--- a/Tests/Rules/WrapMultilineFunctionChainsTests.swift
+++ b/Tests/Rules/WrapMultilineFunctionChainsTests.swift
@@ -24,7 +24,7 @@ final class WrapMultilineFunctionChainsTests: XCTestCase {
             .reduce(0, +)
         """
 
-        testFormatting(for: input, [output], rules: [.wrapMultilineFunctionChains, .indent])
+        testFormatting(for: input, [output], rules: [.wrapMultilineFunctionChains, .indent], exclude: [.preferLazyMap])
     }
 
     func testWrapMultipleFunctionCalls() {


### PR DESCRIPTION
#### Summary

Adds a `preferLazyMap` rule (disabled by default) that inserts `.lazy` before a `map` whose result is immediately consumed in a single pass.

```diff
- let minY = vertices.map { $0.y }.min()
+ let minY = vertices.lazy.map { $0.y }.min()

- let names = users.map { $0.name }.joined(separator: ", ")
+ let names = users.lazy.map { $0.name }.joined(separator: ", ")
```

#### Reasoning

`xs.map { ... }.min()` allocates a full intermediate array just to walk it once and throw it away. `.lazy` avoids the allocation while leaving the expression otherwise untouched.

The rule applies to operations that consume their receiver in a single pass without materializing it, in two groups:

- **`min`, `max`, `reduce`, `joined`** visit every element exactly once, so the closure is called the same number of times whether the map is eager or lazy — behavior-preserving even for a closure with side effects.
- **`contains`, `allSatisfy`, `first(where:)`** may exit early, so a lazy map can call the closure *fewer* times than an eager one. This is the same tradeoff `preferFirstWhere` already makes, and the win is bigger: in a quick benchmark, finding an early match in a 1M-element collection went from 1,000,000 closure calls down to 6.

`sorted()` and `reversed()` are deliberately excluded — they must materialize their receiver anyway, so laziness buys nothing.

#### On `first`

The consumer must actually be *called*, with either an argument list (`min()`) or a trailing closure (`allSatisfy { ... }`). That requirement is what limits `first` to `first(where:)`, which matters: the `first` **property** is declared on `Collection` rather than `Sequence`, so unlike every operation above it is not available on a lazy map over a `Sequence`-only receiver. Eager `map` always returns an `Array`, so `seq.map { ... }.first` compiles while `seq.lazy.map { ... }.first` may not — and which one applies depends on type information the formatter doesn't have. Requiring a call sidesteps that entirely. A `{` that opens a control-flow body rather than a closure doesn't count as a call either.

The rule also skips a receiver that is already `lazy`, and `map(transform)` called without a trailing closure.

#### Notes

Four existing tests in other rules' suites now pass `exclude: [.preferLazyMap]`, since their fixtures contain `map { ... }.reduce(...)` / `.joined()` chains that this rule rewrites.