### PR TITLE
Fix preferLazyMap rewrites that were not behavior-preserving

### DIFF
--- a/Sources/Rules/PreferLazyMap.swift
+++ b/Sources/Rules/PreferLazyMap.swift
@@ -31,6 +31,26 @@ public extension FormatRule {
                 return
             }
 
+            // An identity `map { $0 }` transforms nothing, so making it lazy saves no work while
+            // still requiring `lazy` on the receiver — which only exists on a `Sequence`, and the
+            // receiver's type isn't knowable here. Leave these alone: there is nothing to gain, and
+            // `map` is defined on plenty of non-`Sequence` types.
+            if let onlyBodyIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: openBraceIndex),
+               formatter.tokens[onlyBodyIndex] == .identifier("$0"),
+               formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: onlyBodyIndex) == closeBraceIndex
+            {
+                return
+            }
+
+            // `lazy.map` stores its transform, so the closure becomes escaping. Inside a reference
+            // type that turns an implicit `self` reference — legal in the non-escaping closure that
+            // eager `map` takes — into "requires explicit use of 'self'", so the rewrite would not
+            // compile. Whether a bare name is a member of `self` can't be resolved from the tokens,
+            // so bail on any of them.
+            guard formatter.closureBodyOnlyReferencesItsArguments(atStartOfScope: openBraceIndex) else {
+                return
+            }
+
             // The mapped sequence must be consumed directly by one of the operations that walks it
             // a single time, since those never need the intermediate array an eager `map` allocates.
             guard let dotBeforeConsumer = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: closeBraceIndex),
@@ -51,6 +71,17 @@ public extension FormatRule {
                 || (callToken == .startOfScope("{") && formatter.isStartOfClosure(at: callIndex))
             else { return }
 
+            // `joined()` has to be passed a separator. Without one it resolves differently on a lazy
+            // sequence — to the overload that flattens a sequence of sequences, rather than the
+            // `StringProtocol` one — so a `String` result silently becomes a lazy sequence, and any
+            // string interpolation of it starts emitting the sequence's description.
+            // `joined(separator:)` returns `String` either way.
+            if consumer == "joined" {
+                guard callToken == .startOfScope("("),
+                      !formatter.parseFunctionCallArguments(startOfScope: callIndex).isEmpty
+                else { return }
+            }
+
             formatter.insert([.identifier("lazy"), .operator(".", .infix)], at: mapIndex)
         }
     } examples: {
@@ -70,6 +101,52 @@ public extension FormatRule {
 }
 
 extension Formatter {
+    /// Whether the body of the closure starting at `startOfScopeIndex` refers to nothing but its own
+    /// arguments — either the implicit `$0` shorthand or names it declares in its parameter list.
+    ///
+    /// Any other bare name may be an implicit `self` member, which is only legal in a non-escaping
+    /// closure, so callers that make a closure escaping must not rewrite when this returns `false`.
+    /// Names reached through a `.` (`$0.foo`), argument labels, keywords, and literals are all fine.
+    ///
+    /// This is deliberately conservative: a bare name that is really a global function or a type
+    /// (`hypot($0)`, `String($0)`) is indistinguishable from a member of `self` here, so it is
+    /// treated as one.
+    func closureBodyOnlyReferencesItsArguments(atStartOfScope startOfScopeIndex: Int) -> Bool {
+        assert(tokens[startOfScopeIndex] == .startOfScope("{"))
+        guard let endOfScopeIndex = endOfScope(at: startOfScopeIndex) else { return false }
+
+        let arguments = parseClosureArguments(at: startOfScopeIndex)
+        let argumentNames = Set((arguments?.argumentIndices ?? []).map { tokens[$0].string })
+        let bodyStartIndex = arguments?.inKeywordIndex ?? startOfScopeIndex
+
+        for index in (bodyStartIndex + 1) ..< endOfScopeIndex {
+            guard case let .identifier(name) = tokens[index] else { continue }
+            // Literals, which the tokenizer represents as identifiers rather than keywords.
+            if ["true", "false", "nil", "_"].contains(name) {
+                continue
+            }
+            // `$0` and friends are the closure's own arguments.
+            if name.hasPrefix("$") {
+                continue
+            }
+            // A name declared by the closure's parameter list.
+            if argumentNames.contains(name) {
+                continue
+            }
+            // A member of another value rather than a bare name, as in `$0.foo`.
+            if last(.nonSpaceOrCommentOrLinebreak, before: index)?.isOperator(".") == true {
+                continue
+            }
+            // An argument label, as in `$0.reduce(into: [])`.
+            if isLabel(at: index) {
+                continue
+            }
+            return false
+        }
+
+        return true
+    }
+
     /// `Sequence` operations that consume their receiver in a single pass without materializing it,
     /// so a preceding `map` can be made lazy to avoid allocating an intermediate array.
     ///

--- a/Tests/Rules/PreferLazyMapTests.swift
+++ b/Tests/Rules/PreferLazyMapTests.swift
@@ -203,6 +203,78 @@ final class PreferLazyMapTests: XCTestCase {
         testFormatting(for: input, output, rule: .preferLazyMap)
     }
 
+    func testPreservesIdentityMap() {
+        let input = """
+        let smallest = values.map { $0 }.min()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesJoinedWithoutSeparator() {
+        let input = """
+        let combined = parts.map { $0.title }.joined()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesImplicitSelfMethodCall() {
+        let input = """
+        final class Generator {
+            func render(_ value: Int) -> String {
+                "\\(value)"
+            }
+
+            func synthesize() -> String {
+                values.map { render($0) }.joined(separator: ",")
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesImplicitSelfPropertyReference() {
+        let input = """
+        final class Generator {
+            func synthesize() -> String {
+                values.map { "\\(indentation)\\($0)" }.joined(separator: ",")
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesGlobalFunctionCall() {
+        let input = """
+        let closest = points.map { hypot($0.x, $0.y) }.min()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testPreservesTypeConversion() {
+        let input = """
+        let joined = ids.map { String($0) }.joined(separator: ",")
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
+    func testInsertsLazyForArgumentLabelInMemberCall() {
+        let input = """
+        let names = users.map { $0.name(includingMiddle: true) }.joined(separator: ", ")
+        """
+
+        let output = """
+        let names = users.lazy.map { $0.name(includingMiddle: true) }.joined(separator: ", ")
+        """
+
+        testFormatting(for: input, output, rule: .preferLazyMap)
+    }
+
     func testPreservesFirstProperty() {
         let input = """
         let firstY = vertices.map { $0.y }.first


### PR DESCRIPTION
#### Summary

Follow-up to #2656. Enabling `preferLazyMap` across a ~50k-file first-party codebase surfaced three ways the rewrite was not behavior-preserving. This tightens the rule so the same sweep now builds clean.

Making a `map` lazy changes more than whether an intermediate array is allocated:

| | Cause | Symptom |
|---|---|---|
| 1 | Closure becomes escaping | compile error on implicit `self` in a reference type |
| 2 | `joined()` resolves to a different overload | **silent** — `String` becomes a lazy sequence |
| 3 | `.lazy` requires `Sequence` | compile error on other `map`-providing types |

#### 1. Implicit `self` in the closure

`lazy.map` stores its transform, so its closure is escaping while eager `map`'s is not. Inside a reference type that difference is load-bearing:

```swift
final class Generator {
  func render(_ value: Int) -> String { "\(value)" }
  func eager() -> String { values.map { render($0) }.joined(separator: ",") }
  // error: call to method 'render' in closure requires explicit use of 'self'
  func lazyOne() -> String { values.lazy.map { render($0) }.joined(separator: ",") }
}
```

Whether a bare name is a member of `self`, a global function, or a type isn't resolvable from tokens, so the rule now rewrites only when the closure body references nothing but its own arguments. Member accesses through a `.`, argument labels, keywords and literals still qualify, so the projections this rule targets (`$0.foo`, `$0.a.b`, `$0.name(x: true)`) are unaffected. Deliberately conservative: `hypot($0.x, $0.y)` is skipped even though it captures no self, being indistinguishable from a member reference here.

#### 2. `joined()` with no separator

On a lazy sequence this resolves to the sequence-flattening overload instead of the `StringProtocol` one:

```swift
parts.map { $0 + "!" }.joined()       // String
parts.lazy.map { $0 + "!" }.joined()  // LazySequence<FlattenSequence<...>>
```

This is the one I'd flag hardest, because it doesn't fail at the rewritten line. In a string interpolation it emits the sequence's *description*, which corrupted the generated output of a macro that string-builds source. `joined` now requires a separator argument; `joined(separator:)` returns `String` either way.

#### 3. Identity maps

`map { $0 }` transforms nothing, so laziness saves no work while `lazy` still has to exist on the receiver. `map` is defined on plenty of non-`Sequence` types (`Optional`, `Result`, publishers, custom iterators), so these are now left alone: no upside, and it removes a way for the rewrite to stop compiling.

#### A caveat worth naming

(3) only removes the instances we hit. In general a token-based rule cannot know that the receiver of `.map` is a `Sequence`, so a rewrite can still fail to compile on a non-`Sequence` receiver. That seems acceptable for a disabled-by-default rule, but I'm happy to document it in the rule's help text, or narrow the rule further.