### PR TITLE
Add Token.isLiteralIdentifier

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -1364,7 +1364,7 @@ extension Formatter {
             else {
                 return false
             }
-            if prevToken.isIdentifier, !["true", "false", "nil"].contains(prevToken.string) {
+            if prevToken.isIdentifier, !prevToken.isLiteralIdentifier {
                 return false
             }
             if [.endOfScope(")"), .endOfScope("]")].contains(prevToken),

--- a/Sources/Rules/PreferLazyMap.swift
+++ b/Sources/Rules/PreferLazyMap.swift
@@ -121,8 +121,9 @@ extension Formatter {
 
         for index in (bodyStartIndex + 1) ..< endOfScopeIndex {
             guard case let .identifier(name) = tokens[index] else { continue }
-            // Literals, which the tokenizer represents as identifiers rather than keywords.
-            if ["true", "false", "nil", "_"].contains(name) {
+            // Literals, which the tokenizer represents as identifiers rather than keywords, and the
+            // wildcard. None of these name anything.
+            if tokens[index].isLiteralIdentifier || name == "_" {
                 continue
             }
             // `$0` and friends are the closure's own arguments.

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -426,6 +426,13 @@ public extension Token {
         hasType(of: .number("", .integer))
     }
 
+    /// Whether this is one of the literals the tokenizer represents as an identifier rather than a
+    /// keyword: `true`, `false`, or `nil`. Worth checking wherever an identifier is being treated as
+    /// a name that refers to something, since these refer to nothing.
+    var isLiteralIdentifier: Bool {
+        self == .identifier("true") || self == .identifier("false") || self == .identifier("nil")
+    }
+
     var isError: Bool {
         hasType(of: .error(""))
     }


### PR DESCRIPTION
#### Summary

Small readability change: names the fact that `true`, `false`, and `nil` are tokenized as identifiers rather than keywords, so rules don't each have to remember it.

#### Reasoning

Any rule that treats an identifier as a name referring to *something* has to exclude these three, and that check was written out by hand in a handful of places — including inside `ParsingHelpers` itself:

```swift
if prevToken.isIdentifier, !["true", "false", "nil"].contains(prevToken.string) {
```

This is easy to miss, which is the motivation: while writing `preferLazyMap` I did miss it, and the rule initially rejected any closure body containing a boolean literal. Putting the predicate next to `isNumber` and the other token checks makes it discoverable instead of rediscovered.

Adopted at the two sites where it's a drop-in replacement. The other sites match these literals as `switch` patterns (`case .identifier("true"), .identifier("false"), ...`), where spelling them out reads at least as clearly as a `where` clause would, so I left them alone. `redundantType` keeps its own `true`/`false`-only check on purpose — `nil` has no inferable type and shouldn't be folded in.

Full test suite passes.