### PR TITLE
Don't rewrite map/reduce chains on a lazy receiver

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -595,6 +595,19 @@ extension Formatter {
     /// leading prefix `!` then bounds the receiver on the left (the returned index is the receiver
     /// root just after the `!`) instead of causing a `nil` bail; the caller can find the `!` itself
     /// with `index(of:.nonSpaceOrCommentOrLinebreak, before:)`.
+    /// Whether the receiver of the member call whose dot is at `dotIndex` is reached through `lazy`,
+    /// making it a lazy sequence rather than an eager collection.
+    ///
+    /// The whole receiver chain is checked, because `lazy` need not be adjacent to the call in
+    /// question: `xs.lazy.filter { ... }.map { ... }` is every bit as lazy as `xs.lazy.map { ... }`.
+    func memberCallReceiverIsLazy(endingAt dotIndex: Int) -> Bool {
+        guard tokens[dotIndex] == .operator(".", .infix),
+              let startIndex = startOfMemberCallReceiver(endingAt: dotIndex)
+        else { return false }
+
+        return tokens[startIndex ... dotIndex].contains(.identifier("lazy"))
+    }
+
     func startOfMemberCallReceiver(endingAt dotIndex: Int, stoppingAtLeadingNegation: Bool = false) -> Int? {
         var start = dotIndex
         while let prev = index(of: .nonSpaceOrCommentOrLinebreak, before: start) {

--- a/Sources/Rules/PreferFlatMap.swift
+++ b/Sources/Rules/PreferFlatMap.swift
@@ -16,6 +16,15 @@ public extension FormatRule {
         formatter.forEach(.identifier("map")) { mapIndex, _ in
             guard let nextIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, after: mapIndex) else { return }
 
+            // `reduce([], +)` produces an `Array` whatever it reduces, but `flatMap` on a lazy
+            // receiver produces a lazy sequence, so rewriting one into the other would change the
+            // type of the expression. Leave anything reached through `lazy` alone.
+            if let dotBeforeMapIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: mapIndex),
+               formatter.memberCallReceiverIsLazy(endingAt: dotBeforeMapIndex)
+            {
+                return
+            }
+
             // Parse the `map` call, which takes exactly one closure
             // and is either `map { ... }` or `map({ ... })`
             let endOfMapCall: Int

--- a/Sources/Rules/PreferLazyMap.swift
+++ b/Sources/Rules/PreferLazyMap.swift
@@ -24,10 +24,10 @@ public extension FormatRule {
                   let closeBraceIndex = formatter.endOfScope(at: openBraceIndex)
             else { return }
 
-            // Don't insert `.lazy` again if the receiver already has it.
-            if let receiverIndex = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: dotBeforeMap),
-               formatter.tokens[receiverIndex] == .identifier("lazy")
-            {
+            // Don't insert `.lazy` again if the receiver is already lazy. `lazy` can sit anywhere in
+            // the chain — `xs.lazy.filter { ... }.map { ... }` is already lazy — so checking only the
+            // token before the `map` would append a second, redundant `.lazy`.
+            if formatter.memberCallReceiverIsLazy(endingAt: dotBeforeMap) {
                 return
             }
 

--- a/Tests/Rules/PreferFlatMapTests.swift
+++ b/Tests/Rules/PreferFlatMapTests.swift
@@ -159,4 +159,20 @@ final class PreferFlatMapTests: XCTestCase {
 
         testFormatting(for: input, rule: .preferFlatMap)
     }
+
+    func testPreservesLazyReceiver() {
+        let input = """
+        let allItems = sections.lazy.map { $0.items }.reduce([], +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
+
+    func testPreservesLazyReceiverEarlierInTheChain() {
+        let input = """
+        let allItems = sections.lazy.filter { $0.isVisible }.map { $0.items }.reduce([], +)
+        """
+
+        testFormatting(for: input, rule: .preferFlatMap)
+    }
 }

--- a/Tests/Rules/PreferLazyMapTests.swift
+++ b/Tests/Rules/PreferLazyMapTests.swift
@@ -481,6 +481,14 @@ final class PreferLazyMapTests: XCTestCase {
         testFormatting(for: input, rule: .preferLazyMap)
     }
 
+    func testPreservesReceiverMadeLazyEarlierInTheChain() {
+        let input = """
+        let minY = vertices.lazy.filter { $0.isVisible }.map { $0.y }.min()
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
     func testPreservesSorted() {
         let input = """
         let sortedYs = vertices.map { $0.y }.sorted()


### PR DESCRIPTION
#### Summary

Fixes a type-changing rewrite in `preferFlatMap`, plus the mirror-image bug it exposed in `preferLazyMap`.

#### preferFlatMap changes the expression's type on a lazy receiver

`reduce([], +)` produces an `Array` whatever it is reducing, but `flatMap` on a lazy receiver produces a lazy sequence:

```swift
sections.lazy.map { $0.items }.reduce([], +)  // Array<Int>
sections.lazy.flatMap { $0.items }            // LazySequence<FlattenSequence<LazyMapSequence<...>>>
```

It compiles where the result is explicitly typed — Swift then selects the eager `flatMap` overload — and silently differs where the type is inferred, which is the uncomfortable half. `preferFlatMap` now leaves anything reached through `lazy` alone.

#### preferLazyMap inserts a redundant `.lazy`

Its "already lazy" check only looked at the token immediately before the `map`, so a receiver made lazy earlier in the chain got a second one:

```diff
- sections.lazy.filter { $0.isVisible }.map { $0.items }
+ sections.lazy.filter { $0.isVisible }.lazy.map { $0.items }
```

Harmless to compile, but a formatter shouldn't emit a no-op.

Both rules need to answer the same question, so the chain walk lives in `memberCallReceiverIsLazy(endingAt:)` in `ParsingHelpers` and both call it. It checks the whole receiver chain, since `lazy` need not be adjacent to the call in question.