### PR TITLE
Fix preferLazyMap failing to terminate on an optional-chained receiver

### DIFF
--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -598,13 +598,22 @@ extension Formatter {
     /// Whether the receiver of the member call whose dot is at `dotIndex` is reached through `lazy`,
     /// making it a lazy sequence rather than an eager collection.
     ///
-    /// The whole receiver chain is checked, because `lazy` need not be adjacent to the call in
-    /// question: `xs.lazy.filter { ... }.map { ... }` is every bit as lazy as `xs.lazy.map { ... }`.
+    /// `lazy` need not be adjacent to the call in question — `xs.lazy.filter { ... }.map { ... }` is
+    /// every bit as lazy as `xs.lazy.map { ... }` — so the receiver chain is checked as well. That
+    /// walk gives up on a receiver it can't read to the end of, notably one using optional chaining,
+    /// so a `false` result means "no `lazy` found", not "definitely eager".
     func memberCallReceiverIsLazy(endingAt dotIndex: Int) -> Bool {
-        guard tokens[dotIndex] == .operator(".", .infix),
-              let startIndex = startOfMemberCallReceiver(endingAt: dotIndex)
-        else { return false }
+        guard tokens[dotIndex] == .operator(".", .infix) else { return false }
 
+        // Check the immediately preceding token first, and without consulting the receiver walk.
+        // `.lazy` directly before the call is the shape a rule inserting it produces, so recognising
+        // that shape unconditionally is what lets such a rule reach a fixed point — including on the
+        // receivers the walk below refuses to read.
+        if last(.nonSpaceOrCommentOrLinebreak, before: dotIndex) == .identifier("lazy") {
+            return true
+        }
+
+        guard let startIndex = startOfMemberCallReceiver(endingAt: dotIndex) else { return false }
         return tokens[startIndex ... dotIndex].contains(.identifier("lazy"))
     }
 

--- a/Tests/Rules/PreferLazyMapTests.swift
+++ b/Tests/Rules/PreferLazyMapTests.swift
@@ -481,6 +481,14 @@ final class PreferLazyMapTests: XCTestCase {
         testFormatting(for: input, rule: .preferLazyMap)
     }
 
+    func testPreservesLazyReceiverReachedByOptionalChaining() {
+        let input = """
+        let first = listing.edges?.lazy.map { $0.node }.first(where: { $0.id == target })
+        """
+
+        testFormatting(for: input, rule: .preferLazyMap)
+    }
+
     func testPreservesReceiverMadeLazyEarlierInTheChain() {
         let input = """
         let minY = vertices.lazy.filter { $0.isVisible }.map { $0.y }.min()


### PR DESCRIPTION
#### Summary

Regression from #2664. `preferLazyMap` can fail to reach a fixed point, which aborts the entire formatter run.

#### The bug

`memberCallReceiverIsLazy` leaned entirely on `startOfMemberCallReceiver`, which deliberately returns `nil` when the receiver uses optional chaining. That's correct for its own contract — it returns the receiver *root* for callers that want to prefix it, and prefixing past a `?` would change the result type. My mistake was reading `nil` as "not lazy".

So on a receiver like this, the rule couldn't see the `.lazy` it had just inserted, and inserted another on the next pass:

```swift
listing.edges?.lazy.map { $0.node }.first(where: { $0.id == target })
```

SwiftFormat reports that as `The preferLazyMap rule failed to terminate` and then aborts with `SwiftFormat failed with unexpected internal error` — so one file of this shape stops the run for everything.

#### The fix

`memberCallReceiverIsLazy` now checks the token immediately before the call first, without consulting the receiver walk. That's exactly the shape a rule inserting `.lazy` produces, so recognising it unconditionally is what guarantees convergence, whatever the rest of the receiver looks like. The chain walk stays for the non-adjacent case (`xs.lazy.filter { ... }.map { ... }`), and its limitation is now documented: `false` means no `lazy` was found, not that the receiver is definitely eager.

#### Remaining limitation

For a receiver that *both* uses optional chaining and has an intervening call between `lazy` and the `map`, the walk still can't tell, so `preferFlatMap` may rewrite it and change the type. That's the narrow remainder of #2664's issue. I left it rather than reimplementing the receiver walk with different bail rules, since the termination bug was the urgent part — happy to follow up if you'd like that closed properly.

#### Testing

Added a test reproducing the optional-chained shape (it fails with `failed to terminate` before this change). Full suite passes. I also confirmed against the four real files: all four now terminate with no changes wanted, and re-running the formatter across the whole codebase is clean.