### PR TITLE
Increase stack size to 1MB for Linux release builds

### DIFF
--- a/Scripts/build-linux-release.sh
+++ b/Scripts/build-linux-release.sh
@@ -8,6 +8,7 @@ BUILD_ARGS=(
 	--product swiftformat
 	--configuration release
 	-Xlinker -S
+	-Xlinker -zstack-size=1073741824
 )
 
 if [[ -z "$TARGETPLATFORM" ]]; then


### PR DESCRIPTION
Decided to revisit some old crashes. Finally got a proper backtrace for this one and it looked like a stack overflow. Musl has 128kB stack size by default, so I decided to increase it to 1MB, which fixed the crash. Tested with https://codeberg.org/Cyberbeni/Wiring/commit/4f79227 just running `swiftformat .`

The [other type of crash](https://github.com/nicklockwood/SwiftFormat/issues/2173) might be fixed by this: https://github.com/swiftlang/swift-docker/pull/557