### PR TITLE
Fix sortDeclarations handling trailing whitespace and  comments

### DIFF
--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -46,7 +46,7 @@ public extension FormatRule {
                 }),
                     let sortRangeStart = formatter.index(of: .nonSpaceOrComment, after: index),
                     let firstRangeToken = formatter.index(of: .nonLinebreak, after: sortRangeStart),
-                    let lastRangeToken = formatter.index(of: .nonSpaceOrCommentOrLinebreak, before: endCommentIndex - 2)
+                    let lastRangeToken = formatter.index(of: .nonSpaceOrLinebreak, before: endCommentIndex - 2)
                 else { return }
 
                 rangeToSort = sortRangeStart ... lastRangeToken
@@ -55,7 +55,7 @@ public extension FormatRule {
                 guard let typeOpenBrace = formatter.index(of: .startOfScope("{"), after: index),
                       let typeCloseBrace = formatter.endOfScope(at: typeOpenBrace),
                       let firstTypeBodyToken = formatter.index(of: .nonLinebreak, after: typeOpenBrace),
-                      let lastTypeBodyToken = formatter.index(of: .nonLinebreak, before: typeCloseBrace),
+                      let lastTypeBodyToken = formatter.index(of: .nonSpaceOrLinebreak, before: typeCloseBrace),
                       let declarationKeywordIndex = formatter.indexOfLastSignificantKeyword(at: typeOpenBrace),
                       lastTypeBodyToken > typeOpenBrace
                 else { return }

--- a/Tests/Rules/SortDeclarationsTests.swift
+++ b/Tests/Rules/SortDeclarationsTests.swift
@@ -10,6 +10,70 @@ import XCTest
 @testable import SwiftFormat
 
 final class SortDeclarationsTests: XCTestCase {
+    func testSortNestedDeclarationsDoesNotMoveClosingBraceIndentation() {
+        let input = """
+        public extension String {
+            // swiftformat:sort
+            enum Feature {
+                /// comment
+                case bFeature = "bFeature"
+                /// comment
+                case cFeature = "cFeature"
+                /// comment
+                case aFeature = "aFeature" // Trailing comment -- a feature
+            }
+
+            // swiftformat:sort
+            extension Feature {
+                /// comment
+                var b: Bool {
+                    true
+                }
+                /// comment
+                var c: Bool {
+                    true
+                }
+                /// comment
+                var a: Bool {
+                    true
+                }
+            }
+        }
+        """
+
+        let output = """
+        public extension String {
+            // swiftformat:sort
+            enum Feature {
+                /// comment
+                case aFeature = "aFeature" // Trailing comment -- a feature
+                /// comment
+                case bFeature = "bFeature"
+                /// comment
+                case cFeature = "cFeature"
+            }
+
+            // swiftformat:sort
+            extension Feature {
+                /// comment
+                var a: Bool {
+                    true
+                }
+                /// comment
+                var b: Bool {
+                    true
+                }
+                /// comment
+                var c: Bool {
+                    true
+                }
+            }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .sortDeclarations, exclude: [.blankLinesBetweenScopes])
+    }
+
     func testSortEnumBody() {
         let input = """
         // swiftformat:sort
@@ -173,8 +237,9 @@ final class SortDeclarationsTests: XCTestCase {
             // swiftformat:sort:begin
             case upsellB
             case fooFeature
-            case barFeature
-            case upsellA
+            case barFeature // Trailing comment -- bar feature
+            /// Leading comment -- upsell A
+            case upsellA // Trailing comment -- upsell A
             // swiftformat:sort:end
 
             var anUnsortedProperty: Foo {
@@ -186,9 +251,10 @@ final class SortDeclarationsTests: XCTestCase {
         let output = """
         enum FeatureFlags {
             // swiftformat:sort:begin
-            case barFeature
+            case barFeature // Trailing comment -- bar feature
             case fooFeature
-            case upsellA
+            /// Leading comment -- upsell A
+            case upsellA // Trailing comment -- upsell A
             case upsellB
             // swiftformat:sort:end
 


### PR DESCRIPTION
#### Summary

Fixes two sortDeclarations boundary issues:

- full `// swiftformat:sort` could move the indentation before a nested type’s closing brace with the final declaration;
- partial `// swiftformat:sort:begin / // swiftformat:sort:end` could attach the final declaration’s trailing comment to the declaration that followed it after sorting.

#### Full sort

Before this change, sorting the following nested type:

```swift
public extension String {
    // swiftformat:sort
    enum Feature {
        /// comment
        case bFeature = "bFeature"
        /// comment
        case cFeature = "cFeature"
        /// comment
        case aFeature = "aFeature"
    }
}
```

produced an indented blank line after the moved declaration:

```swift
public extension String {
    // swiftformat:sort
    enum Feature {
        /// comment
        case aFeature = "aFeature"
    
        /// comment
        case bFeature = "bFeature"
        /// comment
        case cFeature = "cFeature"
    }
}
```

#### Partial sort

Before this change, sorting this range:

```swift
enum FeatureFlags {
    // swiftformat:sort:begin
    case upsellB
    case fooFeature
    case barFeature // Trailing comment -- bar feature
    /// Leading comment -- upsell A
    case upsellA // Trailing comment -- upsell A
    // swiftformat:sort:end
}
```

attached upsellA`’s trailing comment to `upsellB:

```swift
enum FeatureFlags {
    // swiftformat:sort:begin
    case barFeature // Trailing comment -- bar feature
    case fooFeature
    /// Leading comment -- upsell A
    case upsellA
    case upsellB // Trailing comment -- upsell A
    // swiftformat:sort:end
}
```

#### Fix

Both sort paths now use `.nonSpaceOrLinebreak` when finding the final token. This excludes trailing whitespace while preserving trailing comments in the sortable range.

#### Testing

Adds regression coverage for nested enum and extension declarations, as well as leading and trailing comments in partial sort ranges. SortDeclarationsTests pass.