### PR TITLE
Add `spi-last` option to `--import-grouping`

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3421,7 +3421,7 @@ Sort and group import statements.
 
 Option | Description
 --- | ---
-`--import-grouping` | Comma-delimited list of import sorting/grouping options: "alpha", "access-control", "length", "testable-first", "testable-last". Defaults to "access-control,alpha"
+`--import-grouping` | Comma-delimited list of import sorting/grouping options: "alpha", "access-control", "length", "testable-first", "testable-last", "spi-last". Defaults to "access-control,alpha"
 `--hoist-imports` | Hoist file-scope imports to top of file
 
 <details>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -858,15 +858,14 @@ struct _Descriptors {
     let importGrouping = OptionDescriptor(
         argumentName: "import-grouping",
         displayName: "Import Grouping",
-        help: "Comma-delimited list of import sorting/grouping options: \"alpha\", \"access-control\", \"length\", \"testable-first\", \"testable-last\". Defaults to \"access-control,alpha\"",
+        help: "Comma-delimited list of import sorting/grouping options: \"alpha\", \"access-control\", \"length\", \"testable-first\", \"testable-last\", \"spi-last\". Defaults to \"access-control,alpha\"",
         keyPath: \FormatOptions.importGrouping,
         type: .text,
         fromArgument: { arg in
-            Set(parseCommaDelimitedList(arg).compactMap { ImportGrouping(rawValue: $0) })
+            parseCommaDelimitedList(arg).compactMap { ImportGrouping(rawValue: $0) }
         },
         toArgument: { options in
-            let order = ImportGrouping.allCases
-            return order.filter { options.contains($0) }.map(\.rawValue).joined(separator: ",")
+            options.map(\.rawValue).joined(separator: ",")
         }
     )
     let hoistImports = OptionDescriptor(

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -454,13 +454,16 @@ public enum Grouping: Equatable, RawRepresentable, CustomStringConvertible {
     }
 }
 
-/// Individual import sorting/grouping options, combined as a Set
+/// Individual import sorting/grouping options. The order of the options is
+/// significant when using more than one of the separate-group options,
+/// like `testable-last` and `spi-last`.
 public enum ImportGrouping: String, CaseIterable, Hashable {
     case alpha
     case length
     case accessControl = "access-control"
     case testableFirst = "testable-first"
     case testableLast = "testable-last"
+    case spiLast = "spi-last"
 
     public init?(rawValue: String) {
         switch rawValue {
@@ -478,6 +481,9 @@ public enum ImportGrouping: String, CaseIterable, Hashable {
         case "testable-last",
              "testable-bottom":
             self = .testableLast
+        case "spi-last",
+             "spi-bottom":
+            self = .spiLast
         default:
             return nil
         }
@@ -846,7 +852,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var throwCapturing: Set<String>
     public var asyncCapturing: Set<String>
     public var experimentalRules: Bool
-    public var importGrouping: Set<ImportGrouping>
+    public var importGrouping: [ImportGrouping]
     public var hoistImports: Bool
     public var trailingClosures: Set<String>
     public var neverTrailing: Set<String>
@@ -1000,7 +1006,7 @@ public struct FormatOptions: CustomStringConvertible {
                 throwCapturing: Set<String> = [],
                 asyncCapturing: Set<String> = [],
                 experimentalRules: Bool = false,
-                importGrouping: Set<ImportGrouping> = [.accessControl, .alpha],
+                importGrouping: [ImportGrouping] = [.accessControl, .alpha],
                 hoistImports: Bool = true,
                 trailingClosures: Set<String> = [],
                 neverTrailing: Set<String> = [],
@@ -1271,8 +1277,8 @@ public struct FormatOptions: CustomStringConvertible {
                 value = array.joined(separator: ",")
             case let set as Set<String>:
                 value = set.sorted().joined(separator: ",")
-            case let set as Set<ImportGrouping>:
-                value = ImportGrouping.allCases.filter { set.contains($0) }.map(\.rawValue).joined(separator: ",")
+            case let array as [ImportGrouping]:
+                value = array.map(\.rawValue).joined(separator: ",")
             default:
                 break
             }

--- a/Sources/ParsingHelpers.swift
+++ b/Sources/ParsingHelpers.swift
@@ -2614,6 +2614,10 @@ extension Formatter {
             attributes.contains("@testable")
         }
 
+        var isSPI: Bool {
+            attributes.contains("@_spi")
+        }
+
         static func < (lhs: ImportRange, rhs: ImportRange) -> Bool {
             let la = lhs.module.lowercased()
             let lb = rhs.module.lowercased()

--- a/Sources/Rules/SortImports.swift
+++ b/Sources/Rules/SortImports.swift
@@ -59,16 +59,7 @@ extension Formatter {
     func sortRanges(_ ranges: [Formatter.ImportRange]) -> [Formatter.ImportRange] {
         let grouping = options.importGrouping
 
-        let partitions: [[Formatter.ImportRange]]
-        if grouping.contains(.testableFirst) {
-            partitions = [ranges.filter(\.isTestable), ranges.filter { !$0.isTestable }]
-        } else if grouping.contains(.testableLast) {
-            partitions = [ranges.filter { !$0.isTestable }, ranges.filter(\.isTestable)]
-        } else {
-            partitions = [ranges]
-        }
-
-        return partitions.flatMap { partition in
+        return partitionImports(ranges).flatMap { partition in
             partition.sorted { lhs, rhs in
                 if grouping.contains(.accessControl) {
                     let lhsAccessOrder = accessLevelSortOrder(for: lhs)
@@ -91,6 +82,46 @@ extension Formatter {
                 return lhs < rhs
             }
         }
+    }
+
+    /// Splits the imports into the separately sorted groups defined by options like
+    /// `testable-last` and `spi-last`, in the order those groups should appear.
+    /// Groups are ordered relative to each other by the order of the options themselves.
+    func partitionImports(_ ranges: [Formatter.ImportRange]) -> [[Formatter.ImportRange]] {
+        var groupsBeforeOtherImports = [[Formatter.ImportRange]]()
+        var groupsAfterOtherImports = [[Formatter.ImportRange]]()
+        var otherImports = ranges
+
+        for option in options.importGrouping {
+            let isInGroup: (Formatter.ImportRange) -> Bool
+            let groupedBeforeOtherImports: Bool
+            switch option {
+            case .testableFirst:
+                isInGroup = { $0.isTestable }
+                groupedBeforeOtherImports = true
+            case .testableLast:
+                isInGroup = { $0.isTestable }
+                groupedBeforeOtherImports = false
+            case .spiLast:
+                isInGroup = { $0.isSPI }
+                groupedBeforeOtherImports = false
+            case .alpha, .length, .accessControl:
+                continue
+            }
+
+            // Each import joins the first group it matches, so an import that is both
+            // `@testable` and `@_spi` is grouped using whichever option comes first.
+            let group = otherImports.filter(isInGroup)
+            otherImports.removeAll(where: isInGroup)
+
+            if groupedBeforeOtherImports {
+                groupsBeforeOtherImports.append(group)
+            } else {
+                groupsAfterOtherImports.append(group)
+            }
+        }
+
+        return groupsBeforeOtherImports + [otherImports] + groupsAfterOtherImports
     }
 
     /// Sort order for import access level using aclModifiers (higher index = more visible).

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -399,4 +399,23 @@ final class OptionDescriptorTests: XCTestCase {
         XCTAssertNoThrow(try Descriptors.importGrouping.toOptions("testable-top", &options))
         XCTAssertEqual(options.importGrouping, [.testableFirst])
     }
+
+    func testImportGroupingAcceptsSPILast() {
+        var options: FormatOptions = .default
+        XCTAssertNoThrow(try Descriptors.importGrouping.toOptions("spi-last", &options))
+        XCTAssertEqual(options.importGrouping, [.spiLast])
+    }
+
+    func testImportGroupingAcceptsSPIBottom() {
+        var options: FormatOptions = .default
+        XCTAssertNoThrow(try Descriptors.importGrouping.toOptions("spi-bottom", &options))
+        XCTAssertEqual(options.importGrouping, [.spiLast])
+    }
+
+    func testImportGroupingPreservesOptionOrder() {
+        var options: FormatOptions = .default
+        XCTAssertNoThrow(try Descriptors.importGrouping.toOptions("spi-last,alpha,testable-last", &options))
+        XCTAssertEqual(options.importGrouping, [.spiLast, .alpha, .testableLast])
+        XCTAssertEqual(Descriptors.importGrouping.fromOptions(options), "spi-last,alpha,testable-last")
+    }
 }

--- a/Tests/Rules/SortImportsTests.swift
+++ b/Tests/Rules/SortImportsTests.swift
@@ -647,6 +647,117 @@ final class SortImportsTests: XCTestCase {
         testFormatting(for: input, output, rule: .sortImports, options: options)
     }
 
+    // MARK: - SPI imports
+
+    func testSPIImportsSortedLast() {
+        let input = """
+        @_spi(Foo) import UIKit
+        import Baz
+        @_spi(Bar) import Bar
+        """
+        let output = """
+        import Baz
+        @_spi(Bar) import Bar
+        @_spi(Foo) import UIKit
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .spiLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testSPIImportsSortedByAccessControlAndAlpha() {
+        let input = """
+        @_spi(Foo) import BModule
+        import Regular
+        @_spi(Foo) public import AModule
+        """
+        let output = """
+        import Regular
+        @_spi(Foo) public import AModule
+        @_spi(Foo) import BModule
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .accessControl, .spiLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testTestableGroupedBeforeSPIGroupWhenListedFirst() {
+        let input = """
+        @_spi(Foo) import SPIModule
+        @testable import TestableModule
+        import RegularModule
+        """
+        let output = """
+        import RegularModule
+        @testable import TestableModule
+        @_spi(Foo) import SPIModule
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .testableLast, .spiLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testSPIGroupedBeforeTestableGroupWhenListedFirst() {
+        let input = """
+        @testable import TestableModule
+        @_spi(Foo) import SPIModule
+        import RegularModule
+        """
+        let output = """
+        import RegularModule
+        @_spi(Foo) import SPIModule
+        @testable import TestableModule
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .spiLast, .testableLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testTestableAndSPIImportGroupedWithTestable() {
+        let input = """
+        @_spi(Foo) import SPIOnly
+        @testable @_spi(Foo) import Both
+        @testable import TestableOnly
+        import Regular
+        """
+        let output = """
+        import Regular
+        @testable @_spi(Foo) import Both
+        @testable import TestableOnly
+        @_spi(Foo) import SPIOnly
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .testableLast, .spiLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testTestableAndSPIImportGroupedWithSPI() {
+        let input = """
+        @testable import TestableOnly
+        @testable @_spi(Foo) import Both
+        @_spi(Foo) import SPIOnly
+        import Regular
+        """
+        let output = """
+        import Regular
+        @testable @_spi(Foo) import Both
+        @_spi(Foo) import SPIOnly
+        @testable import TestableOnly
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .spiLast, .testableLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
+    func testSPILastWithTestableFirst() {
+        let input = """
+        import RegularModule
+        @_spi(Foo) import SPIModule
+        @testable import TestableModule
+        """
+        let output = """
+        @testable import TestableModule
+        import RegularModule
+        @_spi(Foo) import SPIModule
+        """
+        let options = FormatOptions(importGrouping: [.alpha, .testableFirst, .spiLast])
+        testFormatting(for: input, output, rule: .sortImports, options: options)
+    }
+
     // MARK: - hoistImports
 
     func testHoistStrayImport() {


### PR DESCRIPTION
This PR adds a new `spi-last` option to `--import-grouping`