### PR TITLE
Add `--locale` option for deterministic sorting

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -3450,7 +3450,7 @@ Sort switch cases alphabetically.
 
 Option | Description
 --- | ---
-`--sort-switch-cases-locale` | Locale for sorting switch cases: "system" (default) or a locale identifier such as "en_US"
+`--locale` | Locale for sorting: "en_US" (default), "system", or any valid locale identifier
 
 <details>
 <summary>Examples</summary>

--- a/Rules.md
+++ b/Rules.md
@@ -3448,6 +3448,10 @@ Option | Description
 
 Sort switch cases alphabetically.
 
+Option | Description
+--- | ---
+`--sort-switch-cases-locale` | Locale for sorting switch cases: "system" (default) or a locale identifier such as "en_US"
+
 <details>
 <summary>Examples</summary>
 

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1204,6 +1204,12 @@ struct _Descriptors {
         help: "List of patterns to sort alphabetically without `:sort` mark",
         keyPath: \.alphabeticallySortedDeclarationPatterns
     )
+    let sortSwitchCasesLocale = OptionDescriptor(
+        argumentName: "sort-switch-cases-locale",
+        displayName: "Switch Case Sort Locale",
+        help: "Locale for sorting switch cases: \"system\" (default) or a locale identifier such as \"en_US\"",
+        keyPath: \.sortSwitchCasesLocale
+    )
     let funcAttributes = OptionDescriptor(
         argumentName: "func-attributes",
         displayName: "Function Attributes",

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1204,11 +1204,11 @@ struct _Descriptors {
         help: "List of patterns to sort alphabetically without `:sort` mark",
         keyPath: \.alphabeticallySortedDeclarationPatterns
     )
-    let sortSwitchCasesLocale = OptionDescriptor(
-        argumentName: "sort-switch-cases-locale",
-        displayName: "Switch Case Sort Locale",
-        help: "Locale for sorting switch cases: \"system\" (default) or a locale identifier such as \"en_US\"",
-        keyPath: \.sortSwitchCasesLocale
+    let locale = OptionDescriptor(
+        argumentName: "locale",
+        displayName: "Sorting Locale",
+        help: "Locale for sorting: \"en_US\" (default), \"system\", or any valid locale identifier",
+        keyPath: \.locale
     )
     let funcAttributes = OptionDescriptor(
         argumentName: "func-attributes",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -660,8 +660,8 @@ public enum FormatTimeZone: Equatable, RawRepresentable, CustomStringConvertible
     }
 }
 
-/// Locale to use when sorting switch cases
-public enum SortSwitchCasesLocale: Equatable, RawRepresentable, CustomStringConvertible {
+/// Locale to use when sorting
+public enum FormatLocale: Equatable, RawRepresentable, CustomStringConvertible {
     case system
     case identifier(String)
 
@@ -688,12 +688,16 @@ public enum SortSwitchCasesLocale: Equatable, RawRepresentable, CustomStringConv
         }
     }
 
-    public var locale: Locale? {
+    func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
         switch self {
         case .system:
-            return nil
+            return lhs.localizedStandardCompare(rhs)
         case let .identifier(identifier):
-            return Locale(identifier: identifier)
+            return lhs.compare(
+                rhs,
+                options: [.caseInsensitive, .numeric, .widthInsensitive, .forcedOrdering],
+                locale: Locale(identifier: identifier)
+            )
         }
     }
 
@@ -941,7 +945,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var customTypeMarks: Set<String>
     public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
-    public var sortSwitchCasesLocale: SortSwitchCasesLocale
+    public var locale: FormatLocale
     public var swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
@@ -1096,7 +1100,7 @@ public struct FormatOptions: CustomStringConvertible {
                 customTypeMarks: Set<String> = [],
                 blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
-                sortSwitchCasesLocale: SortSwitchCasesLocale = .system,
+                locale: FormatLocale = .identifier("en_US"),
                 swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode = .none,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
@@ -1240,7 +1244,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.customTypeMarks = customTypeMarks
         self.blankLineAfterSubgroups = blankLineAfterSubgroups
         self.alphabeticallySortedDeclarationPatterns = alphabeticallySortedDeclarationPatterns
-        self.sortSwitchCasesLocale = sortSwitchCasesLocale
+        self.locale = locale
         self.swiftUIPropertiesSortMode = swiftUIPropertiesSortMode
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -669,9 +669,10 @@ public enum SortSwitchCasesLocale: Equatable, RawRepresentable, CustomStringConv
         if rawValue.lowercased() == Self.system.rawValue {
             self = .system
         } else {
-            let identifier = Locale(identifier: rawValue).identifier
-            let normalizedIdentifier = identifier.replacingOccurrences(of: "-", with: "_")
-            guard Locale.availableIdentifiers.contains(normalizedIdentifier) else {
+            let normalizedIdentifier = rawValue.lowercased().replacingOccurrences(of: "-", with: "_")
+            guard let identifier = Locale.availableIdentifiers.first(where: {
+                $0.lowercased().replacingOccurrences(of: "-", with: "_") == normalizedIdentifier
+            }) else {
                 return nil
             }
             self = .identifier(identifier)

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -660,6 +660,47 @@ public enum FormatTimeZone: Equatable, RawRepresentable, CustomStringConvertible
     }
 }
 
+/// Locale to use when sorting switch cases
+public enum SortSwitchCasesLocale: Equatable, RawRepresentable, CustomStringConvertible {
+    case system
+    case identifier(String)
+
+    public init?(rawValue: String) {
+        if rawValue.lowercased() == Self.system.rawValue {
+            self = .system
+        } else {
+            let identifier = Locale(identifier: rawValue).identifier
+            let normalizedIdentifier = identifier.replacingOccurrences(of: "-", with: "_")
+            guard Locale.availableIdentifiers.contains(normalizedIdentifier) else {
+                return nil
+            }
+            self = .identifier(identifier)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .system:
+            return "system"
+        case let .identifier(identifier):
+            return identifier
+        }
+    }
+
+    public var locale: Locale? {
+        switch self {
+        case .system:
+            return nil
+        case let .identifier(identifier):
+            return Locale(identifier: identifier)
+        }
+    }
+
+    public var description: String {
+        rawValue
+    }
+}
+
 /// When initializing an optional value type,
 /// is it necessary to explicitly declare a default value
 public enum NilInitType: String, CaseIterable {
@@ -899,6 +940,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var customTypeMarks: Set<String>
     public var blankLineAfterSubgroups: Bool
     public var alphabeticallySortedDeclarationPatterns: Set<String>
+    public var sortSwitchCasesLocale: SortSwitchCasesLocale
     public var swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode
     public var yodaSwap: YodaMode
     public var extensionACLPlacement: ExtensionACLPlacement
@@ -1053,6 +1095,7 @@ public struct FormatOptions: CustomStringConvertible {
                 customTypeMarks: Set<String> = [],
                 blankLineAfterSubgroups: Bool = true,
                 alphabeticallySortedDeclarationPatterns: Set<String> = [],
+                sortSwitchCasesLocale: SortSwitchCasesLocale = .system,
                 swiftUIPropertiesSortMode: SwiftUIPropertiesSortMode = .none,
                 yodaSwap: YodaMode = .always,
                 extensionACLPlacement: ExtensionACLPlacement = .onExtension,
@@ -1196,6 +1239,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.customTypeMarks = customTypeMarks
         self.blankLineAfterSubgroups = blankLineAfterSubgroups
         self.alphabeticallySortedDeclarationPatterns = alphabeticallySortedDeclarationPatterns
+        self.sortSwitchCasesLocale = sortSwitchCasesLocale
         self.swiftUIPropertiesSortMode = swiftUIPropertiesSortMode
         self.yodaSwap = yodaSwap
         self.extensionACLPlacement = extensionACLPlacement

--- a/Sources/Rules/OrganizeDeclarations.swift
+++ b/Sources/Rules/OrganizeDeclarations.swift
@@ -22,7 +22,7 @@ public extension FormatRule {
             "organization-mode", "type-body-marks", "visibility-order", "type-order", "visibility-marks",
             "type-marks", "group-blank-lines", "sort-swiftui-properties",
         ],
-        sharedOptions: ["sorted-patterns", "line-after-marks", "linebreaks"]
+        sharedOptions: ["sorted-patterns", "locale", "line-after-marks", "linebreaks"]
     ) { formatter in
         formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
             // Organize the body of type declarations
@@ -257,7 +257,7 @@ extension Formatter {
                    let rhsName = rhs.declaration.name,
                    lhsName != rhsName
                 {
-                    return lhsName.localizedCompare(rhsName) == .orderedAscending
+                    return options.locale.compare(lhsName, rhsName) == .orderedAscending
                 }
 
                 if lhs.category.type == rhs.category.type,
@@ -268,7 +268,7 @@ extension Formatter {
                     case .none:
                         break
                     case .alphabetize:
-                        return lhs.localizedCompare(rhs) == .orderedAscending
+                        return options.locale.compare(lhs, rhs) == .orderedAscending
                     case .firstAppearanceSort:
                         return customDeclarationSortOrder.areInRelativeOrder(lhs: lhs, rhs: rhs)
                     }

--- a/Sources/Rules/SortDeclarations.swift
+++ b/Sources/Rules/SortDeclarations.swift
@@ -16,7 +16,7 @@ public extension FormatRule {
         // swiftformat:sort:end comments.
         """,
         options: ["sorted-patterns"],
-        sharedOptions: ["linebreaks", "organize-types", "struct-threshold", "class-threshold", "enum-threshold", "extension-threshold"]
+        sharedOptions: ["locale", "linebreaks", "organize-types", "struct-threshold", "class-threshold", "enum-threshold", "extension-threshold"]
     ) { formatter in
         formatter.forEachToken(
             where: {
@@ -90,7 +90,7 @@ public extension FormatRule {
                        let rhsName = rhsDeclaration.name,
                        lhsName != rhsName
                     {
-                        return lhsName.localizedCompare(rhsName) == .orderedAscending
+                        return formatter.options.locale.compare(lhsName, rhsName) == .orderedAscending
                     }
 
                     // Otherwise preserve the existing order

--- a/Sources/Rules/SortSwitchCases.swift
+++ b/Sources/Rules/SortSwitchCases.swift
@@ -13,7 +13,7 @@ public extension FormatRule {
     static let sortSwitchCases = FormatRule(
         help: "Sort switch cases alphabetically.",
         disabledByDefault: true,
-        options: ["sort-switch-cases-locale"]
+        options: ["locale"]
     ) { formatter in
         formatter.parseSwitchCaseRanges()
             .reversed() // don't mess with indexes
@@ -30,14 +30,7 @@ public extension FormatRule {
                     let rhs = formatter.tokens[case2.beforeDelimiterRange]
                         .compactMap(formatter.sortableValue)
                     for (lhs, rhs) in zip(lhs, rhs) {
-                        let comparison = formatter.options.sortSwitchCasesLocale.locale.map {
-                            lhs.compare(
-                                rhs,
-                                options: [.caseInsensitive, .numeric, .widthInsensitive, .forcedOrdering],
-                                locale: $0
-                            )
-                        } ?? lhs.localizedStandardCompare(rhs)
-                        switch comparison {
+                        switch formatter.options.locale.compare(lhs, rhs) {
                         case .orderedAscending:
                             return true
                         case .orderedDescending:

--- a/Sources/Rules/SortSwitchCases.swift
+++ b/Sources/Rules/SortSwitchCases.swift
@@ -12,7 +12,8 @@ public extension FormatRule {
     /// Sorts switch cases alphabetically
     static let sortSwitchCases = FormatRule(
         help: "Sort switch cases alphabetically.",
-        disabledByDefault: true
+        disabledByDefault: true,
+        options: ["sort-switch-cases-locale"]
     ) { formatter in
         formatter.parseSwitchCaseRanges()
             .reversed() // don't mess with indexes
@@ -29,7 +30,14 @@ public extension FormatRule {
                     let rhs = formatter.tokens[case2.beforeDelimiterRange]
                         .compactMap(formatter.sortableValue)
                     for (lhs, rhs) in zip(lhs, rhs) {
-                        switch lhs.localizedStandardCompare(rhs) {
+                        let comparison = formatter.options.sortSwitchCasesLocale.locale.map {
+                            lhs.compare(
+                                rhs,
+                                options: [.caseInsensitive, .numeric, .widthInsensitive, .forcedOrdering],
+                                locale: $0
+                            )
+                        } ?? lhs.localizedStandardCompare(rhs)
+                        switch comparison {
                         case .orderedAscending:
                             return true
                         case .orderedDescending:

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -228,15 +228,16 @@ final class OptionDescriptorTests: XCTestCase {
         validateFromOptionalArguments(descriptor, keyPath: \FormatOptions.fileHeader, expectations: fromArgumentExpectations, testCaseVariation: false)
     }
 
-    func testSortSwitchCasesLocale() {
-        let descriptor = Descriptors.sortSwitchCasesLocale
-        let expectations: [OptionArgumentMapping<SortSwitchCasesLocale>] = [
-            (optionValue: .system, argumentValue: "system"),
+    func testLocale() {
+        let descriptor = Descriptors.locale
+        let expectations: [OptionArgumentMapping<FormatLocale>] = [
+            (optionValue: .identifier("en_US"), argumentValue: "en_US"),
             (optionValue: .identifier("cs_CZ"), argumentValue: "cs_CZ"),
+            (optionValue: .system, argumentValue: "system"),
         ]
 
-        validateFromOptions(descriptor, keyPath: \FormatOptions.sortSwitchCasesLocale, expectations: expectations)
-        validateFromArguments(descriptor, keyPath: \FormatOptions.sortSwitchCasesLocale, expectations: expectations)
+        validateFromOptions(descriptor, keyPath: \FormatOptions.locale, expectations: expectations)
+        validateFromArguments(descriptor, keyPath: \FormatOptions.locale, expectations: expectations)
         validateDescriptorThrowsOptionsError(descriptor)
     }
 

--- a/Tests/OptionDescriptorTests.swift
+++ b/Tests/OptionDescriptorTests.swift
@@ -228,6 +228,18 @@ final class OptionDescriptorTests: XCTestCase {
         validateFromOptionalArguments(descriptor, keyPath: \FormatOptions.fileHeader, expectations: fromArgumentExpectations, testCaseVariation: false)
     }
 
+    func testSortSwitchCasesLocale() {
+        let descriptor = Descriptors.sortSwitchCasesLocale
+        let expectations: [OptionArgumentMapping<SortSwitchCasesLocale>] = [
+            (optionValue: .system, argumentValue: "system"),
+            (optionValue: .identifier("cs_CZ"), argumentValue: "cs_CZ"),
+        ]
+
+        validateFromOptions(descriptor, keyPath: \FormatOptions.sortSwitchCasesLocale, expectations: expectations)
+        validateFromArguments(descriptor, keyPath: \FormatOptions.sortSwitchCasesLocale, expectations: expectations)
+        validateDescriptorThrowsOptionsError(descriptor)
+    }
+
     func testNoSpaceOperators() {
         let descriptor = Descriptors.noSpaceOperators
         let validations: [FreeTextValidationExpectation] = [

--- a/Tests/Rules/OrganizeDeclarationsTests.swift
+++ b/Tests/Rules/OrganizeDeclarationsTests.swift
@@ -3904,6 +3904,29 @@ final class OrganizeDeclarationsTests: XCTestCase {
         testFormatting(for: input, [output], rules: [.organizeDeclarations, .sortDeclarations])
     }
 
+    func testOrganizeDeclarationsUsesConfiguredLocaleWhenSorting() {
+        let input = """
+        // swiftformat:sort
+        public enum Words {
+            public static let chata = "chata"
+            public static let idea = "idea"
+            public static let hora = "hora"
+        }
+        """
+
+        let output = """
+        // swiftformat:sort
+        public enum Words {
+            public static let hora = "hora"
+            public static let chata = "chata"
+            public static let idea = "idea"
+        }
+        """
+
+        let options = FormatOptions(locale: .identifier("cs_CZ"))
+        testFormatting(for: input, [output], rules: [.organizeDeclarations, .sortDeclarations], options: options)
+    }
+
     func testIssue2045() {
         let input = """
         public final class A {

--- a/Tests/Rules/SortDeclarationsTests.swift
+++ b/Tests/Rules/SortDeclarationsTests.swift
@@ -122,6 +122,47 @@ final class SortDeclarationsTests: XCTestCase {
         testFormatting(for: input, output, rule: .sortDeclarations)
     }
 
+    func testSortDeclarationsUsesEnglishLocaleByDefault() {
+        let input = """
+        // swiftformat:sort
+        enum Words {
+            case idea
+            case hora
+            case chata
+        }
+        """
+        let output = """
+        // swiftformat:sort
+        enum Words {
+            case chata
+            case hora
+            case idea
+        }
+        """
+        testFormatting(for: input, output, rule: .sortDeclarations)
+    }
+
+    func testSortDeclarationsWithCzechLocale() {
+        let input = """
+        // swiftformat:sort
+        enum Words {
+            case chata
+            case idea
+            case hora
+        }
+        """
+        let output = """
+        // swiftformat:sort
+        enum Words {
+            case hora
+            case chata
+            case idea
+        }
+        """
+        let options = FormatOptions(locale: .identifier("cs_CZ"))
+        testFormatting(for: input, output, rule: .sortDeclarations, options: options)
+    }
+
     func testSortEnumBodyWithOnlyOneCase() {
         let input = """
         // swiftformat:sort
@@ -339,7 +380,7 @@ final class SortDeclarationsTests: XCTestCase {
         testFormatting(for: input, rules: [.sortDeclarations, .blankLinesBetweenScopes], options: options, exclude: [.redundantPublic])
     }
 
-    func testSortDeclarationsUsesLocalizedCompare() {
+    func testSortDeclarationsUsesCaseInsensitiveCompare() {
         let input = """
         // swiftformat:sort
         enum FeatureFlags {

--- a/Tests/Rules/SortSwitchCasesTests.swift
+++ b/Tests/Rules/SortSwitchCasesTests.swift
@@ -221,6 +221,24 @@ final class SortSwitchCasesTests: XCTestCase {
                        exclude: [.wrapSwitchCases])
     }
 
+    func testSortSwitchCasesWithSystemLocale() {
+        let input = """
+        switch self {
+        case .b, .a:
+            break
+        }
+        """
+        let output = """
+        switch self {
+        case .a, .b:
+            break
+        }
+        """
+        let options = FormatOptions(locale: .system)
+        testFormatting(for: input, output, rule: .sortSwitchCases, options: options,
+                       exclude: [.wrapSwitchCases])
+    }
+
     func testSortedSwitchWhereConditionNotLastCase() {
         let input = """
         switch self {

--- a/Tests/Rules/SortSwitchCasesTests.swift
+++ b/Tests/Rules/SortSwitchCasesTests.swift
@@ -186,7 +186,7 @@ final class SortSwitchCasesTests: XCTestCase {
                        exclude: [.wrapSwitchCases])
     }
 
-    func testSortSwitchCasesWithEnglishLocale() {
+    func testSortSwitchCasesUsesEnglishLocaleByDefault() {
         let input = """
         switch self {
         case .hora, .chata, .idea:
@@ -199,8 +199,7 @@ final class SortSwitchCasesTests: XCTestCase {
             break
         }
         """
-        let options = FormatOptions(sortSwitchCasesLocale: .identifier("en_US"))
-        testFormatting(for: input, output, rule: .sortSwitchCases, options: options,
+        testFormatting(for: input, output, rule: .sortSwitchCases,
                        exclude: [.wrapSwitchCases])
     }
 
@@ -217,7 +216,7 @@ final class SortSwitchCasesTests: XCTestCase {
             break
         }
         """
-        let options = FormatOptions(sortSwitchCasesLocale: .identifier("cs_CZ"))
+        let options = FormatOptions(locale: .identifier("cs_CZ"))
         testFormatting(for: input, output, rule: .sortSwitchCases, options: options,
                        exclude: [.wrapSwitchCases])
     }

--- a/Tests/Rules/SortSwitchCasesTests.swift
+++ b/Tests/Rules/SortSwitchCasesTests.swift
@@ -186,6 +186,42 @@ final class SortSwitchCasesTests: XCTestCase {
                        exclude: [.wrapSwitchCases])
     }
 
+    func testSortSwitchCasesWithEnglishLocale() {
+        let input = """
+        switch self {
+        case .hora, .chata, .idea:
+            break
+        }
+        """
+        let output = """
+        switch self {
+        case .chata, .hora, .idea:
+            break
+        }
+        """
+        let options = FormatOptions(sortSwitchCasesLocale: .identifier("en_US"))
+        testFormatting(for: input, output, rule: .sortSwitchCases, options: options,
+                       exclude: [.wrapSwitchCases])
+    }
+
+    func testSortSwitchCasesWithCzechLocale() {
+        let input = """
+        switch self {
+        case .chata, .idea, .hora:
+            break
+        }
+        """
+        let output = """
+        switch self {
+        case .hora, .chata, .idea:
+            break
+        }
+        """
+        let options = FormatOptions(sortSwitchCasesLocale: .identifier("cs_CZ"))
+        testFormatting(for: input, output, rule: .sortSwitchCases, options: options,
+                       exclude: [.wrapSwitchCases])
+    }
+
     func testSortedSwitchWhereConditionNotLastCase() {
         let input = """
         switch self {


### PR DESCRIPTION
Adds a shared `--locale` option for alphabetical sorting performed by `sortSwitchCases` and `sortDeclarations`. The sorting delegated to `organizeDeclarations` uses the same configuration.

The option defaults to `en_US`, ensuring deterministic output across systems. A custom locale identifier, such as `cs_CZ`, can be specified for language-specific collation. The original system-dependent behavior remains available using `--locale system`.

All affected rules use the same case-insensitive, numeric, width-insensitive, and forced-ordering comparison.