### PR TITLE
Add `extensionAttributes` rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -27,6 +27,7 @@
 * [enumNamespaces](#enumNamespaces)
 * [environmentEntry](#environmentEntry)
 * [extensionAccessControl](#extensionAccessControl)
+* [extensionAttributes](#extensionAttributes)
 * [fileHeader](#fileHeader)
 * [fileMacro](#fileMacro)
 * [genericExtensions](#genericExtensions)
@@ -1027,6 +1028,33 @@ Option | Description
 +     public func baz() {}
 +     func quux() {}
   }
+```
+
+</details>
+<br/>
+
+## extensionAttributes
+
+Hoist common member attributes onto the extension.
+
+Option | Description
+--- | ---
+`--type-attributes` | Placement for type @attributes: "prev-line", "same-line" or "preserve" (default)
+
+<details>
+<summary>Examples</summary>
+
+```diff
+- extension Foo {
+-     @MainActor func bar() {}
+-     @MainActor func baz() {}
+- }
+
++ @MainActor
++ extension Foo {
++     func bar() {}
++     func baz() {}
++ }
 ```
 
 </details>

--- a/Sources/RuleRegistry.generated.swift
+++ b/Sources/RuleRegistry.generated.swift
@@ -38,6 +38,7 @@ let ruleRegistry: [String: FormatRule] = [
     "enumNamespaces": .enumNamespaces,
     "environmentEntry": .environmentEntry,
     "extensionAccessControl": .extensionAccessControl,
+    "extensionAttributes": .extensionAttributes,
     "fileHeader": .fileHeader,
     "fileMacro": .fileMacro,
     "genericExtensions": .genericExtensions,

--- a/Sources/Rules/ExtensionAttributes.swift
+++ b/Sources/Rules/ExtensionAttributes.swift
@@ -84,7 +84,7 @@ extension Formatter {
         var attributes = [HoistableAttribute]()
 
         _ = modifiersForDeclaration(at: declaration.keywordIndex) { index, modifier in
-            guard isHoistableExtensionAttribute(modifier),
+            guard isHoistableExtensionAttribute(modifier, for: declaration),
                   let endIndex = endOfAttribute(at: index)
             else { return false }
 
@@ -111,8 +111,12 @@ extension Formatter {
         }
     }
 
-    func isHoistableExtensionAttribute(_ attribute: String) -> Bool {
-        attribute == "@MainActor" || attribute.hasPrefix("@available(")
+    func isHoistableExtensionAttribute(_ attribute: String, for declaration: Declaration) -> Bool {
+        if attribute == "@MainActor" {
+            return !declaration.definesType
+        }
+
+        return attribute.hasPrefix("@available(")
     }
 
     func removableAttributeRange(from startIndex: Int, to endIndex: Int) -> Range<Int>? {

--- a/Sources/Rules/ExtensionAttributes.swift
+++ b/Sources/Rules/ExtensionAttributes.swift
@@ -1,0 +1,171 @@
+//
+//  ExtensionAttributes.swift
+//  SwiftFormat
+//
+//  Created by Nick Lockwood on 9/8/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import Foundation
+
+public extension FormatRule {
+    /// Hoist common attributes from extension members to the extension.
+    static let extensionAttributes = FormatRule(
+        help: "Hoist common member attributes onto the extension.",
+        options: ["type-attributes"],
+        sharedOptions: ["linebreaks"]
+    ) { formatter in
+        formatter.parseDeclarations().forEachRecursiveDeclaration { declaration in
+            guard let extensionDeclaration = declaration.asTypeDeclaration,
+                  extensionDeclaration.keyword == "extension",
+                  extensionDeclaration.conformances.isEmpty
+            else { return }
+
+            let bodyDeclarations = extensionDeclaration.body.directDeclarationsExcludingTypeBodies
+            guard !bodyDeclarations.isEmpty else { return }
+
+            let extensionAttributes = Set(formatter.hoistableAttributes(for: extensionDeclaration).map(\.text))
+            let bodyAttributes = bodyDeclarations.map { formatter.hoistableAttributes(for: $0) }
+            let commonBodyAttributes = bodyAttributes
+                .map { Set($0.map(\.text)) }
+                .reduce(nil as Set<String>?) { commonAttributes, declarationAttributes in
+                    commonAttributes?.intersection(declarationAttributes) ?? declarationAttributes
+                } ?? []
+
+            let attributesToRemove = commonBodyAttributes.union(extensionAttributes)
+            let attributesToHoist = bodyAttributes[0].filter {
+                commonBodyAttributes.contains($0.text) && !extensionAttributes.contains($0.text)
+            }
+            guard !attributesToHoist.isEmpty || !attributesToRemove.isEmpty else { return }
+
+            if !attributesToHoist.isEmpty {
+                let insertionIndex = extensionDeclaration.startOfModifiersIndex(includingAttributes: true)
+                let insertionTokens = formatter.extensionAttributeTokens(
+                    for: attributesToHoist,
+                    at: insertionIndex
+                )
+                formatter.insert(insertionTokens, at: insertionIndex)
+            }
+
+            for bodyDeclaration in bodyDeclarations {
+                let declarationAttributes = formatter.hoistableAttributes(for: bodyDeclaration).map(\.text)
+                for attribute in declarationAttributes.filter(attributesToRemove.contains).reversed() {
+                    formatter.removeHoistableAttribute(attribute, from: bodyDeclaration)
+                }
+            }
+        }
+    } examples: {
+        """
+        ```diff
+        - extension Foo {
+        -     @MainActor func bar() {}
+        -     @MainActor func baz() {}
+        - }
+
+        + @MainActor
+        + extension Foo {
+        +     func bar() {}
+        +     func baz() {}
+        + }
+        ```
+        """
+    }
+}
+
+struct HoistableAttribute {
+    let text: String
+    let tokens: [Token]
+}
+
+extension Formatter {
+    /// Attributes where applying the attribute to an extension is equivalent to
+    /// applying the exact same attribute to every direct member declaration.
+    func hoistableAttributes(for declaration: Declaration) -> [HoistableAttribute] {
+        var attributes = [HoistableAttribute]()
+
+        _ = modifiersForDeclaration(at: declaration.keywordIndex) { index, modifier in
+            guard isHoistableExtensionAttribute(modifier),
+                  let endIndex = endOfAttribute(at: index)
+            else { return false }
+
+            attributes.append(HoistableAttribute(
+                text: modifier,
+                tokens: Array(tokens[index ... endIndex])
+            ))
+
+            return false
+        }
+
+        return attributes
+    }
+
+    func removeHoistableAttribute(_ attribute: String, from declaration: Declaration) {
+        _ = modifiersForDeclaration(at: declaration.keywordIndex) { index, modifier in
+            guard modifier == attribute,
+                  let endIndex = endOfAttribute(at: index),
+                  let removalRange = removableAttributeRange(from: index, to: endIndex)
+            else { return false }
+
+            removeTokens(in: removalRange)
+            return true
+        }
+    }
+
+    func isHoistableExtensionAttribute(_ attribute: String) -> Bool {
+        attribute == "@MainActor" || attribute.hasPrefix("@available(")
+    }
+
+    func removableAttributeRange(from startIndex: Int, to endIndex: Int) -> Range<Int>? {
+        var end = endIndex + 1
+
+        while token(at: end)?.isSpace == true {
+            end += 1
+        }
+
+        if token(at: end)?.isComment == true {
+            return nil
+        }
+
+        if token(at: end)?.isLinebreak == true {
+            end += 1
+
+            var nextTokenIndex = end
+            while token(at: nextTokenIndex)?.isSpace == true {
+                nextTokenIndex += 1
+            }
+
+            if token(at: nextTokenIndex)?.isComment != true {
+                end = nextTokenIndex
+            }
+        }
+
+        return startIndex ..< end
+    }
+
+    func extensionAttributeTokens(for attributes: [HoistableAttribute], at insertionIndex: Int) -> [Token] {
+        switch options.typeAttributes {
+        case .sameLine:
+            return attributes.flatMap { $0.tokens + [.space(" ")] }
+
+        case .prevLine, .preserve:
+            let indent = currentIndentForLine(at: insertionIndex)
+            return attributes.flatMap { attribute -> [Token] in
+                var tokens = attribute.tokens + [linebreakToken(for: insertionIndex)]
+                if !indent.isEmpty {
+                    tokens.append(.space(indent))
+                }
+                return tokens
+            }
+        }
+    }
+}
+
+extension Collection<Declaration> {
+    var directDeclarationsExcludingTypeBodies: [Declaration] {
+        var declarations = [Declaration]()
+        forEachRecursiveDeclarationExcludingTypeBodies { declaration in
+            declarations.append(declaration)
+        }
+        return declarations
+    }
+}

--- a/Tests/Rules/ExtensionAttributesTests.swift
+++ b/Tests/Rules/ExtensionAttributesTests.swift
@@ -1,0 +1,219 @@
+//
+//  ExtensionAttributesTests.swift
+//  SwiftFormatTests
+//
+//  Created by Nick Lockwood on 9/8/26.
+//  Copyright © 2026 Nick Lockwood. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftFormat
+
+final class ExtensionAttributesTests: XCTestCase {
+    func testHoistsMainActorAttributeToPreviousLineByDefault() {
+        let input = """
+        extension Foo {
+            @MainActor func bar() {}
+            @MainActor func baz() {}
+        }
+        """
+
+        let output = """
+        @MainActor
+        extension Foo {
+            func bar() {}
+            func baz() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes)
+    }
+
+    func testHoistsMainActorAttributeToSameLineIfConfigured() {
+        let input = """
+        extension Foo {
+            @MainActor func bar() {}
+            @MainActor func baz() {}
+        }
+        """
+
+        let output = """
+        @MainActor extension Foo {
+            func bar() {}
+            func baz() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output, rule: .extensionAttributes,
+            options: FormatOptions(typeAttributes: .sameLine)
+        )
+    }
+
+    func testHoistsAvailableAttribute() {
+        let input = """
+        extension Foo {
+            @available(iOS 17.0, *)
+            func bar() {}
+
+            @available(iOS 17.0, *)
+            var baz: Int { 0 }
+        }
+        """
+
+        let output = """
+        @available(iOS 17.0, *)
+        extension Foo {
+            func bar() {}
+
+            var baz: Int { 0 }
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes, exclude: [.wrapPropertyBodies])
+    }
+
+    func testRemovesRedundantAttributesWhenExtensionAlreadyHasAttribute() {
+        let input = """
+        @MainActor extension Foo {
+            @MainActor func bar() {}
+            @MainActor func baz() {}
+        }
+        """
+
+        let output = """
+        @MainActor extension Foo {
+            func bar() {}
+            func baz() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes)
+    }
+
+    func testHoistsMainActorAttributeToPreviousLineIfConfigured() {
+        let input = """
+        extension Foo {
+            @MainActor func bar() {}
+            @MainActor func baz() {}
+        }
+        """
+
+        let output = """
+        @MainActor
+        extension Foo {
+            func bar() {}
+            func baz() {}
+        }
+        """
+
+        testFormatting(
+            for: input, output, rule: .extensionAttributes,
+            options: FormatOptions(typeAttributes: .prevLine)
+        )
+    }
+
+    func testDoesntHoistAttributeNotOnAllMembers() {
+        let input = """
+        extension Foo {
+            @MainActor func bar() {}
+            func baz() {}
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes)
+    }
+
+    func testDoesntHoistDifferentAvailableAttributes() {
+        let input = """
+        extension Foo {
+            @available(iOS 17.0, *) func bar() {}
+            @available(iOS 18.0, *) func baz() {}
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes)
+    }
+
+    func testDoesntHoistUnsupportedAttribute() {
+        let input = """
+        extension Foo {
+            @discardableResult func bar() -> Int { 0 }
+            @discardableResult func baz() -> Int { 0 }
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes, exclude: [.wrapFunctionBodies])
+    }
+
+    func testDoesntHoistObjcAttribute() {
+        let input = """
+        extension Foo {
+            @objc func bar() {}
+            @objc(bazWithValue:) func baz(value: Int) {}
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes, exclude: [.unusedArguments])
+    }
+
+    func testDoesntHoistAttributesOntoConformingExtension() {
+        let input = """
+        extension Foo: Bar {
+            @MainActor func bar() {}
+            @MainActor func baz() {}
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes)
+    }
+
+    func testHoistsAttributeWithConditionalCompilationMembers() {
+        let input = """
+        extension Foo {
+            #if DEBUG
+                @MainActor func bar() {}
+            #else
+                @MainActor func baz() {}
+            #endif
+        }
+        """
+
+        let output = """
+        @MainActor
+        extension Foo {
+            #if DEBUG
+                func bar() {}
+            #else
+                func baz() {}
+            #endif
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes)
+    }
+
+    func testDoesntRemoveAttributeWithTrailingComment() {
+        let input = """
+        extension Foo {
+            @MainActor // required
+            func bar() {}
+
+            @MainActor
+            func baz() {}
+        }
+        """
+
+        let output = """
+        @MainActor
+        extension Foo {
+            @MainActor // required
+            func bar() {}
+
+            func baz() {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes)
+    }
+}

--- a/Tests/Rules/ExtensionAttributesTests.swift
+++ b/Tests/Rules/ExtensionAttributesTests.swift
@@ -73,6 +73,47 @@ final class ExtensionAttributesTests: XCTestCase {
         testFormatting(for: input, output, rule: .extensionAttributes, exclude: [.wrapPropertyBodies])
     }
 
+    func testHoistsAvailableAttributeFromNestedTypes() {
+        let input = """
+        extension Foo {
+            @available(iOS 17.0, *)
+            struct Bar {}
+
+            @available(iOS 17.0, *)
+            enum Baz {}
+        }
+        """
+
+        let output = """
+        @available(iOS 17.0, *)
+        extension Foo {
+            struct Bar {}
+
+            enum Baz {}
+        }
+        """
+
+        testFormatting(for: input, output, rule: .extensionAttributes)
+    }
+
+    func testDoesntHoistMainActorAttributeFromNestedTypes() {
+        let input = """
+        extension Foo {
+            @MainActor
+            struct Bar {
+                func baaz() {}
+            }
+
+            @MainActor
+            struct Quux {
+                func corge() {}
+            }
+        }
+        """
+
+        testFormatting(for: input, rule: .extensionAttributes)
+    }
+
     func testRemovesRedundantAttributesWhenExtensionAlreadyHasAttribute() {
         let input = """
         @MainActor extension Foo {


### PR DESCRIPTION
This PR adds a new rule called `extensionAttributes` that works similarly to `extensionAccessControl` by hoisting common extension member attributes such as `@MainActor` or `@available` onto the extension itself.