### PR TITLE
noGuardInTests: add --boolean-guards-in-tests to preserve boolean guards

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1668,6 +1668,7 @@ Convert guard statements and trailing if statements in unit tests to
 Option | Description
 --- | ---
 `--guard-like-if-statements` | Convert guard-like trailing if statements in tests: "convert" or "preserve" (default)
+`--boolean-guards-in-tests` | Convert guards with boolean conditions in tests: "convert" (default) or "preserve"
 
 <details>
 <summary>Examples</summary>

--- a/Sources/OptionDescriptor.swift
+++ b/Sources/OptionDescriptor.swift
@@ -1509,6 +1509,15 @@ struct _Descriptors {
         falseValues: ["preserve"]
     )
 
+    let booleanGuardsInTests = OptionDescriptor(
+        argumentName: "boolean-guards-in-tests",
+        displayName: "Boolean Guards In Tests",
+        help: "Convert guards with boolean conditions in tests:",
+        keyPath: \.booleanGuardsInTests,
+        trueValues: ["convert"],
+        falseValues: ["preserve"]
+    )
+
     let redundantOptionalBinding = OptionDescriptor(
         argumentName: "redundant-optional-binding",
         displayName: "Redundant Optional Binding",

--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -934,6 +934,7 @@ public struct FormatOptions: CustomStringConvertible {
     public var suiteNameFormat: SwiftTestingNameFormat
     public var testCaseAccessControl: Visibility
     public var guardLikeIfStatements: Bool
+    public var booleanGuardsInTests: Bool
     public var redundantOptionalBinding: RedundantOptionalBindingMode
     public var singleLineTernary: SingleLineTernary
 
@@ -1087,6 +1088,7 @@ public struct FormatOptions: CustomStringConvertible {
                 suiteNameFormat: SwiftTestingNameFormat = .preserve,
                 testCaseAccessControl: Visibility = .internal,
                 guardLikeIfStatements: Bool = false,
+                booleanGuardsInTests: Bool = true,
                 redundantOptionalBinding: RedundantOptionalBindingMode = .sameNameOnly,
                 singleLineTernary: SingleLineTernary = .convert,
                 // Doesn't really belong here, but hard to put elsewhere
@@ -1229,6 +1231,7 @@ public struct FormatOptions: CustomStringConvertible {
         self.suiteNameFormat = suiteNameFormat
         self.testCaseAccessControl = testCaseAccessControl
         self.guardLikeIfStatements = guardLikeIfStatements
+        self.booleanGuardsInTests = booleanGuardsInTests
         self.redundantOptionalBinding = redundantOptionalBinding
         self.singleLineTernary = singleLineTernary
         self.indentComments = indentComments

--- a/Sources/Rules/NoGuardInTests.swift
+++ b/Sources/Rules/NoGuardInTests.swift
@@ -15,7 +15,7 @@ public extension FormatRule {
         `try #require(...)` or `try XCTUnwrap(...)` / `XCTAssert(...)`.
         """,
         disabledByDefault: true,
-        options: ["guard-like-if-statements"],
+        options: ["guard-like-if-statements", "boolean-guards-in-tests"],
         sharedOptions: ["linebreaks"]
     ) { formatter in
         guard let testFramework = formatter.detectTestingFramework() else {
@@ -172,6 +172,13 @@ public extension FormatRule {
                         // Skip if #available / #unavailable (can't be converted to #expect)
                         return true
                     case .booleanExpression:
+                        // Converting a boolean guard discards its early exit, so any code
+                        // after the guard now runs even when the condition is false.
+                        // Skip unless the caller opts in with `--boolean-guards-in-tests convert`.
+                        if isGuard, !formatter.options.booleanGuardsInTests {
+                            return true
+                        }
+
                         // XCTAssert doesn't halt the test, so we can't use it to replace
                         // if statement conditions. For guard statements, XCTAssert is fine
                         // since the guard else block handles early exit.

--- a/Tests/Rules/NoGuardInTestsTests.swift
+++ b/Tests/Rules/NoGuardInTestsTests.swift
@@ -1238,6 +1238,116 @@ final class NoGuardInTestsTests: XCTestCase {
         testFormatting(for: input, output, rule: .noGuardInTests)
     }
 
+    func testPreservesBooleanGuardWithOptionDisabled() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                guard polygons.count > 1 else {
+                    return
+                }
+
+                let a = Set(polygons[0].vertices)
+            }
+        }
+        """
+        let options = FormatOptions(booleanGuardsInTests: false)
+        testFormatting(for: input, rule: .noGuardInTests, options: options, exclude: [.blankLinesAfterGuardStatements])
+    }
+
+    func testPreservesBooleanGuardWithOptionDisabledSwiftTesting() {
+        let input = """
+        import Testing
+
+        struct SomeTests {
+            @Test
+            func something() {
+                guard polygons.count > 1 else {
+                    return
+                }
+
+                let a = Set(polygons[0].vertices)
+            }
+        }
+        """
+        let options = FormatOptions(booleanGuardsInTests: false)
+        testFormatting(for: input, rule: .noGuardInTests, options: options, exclude: [.blankLinesAfterGuardStatements])
+    }
+
+    func testPreservesGuardWithMixedConditionsWithOptionDisabled() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                guard someCondition,
+                      let value = optionalValue else {
+                    XCTFail()
+                    return
+                }
+                print(value)
+            }
+        }
+        """
+        let options = FormatOptions(booleanGuardsInTests: false)
+        testFormatting(for: input, rule: .noGuardInTests, options: options, exclude: [.blankLinesAfterGuardStatements, .unusedArguments, .elseOnSameLine, .wrapMultilineStatementBraces])
+    }
+
+    func testStillConvertsOptionalBindingGuardWithOptionDisabled() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                guard let value = optionalValue else {
+                    XCTFail()
+                    return
+                }
+                print(value)
+            }
+        }
+        """
+        let output = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() throws {
+                let value = try XCTUnwrap(optionalValue)
+                print(value)
+            }
+        }
+        """
+        let options = FormatOptions(booleanGuardsInTests: false)
+        testFormatting(for: input, output, rule: .noGuardInTests, options: options, exclude: [.blankLinesAfterGuardStatements, .unusedArguments])
+    }
+
+    func testStillConvertsTrailingIfWithOptionDisabled() {
+        let input = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() {
+                if let value = optionalValue {
+                    print(value)
+                }
+            }
+        }
+        """
+        let output = """
+        import XCTest
+
+        class TestCase: XCTestCase {
+            func test_something() throws {
+                let value = try XCTUnwrap(optionalValue)
+                print(value)
+            }
+        }
+        """
+        let options = FormatOptions(guardLikeIfStatements: true, booleanGuardsInTests: false)
+        testFormatting(for: input, [output], rules: [.noGuardInTests, .indent], options: options)
+    }
+
     func testPreservesGuardWithShadowedVariable() {
         let input = """
         import XCTest


### PR DESCRIPTION
`noGuardInTests` converts a guard with a boolean condition into a bare assertion, which drops the guard's early exit. Under XCTest the replacement is `XCTAssert(...)`, which records a failure but does not stop the test, so everything after the guard now executes with the condition false.

This is the case Nick reported in #2193 — the bounds check disappears and the array subscript that it protected becomes reachable on an empty array.

Reproduction against `main` (`0256422`, 0.63.0), `swiftformat Guard.swift --rules noGuardInTests --swiftversion 6.1`:

```swift
// before
import XCTest

final class PolygonTests: XCTestCase {
    func testCoplanar() {
        guard polygons.count > 1 else {
            return
        }

        let a = Set(polygons[0].vertices)
        XCTAssertEqual(a.count, 3)
    }
}
```

```swift
// after
import XCTest

final class PolygonTests: XCTestCase {
    func testCoplanar() {
        XCTAssert(polygons.count > 1)

        let a = Set(polygons[0].vertices)
        XCTAssertEqual(a.count, 3)
    }
}
```

With `polygons` empty, the input fails cleanly and returns; the output reports the assertion failure and then traps on `polygons[0]`.

Worth noting that the rule already contains the reasoning for this, but reaches the opposite conclusion for guards:

```swift
case .booleanExpression:
    // XCTAssert doesn't halt the test, so we can't use it to replace
    // if statement conditions. For guard statements, XCTAssert is fine
    // since the guard else block handles early exit.
```

The guard's else block does not handle the early exit after the transform, because the transform deletes it.

### The change

Adds `--boolean-guards-in-tests`, mirroring the shape of `--guard-like-if-statements` (#2588):

- `convert` (default) — today's behaviour, unchanged.
- `preserve` — skip any guard that contains a boolean condition.

Optional-binding guards still convert in both modes: `try XCTUnwrap(...)` and `try #require(...)` throw, so the early exit survives. A guard mixing the two (`guard someCondition, let value = optionalValue else`) is preserved under `preserve`, since the boolean half is the unsafe half — this matches Nick's framing of "only remove `guard let` constructs and not other types of guard".

### The judgement call

I defaulted to `convert`, i.e. no behaviour change for anyone currently using the rule. That follows Cal's note that he hit this two or three times and chose to leave it in, and matches how `--guard-like-if-statements` shipped (default = existing behaviour).

The alternative is defaulting to `preserve` on the grounds that the current output is unsound rather than merely opinionated. There is a real argument for it — the transform is never semantics-preserving for a boolean guard under XCTest — and `noGuardInTests` is `disabledByDefault`, so the blast radius of flipping the default is small. I did not want to make that call unilaterally. Happy to switch it if you would rather; it is a one-line change plus test updates.

A narrower option is also possible: restrict the skip to XCTest only, since under Swift Testing `try #require(...)` throws and the conversion *is* semantics-preserving. I made the option framework-independent because the request in #2193 reads as a style preference about guards in general, not only about the unsound case. Also easy to narrow if you prefer.

The option name is the part I am least attached to.

### Verification

- `swift test` on macOS arm64 (Swift 6.2): the 5 new cases pass and the `NoGuardInTestsTests` suite is green (82 tests, 0 failures).
- Five failures in the full run — `CommandLineTests.testBadConfigFails2` and four `SwiftFormatTests.testInputFile*` cases — reproduce identically on a clean `main` checkout with no changes, so they are pre-existing here and unrelated. CI will need to confirm Linux.
- `Rules.md` is the regenerated output from `MetadataTests`, not hand-edited.

Fixes #2193.
